### PR TITLE
TRAFODION-1418 Fixing Jenkins test failure of fullstack/TEST062 in release mode.

### DIFF
--- a/core/sql/regress/tools/runregr_fullstack2.ksh
+++ b/core/sql/regress/tools/runregr_fullstack2.ksh
@@ -407,8 +407,8 @@ for i in $prettyfiles; do
      fi
 
      if [ $BUILD_FLAVOR = "RELEASE" ]; then
-          if [ "$seabase" -ne 0 -a -r "$REGRTSTDIR/EXPECTED$tnum.SB.RELEASE" ]; then
-             exp="EXPECTED$tnum.SB.RELEASE"
+          if [ "$seabase" -ne 0 -a -r "$REGRTSTDIR/EXPECTED$tnum.RELEASE" ]; then
+             exp="EXPECTED$tnum.RELEASE"
           elif [ -r "$REGRTSTDIR/EXPECTED$tnum.LINUX.RELEASE" ]; then
              exp="EXPECTED$tnum.LINUX.RELEASE"
           fi


### PR DESCRIPTION
I checked in a file EXPECTED062.RELEASE, but the test was looking for
EXPECTED062.SB.RELEASE.