### PR TITLE
[TRAFODION-6]JDBC T2 has compilation errors when use -D_DEBUG option

### DIFF
--- a/core/conn/jdbc_type2/native/Debug.cpp
+++ b/core/conn/jdbc_type2/native/Debug.cpp
@@ -45,8 +45,8 @@
 #include <time.h>
 #include <sys/times.h>
 #include <sys/types.h>
+#include <sys/syscall.h>
 #include <unistd.h>
-#include <windows.h>
 #ifdef NSK_PLATFORM
 	#include <sqlWin.h>
 #else
@@ -56,13 +56,11 @@
 #include "SrvrCommon.h"
 #include "SrvrKds.h"
 #include "SqlInterface.h"
-#include "commondiags.h"
 //#include "spthread.h" commented by Venu for TSLX
 
 #include "jni.h"
 
 #include "Vproc.h"
-#include <tslxExt.h> //added by venu for TSLX
 
 // Maximum output line length
 #define DEBUG_MAX_LINE_LEN 1024UL
@@ -183,8 +181,7 @@ static const char *UCase(const char *text)
 
 static unsigned long GetThreadId(void)
 {
-	_TSLX_t thread_id = tslx_ext_pthread_self();
-	return((unsigned long) thread_id.field1);
+        return syscall(SYS_gettid);
 }
 
 static const char *GetId(void)
@@ -665,7 +662,7 @@ const char *DebugFormat(const char *fmt, ...)
 
 	if (fmt==NULL) return(NULL);
 
-	va_list marker
+	va_list marker;
 	va_start( marker, fmt );     /* Initialize variable arguments. */
 	vsprintf(buffer, fmt, marker);
 	va_end( marker );            /* Reset variable arguments.      */
@@ -1002,15 +999,6 @@ void DebugTransTag(const char * filename, unsigned long line)
 			return;
 		}
 
-		//Convert txn identifier from internal form to external ASCII form
-		status = TRANSIDTOTEXT(txnId,buffer,(short)sizeof(buffer),&length);
-		if (status != 0)
-		{
-			// Report error status and return null
-			DebugOutput(DebugFormat("Status from TRANSIDTOTEXT = %d", status),
-						filename, line);
-			return;
-		}
 		buffer[length] = 0;
 		DebugOutput(DebugFormat("transTagASCII = '%s'", buffer),
 					filename, line);
@@ -1294,7 +1282,7 @@ void CliDebugShowServerStatement(void *vSrvrStmt,
 			line);
 		DEBUG_OUT_LOC(DEBUG_LEVEL_CLI|DEBUG_LEVEL_DATA|DEBUG_LEVEL_STMT,
 			("  Statement='%s'",
-				DebugString(pSrvrStmt->sqlString.dataValue._buffer)),
+				DebugString((const char *)pSrvrStmt->sqlString.dataValue._buffer)),
 			filename,
 			line);
 		DEBUG_OUT_LOC(DEBUG_LEVEL_CLI|DEBUG_LEVEL_DATA|DEBUG_LEVEL_STMT,
@@ -1653,6 +1641,7 @@ void CliDebugShowDesc(void *vSrvrStmt, int uDescType,
 				}
 				break;
 			default:
+                                break;
 			}
 			descItemIdx++;
 		}
@@ -2136,7 +2125,7 @@ SQLCLI_LIB_FUNC long CliDebug_ClearDiagnostics (SQLSTMT_ID *statement_id,
 	CLI_DEBUG_RETURN_SQL_LOC(rc,filename,line);
 }
 
-SQLCLI_LIB_FUNC long CliDebug_GetDiagnosticsStmtInfo2(SQLSTMT_ID *statement_id, long what_to_get, int *numeric_value, char *string_value,
+SQLCLI_LIB_FUNC long CliDebug_GetDiagnosticsStmtInfo2(SQLSTMT_ID *statement_id, long what_to_get, void *numeric_value, char *string_value,
 													  long max_string_len, int *len_of_item,
 													  const char *filename, unsigned long line)
 {
@@ -2149,11 +2138,9 @@ SQLCLI_LIB_FUNC long CliDebug_GetDiagnosticsStmtInfo2(SQLSTMT_ID *statement_id, 
 			len_of_item),
 		filename, line);
 
-	if (numeric_value) *numeric_value = 0;
-	if (max_string_len) *string_value = 0;
 	long rc = SQL_EXEC_GetDiagnosticsStmtInfo2(statement_id, what_to_get, numeric_value, string_value, max_string_len, len_of_item);
 	if (numeric_value)
-		DEBUG_OUT_LOC(org_trafodion_jdbc_t2_JdbcDebug_debugLevelCLI,("numeric_value=%ld",*numeric_value),filename,line);
+		DEBUG_OUT_LOC(org_trafodion_jdbc_t2_JdbcDebug_debugLevelCLI,("numeric_value=%ld",(Int64 *)numeric_value),filename,line);
 	if (max_string_len)
 		DEBUG_OUT_LOC(org_trafodion_jdbc_t2_JdbcDebug_debugLevelCLI,("string_value=%s",string_value),filename,line);
 	CLI_DEBUG_RETURN_SQL_LOC(rc,filename,line);

--- a/core/conn/jdbc_type2/native/Debug.h
+++ b/core/conn/jdbc_type2/native/Debug.h
@@ -277,8 +277,6 @@ const char *WrapperDataTypeStr(jbyte dataType);
 
 #define BENCHMARK_ADD_COUNTER(index,name,value)
 
-extern unsigned long debugLevel;
-
 #else /* !_DEBUG */
 
 #ifdef _BENCHMARK
@@ -361,7 +359,7 @@ SQLCLI_LIB_FUNC long CliDebug_CurrentContext(SQLCTX_HANDLE *contextHandle, const
 #define CLI_ClearDiagnostics(statement_id) CliDebug_ClearDiagnostics(statement_id, __FILE__, __LINE__)
 SQLCLI_LIB_FUNC long CliDebug_ClearDiagnostics (SQLSTMT_ID *statement_id, const char *filename, unsigned long line);
 #define CLI_GetDiagnosticsStmtInfo2(statement_id, what_to_get, numeric_value, string_value, max_string_len, len_of_item) CliDebug_GetDiagnosticsStmtInfo2(statement_id, what_to_get, numeric_value, string_value, max_string_len, len_of_item, __FILE__, __LINE__)
-SQLCLI_LIB_FUNC long CliDebug_GetDiagnosticsStmtInfo2(SQLSTMT_ID *statement_id, long what_to_get, int *numeric_value, char *string_value, long max_string_len, int *len_of_item, const char *filename, unsigned long line);
+SQLCLI_LIB_FUNC long CliDebug_GetDiagnosticsStmtInfo2(SQLSTMT_ID *statement_id, long what_to_get, void *numeric_value, char *string_value, long max_string_len, int *len_of_item, const char *filename, unsigned long line);
 #define CLI_DeallocDesc(desc_id) CliDebug_DeallocDesc(desc_id, __FILE__, __LINE__)
 SQLCLI_LIB_FUNC long CliDebug_DeallocDesc(SQLDESC_ID *desc_id, const char *filename, unsigned long line);
 #define CLI_DeallocStmt(statement_id) CliDebug_DeallocStmt(statement_id, __FILE__, __LINE__)

--- a/core/conn/jdbc_type2/native/SQLMXConnection.cpp
+++ b/core/conn/jdbc_type2/native/SQLMXConnection.cpp
@@ -385,7 +385,7 @@ JNIEXPORT void JNICALL Java_org_trafodion_jdbc_t2_SQLMXConnection_connectInit
                     queryTimeout));
     DEBUG_OUT(DEBUG_LEVEL_ENTRY,("  statisticsIntervalTime=%ld, statisticsLimitTime=%ld, statisticsType=%s, programStatisticsEnabled=%s, statisticsSqlPlanEnabled=%s",
                     statisticsIntervalTime,
-                    statisticsLimitTime
+                    statisticsLimitTime,
                     DebugJString(jenv,statisticsType),
                     DebugJString(jenv,programStatisticsEnabled),
                     DebugJString(jenv,statisticsSqlPlanEnabled)


### PR DESCRIPTION
 With this check-in, JDBC T2 can use -D_DEBUG to make a debug version.
The debug version can output many debug informations and detect the
memory leak.
Change-Id: Ibf5dc2ae7e73b232bf0f3499fa3194d7f04c2e0e