### PR TITLE
Fix for [TRAFODION-27] - Time consuming compilation for

### DIFF
--- a/core/sql/cli/Statement.cpp
+++ b/core/sql/cli/Statement.cpp
@@ -1400,43 +1400,6 @@ RETCODE Statement::prepare(char *source, ComDiagsArea &diagsArea,
 			passed_gen_code, passed_gen_code_len,
 			charset, unpackTdbs, cliFlags);
 
-  if (rc == 0)
-    {
-      if ((NOT (cliFlags & PREPARE_AUTO_QUERY_RETRY)) &&
-	  (NOT (cliFlags & PREPARE_NO_TEXT_CACHE)) &&
-	  source &&
-	  (stmt_type == DYNAMIC_STMT) &&
-	  unpackTdbs &&
-	  root_tdb &&
-	  root_tdb->qCacheInfoIsClass() &&
-	  root_tdb->qcInfo() &&
-	  root_tdb->qcInfo()->cacheWasHit() &&
-	  (! root_tdb->getLateNameInfoList()->variablePresent()) &&
-	  //	  (! root_tdb->getUdrStoiList()) &&
-	  //	  (context_->getSessionDefaults()->aqr()) &&
-	  (root_tdb->aqrEnabled()) &&
-	  (context_->getNumOfCliCalls() == 1))
-	{
-	  rc = execute(cliGlobals_, NULL,
-		       diagsArea, INITIAL_STATE_,
-		       TRUE, cliFlags);
-	  if (rc == 0)
-	    {
-	      // if a Xn was started by exe, then
-	      // set an indication in aqr that it was started
-	      // during prepare. Used at statement dealloc time to commit
-	      // that xn, if autocommit is on and the Xn still exists.
-	      ExTransaction * exTransaction = context_->getTransaction();
-	      if ((exTransaction->xnInProgress()) &&
-		  (exTransaction->exeStartedXn()) &&
-		  (exTransaction->implicitXn()))
-		context_->aqrInfo()->setXnStartedAtPrepare(TRUE);
-	      else
-		context_->aqrInfo()->setXnStartedAtPrepare(FALSE);
-	    }
-	}
-    }
-
   StmtDebug2("[END prepare] %p, result is %s", this, RetcodeToString(rc));
   return rc;
 }

--- a/core/sql/generator/GenProbeCache.cpp
+++ b/core/sql/generator/GenProbeCache.cpp
@@ -370,25 +370,18 @@ short ProbeCache::codeGen(Generator *generator)
       if (estimatedMemory > memoryLimitPerCpu) {
           numInnerTuples_ = memoryLimitPerCpu / innerRecLength;
           queue_index pUpSize_calc;
-          queue_index pDownSize_calc;                  
  
-          pUpSize_calc = numInnerTuples_ * pUpSize / (pUpSize + pDownSize);
-          pDownSize_calc = numInnerTuples_ * pDownSize / (pUpSize + pDownSize);
+          pUpSize_calc = numInnerTuples_ ;
           queue_index pq2 = 1;
           queue_index bits = pUpSize_calc;
           while (bits && pq2 < pUpSize_calc) {
               bits = bits  >> 1;
               pq2 = pq2 << 1;
           }
-          pUpSize = pq2;
-          pq2 = 1;
-          bits = pDownSize_calc;
-          while (bits && pq2 < pUpSize_calc) {
-              bits = bits  >> 1;
-              pq2 = pq2 << 1;
-          }
-          pDownSize = pq2;
-          pcNumEntries = numInnerTuples_;
+          pUpSize = MINOF(pq2/2, 4); 
+          pDownSize = MINOF(pq2/2, 4);
+          pcNumEntries = MINOF(numInnerTuples_, 4);
+          numInnerTuples_ = pcNumEntries;
           numCachedProbes_ = pcNumEntries;
       }
    } 

--- a/core/sql/generator/GenProbeCache.cpp
+++ b/core/sql/generator/GenProbeCache.cpp
@@ -361,6 +361,38 @@ short ProbeCache::codeGen(Generator *generator)
       // that there is room enough for one row.
     }
 
+   double  memoryLimitPerCpu =
+      ActiveSchemaDB()->getDefaults().getAsLong(EXE_MEMORY_FOR_PROBE_CACHE_IN_MB) * 1024 * 1024;
+   double estimatedMemory;
+   
+   if (numInnerTuples_ > 0) {
+      estimatedMemory = numInnerTuples_ * innerRecLength;
+      if (estimatedMemory > memoryLimitPerCpu) {
+          numInnerTuples_ = memoryLimitPerCpu / innerRecLength;
+          queue_index pUpSize_calc;
+          queue_index pDownSize_calc;                  
+ 
+          pUpSize_calc = numInnerTuples_ * pUpSize / (pUpSize + pDownSize);
+          pDownSize_calc = numInnerTuples_ * pDownSize / (pUpSize + pDownSize);
+          queue_index pq2 = 1;
+          queue_index bits = pUpSize_calc;
+          while (bits && pq2 < pUpSize_calc) {
+              bits = bits  >> 1;
+              pq2 = pq2 << 1;
+          }
+          pUpSize = pq2;
+          pq2 = 1;
+          bits = pDownSize_calc;
+          while (bits && pq2 < pUpSize_calc) {
+              bits = bits  >> 1;
+              pq2 = pq2 << 1;
+          }
+          pDownSize = pq2;
+          pcNumEntries = numInnerTuples_;
+          numCachedProbes_ = pcNumEntries;
+      }
+   } 
+
 
   ///////////////////////////////////////////////////////
   // Create and initialize the ComTdbProbeCache, generate
@@ -454,7 +486,11 @@ CostScalar ProbeCache::getEstimatedRunTimeMemoryUsage(NABoolean perCPU)
        totalMemory *= partFunc->getCountOfPartitions();
      }
   }
-          
+
+  double  memoryLimitPerCpu =
+      ActiveSchemaDB()->getDefaults().getAsLong(EXE_MEMORY_FOR_PROBE_CACHE_IN_MB) * 1024 * 1024;
+  if (totalMemory > memoryLimitPerCpu)
+     totalMemory = memoryLimitPerCpu;          
   return totalMemory;
 }
 

--- a/core/sql/sqlcomp/DefaultConstants.h
+++ b/core/sql/sqlcomp/DefaultConstants.h
@@ -3738,6 +3738,7 @@ enum DefaultConstants
 
   //control lob output size when converting to string/memory 
   LOB_OUTPUT_SIZE,
+  EXE_MEMORY_FOR_PROBE_CACHE_IN_MB,
   // This enum constant must be the LAST one in the list; it's a count,
   // not an Attribute (it's not IN DefaultDefaults; it's the SIZE of it)!
   __NUM_DEFAULT_ATTRIBUTES

--- a/core/sql/sqlcomp/nadefaults.cpp
+++ b/core/sql/sqlcomp/nadefaults.cpp
@@ -1320,6 +1320,7 @@ SDDkwd__(EXE_DIAGNOSTIC_EVENTS,		"OFF"),
 
  SDDui___(EXE_MEMORY_FOR_PARTIALHGB_IN_MB,	"100"),
 
+ SDDui___(EXE_MEMORY_FOR_PROBE_CACHE_IN_MB,	"100"),
 
   // lower-bound memory limit for BMOs/nbmos (in MB)
   DDui___(EXE_MEMORY_LIMIT_LOWER_BOUND_EXCHANGE, "10"),


### PR DESCRIPTION
 queries of BLOB with JOINs

A new CQD EXE_MEMORY_FOR_PROBE_CACHE_IN_MB is introduced
to limit the amount of memory consumed in probe cache
operator. The default value is 100MB.

For other details, refer to JIRA