### PR TITLE
Fix for Trafodion-5

### DIFF
--- a/core/sql/executor/HTableClient.java
+++ b/core/sql/executor/HTableClient.java
@@ -1173,7 +1173,7 @@ public class HTableClient {
               try {
                  future.get(30, TimeUnit.SECONDS);
               } catch(TimeoutException | InterruptedException e) {
-		  logger.error("Asynchronos Thread is Cancelled, " + e);
+		  logger.error("Asynchronous Thread is Cancelled, " + e);
                   retcode = true;
                   future.cancel(true); // Interrupt the thread
               } catch (ExecutionException ee)


### PR DESCRIPTION
System with large number of nodes, some created tables can not be used

The code that generates the unique ID that has been used as OBJECT_UID
is reworked to avoid getting negative numbers. Earlier, it was possible
to get negative number on the nodes at or above 64 nodes.

Please see the inline comments in CatSQLShare.cpp for the new
algorithm.

Change-Id: I7df665c16d9c156e110d9d2db3dcd82bd6dfd615