### PR TITLE
Fix for TRAFODION-4

### DIFF
--- a/core/sql/optimizer/RelExeUtil.cpp
+++ b/core/sql/optimizer/RelExeUtil.cpp
@@ -5512,6 +5512,13 @@ RelExpr * ExeUtilHBaseBulkLoad::bindNode(BindWA *bindWA)
   setUtilTableDesc(bindWA->createTableDesc(naTable, getTableName()));
   if (bindWA->errStatus())
     return this;
+  if ((CmpCommon::getDefault(COMP_BOOL_226) == DF_OFF) && 
+      getUtilTableDesc()->hasSecondaryIndexes() && 
+      !(getUtilTableDesc()->isIdentityColumnGeneratedAlways() && 
+        getUtilTableDesc()->hasIdentityColumnInClusteringKey()) &&
+       !getUtilTableDesc()->getClusteringIndex()->getNAFileSet()->hasSyskey())
+    setRebuildIndexes(TRUE) ;
+  if (!getRebuildIndexes())
   setHasUniqueIndexes(getUtilTableDesc()->hasUniqueIndexes());
 
   return boundExpr;

--- a/core/sql/optimizer/RelExpr.cpp
+++ b/core/sql/optimizer/RelExpr.cpp
@@ -10528,7 +10528,7 @@ const NAString HbaseUpdate::getText() const
   NAString text;
   if (isMerge())
     {
-      text = (isSeabase ? "seabase_merge" : "hbase_merge");
+      text = (isSeabase ? "trafodion_merge" : "hbase_merge");
     }
   else
     {
@@ -12757,7 +12757,7 @@ MergeUpdate::MergeUpdate(const CorrName &name,
 			 ItemExpr *where)
      : Update(name,tabId,otype,child,setExpr,NULL,oHeap),
        insertCols_(insertCols), insertValues_(insertValues),
-       where_(where)
+       where_(where),xformedUpsert_(FALSE)
 {
   setCacheableNode(CmpMain::BIND);
   
@@ -12787,6 +12787,8 @@ RelExpr * MergeUpdate::copyTopNode(RelExpr *derivedNode, CollHeap* outHeap)
 				       outHeap, where_);
   else
     result = (MergeUpdate *) derivedNode;
+  if (xformedUpsert())
+    result->setXformedUpsert();
 
   return Update::copyTopNode(result, outHeap);
 }

--- a/core/sql/optimizer/RelUpdate.h
+++ b/core/sql/optimizer/RelUpdate.h
@@ -1062,7 +1062,7 @@ public:
   NABoolean &enableTransformToSTI() { return enableTransformToSTI_;}
   NABoolean &enableAqrWnrEmpty()    { return enableAqrWnrEmpty_; }
 
-  NABoolean systemGeneratesIdentityValue() 
+  NABoolean systemGeneratesIdentityValue()  const
   { return systemGeneratesIdentityValue_;};
 
   void setSystemGeneratesIdentityValue(NABoolean value) 
@@ -1417,10 +1417,13 @@ public:
 
   ItemExpr * insertCols() {return insertCols_;}
   ItemExpr * insertValues() { return insertValues_;}
+  NABoolean xformedUpsert() {return xformedUpsert_;}
+  void setXformedUpsert() {xformedUpsert_ = TRUE;}
 private:
   ItemExpr *insertCols_;
   ItemExpr *insertValues_;
   ItemExpr *where_;
+  NABoolean xformedUpsert_;
 };
 
 

--- a/core/sql/optimizer/TableDesc.cpp
+++ b/core/sql/optimizer/TableDesc.cpp
@@ -298,6 +298,19 @@ NABoolean TableDesc::isIdentityColumnGeneratedAlways(NAString * value) const
     return result;
 }
 
+NABoolean TableDesc::hasIdentityColumnInClusteringKey() const
+{
+  ValueIdSet pKeyColumns = clusteringIndex_->getIndexKey();
+  NAColumn * column = NULL;
+  for(ValueId id = pKeyColumns.init(); pKeyColumns.next(id);
+      pKeyColumns.advance(id))
+  {
+      column = id.getNAColumn();
+      if (column && column->isIdentityColumn())
+          return TRUE;
+  }
+  return FALSE;
+}
  
 // -----------------------------------------------------------------------
 // Given a column list providing identifiers for columns of this table,

--- a/core/sql/optimizer/TableDesc.h
+++ b/core/sql/optimizer/TableDesc.h
@@ -216,6 +216,7 @@ public:
   ValueIdSet getDivisioningColumns() ;
 
   ValueIdSet getSaltColumnAsSet() ;
+  NABoolean hasIdentityColumnInClusteringKey() const ;
 
 private:
 

--- a/core/sql/regress/core/TEST019
+++ b/core/sql/regress/core/TEST019
@@ -98,9 +98,11 @@ create table t019_g
   (uniqb int not null,
    str1  varchar(50) not null) no partition ;
 
+cqd hbase_serialization 'off' ;
 create table upsertx(id int not null, a int, b int,
                           primary key (id));
 create index upsertix1 on upsertx(a);
+cqd hbase_serialization 'on' ;
 
 
 

--- a/core/sql/regress/executor/EXPECTED015.SB
+++ b/core/sql/regress/executor/EXPECTED015.SB
@@ -73,6 +73,18 @@
 
 --- SQL operation complete.
 >>
+>>create index t015t12i1 on t015t12(b) ;
+
+--- SQL operation complete.
+>>create index t015t12i2 on t015t12(c) salt like table;
+
+--- SQL operation complete.
+>>
+>>create index t015t13i1 on t015t13(c) ;
+
+--- SQL operation complete.
+>>
+>>
 >>insert into t015t1 values (1,1), (2,2);
 
 --- 2 row(s) inserted.
@@ -968,27 +980,23 @@ A            B            C
 >>merge into t015t7 on a = 1 when matched then update set c = 3
 +>                           when not matched then insert (a,c) values (1,2);
 
---- 1 row(s) updated.
+*** ERROR[3241] This MERGE statement is not supported. Reason:  unique indexes not allowed.
+
+*** ERROR[8822] The statement was not prepared.
+
 >>select a,c from t015t7;
 
-A            C          
------------  -----------
-
-          1            2
-
---- 1 row(s) selected.
+--- 0 row(s) selected.
 >>merge into t015t7 on a = 1 when matched then update set c = 3
 +>                           when not matched then insert (a,c) values (1,2);
 
---- 1 row(s) updated.
+*** ERROR[3241] This MERGE statement is not supported. Reason:  unique indexes not allowed.
+
+*** ERROR[8822] The statement was not prepared.
+
 >>select a,c from t015t7;
 
-A            C          
------------  -----------
-
-          1            3
-
---- 1 row(s) selected.
+--- 0 row(s) selected.
 >>
 >>control query default olt_query_opt 'ON';
 
@@ -1363,5 +1371,98 @@ A            B
 +>  when not matched then insert values ('c', 2);
 
 --- 1 row(s) updated.
+>>
+>>-- Upsert that gets converted to merge
+>>upsert into t015t12 values (1,1,1) ;
+
+--- 1 row(s) inserted.
+>>select * from t015t12;
+
+A            B            C          
+-----------  -----------  -----------
+
+          1            1            1
+
+--- 1 row(s) selected.
+>>upsert into t015t12 values (1,-1,1) ;
+
+--- 1 row(s) inserted.
+>>select * from t015t12 ;
+
+A            B            C          
+-----------  -----------  -----------
+
+          1           -1            1
+
+--- 1 row(s) selected.
+>>upsert into t015t12 values (2,2,2),(3,3,3),(1,-1,-1);
+
+--- 3 row(s) inserted.
+>>select * from t015t12 ;
+
+A            B            C          
+-----------  -----------  -----------
+
+          1           -1           -1
+          2            2            2
+          3            3            3
+
+--- 3 row(s) selected.
+>>set parserflags 1;
+
+--- SQL operation complete.
+>>select * from table(index_table t015t12i1) ;
+
+B@           _SALT_      A          
+-----------  ----------  -----------
+
+         -1           0            1
+          2           0            2
+          3           1            3
+
+--- 3 row(s) selected.
+>>select * from table(index_table t015t12i2) ;
+
+_SALT_@     C@           A          
+----------  -----------  -----------
+
+         0           -1            1
+         0            2            2
+         1            3            3
+
+--- 3 row(s) selected.
+>>
+>>upsert into t015t13(b,c) values (1,1);
+
+--- 1 row(s) inserted.
+>>upsert into t015t13(b,c) values (1,2);
+
+--- 1 row(s) inserted.
+>>upsert into t015t13(b,c) values (2,2),(3,3),(4,4);
+
+--- 3 row(s) inserted.
+>>select * from t015t13;
+
+A                     B            C          
+--------------------  -----------  -----------
+
+                   1            1            1
+                   2            1            2
+                   3            2            2
+                   4            3            3
+                   5            4            4
+
+--- 5 row(s) selected.
+>>explain options 'f' upsert into t015t13 (b,c) values (1,1) ;
+
+LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
+---- ---- ---- --------------------  --------  --------------------  ---------
+
+3    .    4    root                  o         x                     1.00E+000
+1    2    3    nested_join                                           1.00E+000
+.    .    2    trafodion_insert                T015T13I1             1.00E+000
+.    .    1    trafodion_upsert                T015T13               1.00E+000
+
+--- SQL operation complete.
 >>
 >>log;

--- a/core/sql/regress/executor/TEST015
+++ b/core/sql/regress/executor/TEST015
@@ -36,6 +36,8 @@ drop table t015t8 cascade;
 drop table t015t9 cascade;
 drop table t015t10 cascade;
 drop table t015t11 cascade;
+drop table t015t12 cascade ;
+drop table t015t13 cascade ;
 drop table temp cascade;
 
 --control query default POS 'OFF';
@@ -143,6 +145,12 @@ hash partition by (i)
 #ifNT
 ;
 
+cqd hbase_serialization 'off' ;
+create table t015t12 (a int not null, b int not null, c int, primary key(a)) salt using 2 partitions ;
+cqd hbase_serialization 'on' ;
+
+create table t015t13 (a largeint generated always as identity, b int not null, c int, primary key(a,b));
+
 set session default ESP_RELEASE_WORK_TIMEOUT '-2';
 log log015 clear;
 
@@ -175,6 +183,12 @@ create unique index t015t8i2 on t015t8(k);
 
 create unique index t015t10i1 on t015t10(j);
 create unique index t015t10i2 on t015t10(k);
+
+create index t015t12i1 on t015t12(b) ;
+create index t015t12i2 on t015t12(c) salt like table;
+
+create index t015t13i1 on t015t13(c) ;
+
 
 insert into t015t1 values (1,1), (2,2);
 insert into t015t3 values (1,1,1), (2,2,2), (3,3,3);
@@ -677,7 +691,24 @@ select * from table (index_table t015t8i2);
 alter table t015t11 add column j int default 0 not null;
 merge into t015t11 on i = 'c' 
   when matched then update set j = 4
-  when not matched then insert values ('c', 2);    
+  when not matched then insert values ('c', 2);  
+
+-- Upsert that gets converted to merge
+upsert into t015t12 values (1,1,1) ;
+select * from t015t12;
+upsert into t015t12 values (1,-1,1) ;  
+select * from t015t12 ;
+upsert into t015t12 values (2,2,2),(3,3,3),(1,-1,-1);
+select * from t015t12 ;
+set parserflags 1;
+select * from table(index_table t015t12i1) ;
+select * from table(index_table t015t12i2) ;
+
+upsert into t015t13(b,c) values (1,1);
+upsert into t015t13(b,c) values (1,2);
+upsert into t015t13(b,c) values (2,2),(3,3),(4,4);
+select * from t015t13; 
+explain options 'f' upsert into t015t13 (b,c) values (1,1) ;
 
 log;
 

--- a/core/sql/regress/hive/EXPECTED015
+++ b/core/sql/regress/hive/EXPECTED015
@@ -209,9 +209,9 @@ Task:  CLEANUP         Status: Started    Object: TRAFODION.HBASE.T015T2
 Task:  CLEANUP         Status: Ended      Object: TRAFODION.HBASE.T015T2
 Task:  PREPARATION     Status: Started    Object: TRAFODION.HBASE.T015T2
        Rows Processed: 5 
-Task:  PREPARATION     Status: Ended      ET: 00:00:00.190
+Task:  PREPARATION     Status: Ended      ET: 00:00:00.186
 Task:  COMPLETION      Status: Started    Object: TRAFODION.HBASE.T015T2
-Task:  COMPLETION      Status: Ended      ET: 00:00:00.530
+Task:  COMPLETION      Status: Ended      ET: 00:00:00.509
 
 --- 5 row(s) loaded.
 >>
@@ -233,9 +233,9 @@ Task:  CLEANUP         Status: Started    Object: TRAFODION.HBASE.T015T2
 Task:  CLEANUP         Status: Ended      Object: TRAFODION.HBASE.T015T2
 Task:  PREPARATION     Status: Started    Object: TRAFODION.HBASE.T015T2
        Rows Processed: 5 
-Task:  PREPARATION     Status: Ended      ET: 00:00:00.177
+Task:  PREPARATION     Status: Ended      ET: 00:00:00.193
 Task:  COMPLETION      Status: Started    Object: TRAFODION.HBASE.T015T2
-Task:  COMPLETION      Status: Ended      ET: 00:00:00.159
+Task:  COMPLETION      Status: Ended      ET: 00:00:00.155
 
 --- 5 row(s) loaded.
 >>
@@ -258,9 +258,9 @@ Task:  CLEANUP         Status: Started    Object: TRAFODION.HBASE.T015T2
 Task:  CLEANUP         Status: Ended      Object: TRAFODION.HBASE.T015T2
 Task:  PREPARATION     Status: Started    Object: TRAFODION.HBASE.T015T2
        Rows Processed: 5 
-Task:  PREPARATION     Status: Ended      ET: 00:00:00.193
+Task:  PREPARATION     Status: Ended      ET: 00:00:00.194
 Task:  COMPLETION      Status: Started    Object: TRAFODION.HBASE.T015T2
-Task:  COMPLETION      Status: Ended      ET: 00:00:00.542
+Task:  COMPLETION      Status: Ended      ET: 00:00:00.819
 
 --- 5 row(s) loaded.
 >>
@@ -288,9 +288,9 @@ Task:  CLEANUP         Status: Started    Object: TRAFODION.HBASE.T015T2
 Task:  CLEANUP         Status: Ended      Object: TRAFODION.HBASE.T015T2
 Task:  PREPARATION     Status: Started    Object: TRAFODION.HBASE.T015T2
        Rows Processed: 5 
-Task:  PREPARATION     Status: Ended      ET: 00:00:00.189
+Task:  PREPARATION     Status: Ended      ET: 00:00:00.192
 Task:  COMPLETION      Status: Started    Object: TRAFODION.HBASE.T015T2
-Task:  COMPLETION      Status: Ended      ET: 00:00:00.532
+Task:  COMPLETION      Status: Ended      ET: 00:00:00.521
 
 --- 5 row(s) loaded.
 >>
@@ -461,9 +461,9 @@ Task:  CLEANUP         Status: Started    Object: TRAFODION.HBASE.CUSTOMER_ADDRE
 Task:  CLEANUP         Status: Ended      Object: TRAFODION.HBASE.CUSTOMER_ADDRESS
 Task:  PREPARATION     Status: Started    Object: TRAFODION.HBASE.CUSTOMER_ADDRESS
        Rows Processed: 5000 
-Task:  PREPARATION     Status: Ended      ET: 00:00:05.183
+Task:  PREPARATION     Status: Ended      ET: 00:00:05.312
 Task:  COMPLETION      Status: Started    Object: TRAFODION.HBASE.CUSTOMER_ADDRESS
-Task:  COMPLETION      Status: Ended      ET: 00:00:00.676
+Task:  COMPLETION      Status: Ended      ET: 00:00:00.642
 
 --- 5000 row(s) loaded.
 >>
@@ -543,9 +543,9 @@ Task:  CLEANUP         Status: Started    Object: TRAFODION.HBASE.CUSTOMER_ADDRE
 Task:  CLEANUP         Status: Ended      Object: TRAFODION.HBASE.CUSTOMER_ADDRESS_NOPK
 Task:  PREPARATION     Status: Started    Object: TRAFODION.HBASE.CUSTOMER_ADDRESS_NOPK
        Rows Processed: 5000 
-Task:  PREPARATION     Status: Ended      ET: 00:00:01.380
+Task:  PREPARATION     Status: Ended      ET: 00:00:01.371
 Task:  COMPLETION      Status: Started    Object: TRAFODION.HBASE.CUSTOMER_ADDRESS_NOPK
-Task:  COMPLETION      Status: Ended      ET: 00:00:00.537
+Task:  COMPLETION      Status: Ended      ET: 00:00:00.541
 
 --- 5000 row(s) loaded.
 >>
@@ -644,9 +644,9 @@ Task:  CLEANUP         Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOG
 Task:  CLEANUP         Status: Ended      Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS
 Task:  PREPARATION     Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS
        Rows Processed: 5000 
-Task:  PREPARATION     Status: Ended      ET: 00:00:03.023
+Task:  PREPARATION     Status: Ended      ET: 00:00:03.149
 Task:  COMPLETION      Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS
-Task:  COMPLETION      Status: Ended      ET: 00:00:00.674
+Task:  COMPLETION      Status: Ended      ET: 00:00:00.601
 
 --- 5000 row(s) loaded.
 >>
@@ -750,9 +750,9 @@ Task:  CLEANUP         Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOG
 Task:  CLEANUP         Status: Ended      Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS_SALT
 Task:  PREPARATION     Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS_SALT
        Rows Processed: 5000 
-Task:  PREPARATION     Status: Ended      ET: 00:00:04.469
+Task:  PREPARATION     Status: Ended      ET: 00:00:04.879
 Task:  COMPLETION      Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS_SALT
-Task:  COMPLETION      Status: Ended      ET: 00:00:01.519
+Task:  COMPLETION      Status: Ended      ET: 00:00:01.637
 
 --- 5000 row(s) loaded.
 >>
@@ -1185,7 +1185,7 @@ A            B            C
 --- 12 row(s) selected.
 >>
 >>
->>--Add  tests with indexes on bulloaded tables
+>>--Add  tests with indexes on bulkoaded tables
 >>drop table customer_demographics_salt cascade;
 
 --- SQL operation complete.
@@ -1202,9 +1202,8 @@ A            B            C
 +>  cd_credit_rating        char(10),
 +>  cd_dep_count            int,
 +>  cd_dep_employed_count   int,
-+>  cd_dep_college_count    int,
-+>  primary key (cd_demo_sk)
-+>);
++>  cd_dep_college_count    int
++>) store by (cd_demo_sk);
 
 --- SQL operation complete.
 >>
@@ -1232,7 +1231,7 @@ A            B            C
 --- SQL operation complete.
 >>
 >>explain options 'f' 
-+>load  transform into customer_demographics 
++>load  transform into customer_demographics
 +>select * from hive.hive.customer_demographics where cd_demo_sk <= 5000;
 
 LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
@@ -1256,6 +1255,9 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 
 --- SQL operation complete.
 >>
+>>cqd comp_bool_226 'off' ;
+
+--- SQL operation complete.
 >>load  into customer_demographics 
 +>select * from hive.hive.customer_demographics where cd_demo_sk <= 5000;
 Task: LOAD             Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS
@@ -1263,9 +1265,9 @@ Task:  CLEANUP         Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOG
 Task:  CLEANUP         Status: Ended      Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS
 Task:  PREPARATION     Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS
        Rows Processed: 5000 
-Task:  PREPARATION     Status: Ended      ET: 00:00:06.461
+Task:  PREPARATION     Status: Ended      ET: 00:00:06.496
 Task:  COMPLETION      Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS
-Task:  COMPLETION      Status: Ended      ET: 00:00:01.879
+Task:  COMPLETION      Status: Ended      ET: 00:00:02.109
 
 --- 5000 row(s) loaded.
 >>
@@ -1306,11 +1308,11 @@ Task:  DISABLE INDEXE  Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOG
 Task:  DISABLE INDEXE  Status: Ended      Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS
 Task:  PREPARATION     Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS
        Rows Processed: 1000 
-Task:  PREPARATION     Status: Ended      ET: 00:00:04.069
+Task:  PREPARATION     Status: Ended      ET: 00:00:05.641
 Task:  COMPLETION      Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS
-Task:  COMPLETION      Status: Ended      ET: 00:00:01.483
+Task:  COMPLETION      Status: Ended      ET: 00:00:02.726
 Task:  POPULATE INDEX  Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS
-Task:  POPULATE INDEX  Status: Ended      ET: 00:00:09.684
+Task:  POPULATE INDEX  Status: Ended      ET: 00:00:03.503
 
 --- 1000 row(s) loaded.
 >>
@@ -1351,11 +1353,15 @@ Task:  POPULATE INDEX  Status: Ended      ET: 00:00:09.684
 Task: LOAD             Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS_SALT
 Task:  CLEANUP         Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS_SALT
 Task:  CLEANUP         Status: Ended      Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS_SALT
+Task:  DISABLE INDEXE  Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS_SALT
+Task:  DISABLE INDEXE  Status: Ended      Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS_SALT
 Task:  PREPARATION     Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS_SALT
        Rows Processed: 5000 
-Task:  PREPARATION     Status: Ended      ET: 00:00:06.372
+Task:  PREPARATION     Status: Ended      ET: 00:00:05.263
 Task:  COMPLETION      Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS_SALT
-Task:  COMPLETION      Status: Ended      ET: 00:00:03.391
+Task:  COMPLETION      Status: Ended      ET: 00:00:02.292
+Task:  POPULATE INDEX  Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS_SALT
+Task:  POPULATE INDEX  Status: Ended      ET: 00:00:12.244
 
 --- 5000 row(s) loaded.
 >>
@@ -1394,7 +1400,9 @@ Task:  COMPLETION      Status: Ended      ET: 00:00:03.391
 
 --- SQL operation complete.
 >>
->>
+>>cqd comp_bool_226 'on' ;
+
+--- SQL operation complete.
 >>
 >>-- --load with upsert using load
 >>-- drop table customer_demographics_salt cascade;
@@ -1532,9 +1540,9 @@ Task:  CLEANUP         Status: Started    Object: TRAFODION.HBASE.CUSTOMER_ADDRE
 Task:  CLEANUP         Status: Ended      Object: TRAFODION.HBASE.CUSTOMER_ADDRESS
 Task:  PREPARATION     Status: Started    Object: TRAFODION.HBASE.CUSTOMER_ADDRESS
        Rows Processed: 5000 
-Task:  PREPARATION     Status: Ended      ET: 00:00:02.368
+Task:  PREPARATION     Status: Ended      ET: 00:00:03.060
 Task:  COMPLETION      Status: Started    Object: TRAFODION.HBASE.CUSTOMER_ADDRESS
-Task:  COMPLETION      Status: Ended      ET: 00:00:01.234
+Task:  COMPLETION      Status: Ended      ET: 00:00:03.318
 
 --- 5000 row(s) loaded.
 >>

--- a/core/sql/regress/hive/TEST015
+++ b/core/sql/regress/hive/TEST015
@@ -392,7 +392,7 @@ load with no output, no duplicate check into t015t6 select a,a,a from t015t1 ;
 select * from t015t4 order by a;
 
 
---Add  tests with indexes on bulloaded tables
+--Add  tests with indexes on bulkoaded tables
 drop table customer_demographics_salt cascade;
 drop table customer_demographics cascade;
 create table customer_demographics
@@ -405,9 +405,8 @@ create table customer_demographics
   cd_credit_rating        char(10),
   cd_dep_count            int,
   cd_dep_employed_count   int,
-  cd_dep_college_count    int,
-  primary key (cd_demo_sk)
-); 
+  cd_dep_college_count    int
+) store by (cd_demo_sk); 
 
 create table customer_demographics_salt
 (
@@ -427,9 +426,10 @@ create index cd_dep_count_IDX on customer_demographics(cd_dep_count);
 create index cd_dep_college_count_IDX on customer_demographics(cd_dep_college_count);
 
 explain options 'f' 
-load  transform into customer_demographics 
+load  transform into customer_demographics
 select * from hive.hive.customer_demographics where cd_demo_sk <= 5000;
 
+cqd comp_bool_226 'off' ;
 load  into customer_demographics 
 select * from hive.hive.customer_demographics where cd_demo_sk <= 5000;
 
@@ -459,7 +459,7 @@ select count(*) from table(index_table cd_dep_college_count_IDX2);
 drop index cd_dep_count_IDX2;
 drop index cd_dep_college_count_IDX2;
 
-
+cqd comp_bool_226 'on' ;
 
 -- --load with upsert using load
 -- drop table customer_demographics_salt cascade;


### PR DESCRIPTION
A prior checkin to address https://bugs.launchpad.net/trafodion/+bug/1460771 caused two tests to fail in the nightly build. The problem was twofold
a) VEG creation was disabled between old and new values in an the WHEN MATCHED clause of a MERGE statement. This caused several MERGE statements to fail.
b) Bulk load was incorrectly taking the merge code path.
Both these problem have been addressed by making the previous checkin apply only to UPSERT statements on tables with index. In addition a few other outstanding issues that could potentially cause inconsistency between table and index have been disabled. These include
a) MERGE statement on table with UNIQUE index
b) UPSERT statement on table with serialized columns.
Bulk load on tables with index will now cause the index to be rebuilt from scratch unless the table has a syskey, in which case the index will be loaded to at the same time as the table.