### PR TITLE
Privilege manager fixes for 1438896 and 1465356

### DIFF
--- a/core/sql/sqlcomp/PrivMgrCommands.cpp
+++ b/core/sql/sqlcomp/PrivMgrCommands.cpp
@@ -486,9 +486,8 @@ PrivStatus privStatus = STATUS_GOOD;
 
    try
    {
-      PrivMgrPrivileges objectPrivileges(getMetadataLocation(),pDiags_);
-      
-      privStatus = objectPrivileges.getPrivRowsForObject(objectUID,objectPrivsRows);
+      PrivMgrPrivileges objectPrivileges(objectUID,getMetadataLocation(),pDiags_);
+      privStatus = objectPrivileges.getPrivRowsForObject(objectPrivsRows);
    }
 
    catch (...)
@@ -871,9 +870,9 @@ PrivStatus privStatus = STATUS_GOOD;
 
    try
    {
-      PrivMgrPrivileges objectPrivileges(getMetadataLocation(),pDiags_);
+      PrivMgrPrivileges objectPrivileges(objectUID, getMetadataLocation(),pDiags_);
       
-      privStatus = objectPrivileges.insertPrivRowsForObject(objectUID,objectPrivsRows);
+      privStatus = objectPrivileges.insertPrivRowsForObject(objectPrivsRows);
    }
 
    catch (...)

--- a/core/sql/sqlcomp/PrivMgrPrivileges.cpp
+++ b/core/sql/sqlcomp/PrivMgrPrivileges.cpp
@@ -431,6 +431,21 @@ PrivMgrPrivileges::PrivMgrPrivileges (
 }
 
 // ----------------------------------------------------------------------------
+// Construct a PrivMgrPrivileges object for an objectUID
+// ----------------------------------------------------------------------------
+PrivMgrPrivileges::PrivMgrPrivileges (
+  const int64_t objectUID,
+  const std::string &metadataLocation,
+  ComDiagsArea *pDiags)
+: PrivMgr(metadataLocation, pDiags),
+  objectUID_(objectUID),
+  grantorID_(0)
+{
+  objectTableName_  = metadataLocation + "." + PRIVMGR_OBJECT_PRIVILEGES;
+  columnTableName_  = metadataLocation + "." + PRIVMGR_COLUMN_PRIVILEGES;
+}
+
+// ----------------------------------------------------------------------------
 // Construct a basic PrivMgrPrivileges object
 // ----------------------------------------------------------------------------
 PrivMgrPrivileges::PrivMgrPrivileges (
@@ -578,7 +593,6 @@ PrivStatus privStatus = getColRowsForGrantee(columnRowList_,granteeID,roleIDs,
 // *                                                       
 // *  Parameters:    
 // *                                                                       
-// *  <objectUID> The unique ID of the object whose grants are being returned
 // *  <objectPrivsRows> Zero or more rows of grants for the object.
 // *                                                                     
 // * Returns: PrivStatus                                               
@@ -589,7 +603,6 @@ PrivStatus privStatus = getColRowsForGrantee(columnRowList_,granteeID,roleIDs,
 // *                                                               
 // *****************************************************************************
 PrivStatus PrivMgrPrivileges::getPrivRowsForObject(
-   const int64_t objectUID,
    std::vector<ObjectPrivsRow> & objectPrivsRows)
    
 {
@@ -1598,7 +1611,6 @@ PrivStatus privStatus = objectPrivsTable.insert(row);
 // *                                                       
 // *  Parameters:    
 // *                                                                       
-// *  <objectUID> The unique ID of the object that grants are being inserted for
 // *  <objectPrivsRows> One or more rows of grants for the object.
 // *                                                                     
 // * Returns: PrivStatus                                               
@@ -1609,7 +1621,6 @@ PrivStatus privStatus = objectPrivsTable.insert(row);
 // *                                                               
 // *****************************************************************************
 PrivStatus PrivMgrPrivileges::insertPrivRowsForObject(
-   const int64_t objectUID,
    const std::vector<ObjectPrivsRow> & objectPrivsRows)
    
 {
@@ -1630,7 +1641,7 @@ PrivStatus PrivMgrPrivileges::insertPrivRowsForObject(
     char granteeTypeString[3] = {0};
     char grantorTypeString[3] = {0};
     
-    row.objectUID_ = objectUID;
+    row.objectUID_ = objectUID_;
     row.objectName_ = rowIn.objectName;
     row.objectType_ = rowIn.objectType;
     row.granteeID_ = rowIn.granteeID;
@@ -2044,10 +2055,8 @@ PrivStatus PrivMgrPrivileges::generateObjectRowList()
 //
 // Params:
 //   objectUsage - the affected object
+//   command - GRANT or REVOKE RESTRICT or REVOKE CASCADE
 //   listOfAffectedObjects - returns the list of affected objects
-//
-// In the future, we want to cache the lists of objects instead of going to the
-// metadata everytime.
 // ****************************************************************************
 PrivStatus PrivMgrPrivileges::getAffectedObjects(
   const ObjectUsage &objectUsage,
@@ -2676,19 +2685,7 @@ PrivStatus PrivMgrPrivileges::revokeObjectPriv (const ComObjectType objectType,
     ObjectUsage *pObj = listOfObjects[i];
     PrivMgrCoreDesc thePrivs = pObj->updatedPrivs.getTablePrivs();
 
-    // If view no longer has select privilege, throw an error
-    if (pObj->objectType == COM_VIEW_OBJECT)
-    {
-      if (!thePrivs.getPriv(SELECT_PRIV))
-      {
-         deleteListOfAffectedObjects(listOfObjects);
-         *pDiags_ << DgSqlCode (-CAT_DEPENDENT_OBJECTS_EXIST)
-                  << DgString0 (pObj->objectName.c_str());
-         return STATUS_ERROR;
-      }
-    }
-
-    int32_t theGrantor = (pObj->objectType == COM_VIEW_OBJECT) ? SYSTEM_AUTH_ID : grantorID_;
+    int32_t theGrantor = grantorID_;
     int32_t theGrantee = pObj->objectOwner;
     int64_t theUID = pObj->objectUID;
 

--- a/core/sql/sqlcomp/PrivMgrPrivileges.h
+++ b/core/sql/sqlcomp/PrivMgrPrivileges.h
@@ -90,6 +90,11 @@ public:
       ComDiagsArea *pDiags = NULL);
 
    PrivMgrPrivileges(
+      const int64_t objectUID,
+      const std::string &metadataLocation,
+      ComDiagsArea *pDiags = NULL);
+
+   PrivMgrPrivileges(
       const std::string &metadataLocation,
       ComDiagsArea *pDiags = NULL);
 
@@ -125,7 +130,6 @@ public:
       std::vector<PrivObjectBitmap> & privBitmaps);
       
    PrivStatus getPrivRowsForObject(
-      const int64_t objectUID,
       std::vector<ObjectPrivsRow> & objectPrivsRows);
 
    PrivStatus getPrivTextForObject(
@@ -182,7 +186,6 @@ public:
       const std::string & creatorName);
       
    PrivStatus insertPrivRowsForObject(
-      const int64_t objectUID,
       const std::vector<ObjectPrivsRow> & objectPrivsRows);
    
    PrivStatus populateObjectPriv(


### PR DESCRIPTION
1438896: Internal error during create or replace view

The objectUID check when getting privilege information was not correct.

1465356: Revoke privilege from role returns dependent object error

There is a check in mainline revoke code to determine if the object type is a
view and if the SELECT privilege is no longer applicable. If so, then the
dependent error is returned. However, this code is incorrect and actually the
correct code exists in the gatherViewPrivileges method. The view check has been
removed.