### PR TITLE
JIRA TRAFODION-9

### DIFF
--- a/core/sqf/export/include/dtm/tmtransid.h
+++ b/core/sqf/export/include/dtm/tmtransid.h
@@ -60,9 +60,8 @@ class TM_Transid
 {
     public:
         TM_Transid ();
-        TM_Transid (int i);
         TM_Transid (TM_Transid &tx);
-        TM_Transid (TM_Native_Type &tx);
+        TM_Transid (TM_Native_Type tx);
         TM_Transid (TM_Txid_Internal &tx);
         ~TM_Transid(){}
 

--- a/core/sqf/src/tm/tmtransid.cpp
+++ b/core/sqf/src/tm/tmtransid.cpp
@@ -36,17 +36,8 @@ TM_Transid::TM_Transid()
     iv_tx.data.id[3] = 0;
 }
 
-TM_Transid::TM_Transid(int i)
-{
-    iv_tx.data.id[0] = i;
-    iv_tx.data.id[1] = 0;
-    iv_tx.data.id[2] = 0;
-    iv_tx.data.id[3] = 0;
-}
-
-TM_Transid::TM_Transid (TM_Native_Type &tx)
+TM_Transid::TM_Transid (TM_Native_Type tx)
 { 
-    //TM_Txid_legacy *txid = (TM_Txid_legacy *) &tx;
     iv_tx.data.id[0] = tx;
     iv_tx.data.id[1] = 0;
     iv_tx.data.id[2] = 0;

--- a/core/sql/comexe/ComTdbHbaseAccess.h
+++ b/core/sql/comexe/ComTdbHbaseAccess.h
@@ -697,6 +697,10 @@ public:
   {(v ? flags_ |= ALIGNED_FORMAT : flags_ &= ~ALIGNED_FORMAT); };
   NABoolean alignedFormat() { return (flags_ & ALIGNED_FORMAT) != 0; };
 
+  void setAsyncOperations(NABoolean v)
+  {(v ? flags_ |= ASYNC_OPERATIONS : flags_ &= ~ASYNC_OPERATIONS); };
+  NABoolean asyncOperations() { return (flags_ & ASYNC_OPERATIONS) != 0; };
+
   void setCanAdjustTrafParams(NABoolean v)
    {(v ? flags2_ |= TRAF_UPSERT_ADJUST_PARAMS : flags2_ &= ~TRAF_UPSERT_ADJUST_PARAMS); };
    NABoolean getCanAdjustTrafParams() { return (flags2_ & TRAF_UPSERT_ADJUST_PARAMS) != 0; };
@@ -849,7 +853,8 @@ public:
     READ_UNCOMMITTED_SCAN            = 0x0800,
     UPDEL_COLNAME_IS_STR             = 0x1000,
     USE_HBASE_XN                     = 0x2000,
-    ALIGNED_FORMAT                   = 0x4000
+    ALIGNED_FORMAT                   = 0x4000,
+    ASYNC_OPERATIONS                 = 0x8000
   };
 
   enum

--- a/core/sql/executor/ExHbaseAccess.cpp
+++ b/core/sql/executor/ExHbaseAccess.cpp
@@ -444,6 +444,9 @@ ExHbaseAccessTcb::ExHbaseAccessTcb(
   rows_.len = 0;
   colVal_.val = 0;
   colVal_.len = 0;
+  asyncCompleteRetryCount_ = 0;
+  asyncOperationTimeout_ = 2;
+  resultArray_ = NULL;
 }
     
 ExHbaseAccessTcb::~ExHbaseAccessTcb()

--- a/core/sql/executor/ExHbaseAccess.h
+++ b/core/sql/executor/ExHbaseAccess.h
@@ -473,6 +473,9 @@ protected:
   ColValVec * colValVec_;
   Lng32 colValVecSize_;
   Lng32 colValEntry_;
+  Int16 asyncCompleteRetryCount_;
+  NABoolean *resultArray_;
+  Int32 asyncOperationTimeout_;
 
   // Redefined and used by ExHbaseAccessBulkLoadPrepSQTcb.
 
@@ -824,6 +827,7 @@ public:
     , HANDLE_ERROR
     , DONE
     , ALL_DONE
+    , ASYNC_INSERT_COMPLETE
 
   } step_;
 
@@ -876,6 +880,7 @@ public:
 
   Lng32 rowsInserted_;
   int lastHandledStep_;
+  Lng32 numRowsInVsbbBuffer_;
 };
 
 
@@ -1128,6 +1133,7 @@ public:
     , CREATE_ROW
     , APPLY_PRED
     , RETURN_ROW
+    , ASYNC_INSERT_COMPLETE
   } step_;
 
   ExHbaseAccessSQRowsetTcb( const ExHbaseAccessTdb &tdb,
@@ -1143,8 +1149,8 @@ public:
   queue_index nextRequest_;    // next request in down queue
 
   Lng32 numRetries_;
-
-  ExHbaseGetSQTaskTcb * getSQTaskTcb_;
+  int lastHandledStep_;
+  Lng32 numRowsInVsbbBuffer_;
 };
 
 class ExHbaseAccessDDLTcb  : public ExHbaseAccessTcb

--- a/core/sql/executor/HBaseClient_JNI.h
+++ b/core/sql/executor/HBaseClient_JNI.h
@@ -199,6 +199,8 @@ typedef enum {
  ,HTC_NEXTCELL_EXCEPTION
  ,HTC_ERROR_GETROWS_PARAM
  ,HTC_ERROR_GETROWS_EXCEPTION
+ ,HTC_ERROR_COMPLETEASYNCOPERATION_EXCEPTION
+ ,HTC_ERROR_ASYNC_OPERATION_NOT_COMPLETE
  ,HTC_LAST
 } HTC_RetCode;
 
@@ -281,13 +283,15 @@ public:
   HTC_RetCode deleteRows(Int64 transID, short rowIDLen, HbaseStr &rowIDs, Int64 timestamp);
   HTC_RetCode checkAndDeleteRow(Int64 transID, HbaseStr &rowID, const Text &columnToCheck, const Text &colValToCheck, Int64 timestamp);
   HTC_RetCode insertRow(Int64 transID, HbaseStr &rowID, HbaseStr &row,
-       Int64 timestamp);
-  HTC_RetCode insertRows(Int64 transID, short rowIDLen, HbaseStr &rowIDs, HbaseStr &rows, Int64 timestamp, bool autoFlush);
+       Int64 timestamp, bool asyncOperation);
+  HTC_RetCode insertRows(Int64 transID, short rowIDLen, HbaseStr &rowIDs, HbaseStr &rows, Int64 timestamp, 
+       bool autoFlush, bool asyncOperation);
   HTC_RetCode setWriteBufferSize(Int64 size);
   HTC_RetCode setWriteToWAL(bool vWAL);
-  HTC_RetCode checkAndInsertRow(Int64 transID, HbaseStr &rowID, HbaseStr &row, Int64 timestamp);
+  HTC_RetCode checkAndInsertRow(Int64 transID, HbaseStr &rowID, HbaseStr &row, Int64 timestamp,
+                                                         bool asyncOperation);
   HTC_RetCode checkAndUpdateRow(Int64 transID, HbaseStr &rowID, HbaseStr &row,
-       const Text &columnToCheck, const Text &colValToCheck, Int64 timestamp);
+       const Text &columnToCheck, const Text &colValToCheck, Int64 timestamp, bool asyncOperation);
   HTC_RetCode coProcAggr(Int64 transID, 
 			 int aggrType, // 0:count, 1:min, 2:max, 3:sum, 4:avg
 			 const Text& startRow, 
@@ -327,6 +331,7 @@ public:
                  HbaseStr &colName,
                  HbaseStr &colVal,
                  Int64 &timestamp);
+  HTC_RetCode completeAsyncOperation(int timeout, NABoolean *resultArray, short resultArrayLen);
 
   //  HTC_RetCode codeProcAggrGetResult();
 
@@ -391,6 +396,7 @@ private:
    ,JM_DIRECT_DELETE_ROWS
    ,JM_FETCH_ROWS
    ,JM_DIRECT_GET_ROWS
+   ,JM_COMPLETE_PUT
    ,JM_LAST
   };
   char *tableName_; 

--- a/core/sql/exp/ExpHbaseDefs.h
+++ b/core/sql/exp/ExpHbaseDefs.h
@@ -126,6 +126,7 @@ typedef enum
     HBASE_DOBULK_LOAD_ERROR,
     HBASE_CLEANUP_HFILE_ERROR,
     HBASE_INIT_HBLC_ERROR,
+    HBASE_RETRY_AGAIN,
     HBASE_MAX_ERROR_NUM     // keep this as the last element in enum list.
 
   } HbaseError;

--- a/core/sql/exp/ExpHbaseInterface.h
+++ b/core/sql/exp/ExpHbaseInterface.h
@@ -201,6 +201,8 @@ class ExpHbaseInterface : public NABasicObject
           HbaseStr &colVal,
           Int64 &timestamp) = 0;
 
+  virtual Lng32 completeAsyncOperation(Int32 timeout, NABoolean *resultArray, Int16 resultArrayLen) = 0;
+
   virtual Lng32 getColVal(int colNo, BYTE *colVal,
           Lng32 &colValLen, NABoolean nullable, BYTE &nullVal) = 0;
 
@@ -252,7 +254,8 @@ class ExpHbaseInterface : public NABasicObject
 		  HbaseStr& rowID, 
 		  HbaseStr& row,
 		  NABoolean noXn,
-		  const int64_t timestamp) = 0;
+		  const int64_t timestamp,
+                  NABoolean asyncOperation) = 0;
 
  virtual Lng32 getRows(
           short rowIDLen,
@@ -266,7 +269,8 @@ class ExpHbaseInterface : public NABasicObject
                   HbaseStr &rows,
 		  NABoolean noXn,
 		  const int64_t timestamp,
-		  NABoolean autoFlush = TRUE) = 0; // by default, flush rows after put
+		  NABoolean autoFlush = TRUE,
+                  NABoolean asyncOperation = FALSE) = 0; // by default, flush rows after put
  
  virtual Lng32 setWriteBufferSize(
                  HbaseStr &tblName,
@@ -314,7 +318,8 @@ class ExpHbaseInterface : public NABasicObject
 				  HbaseStr& rowID, 
 				  HbaseStr& row,
                                   NABoolean noXn,
-				  const int64_t timestamp) = 0;
+				  const int64_t timestamp,
+                                  NABoolean asyncOperation) = 0;
 
   
   virtual Lng32 checkAndUpdateRow(
@@ -325,7 +330,8 @@ class ExpHbaseInterface : public NABasicObject
 				  const Text& colValToCheck,
                                   NABoolean noXn,				
                                  
-				  const int64_t timestamp);
+				  const int64_t timestamp,
+                                  NABoolean asyncOperation);
 
  
   virtual Lng32 getClose() = 0;
@@ -498,6 +504,8 @@ class ExpHbaseInterface_JNI : public ExpHbaseInterface
           HbaseStr &colName,
           HbaseStr &colVal,
           Int64 &timestamp);
+ 
+  virtual Lng32 completeAsyncOperation(Int32 timeout, NABoolean *resultArray, Int16 resultArrayLen);
 
   virtual Lng32 getColVal(int colNo, BYTE *colVal,
           Lng32 &colValLen, NABoolean nullable, BYTE &nullVal);
@@ -548,7 +556,9 @@ class ExpHbaseInterface_JNI : public ExpHbaseInterface
 		  HbaseStr& rowID, 
                   HbaseStr& row,
 		  NABoolean noXn,
-		  const int64_t timestamp);
+		  const int64_t timestamp,
+                  NABoolean asyncOperation);
+
  virtual Lng32 getRows(
           short rowIDLen,
           HbaseStr &rowIDs,
@@ -561,7 +571,8 @@ class ExpHbaseInterface_JNI : public ExpHbaseInterface
                   HbaseStr &rows,
 		  NABoolean noXn,
 		  const int64_t timestamp,
-		  NABoolean autoFlush = TRUE); // by default, flush rows after put
+		  NABoolean autoFlush = TRUE,
+                  NABoolean asyncOperation = FALSE); // by default, flush rows after put
   
   virtual Lng32 setWriteBufferSize(
                   HbaseStr &tblName,
@@ -608,7 +619,8 @@ virtual Lng32 initHFileParams(HbaseStr &tblName,
 				  HbaseStr& rowID, 
 				  HbaseStr& row,
                                   NABoolean noXn,
-				  const int64_t timestamp);
+				  const int64_t timestamp,
+                  		  NABoolean asyncOperation);
 
 
 
@@ -619,7 +631,8 @@ virtual Lng32 initHFileParams(HbaseStr &tblName,
 				  const Text& columnToCheck,
 				  const Text& colValToCheck,
                                   NABoolean noXn,			
-				  const int64_t timestamp);
+				  const int64_t timestamp,
+                                  NABoolean asyncOperation);
 
 
 
@@ -673,6 +686,7 @@ private:
   HTableClient_JNI* htc_;
   HBulkLoadClient_JNI* hblc_;
   HiveClient_JNI* hive_;
+  HTableClient_JNI *asyncHtc_;
   Int32  retCode_;
 };
 

--- a/core/sql/generator/GenRelUpdate.cpp
+++ b/core/sql/generator/GenRelUpdate.cpp
@@ -2747,6 +2747,10 @@ short HbaseInsert::codeGen(Generator *generator)
 
   generator->initTdbFields(hbasescan_tdb);
 
+  if (CmpCommon::getDefault(HBASE_ASYNC_OPERATIONS) == DF_ON
+           && t == ComTdbHbaseAccess::INSERT_)
+     hbasescan_tdb->setAsyncOperations(TRUE);
+
   if (getTableDesc()->getNATable()->isSeabaseTable())
     {
       hbasescan_tdb->setSQHbaseTable(TRUE);

--- a/core/sql/sqlcomp/DefaultConstants.h
+++ b/core/sql/sqlcomp/DefaultConstants.h
@@ -3734,6 +3734,7 @@ enum DefaultConstants
   // return a warning on truncation.
   TRAF_STRING_AUTO_TRUNCATE_WARNING,
   NCM_UDR_NANOSEC_FACTOR,
+  HBASE_ASYNC_OPERATIONS,
 
   //control lob output size when converting to string/memory 
   LOB_OUTPUT_SIZE,

--- a/core/sql/sqlcomp/nadefaults.cpp
+++ b/core/sql/sqlcomp/nadefaults.cpp
@@ -1730,6 +1730,7 @@ SDDkwd__(EXE_DIAGNOSTIC_EVENTS,		"OFF"),
   // HBASE_SQL_IUD_SEMANTICS:      Off: Don't check for existing rows for insert/update
 
   DDkwd__(HBASE_ASYNC_DROP_TABLE,		"OFF"),
+  DDkwd__(HBASE_ASYNC_OPERATIONS,		"OFF"),
  // HBASE_CACHE_BLOCKS, ON => cache every scan, OFF => cache no scan
  // SYSTEM => cache scans which take less than 1 RS block cache mem.
  DDui___(HBASE_BLOCK_SIZE,                      "65536"),


### PR DESCRIPTION
Non-blocking hbase operation to smoothen the data flow in trafodion engine

A new CQD HBASE_ASYNC_OPERATIONS is introduced to enable non-blocking
hbase operation for checkAndInsert operations. The default value is
'OFF'.

This allows the trafodion engine to insert rows into base table and
indexes at the same time. checkAndInsert operations always done under
a transaction ensuring the data consistency between tables and indexes
for a single row insert operation.

During this process, TM is refactored to enable passing a transaction
id created in a thread to another thread.

Change-Id: I0d09e5b0a3f988808c44bd83463df45fd21c67c0