### PR TITLE
TRAFODION-40 Make index-maintenance delete conditional

### DIFF
--- a/core/sql/comexe/ComTdbHbaseAccess.cpp
+++ b/core/sql/comexe/ComTdbHbaseAccess.cpp
@@ -308,7 +308,7 @@ ComTdbHbaseAccess::~ComTdbHbaseAccess()
 Int32
 ComTdbHbaseAccess::numExpressions() const
 {
-  return(15);
+  return(16);
 }
  
 // Return the expression names of the explain TDB based on some 
@@ -348,6 +348,8 @@ ComTdbHbaseAccess::getExpressionName(Int32 expNum) const
       return "keyColValExpr";
     case 14:
       return "hbaseFilterExpr";
+    case 15:
+      return "deletePreCondExpr";
     default:
       return 0;
     }  
@@ -390,6 +392,8 @@ ComTdbHbaseAccess::getExpressionNode(Int32 expNum)
       return keyColValExpr_;
     case 14:
       return hbaseFilterExpr_;
+    case 15:
+      return deletePreCondExpr_;
     default:
       return NULL;
     }  
@@ -410,6 +414,7 @@ Long ComTdbHbaseAccess::pack(void * space)
   rowIdExpr_.pack(space);
   encodedKeyExpr_.pack(space);
   keyColValExpr_.pack(space);
+  deletePreCondExpr_.pack(space);
   hbaseFilterExpr_.pack(space);
   colFamNameList_.pack(space);
   workCriDesc_.pack(space);
@@ -477,6 +482,7 @@ Lng32 ComTdbHbaseAccess::unpack(void * base, void * reallocator)
   if(rowIdExpr_.unpack(base, reallocator)) return -1;
   if(encodedKeyExpr_.unpack(base, reallocator)) return -1;
   if(keyColValExpr_.unpack(base, reallocator)) return -1;
+  if(deletePreCondExpr_.unpack(base, reallocator)) return -1;
   if(hbaseFilterExpr_.unpack(base, reallocator)) return -1;
   if(colFamNameList_.unpack(base, reallocator)) return -1;
   if(workCriDesc_.unpack(base, reallocator)) return -1;

--- a/core/sql/executor/ExHbaseAccess.cpp
+++ b/core/sql/executor/ExHbaseAccess.cpp
@@ -333,6 +333,8 @@ ExHbaseAccessTcb::ExHbaseAccessTcb(
     encodedKeyExpr()->fixup(0, getExpressionMode(), this,  space, heap, FALSE, glob);
   if (keyColValExpr())
     keyColValExpr()->fixup(0, getExpressionMode(), this,  space, heap, FALSE, glob);
+  if (deletePreCondExpr())
+    deletePreCondExpr()->fixup(0, getExpressionMode(), this,  space, heap, FALSE, glob);
   if (hbaseFilterValExpr())
     hbaseFilterValExpr()->fixup(0, getExpressionMode(), this,  space, heap, FALSE, glob);
   

--- a/core/sql/generator/GenPreCode.cpp
+++ b/core/sql/generator/GenPreCode.cpp
@@ -4527,6 +4527,28 @@ RelExpr * UpdateCursor::preCodeGen(Generator * generator,
   return this;
 } // UpdateCursor::preCodeGen()
 
+RelExpr * Delete::preCodeGen(Generator * generator,
+                             const ValueIdSet & externalInputs,
+                             ValueIdSet &pulledNewInputs)
+{
+  if (nodeIsPreCodeGenned())
+    return this;
+  
+  if (! GenericUpdate::preCodeGen(generator,externalInputs,pulledNewInputs))
+    return NULL;
+
+  ValueIdSet availableValues;
+  getInputValuesFromParentAndChildren(availableValues);
+
+  precondition_.replaceVEGExpressions
+                        (availableValues,
+			 getGroupAttr()->getCharacteristicInputs());
+
+  markAsPreCodeGenned();
+
+  return this;
+}
+
 RelExpr * MergeDelete::preCodeGen(Generator * generator,
 				  const ValueIdSet & externalInputs,
 				  ValueIdSet &pulledNewInputs)
@@ -4793,7 +4815,7 @@ RelExpr * HbaseDelete::preCodeGen(Generator * generator,
            listOfDelSubsetRows_))
     return NULL;
 
-  if (! GenericUpdate::preCodeGen(generator, externalInputs, pulledNewInputs))
+  if (! Delete::preCodeGen(generator, externalInputs, pulledNewInputs))
     return NULL;
 
   if (((getTableDesc()->getNATable()->isHbaseRowTable()) ||

--- a/core/sql/optimizer/BindRelExpr.cpp
+++ b/core/sql/optimizer/BindRelExpr.cpp
@@ -12814,9 +12814,19 @@ RelExpr *LeafDelete::bindNode(BindWA *bindWA)
     if (GU_DEBUG) cerr << "\nLeafDelete " << getUpdTableNameText() << endl;
   #endif
 
+  if (getPreconditionTree()) {
+    ValueIdSet pc;
+
+    getPreconditionTree()->convertToValueIdSet(pc, bindWA, ITM_AND);
+    if (bindWA->errStatus())
+      return this;
+
+    setPreconditionTree(NULL);
+    setPrecondition(pc);
+  }
+
   RelExpr *boundExpr = GenericUpdate::bindNode(bindWA);
   if (bindWA->errStatus()) return boundExpr;
-
 
   //Set the beginKeyPred
   if (TriggersTempTable *tempTableObj = getTrigTemp())

--- a/core/sql/optimizer/ImplRule.cpp
+++ b/core/sql/optimizer/ImplRule.cpp
@@ -719,6 +719,7 @@ void copyCommonDeleteFields(Delete *result,
   result->mergeInsertRecExprArray()     = bef->mergeInsertRecExprArray();
 
   result->csl() = bef->csl();
+  result->setPrecondition(bef->getPrecondition());
 }
 
 // -----------------------------------------------------------------------
@@ -2653,6 +2654,16 @@ RelExpr * HbaseInsertRule::nextSubstitute(RelExpr * before,
   result = new(CmpCommon::statementHeap()) 
     HbaseInsert(bef->getTableName(),bef->getTableDesc());
 
+  result->setInsertType(bef->getInsertType());
+
+  DefaultToken vsbbTok = CmpCommon::getDefault(INSERT_VSBB);
+  if ((numberOfRowsToBeInserted > 1) &&
+      (vsbbTok != DF_OFF) &&
+      (result->getInsertType() != Insert::UPSERT_LOAD))
+    {
+      result->setInsertType(Insert::VSBB_INSERT_USER);
+    }
+
   copyCommonGenericUpdateFields(result, bef);
 
   result->setPartKey(skey);
@@ -2669,16 +2680,6 @@ RelExpr * HbaseInsertRule::nextSubstitute(RelExpr * before,
 
   if (result->getGroupAttr()->isEmbeddedInsert())
     result->executorPred() += bef->selectionPred();
-
-  result->setInsertType(bef->getInsertType());
-
-  DefaultToken vsbbTok = CmpCommon::getDefault(INSERT_VSBB);
-  if ((numberOfRowsToBeInserted > 1) &&
-      (vsbbTok != DF_OFF) &&
-      (result->getInsertType() != Insert::UPSERT_LOAD))
-    {
-      result->setInsertType(Insert::VSBB_INSERT_USER);
-    }
 
   return result;
 }

--- a/core/sql/optimizer/Inlining.cpp
+++ b/core/sql/optimizer/Inlining.cpp
@@ -1869,9 +1869,10 @@ static RelExpr *createIMNode(BindWA *bindWA,
 			     CorrName &tableCorrName,
 			     const CorrName &indexCorrName,
 			     IndexDesc *index,
-			     NABoolean isInsert,
+			     NABoolean isIMInsert,
 			     NABoolean useInternalSyskey,
-                           NABoolean isMerge)
+                             NABoolean isForUpdate,
+                             NABoolean isForMerge)
 {
    
  // See createOldAndNewCorrelationNames() for info on OLDCorr/NEWCorr
@@ -1886,13 +1887,14 @@ static RelExpr *createIMNode(BindWA *bindWA,
   // key belonging to a different row). Hence in this case, it is better to always
   // match not only the index key but also remaining columns in the index table
   // that correspond to the base table. Hence we introduce robustDelete below. 
-  NABoolean robustDelete = isMerge && index->isUniqueIndex();
+  NABoolean robustDelete = isForMerge && index->isUniqueIndex();
 
-  tableCorrName.setCorrName((isInsert || robustDelete)? NEWCorr : OLDCorr);
+  tableCorrName.setCorrName((isIMInsert || robustDelete)? NEWCorr : OLDCorr);
   
   ItemExprList *colRefList = new(bindWA->wHeap()) ItemExprList(bindWA->wHeap());
 
-  const ValueIdList &indexColVids = ((isInsert || robustDelete)? index->getIndexColumns() : index->getIndexKey());
+  const ValueIdList &indexColVids = ((isIMInsert || robustDelete)? index->getIndexColumns() : index->getIndexKey());
+  ItemExpr *preCond = NULL; // pre-condition for delete, if any
   
   for (CollIndex i=0; i < indexColVids.entries(); i++) {
 
@@ -1911,11 +1913,51 @@ static RelExpr *createIMNode(BindWA *bindWA,
     colRefList->insert(colRef);
   }
 
+  if (!isIMInsert && isForUpdate)
+    {
+      // For delete nodes that are part of an update, generate a
+      // comparison expression between old and new index column values
+      // and suppress the delete if no columns change. This avoids the
+      // situation where we delete and then re-insert the same index
+      // row within one millisecond and get the same HBase timestamp
+      // value assigned. In that case, the delete will win out over
+      // the insert, even though the insert happens later in time. The
+      // HBase-trx folks are also working on a change to avoid that.
+
+      CorrName newValues(tableCorrName);
+
+      newValues.setCorrName(NEWCorr);
+
+      for (CollIndex cc=0; cc<colRefList->entries(); cc++)
+        {
+          ColReference *oldColRef = static_cast<ColReference *>((*colRefList)[cc]);
+
+          // create a predicate OLD@.<col> = NEW@.<col>
+          BiRelat *comp1Col = new (bindWA->wHeap())
+            BiRelat(ITM_EQUAL,
+                    oldColRef,
+                    new (bindWA->wHeap()) ColReference(
+                         new (bindWA->wHeap()) ColRefName(
+                              oldColRef->getColRefNameObj().getColName(),
+                              newValues,
+                              bindWA->wHeap())),
+                    TRUE); // special NULLs, treat NULL == NULL as true
+
+          if (preCond == NULL)
+            preCond = comp1Col;
+          else
+            preCond = new (bindWA->wHeap()) BiLogic(ITM_AND, preCond, comp1Col);
+        }
+
+      // the actual condition is that the values are NOT the same
+      preCond = new (bindWA->wHeap()) UnLogic(ITM_NOT, preCond);
+    }
+
   // NULL tableDesc here, like all Insert/Update/Delete ctors in SqlParser,
   // because the LeafXxx::bindNode will call GenericUpdate::bindNode
   // which will do the appropriate createTableDesc.
   GenericUpdate *imNode;
-  if (isInsert)
+  if (isIMInsert)
     {
       if (!bindWA->isTrafLoadPrep())
       {
@@ -1924,7 +1966,13 @@ static RelExpr *createIMNode(BindWA *bindWA,
         if (arrayWA && arrayWA->hasHostArraysInTuple()) {
           if (arrayWA->getTolerateNonFatalError() == TRUE)
             imNode->setTolerateNonFatalError(RelExpr::NOT_ATOMIC_);    
-        }	
+        }
+        // For index maintenance on non-unique HBase indexes we can use a put.
+        // In fact we must use a put, otherwise we'll get a uniqueness constraint
+        // violation for those rows that didn't change and therefore didn't get
+        // deleted, due to the precondition (see below).
+        if (!index->isUniqueIndex())
+          imNode->setNoCheck(TRUE);
       } // regular insert
       else {
         imNode = new (bindWA->wHeap()) Insert(indexCorrName,
@@ -1938,10 +1986,15 @@ static RelExpr *createIMNode(BindWA *bindWA,
       } // traf load prep
     }
   else
-    imNode = new (bindWA->wHeap()) LeafDelete(indexCorrName,
-                                        NULL,
-                                        colRefList,
-                                        (robustDelete)?TRUE:FALSE);
+    {
+      imNode = new (bindWA->wHeap()) LeafDelete(indexCorrName,
+                                                NULL,
+                                                colRefList,
+                                                (robustDelete)?TRUE:FALSE,
+                                                REL_LEAF_DELETE,
+                                                preCond,
+                                                bindWA->wHeap());
+    }
 
    // The base table's rowsAffected() will get set in ImplRule.cpp,
   // but we don't want any of these indexes' rowsAffected to be computed
@@ -1977,6 +2030,8 @@ RelExpr *GenericUpdate::createIMNodes(BindWA *bindWA,
     indexCorrName.setIsVolatile(TRUE);
 
   RelExpr *indexInsert = NULL, *indexDelete = NULL, *indexOp = NULL;
+  NABoolean isForUpdate = (getOperatorType() == REL_UNARY_UPDATE ||
+                           isMergeUpdate());
 
   if (indexCorrName.getUgivenName().isNull())
     {
@@ -1994,7 +2049,8 @@ RelExpr *GenericUpdate::createIMNodes(BindWA *bindWA,
 					 index, 
 					 TRUE, 
 					 useInternalSyskey,
-                                      isMerge());
+                                         isForUpdate,
+                                         isMerge());
 
   // Create a list of base columns ColReferences for
   // ONLY the index KEY columns as BEFORE/OLD columns.
@@ -2006,7 +2062,8 @@ RelExpr *GenericUpdate::createIMNodes(BindWA *bindWA,
 					 index, 
 					 FALSE,
     			       		 useInternalSyskey,
-                                      isMerge());
+                                         isForUpdate,
+                                         isMerge());
 
   if (getOperatorType() == REL_UNARY_UPDATE) {
     indexOp = new (bindWA->wHeap()) Union(indexDelete, indexInsert, 

--- a/core/sql/optimizer/NormRelExpr.cpp
+++ b/core/sql/optimizer/NormRelExpr.cpp
@@ -6421,6 +6421,7 @@ void GenericUpdate::recomputeOuterReferences()
   allMyExpr += executorPred();
   allMyExpr += usedColumns();
   allMyExpr += getSelectionPred();
+  allMyExpr += exprsInDerivedClasses_;
 
   ValueIdSet beginKeyPredSet(beginKeyPred());
   allMyExpr += beginKeyPredSet;
@@ -6525,6 +6526,17 @@ RelExpr * Insert::normalizeNode(NormWA & normWARef)
   // ON STATEMENT MV source table
 
   return normalizedThis;
+}
+
+void Delete::rewriteNode(NormWA &normWARef)
+{
+  precondition_.normalizeNode(normWARef);
+
+  // these are no longer used in the following phases,
+  // so remove them instead of rewriting them
+  exprsInDerivedClasses_.clear();
+
+  GenericUpdate::rewriteNode(normWARef);
 }
 
 // ***********************************************************************

--- a/core/sql/optimizer/RelExpr.cpp
+++ b/core/sql/optimizer/RelExpr.cpp
@@ -12530,6 +12530,9 @@ void GenericUpdate::pushdownCoveredExpr(const ValueIdSet &outputExpr,
   // QSTUFF ?? again need to understand details 
   ValueIdSet localExprs(newRecExpr());
 
+  if (setOfValuesReqdByParent)
+    localExprs += *setOfValuesReqdByParent;
+
   // QSTUFF
   localExprs.insertList(newRecBeforeExpr());
   // QSTUFF
@@ -12545,6 +12548,8 @@ void GenericUpdate::pushdownCoveredExpr(const ValueIdSet &outputExpr,
   localExprs.insertList(updateToSelectMap().getBottomValues());
   if (setOfValuesReqdByParent)
     localExprs += *setOfValuesReqdByParent ;
+  localExprs += exprsInDerivedClasses_;
+
   // ---------------------------------------------------------------------
   // Check which expressions can be evaluated by my child.
   // Modify the Group Attributes of those children who inherit some of
@@ -12808,7 +12813,8 @@ Delete::Delete(const CorrName &name, TableDesc *tabId, OperatorTypeEnum otype,
 	       CollHeap *oHeap)
   : GenericUpdate(name,tabId,otype,child,newRecExpr,currOfCursorName,oHeap),
     isFastDelete_(FALSE),
-    csl_(csl),estRowsAccessed_(0)
+    csl_(csl),estRowsAccessed_(0),
+    preconditionTree_(NULL)
 {
   setCacheableNode(CmpMain::BIND);
 }
@@ -12840,8 +12846,27 @@ RelExpr * Delete::copyTopNode(RelExpr *derivedNode, CollHeap* outHeap)
   result->isFastDelete_       = isFastDelete_;
   result->csl() = csl();
   result->setEstRowsAccessed(getEstRowsAccessed());
+  if (preconditionTree_)
+    result->preconditionTree_ = preconditionTree_->copyTree(outHeap)->castToItemExpr();
+  result->setPrecondition(precondition_);
+  result->exprsInDerivedClasses_ = exprsInDerivedClasses_;
 
   return GenericUpdate::copyTopNode(result, outHeap);
+}
+
+void Delete::addLocalExpr(LIST(ExprNode *) &xlist,
+                          LIST(NAString) &llist) const
+{
+  if (preconditionTree_ != NULL OR
+      precondition_.entries() > 0)
+    {
+      if (preconditionTree_ != NULL)
+        xlist.insert(preconditionTree_);
+      else
+        xlist.insert(precondition_.rebuildExprTree(ITM_AND));
+      llist.insert("precondition");
+    }
+  GenericUpdate::addLocalExpr(xlist, llist);
 }
 
 // -----------------------------------------------------------------------


### PR DESCRIPTION
This fixes the issue where we update an indexed column to itself, and
the index maintenance tree both deletes and re-inserts the index row
within the same millisecond. This makes the index row disappear, as the
delete takes precedence over the insert, even though it happened earlier.

As a side-effect, index maintenance may get faster, because we are
also replacing the CheckAndPut of the index insert with a Put.
We could further improve this by processing multiple Puts together.