### PR TITLE
[TRAFODION-14] Inconsistency in index

### DIFF
--- a/core/sql/comexe/ComTdbHbaseAccess.cpp
+++ b/core/sql/comexe/ComTdbHbaseAccess.cpp
@@ -735,7 +735,7 @@ ComTdbHbaseAccess::getNodeName() const
           case INSERT_:
             {
               if ((vsbbInsert()) && (NOT hbaseSqlIUD()))
-                return ("EX_TRAF_VSBB_INSERT");
+                return ("EX_TRAF_VSBB_UPSERT");
               else
                 return ("EX_TRAF_INSERT");
             }
@@ -762,15 +762,15 @@ ComTdbHbaseAccess::getNodeName() const
             break;
 
           case UPDATE_:
-            return (rowsetOper()? "EX_TRAF_ROWSET_UPDATE": "EX_TRAF_UPDATE");
+            return (rowsetOper()? "EX_TRAF_VSBB_UPDATE": "EX_TRAF_UPDATE");
             break;
 
           case MERGE_:
-            return (rowsetOper()? "EX_TRAF_ROWSET_MERGE": "EX_TRAF_MERGE");
+            return (rowsetOper()? "EX_TRAF_VSBB_MERGE": "EX_TRAF_MERGE");
             break;
 
           case DELETE_:
-            return (rowsetOper()? "EX_TRAF_ROWSET_DELETE": "EX_TRAF_DELETE");
+            return (rowsetOper()? "EX_TRAF_VSBB_DELETE": "EX_TRAF_DELETE");
             break;
 
           case COPROC_:
@@ -831,15 +831,15 @@ ComTdbHbaseAccess::getNodeName() const
         break;
 
       case UPDATE_:
-        return (rowsetOper()? "EX_HBASE_ROWSET_UPDATE": "EX_HBASE_UPDATE");
+        return (rowsetOper()? "EX_HBASE_VSBB_UPDATE": "EX_HBASE_UPDATE");
         break;
 
       case MERGE_:
-        return (rowsetOper()? "EX_HBASE_ROWSET_MERGE": "EX_HBASE_MERGE");
+        return (rowsetOper()? "EX_HBASE_VSBB_MERGE": "EX_HBASE_MERGE");
         break;
 
       case DELETE_:
-        return (rowsetOper()? "EX_HBASE_ROWSET_DELETE": "EX_HBASE_DELETE");
+        return (rowsetOper()? "EX_HBASE_VSBB_DELETE": "EX_HBASE_DELETE");
         break;
 
       case COPROC_:

--- a/core/sql/executor/ExHbaseIUD.cpp
+++ b/core/sql/executor/ExHbaseIUD.cpp
@@ -3934,11 +3934,19 @@ ExWorkProcRetcode ExHbaseAccessSQRowsetTcb::work()
 	  {
 	    rowIds_.clear();
 	    retcode = setupUniqueKeyAndCols(FALSE);
-	    if (retcode == -1)
-	      {
+	    if (retcode == -1) {
 		step_ = HANDLE_ERROR;
 		break;
-	      }
+	    }
+            rc = evalDeletePreCondExpr();
+            if (rc == -1) {
+                step_ = HANDLE_ERROR;
+                break;
+            }
+            if (rc == 0) { // No need to delete
+               step_ = NEXT_ROW;
+               break;
+            }
 
 	    copyRowIDToDirectBuffer(rowIds_[0]);
 


### PR DESCRIPTION
Evaluated the DeletePreCond expression in the VSBB delete and
skipped the rows to be deleted when needed. This is expected to resolve
the random failures with executor/TEST015.

Also, changed some of the tcb names to match the compiler names.
EX_TRAF_VSBB_INSERT -> EX_TRAF_VSBB_UPSERT
EX_TRAF_ROWSET_UPDATE -> EX_TRAF_VSBB_UPATE
EX_TRAF_ROWSET_DELETE -> EX_TRAF_VSBB_DELETE
EX_TRAF_ROWSET_MERGE -> EX_TRAF_VSBB_MERGE