### PR TITLE
Changes related to JIRA [TRAFODION-14]

### DIFF
--- a/core/sql/executor/ExHbaseAccess.h
+++ b/core/sql/executor/ExHbaseAccess.h
@@ -276,11 +276,11 @@ protected:
   short handleDone(ExWorkProcRetcode &rc, Int64 rowsAffected = 0);
   short createColumnwiseRow();
   short createRowwiseRow();
-  Lng32 createSQRowFromHbaseFormat();
+  Lng32 createSQRowFromHbaseFormat(Int64 *lastestRowTimestamp = NULL);
   Lng32 createSQRowFromHbaseFormatMulti();
-  Lng32 createSQRowFromAlignedFormat();
+  Lng32 createSQRowFromAlignedFormat(Int64 *lastestRowTimestamp = NULL);
   short copyCell();
-  Lng32 createSQRowDirect();
+  Lng32 createSQRowDirect(Int64 *lastestRowTimestamp = NULL);
   Lng32 setupSQMultiVersionRow();
 
   void extractColNameFields
@@ -1032,6 +1032,7 @@ public:
 
  protected:
   NABoolean rowUpdated_;
+  Int64 latestRowTimestamp_;
 };
 
 // UMD: unique UpdMergeDel on native Hbase table

--- a/core/sql/executor/HBaseClient_JNI.cpp
+++ b/core/sql/executor/HBaseClient_JNI.cpp
@@ -3389,7 +3389,7 @@ HTC_RetCode HTableClient_JNI::startGets(Int64 transID, const LIST(HbaseStr)& row
 //////////////////////////////////////////////////////////////////////////////
 // 
 //////////////////////////////////////////////////////////////////////////////
-HTC_RetCode HTableClient_JNI::deleteRow(Int64 transID, HbaseStr &rowID, const LIST(HbaseStr)& cols, Int64 timestamp)
+HTC_RetCode HTableClient_JNI::deleteRow(Int64 transID, HbaseStr &rowID, const LIST(HbaseStr) *cols, Int64 timestamp)
 {
   QRLogger::log(CAT_SQL_HBASE, LL_DEBUG, "HTableClient_JNI::deleteRow(%ld, %s) called.", transID, rowID.val);
 
@@ -3406,9 +3406,9 @@ HTC_RetCode HTableClient_JNI::deleteRow(Int64 transID, HbaseStr &rowID, const LI
   }
   jenv_->SetByteArrayRegion(jba_rowID, 0, rowID.len, (const jbyte*)rowID.val);
   jobjectArray j_cols = NULL;
-  if (!cols.isEmpty())
+  if (cols != NULL && !cols->isEmpty())
   {
-     j_cols = convertToByteArrayObjectArray(cols);
+     j_cols = convertToByteArrayObjectArray(*cols);
      if (j_cols == NULL)
      {
         getExceptionDetails();

--- a/core/sql/executor/HBaseClient_JNI.h
+++ b/core/sql/executor/HBaseClient_JNI.h
@@ -279,7 +279,7 @@ public:
   HTC_RetCode startGets(Int64 transID, const LIST(HbaseStr)& rowIDs, const LIST(HbaseStr) & cols, 
 		Int64 timestamp);
   HTC_RetCode getRows(Int64 transID, short rowIDLen, HbaseStr &rowIDs, const LIST(HbaseStr)& columns);
-  HTC_RetCode deleteRow(Int64 transID, HbaseStr &rowID, const LIST(HbaseStr)& columns, Int64 timestamp);
+  HTC_RetCode deleteRow(Int64 transID, HbaseStr &rowID, const LIST(HbaseStr) *columns, Int64 timestamp);
   HTC_RetCode deleteRows(Int64 transID, short rowIDLen, HbaseStr &rowIDs, Int64 timestamp);
   HTC_RetCode checkAndDeleteRow(Int64 transID, HbaseStr &rowID, const Text &columnToCheck, const Text &colValToCheck, Int64 timestamp);
   HTC_RetCode insertRow(Int64 transID, HbaseStr &rowID, HbaseStr &row,

--- a/core/sql/exp/ExpHbaseInterface.cpp
+++ b/core/sql/exp/ExpHbaseInterface.cpp
@@ -147,7 +147,7 @@ Int32 ExpHbaseInterface_JNI::deleteColumns(
             done = TRUE; 
             break;
          }
-         retcode = htc_->deleteRow(transID, rowID, columns, -1);
+         retcode = htc_->deleteRow(transID, rowID, &columns, -1);
          if (retcode != HTC_OK) 
          {
             done = TRUE;
@@ -213,11 +213,10 @@ Lng32 ExpHbaseInterface::checkAndDeleteRow(
       return HBASE_ROW_NOTFOUND_ERROR;
     }
 
-  LIST(HbaseStr) columns(heap_);
   // row exists, delete it
   retcode = deleteRow(tblName,
 		      rowID,
-		      columns,
+		      NULL,
                       noXn,
 		      timestamp);
 
@@ -797,7 +796,7 @@ Lng32 ExpHbaseInterface_JNI::getRowsOpen(
 Lng32 ExpHbaseInterface_JNI::deleteRow(
 	  HbaseStr &tblName,
 	  HbaseStr& row, 
-	  const LIST(HbaseStr) & columns,
+	  const LIST(HbaseStr) *columns,
 	  NABoolean noXn,
 	  const int64_t timestamp)
 

--- a/core/sql/exp/ExpHbaseInterface.h
+++ b/core/sql/exp/ExpHbaseInterface.h
@@ -221,7 +221,7 @@ class ExpHbaseInterface : public NABasicObject
   virtual Lng32 deleteRow(
 		  HbaseStr &tblName,
 		  HbaseStr& row, 
-		  const LIST(HbaseStr) & columns,
+		  const LIST(HbaseStr) *columns,
 		  NABoolean noXn,
 		  const int64_t timestamp) = 0;
 
@@ -525,7 +525,7 @@ class ExpHbaseInterface_JNI : public ExpHbaseInterface
   virtual Lng32 deleteRow(
 		  HbaseStr &tblName,
 		  HbaseStr &row, 
-		  const LIST(HbaseStr) & columns,
+		  const LIST(HbaseStr) *columns,
 		  NABoolean noXn,
 		  const int64_t timestamp);
 


### PR DESCRIPTION
upsert or merge into a table with indexes can result in
inconsistency between index and table

The change is to pass the recent row timestamp to the Delete
operator. However, this may not solve the above issue because
tombstone marker timestamp can be same or later than the
recently added row even with this change.

This change is pushed for the following reasons:
a) To enable Trafodion async operation concept for the merge
   operation
b) To optimize delete operation by removing unwanted memory
   allocation.