### PR TITLE
Fixes for 1438896 and 1465356

### DIFF
--- a/sql/sqlcomp/PrivMgrCommands.cpp
+++ b/sql/sqlcomp/PrivMgrCommands.cpp
@@ -486,9 +486,9 @@ PrivStatus privStatus = STATUS_GOOD;
 
    try
    {
-      PrivMgrPrivileges objectPrivileges(getMetadataLocation(),pDiags_);
+      PrivMgrPrivileges objectPrivileges(objectUID, getMetadataLocation(),pDiags_);
       
-      privStatus = objectPrivileges.getPrivRowsForObject(objectUID,objectPrivsRows);
+      privStatus = objectPrivileges.getPrivRowsForObject(objectPrivsRows);
    }
 
    catch (...)
@@ -867,9 +867,9 @@ PrivStatus privStatus = STATUS_GOOD;
 
    try
    {
-      PrivMgrPrivileges objectPrivileges(getMetadataLocation(),pDiags_);
+      PrivMgrPrivileges objectPrivileges(objectUID, getMetadataLocation(),pDiags_);
       
-      privStatus = objectPrivileges.insertPrivRowsForObject(objectUID,objectPrivsRows);
+      privStatus = objectPrivileges.insertPrivRowsForObject(objectPrivsRows);
    }
 
    catch (...)

--- a/sql/sqlcomp/PrivMgrPrivileges.h
+++ b/sql/sqlcomp/PrivMgrPrivileges.h
@@ -90,6 +90,11 @@ public:
       ComDiagsArea *pDiags = NULL);
 
    PrivMgrPrivileges(
+      const int64_t objectUID,
+      const std::string &metadataLocation,
+      ComDiagsArea *pDiags = NULL);
+
+   PrivMgrPrivileges(
       const std::string &metadataLocation,
       ComDiagsArea *pDiags = NULL);
 
@@ -125,7 +130,6 @@ public:
       std::vector<PrivObjectBitmap> & privBitmaps);
       
    PrivStatus getPrivRowsForObject(
-      const int64_t objectUID,
       std::vector<ObjectPrivsRow> & objectPrivsRows);
 
    PrivStatus getPrivTextForObject(
@@ -182,7 +186,6 @@ public:
       const std::string & creatorName);
       
    PrivStatus insertPrivRowsForObject(
-      const int64_t objectUID,
       const std::vector<ObjectPrivsRow> & objectPrivsRows);
    
    PrivStatus populateObjectPriv(


### PR DESCRIPTION
1438896: Internal error during create or replace view

The objectUID check when getting privilege information was not correct.

1465356: Revoke privilege from role returns dependent object error

There is a check in mainline revoke code to determine if the object type is a
view and if the SELECT privilege is no longer applicable. If so, then the
dependent error is returned. However, this code is incorrect and actually the
correct code exists in the gatherViewPrivileges method. The view check has been
removed.

Change-Id: Ia1a00f18bad301dd1439c2ceb079d69808de7bdd