### PR TITLE
Fix for [TRAFODION-14]

### DIFF
--- a/core/sql/comexe/ComTdbHbaseAccess.cpp
+++ b/core/sql/comexe/ComTdbHbaseAccess.cpp
@@ -127,6 +127,7 @@ ComTdbHbaseAccess::ComTdbHbaseAccess(
   returnMergeInsertExpr_(returnMergeInsertExpr),
   encodedKeyExpr_(encodedKeyExpr),
   keyColValExpr_(keyColValExpr),
+  deletePreCondExpr_(NULL),
   hbaseFilterExpr_(hbaseFilterExpr),
 
   asciiRowLen_(asciiRowLen),
@@ -234,6 +235,7 @@ ComTdbHbaseAccess::ComTdbHbaseAccess(
   returnMergeInsertExpr_(NULL),
   encodedKeyExpr_(NULL),
   keyColValExpr_(NULL),
+  deletePreCondExpr_(NULL),
   hbaseFilterExpr_(NULL),
 
   asciiRowLen_(0),

--- a/core/sql/comexe/ComTdbHbaseAccess.h
+++ b/core/sql/comexe/ComTdbHbaseAccess.h
@@ -835,6 +835,10 @@ public:
 
    UInt32 getMaxErrorRows() const{ return maxErrorRows_; }
    void setMaxErrorRows(UInt32 v ) { maxErrorRows_= v; }
+  
+   void setDeletePreCondExpr(ExExprPtr exprPtr) {
+        deletePreCondExpr_ = exprPtr;
+   }
 
  protected:
   enum
@@ -900,7 +904,7 @@ public:
   UInt32 mergeInsertRowLen_;
   UInt32 returnFetchedRowLen_;
   UInt32 returnUpdatedRowLen_;
-
+  
   UInt32 rowIdLen_;
   UInt32 outputRowLen_;
   UInt32 rowIdAsciiRowLen_;
@@ -930,6 +934,7 @@ public:
   ExExprPtr encodedKeyExpr_;
 
   ExExprPtr keyColValExpr_;
+  ExExprPtr deletePreCondExpr_;
   ExExprPtr hbaseFilterExpr_;
 
   ExCriDescPtr workCriDesc_;      

--- a/core/sql/executor/ExHbaseAccess.h
+++ b/core/sql/executor/ExHbaseAccess.h
@@ -229,6 +229,9 @@ protected:
   inline ex_expr *keyColValExpr() const 
     { return hbaseAccessTdb().keyColValExpr_; }
 
+  inline ex_expr *deletePreCondExpr() const
+    { return hbaseAccessTdb().deletePreCondExpr_; }
+
   inline ex_expr *hbaseFilterValExpr() const 
     { return hbaseAccessTdb().hbaseFilterExpr_; }
 
@@ -291,7 +294,8 @@ protected:
 		  char * tuppRow = NULL);
   void setupPrevRowId();
   short extractColFamilyAndName(char * input, Text &colFam, Text &colName);
-  short evalKeyColValExpr(Text &columnToCheck, Text &colValToCheck);
+  short evalKeyColValExpr(HbaseStr &columnToCheck, HbaseStr &colValToCheck);
+  short evalDeletePreCondExpr();
   short evalEncodedKeyExpr();
   short evalRowIdExpr(NABoolean noVarchar = FALSE);
   short evalRowIdAsciiExpr(NABoolean noVarchar = FALSE);
@@ -1033,6 +1037,8 @@ public:
  protected:
   NABoolean rowUpdated_;
   Int64 latestRowTimestamp_;
+  HbaseStr columnToCheck_;
+  HbaseStr colValToCheck_;
 };
 
 // UMD: unique UpdMergeDel on native Hbase table

--- a/core/sql/executor/HBaseClient_JNI.cpp
+++ b/core/sql/executor/HBaseClient_JNI.cpp
@@ -3527,10 +3527,10 @@ HTC_RetCode HTableClient_JNI::deleteRows(Int64 transID, short rowIDLen, HbaseStr
 // 
 //////////////////////////////////////////////////////////////////////////////
 HTC_RetCode HTableClient_JNI::checkAndDeleteRow(Int64 transID, HbaseStr &rowID,
-	    const Text &columnToCheck, const Text &colValToCheck,
+	    HbaseStr &columnToCheck, HbaseStr &colValToCheck,
 	    Int64 timestamp)
 {
-  QRLogger::log(CAT_SQL_HBASE, LL_DEBUG, "HTableClient_JNI::checkAndDeleteRow(%s, %s, %s) called.", rowID.val, columnToCheck.data(), colValToCheck.data());
+  QRLogger::log(CAT_SQL_HBASE, LL_DEBUG, "HTableClient_JNI::checkAndDeleteRow(%s) called.", rowID.val);
 
   if (jenv_->PushLocalFrame(jniHandleCapacity_) != 0) {
     getExceptionDetails();
@@ -3545,7 +3545,7 @@ HTC_RetCode HTableClient_JNI::checkAndDeleteRow(Int64 transID, HbaseStr &rowID,
   }
   jenv_->SetByteArrayRegion(jba_rowID, 0, rowID.len, (const jbyte*)rowID.val);
 
-  int len = columnToCheck.size();
+  int len = columnToCheck.len;
   jbyteArray jba_columntocheck = jenv_->NewByteArray(len);
   if (jba_columntocheck == NULL) 
   {
@@ -3553,9 +3553,9 @@ HTC_RetCode HTableClient_JNI::checkAndDeleteRow(Int64 transID, HbaseStr &rowID,
     jenv_->PopLocalFrame(NULL);
     return HTC_ERROR_CHECKANDDELETEROW_PARAM;
   }
-  jenv_->SetByteArrayRegion(jba_columntocheck, 0, len, (const jbyte*)columnToCheck.data());
+  jenv_->SetByteArrayRegion(jba_columntocheck, 0, len, (const jbyte*)columnToCheck.val);
 
-  len = colValToCheck.size();
+  len = colValToCheck.len;
   jbyteArray jba_colvaltocheck = jenv_->NewByteArray(len);
   if (jba_colvaltocheck == NULL) 
   {
@@ -3564,7 +3564,7 @@ HTC_RetCode HTableClient_JNI::checkAndDeleteRow(Int64 transID, HbaseStr &rowID,
     return HTC_ERROR_CHECKANDDELETEROW_PARAM;
   }
   jenv_->SetByteArrayRegion(jba_colvaltocheck, 0, len, 
-			    (const jbyte*)colValToCheck.data());
+			    (const jbyte*)colValToCheck.val);
  
   jlong j_tid = transID;  
   jlong j_ts = timestamp;
@@ -3582,7 +3582,8 @@ HTC_RetCode HTableClient_JNI::checkAndDeleteRow(Int64 transID, HbaseStr &rowID,
   if (hbs_)
     hbs_->getTimer().start();
   tsRecentJMFromJNI = JavaMethods_[JM_CHECKANDDELETE].jm_full_name;
-  jboolean jresult = jenv_->CallBooleanMethod(javaObj_, JavaMethods_[JM_CHECKANDDELETE].methodID, j_tid, jba_rowID, jba_columntocheck, jba_colvaltocheck, j_ts);
+  jboolean jresult = jenv_->CallBooleanMethod(javaObj_, JavaMethods_[JM_CHECKANDDELETE].methodID, j_tid, 
+                  jba_rowID, jba_columntocheck, jba_colvaltocheck, j_ts);
   if (hbs_)
     {
       hbs_->incMaxHbaseIOTime(hbs_->getTimer().stop());
@@ -3967,7 +3968,7 @@ HbaseStr &row, Int64 timestamp, bool asyncOperation)
 
 HTC_RetCode HTableClient_JNI::checkAndUpdateRow(Int64 transID, HbaseStr &rowID,
             HbaseStr &row,
-	    const Text &columnToCheck, const Text &colValToCheck, 
+	    HbaseStr &columnToCheck,  HbaseStr &colValToCheck, 
             Int64 timestamp,
             bool asyncOperation)
 {
@@ -3994,7 +3995,7 @@ HTC_RetCode HTableClient_JNI::checkAndUpdateRow(Int64 transID, HbaseStr &rowID,
     return HTC_ERROR_CHECKANDUPDATEROW_PARAM;
   }
   
-  int len = columnToCheck.size();
+  int len = columnToCheck.len;
   jbyteArray jba_columntocheck = jenv_->NewByteArray(len);
   if (jba_columntocheck == NULL) 
   {
@@ -4003,9 +4004,9 @@ HTC_RetCode HTableClient_JNI::checkAndUpdateRow(Int64 transID, HbaseStr &rowID,
     return HTC_ERROR_CHECKANDUPDATEROW_PARAM;
   }
   jenv_->SetByteArrayRegion(jba_columntocheck, 0, len, 
-			    (const jbyte*)columnToCheck.data());
+			    (const jbyte*)columnToCheck.val);
  
-  len = colValToCheck.size();
+  len = colValToCheck.len;
   jbyteArray jba_colvaltocheck = jenv_->NewByteArray(len);
   if (jba_colvaltocheck == NULL) 
   {
@@ -4014,7 +4015,7 @@ HTC_RetCode HTableClient_JNI::checkAndUpdateRow(Int64 transID, HbaseStr &rowID,
     return HTC_ERROR_CHECKANDUPDATEROW_PARAM;
   }
   jenv_->SetByteArrayRegion(jba_colvaltocheck, 0, len, 
-			    (const jbyte*)colValToCheck.data());
+			    (const jbyte*)colValToCheck.val);
  
   jlong j_tid = transID;  
   jlong j_ts = timestamp;

--- a/core/sql/executor/HBaseClient_JNI.h
+++ b/core/sql/executor/HBaseClient_JNI.h
@@ -20,6 +20,7 @@
 #ifndef HBASE_CLIENT_H
 #define HBASE_CLIENT_H
 #define INLINE_COLNAME_LEN 256
+#define MAX_COLNAME_LEN 32767 
 
 #include <list>
 #include "Platform.h"
@@ -281,7 +282,7 @@ public:
   HTC_RetCode getRows(Int64 transID, short rowIDLen, HbaseStr &rowIDs, const LIST(HbaseStr)& columns);
   HTC_RetCode deleteRow(Int64 transID, HbaseStr &rowID, const LIST(HbaseStr) *columns, Int64 timestamp);
   HTC_RetCode deleteRows(Int64 transID, short rowIDLen, HbaseStr &rowIDs, Int64 timestamp);
-  HTC_RetCode checkAndDeleteRow(Int64 transID, HbaseStr &rowID, const Text &columnToCheck, const Text &colValToCheck, Int64 timestamp);
+  HTC_RetCode checkAndDeleteRow(Int64 transID, HbaseStr &rowID, HbaseStr &columnToCheck, HbaseStr &colValToCheck, Int64 timestamp);
   HTC_RetCode insertRow(Int64 transID, HbaseStr &rowID, HbaseStr &row,
        Int64 timestamp, bool asyncOperation);
   HTC_RetCode insertRows(Int64 transID, short rowIDLen, HbaseStr &rowIDs, HbaseStr &rows, Int64 timestamp, 
@@ -291,7 +292,7 @@ public:
   HTC_RetCode checkAndInsertRow(Int64 transID, HbaseStr &rowID, HbaseStr &row, Int64 timestamp,
                                                          bool asyncOperation);
   HTC_RetCode checkAndUpdateRow(Int64 transID, HbaseStr &rowID, HbaseStr &row,
-       const Text &columnToCheck, const Text &colValToCheck, Int64 timestamp, bool asyncOperation);
+       HbaseStr &columnToCheck, HbaseStr &colValToCheck, Int64 timestamp, bool asyncOperation);
   HTC_RetCode coProcAggr(Int64 transID, 
 			 int aggrType, // 0:count, 1:min, 2:max, 3:sum, 4:avg
 			 const Text& startRow, 

--- a/core/sql/exp/ExpHbaseInterface.cpp
+++ b/core/sql/exp/ExpHbaseInterface.cpp
@@ -165,8 +165,8 @@ Lng32 ExpHbaseInterface::checkAndUpdateRow(
 					   HbaseStr &tblName,
 					   HbaseStr &rowID, 
 					   HbaseStr &row,
-					   const Text& columnToCheck,
-					   const Text& colValToCheck,
+					   HbaseStr& columnToCheck,
+					   HbaseStr& colValToCheck,
                                            NABoolean noXn,
 					   const int64_t timestamp,
                                            NABoolean asyncOperation)
@@ -196,8 +196,8 @@ Lng32 ExpHbaseInterface::checkAndUpdateRow(
 Lng32 ExpHbaseInterface::checkAndDeleteRow(
 					   HbaseStr &tblName,
 					   HbaseStr &rowID, 
-					   const Text& columnToCheck,
-					   const Text& colValToCheck,
+					   HbaseStr& columnToCheck,
+					   HbaseStr& colValToCheck,
                                            NABoolean noXn,
 					   const int64_t timestamp)
 {
@@ -866,8 +866,8 @@ Lng32 ExpHbaseInterface_JNI::deleteRows(
 Lng32 ExpHbaseInterface_JNI::checkAndDeleteRow(
 	  HbaseStr &tblName,
 	  HbaseStr& row, 
-	  const Text& columnToCheck,
-	  const Text& colValToCheck,
+	  HbaseStr& columnToCheck,
+	  HbaseStr& colValToCheck,
 	  NABoolean noXn,
 	  const int64_t timestamp)
 
@@ -1344,8 +1344,8 @@ Lng32 ExpHbaseInterface_JNI::checkAndUpdateRow(
 	  HbaseStr &tblName,
 	  HbaseStr &rowID, 
 	  HbaseStr &row,
-	  const Text& columnToCheck,
-	  const Text& colValToCheck,
+	  HbaseStr& columnToCheck,
+	  HbaseStr& colValToCheck,
           NABoolean noXn,
 	  const int64_t timestamp,
           NABoolean asyncOperation)

--- a/core/sql/exp/ExpHbaseInterface.h
+++ b/core/sql/exp/ExpHbaseInterface.h
@@ -238,8 +238,8 @@ class ExpHbaseInterface : public NABasicObject
   virtual Lng32 checkAndDeleteRow(
 				  HbaseStr &tblName,
 				  HbaseStr& row, 
-				  const Text& columnToCheck,
-				  const Text& colValToCheck,
+				  HbaseStr& columnToCheck,
+				  HbaseStr& colValToCheck,
                                   NABoolean noXn,
 				  const int64_t timestamp);
 
@@ -326,8 +326,8 @@ class ExpHbaseInterface : public NABasicObject
 				  HbaseStr &tblName,
 				  HbaseStr& rowID, 
 				  HbaseStr& row,
-				  const Text& columnToCheck,
-				  const Text& colValToCheck,
+				  HbaseStr& columnToCheck,
+				  HbaseStr& colValToCheck,
                                   NABoolean noXn,				
                                  
 				  const int64_t timestamp,
@@ -541,8 +541,8 @@ class ExpHbaseInterface_JNI : public ExpHbaseInterface
   virtual Lng32 checkAndDeleteRow(
 				  HbaseStr &tblName,
 				  HbaseStr& row, 
-				  const Text& columnToCheck,
-				  const Text& colValToCheck,
+				  HbaseStr& columnToCheck,
+				  HbaseStr& colValToCheck,
                                   NABoolean noXn,     
 				  const int64_t timestamp);
 
@@ -628,8 +628,8 @@ virtual Lng32 initHFileParams(HbaseStr &tblName,
 				  HbaseStr &tblName,
 				  HbaseStr& rowID, 
 				  HbaseStr& row,
-				  const Text& columnToCheck,
-				  const Text& colValToCheck,
+				  HbaseStr& columnToCheck,
+				  HbaseStr& colValToCheck,
                                   NABoolean noXn,			
 				  const int64_t timestamp,
                                   NABoolean asyncOperation);


### PR DESCRIPTION
upsert or merge into a table with indexes can result
in inconsistency between index and table

This change avoids the HBase issue of rows getting lost when the
 delete and put operations are done in the same milliseconds
timestamp dimension for the given rowid.

In the trafodion_delete operation execution, the row is skipped
for deletion if the new and old rowid evaluates to the same value.

This needs change from the compiler sub-task in the JIRA to complete
for it to be effective.

In addition removed yet another memory allocation for the delete
operation.