### PR TITLE
fix JIRA 1425 and 1431

### DIFF
--- a/core/sql/executor/HBaseClient_JNI.cpp
+++ b/core/sql/executor/HBaseClient_JNI.cpp
@@ -3018,6 +3018,8 @@ HTC_RetCode HTableClient_JNI::init()
     JavaMethods_[JM_DIRECT_GET_ROWS ].jm_signature = "(JSLjava/lang/Object;[Ljava/lang/Object;)I";
     JavaMethods_[JM_COMPLETE_PUT ].jm_name      = "completeAsyncOperation";
     JavaMethods_[JM_COMPLETE_PUT ].jm_signature = "(I[Z)Z";
+    JavaMethods_[JM_GETBEGINKEYS ].jm_name      = "getStartKeys";
+    JavaMethods_[JM_GETBEGINKEYS ].jm_signature = "()Lorg/trafodion/sql/HBaseAccess/ByteArrayList;";
    
     rc = (HTC_RetCode)JavaObjectInterface::init(className, javaClass_, JavaMethods_, (Int32)JM_LAST, javaMethodsInitialized_);
     javaMethodsInitialized_ = TRUE;
@@ -4223,7 +4225,17 @@ HTC_RetCode HTableClient_JNI::coProcAggr(Int64 transID,
   return HTC_OK;
 }
 
+ByteArrayList* HTableClient_JNI::getBeginKeys()
+{
+   return HTableClient_JNI::getKeys(JM_GETBEGINKEYS);
+}
+
 ByteArrayList* HTableClient_JNI::getEndKeys()
+{
+   return HTableClient_JNI::getKeys(JM_GETENDKEYS);
+}
+
+ByteArrayList* HTableClient_JNI::getKeys(Int32 funcIndex)
 {
 
   if (jenv_->PushLocalFrame(jniHandleCapacity_) != 0) {
@@ -4231,7 +4243,7 @@ ByteArrayList* HTableClient_JNI::getEndKeys()
     return NULL;
   }
   jobject jByteArrayList = 
-     jenv_->CallObjectMethod(javaObj_, JavaMethods_[JM_GETENDKEYS].methodID);
+     jenv_->CallObjectMethod(javaObj_, JavaMethods_[funcIndex].methodID);
 
   if (jenv_->ExceptionCheck())
   {
@@ -4246,16 +4258,16 @@ ByteArrayList* HTableClient_JNI::getEndKeys()
     return NULL;
   }
 
-  ByteArrayList* endKeys = new (heap_) ByteArrayList(heap_, jByteArrayList);
+  ByteArrayList* keys = new (heap_) ByteArrayList(heap_, jByteArrayList);
   jenv_->DeleteLocalRef(jByteArrayList);
-  if (endKeys->init() != BAL_OK)
+  if (keys->init() != BAL_OK)
   {
-     NADELETE(endKeys, ByteArrayList, heap_);
+     NADELETE(keys, ByteArrayList, heap_);
      jenv_->PopLocalFrame(NULL);
      return NULL;
   }
   jenv_->PopLocalFrame(NULL);
-  return endKeys;
+  return keys;
 
 }
 

--- a/core/sql/executor/HBaseClient_JNI.h
+++ b/core/sql/executor/HBaseClient_JNI.h
@@ -345,6 +345,7 @@ public:
   // Get the error description.
   virtual char* getErrorText(HTC_RetCode errEnum);
 
+  ByteArrayList* getBeginKeys();
   ByteArrayList* getEndKeys();
 
   HTC_RetCode flushTable(); 
@@ -378,6 +379,8 @@ public:
 
 private:
   NAString getLastJavaError();
+  ByteArrayList* getKeys(Int32 funcIndex);
+
   enum JAVA_METHODS {
     JM_CTOR = 0
    ,JM_GET_ERROR 
@@ -401,6 +404,7 @@ private:
    ,JM_FETCH_ROWS
    ,JM_DIRECT_GET_ROWS
    ,JM_COMPLETE_PUT
+   ,JM_GETBEGINKEYS
    ,JM_LAST
   };
   char *tableName_; 

--- a/core/sql/exp/ExpHbaseInterface.cpp
+++ b/core/sql/exp/ExpHbaseInterface.cpp
@@ -1456,7 +1456,20 @@ Lng32 ExpHbaseInterface_JNI::revoke(
     return HBASE_ACCESS_SUCCESS;
 }
 
-ByteArrayList* ExpHbaseInterface_JNI::getRegionInfo(const char* tblName)
+ByteArrayList* ExpHbaseInterface_JNI::getRegionBeginKeys(const char* tblName)
+{ 
+  htc_ = client_->getHTableClient((NAHeap *)heap_, tblName, useTRex_, hbs_);
+  if (htc_ == NULL)
+  {
+    retCode_ = HBC_ERROR_GET_HTC_EXCEPTION;
+    return NULL;
+  }
+
+   ByteArrayList* bal = htc_->getBeginKeys();
+   return bal;
+}
+
+ByteArrayList* ExpHbaseInterface_JNI::getRegionEndKeys(const char* tblName)
 { 
   htc_ = client_->getHTableClient((NAHeap *)heap_, tblName, useTRex_, hbs_);
   if (htc_ == NULL)

--- a/core/sql/exp/ExpHbaseInterface.h
+++ b/core/sql/exp/ExpHbaseInterface.h
@@ -360,7 +360,9 @@ class ExpHbaseInterface : public NABasicObject
 		      const Text& tblName,
 		      const std::vector<Text> & actionCodes) = 0;
 
-  virtual ByteArrayList* getRegionInfo(const char*) = 0;
+  virtual ByteArrayList* getRegionBeginKeys(const char*) = 0;
+  virtual ByteArrayList* getRegionEndKeys(const char*) = 0;
+
   virtual Lng32 flushTable() = 0;
   static Lng32 flushAllTables();
 
@@ -663,7 +665,9 @@ virtual Lng32 initHFileParams(HbaseStr &tblName,
   		      const std::vector<Text> & actionCodes);
 
 
-  virtual ByteArrayList* getRegionInfo(const char*);
+  virtual ByteArrayList* getRegionBeginKeys(const char*);
+  virtual ByteArrayList* getRegionEndKeys(const char*);
+
   virtual Lng32 flushTable();
   virtual Lng32 estimateRowCount(HbaseStr& tblName,
                                  Int32 partialRowSize,

--- a/core/sql/optimizer/NAClusterInfo.cpp
+++ b/core/sql/optimizer/NAClusterInfo.cpp
@@ -364,6 +364,17 @@ NAClusterInfo::NAClusterInfo(CollHeap * heap)
           size_t pos = key_nodeName->index('.');
           if (pos && pos != NA_NPOS)
             key_nodeName->remove(pos);
+#ifdef _DEBUG
+          else {
+             // The node names for virtual nodes seen with workstations are of
+             // format <nodeName>:0, <nodeName>:1 etc. In debug mode, we work with
+             // such node names by removing all substrings starting at ':' and 
+             // insert the node name into the nodeIdToNodeNameMap_.
+             pos = key_nodeName->index(':');
+             if (pos && pos != NA_NPOS)
+               key_nodeName->remove(pos);
+          }
+#endif
 
           Int32 *val_nodeId = new Int32(nodeInfo[i].nid);
           nodeNameToNodeIdMap_->insert(key_nodeName, val_nodeId);

--- a/core/sql/optimizer/NATable.cpp
+++ b/core/sql/optimizer/NATable.cpp
@@ -2155,7 +2155,7 @@ static PartitioningFunction * createHash2PartitioningFunction
 
 
 static 
-NodeMap* createNodeMapForHbase(desc_struct* desc, NAMemory* heap)
+NodeMap* createNodeMapForHbase(desc_struct* desc, const NATable* table, NAMemory* heap)
 {
    Int32 partns = 0;
    desc_struct* hrk = desc;
@@ -2167,21 +2167,6 @@ NodeMap* createNodeMapForHbase(desc_struct* desc, NAMemory* heap)
 
    NodeMap* nodeMap = new (heap) 
        NodeMap(heap, partns, NodeMapEntry::ACTIVE, NodeMap::HBASE);
-
-   return nodeMap;
-}
-
-static 
-PartitioningFunction*
-createHash2PartitioningFunctionForHBase(desc_struct* desc, const NATable * table, 
-                                        NAMemory* heap)
-{
-
-   desc_struct* hrk = desc;
- 
-   NodeMap* nodeMap = createNodeMapForHbase(desc, heap);
-
-   Int32 partns = nodeMap->getNumEntries();
 
    // get nodeNames of region servers by making a JNI call
    // do it only for multiple partition table
@@ -2200,6 +2185,21 @@ createHash2PartitioningFunctionForHBase(desc_struct* desc, const NATable * table
        }
      }
    }
+
+   return nodeMap;
+}
+
+static 
+PartitioningFunction*
+createHash2PartitioningFunctionForHBase(desc_struct* desc, const NATable * table, 
+                                        NAMemory* heap)
+{
+
+   desc_struct* hrk = desc;
+ 
+   NodeMap* nodeMap = createNodeMapForHbase(desc, table, heap);
+
+   Int32 partns = nodeMap->getNumEntries();
 
    PartitioningFunction* partFunc;
    if ( partns > 1 )
@@ -2444,6 +2444,7 @@ createRangePartitioningFunctionForSingleRegionHBase(
         tail->header.next = new (heap) struct desc_struct;
         tail = tail->header.next;
      }
+     tail->header.next = NULL;
 
      NAString firstkey('(');
      for ( Int32 i=0; i<keys; i++ ) {
@@ -2490,40 +2491,12 @@ createRangePartitioningFunctionForSingleRegionHBase(
                                  heap);
 }
 
-static 
-PartitioningFunction*
-createRangePartitioningFunctionForMultiRegionHBase(Int32 partns,
-                                        desc_struct* desc, 
-			                const NAColumnArray & partKeyColArray,
-                                        NAMemory* heap)
+void
+populatePartnDescOnEncodingKey( struct desc_struct* prevEndKey,
+                               struct desc_struct* tail, 
+                               struct desc_struct* hrk, 
+                               NAMemory* heap)
 {
-   desc_struct* hrk = desc;
-   desc_struct* prevEndKey = NULL;
- 
-   NodeMap* nodeMap = createNodeMapForHbase(desc, heap);
-
-   struct desc_struct* head = NULL;
-   struct desc_struct* tail = NULL;
-
-   Int32 i=0;
-   while ( hrk ) {
-
-     struct desc_struct *newNode = new (heap) struct desc_struct;
-     memset(&newNode->header, 0, sizeof(newNode->header));
-     memset(&newNode->body.partns_desc, 0, sizeof(tail->body.partns_desc));
-     newNode->header.nodetype = DESC_PARTNS_TYPE;
-
-     if ( tail == NULL ) {
-        head = tail = newNode;
-
-        // to satisfy createRangePartitionBoundaries() in NATable.cpp
-        tail->body.partns_desc.primarypartition = 1;
-
-     } else {
-        tail->header.next = newNode;
-        tail = tail->header.next;
-     }
-
      if (!prevEndKey) {
        // the start key of the first partitions has all zeroes in it
        Int32 len = hrk->body.hbase_region_desc.endKeyLen;
@@ -2546,18 +2519,98 @@ createRangePartitioningFunctionForMultiRegionHBase(Int32 partns,
        memcpy(tail->body.partns_desc.encodedkey, 
               prevEndKey->body.hbase_region_desc.endKey, len);
      }
+}
+
+void
+populatePartnDescOnFirstKey( struct desc_struct* ,
+                             struct desc_struct* tail, 
+                             struct desc_struct* hrk,
+                             NAMemory* heap)
+{
+   char* buf = hrk->body.hbase_region_desc.beginKey;
+   Int32 len = hrk->body.hbase_region_desc.beginKeyLen;
+
+   NAString firstkey('(');
+   firstkey.append('\'');
+   firstkey.append(buf, len);
+   firstkey.append('\'');
+   firstkey.append(')');
+
+   Int32 keyLen = firstkey.length();
+   tail->body.partns_desc.firstkeylen = keyLen;
+   tail->body.partns_desc.firstkey = new (heap) char[keyLen];
+   memcpy(tail->body.partns_desc.firstkey, firstkey.data(), keyLen);
+
+   tail->body.partns_desc.encodedkeylen = keyLen;
+   tail->body.partns_desc.encodedkey = new (heap) char[keyLen];
+   memcpy(tail->body.partns_desc.encodedkey, firstkey.data(), keyLen);
+}
+
+typedef void (*populatePartnDescT)( struct desc_struct* prevEndKey,
+                                    struct desc_struct* tail, 
+                                    struct desc_struct* hrk,
+                                    NAMemory* heap);
+static struct desc_struct*
+convertRangeDescToPartnsDesc(desc_struct* desc, populatePartnDescT funcPtr, NAMemory* heap)
+{
+   desc_struct* hrk = desc;
+   desc_struct* prevEndKey = NULL;
+ 
+   struct desc_struct* head = NULL;
+   struct desc_struct* tail = NULL;
+
+   Int32 i=0;
+   while ( hrk ) {
+
+     struct desc_struct *newNode = new (heap) struct desc_struct;
+     memset(&newNode->header, 0, sizeof(newNode->header));
+     memset(&newNode->body.partns_desc, 0, sizeof(tail->body.partns_desc));
+     newNode->header.nodetype = DESC_PARTNS_TYPE;
+
+     if ( tail == NULL ) {
+        head = tail = newNode;
+
+        // to satisfy createRangePartitionBoundaries() in NATable.cpp
+        tail->body.partns_desc.primarypartition = 1;
+
+     } else {
+        tail->header.next = newNode;
+        tail = tail->header.next;
+     }
+
+     (*funcPtr)(prevEndKey, tail, hrk, heap);
 
      prevEndKey = hrk;
      hrk     = hrk->header.next;
    }
 
+   return head;
+}
+
+
+static 
+PartitioningFunction*
+createRangePartitioningFunctionForMultiRegionHBase(Int32 partns,
+                                        desc_struct* desc, 
+                                        const NATable* table, 
+			                const NAColumnArray & partKeyColArray,
+                                        NAMemory* heap)
+{
+   NodeMap* nodeMap = createNodeMapForHbase(desc, table, heap);
+
+   struct desc_struct* 
+      partns_desc = ( table->isHbaseCellTable() || table->isHbaseRowTable()) ?
+         convertRangeDescToPartnsDesc(desc, populatePartnDescOnFirstKey, heap)
+             :
+         convertRangeDescToPartnsDesc(desc, populatePartnDescOnEncodingKey, heap);
+
+
    return createRangePartitioningFunction
-                                (head,
+                                (partns_desc,
                                  partKeyColArray,
                                  nodeMap,
                                  heap);
 }
-
 
 Int32 findDescEntries(desc_struct* desc)
 {
@@ -2577,7 +2630,8 @@ Int32 findDescEntries(desc_struct* desc)
 static 
 PartitioningFunction*
 createRangePartitioningFunctionForHBase(desc_struct* desc, 
-			                const NAColumnArray & partKeyColArray,
+			                const NATable* table,
+                                        const NAColumnArray & partKeyColArray,
                                         NAMemory* heap)
 {
 
@@ -2590,7 +2644,7 @@ createRangePartitioningFunctionForHBase(desc_struct* desc,
 
    return (partns > 1) ?
       createRangePartitioningFunctionForMultiRegionHBase(partns,
-                                    desc, partKeyColArray, heap)
+                                    desc, table, partKeyColArray, heap)
        :
       createRangePartitioningFunctionForSingleRegionHBase(
                                     partKeyColArray, heap);
@@ -4060,6 +4114,7 @@ NABoolean createNAFileSets(desc_struct * table_desc       /*IN*/,
                 (hbd && hbd->header.nodetype == DESC_HBASE_RANGE_REGION_TYPE))
 	           partFunc = createRangePartitioningFunctionForHBase(
 	    	      ((table_desc_struct*)table_desc)->hbase_regionkey_desc,
+                      table,
 	    	      partitioningKeyColumns,
 		      heap);
               else {
@@ -7473,31 +7528,9 @@ Int32 NATable::computeHBaseRowSizeFromMetaData() const
 // other considerations).
 Int64 NATable::estimateHBaseRowCount() const
 {
-  if (!isHbaseTable() || isSeabaseMDTable() ||
-      getExtendedQualName().getQualifiedNameObj().getObjectName() == HBASE_HISTINT_NAME ||
-      getExtendedQualName().getQualifiedNameObj().getObjectName() == HBASE_HIST_NAME)
-    return ActiveSchemaDB()->getDefaults().getAsDouble(HIST_NO_STATS_ROWCOUNT);
-
-  NADefaults* defs = &ActiveSchemaDB()->getDefaults();
-  const char* server = defs->getValue(HBASE_SERVER);
-  const char* zkPort = defs->getValue(HBASE_ZOOKEEPER_PORT);
-  ExpHbaseInterface* ehi = ExpHbaseInterface::newInstance
-                           (STMTHEAP, server, zkPort);
-
-  Int64 estRowCount;
-  Lng32 retcode = ehi->init(NULL);
-  if (retcode < 0)
-    {
-      *CmpCommon::diags()
-                << DgSqlCode(-8448)
-                << DgString0((char*)"ExpHbaseInterface::init()")
-                << DgString1(getHbaseErrStr(-retcode))
-                << DgInt0(-retcode)
-                << DgString2((char*)GetCliGlobals()->getJniErrorStr().data());
-      delete ehi;
-      estRowCount = 0;
-    }
-  else
+  Int64 estRowCount = 0;
+  ExpHbaseInterface* ehi = getHBaseInterface();
+  if (ehi)
     {
       HbaseStr fqTblName;
       NAString tblName = getTableName().getQualifiedNameAsString();
@@ -7507,7 +7540,7 @@ Int64 NATable::estimateHBaseRowCount() const
       fqTblName.val[fqTblName.len] = '\0';
 
       Int32 partialRowSize = computeHBaseRowSizeFromMetaData();
-      retcode = ehi->estimateRowCount(fqTblName,
+      Lng32 retcode = ehi->estimateRowCount(fqTblName,
                                       partialRowSize,
                                       colcount_,
                                       estRowCount);
@@ -7526,14 +7559,19 @@ Int64 NATable::estimateHBaseRowCount() const
 }
 
 // Method to get hbase regions servers node names
-NABoolean  NATable::getRegionsNodeName(Int32 partns, ARRAY(const char *)& nodeNames ) const
+ExpHbaseInterface* NATable::getHBaseInterface() const
 {
   if (!isHbaseTable() || isSeabaseMDTable() ||
       getExtendedQualName().getQualifiedNameObj().getObjectName() == HBASE_HISTINT_NAME ||
       getExtendedQualName().getQualifiedNameObj().getObjectName() == HBASE_HIST_NAME ||
       getSpecialType() == ExtendedQualName::VIRTUAL_TABLE)
-    return FALSE;
+    return NULL;
 
+   return NATable::getHBaseInterfaceRaw();
+}
+
+ExpHbaseInterface* NATable::getHBaseInterfaceRaw() 
+{
   NADefaults* defs = &ActiveSchemaDB()->getDefaults();
   const char* server = defs->getValue(HBASE_SERVER);
   const char* zkPort = defs->getValue(HBASE_ZOOKEEPER_PORT);
@@ -7550,18 +7588,52 @@ NABoolean  NATable::getRegionsNodeName(Int32 partns, ARRAY(const char *)& nodeNa
               << DgInt0(-retcode)
               << DgString2((char*)GetCliGlobals()->getJniErrorStr().data());
     delete ehi;
-    return FALSE;
+    return NULL;
   }
+
+  return ehi;
+}
+
+ByteArrayList* NATable::getRegionsBeginKey(const char* hbaseName) 
+{
+  ExpHbaseInterface* ehi = getHBaseInterfaceRaw();
+  ByteArrayList* bal = NULL;
+
+  if (!ehi)
+    return NULL;
+  else
+  {
+    bal = ehi->getRegionBeginKeys(hbaseName);
+
+    delete ehi;
+  }
+  return bal;
+}
+
+
+NABoolean  NATable::getRegionsNodeName(Int32 partns, ARRAY(const char *)& nodeNames ) const
+{
+  ExpHbaseInterface* ehi = getHBaseInterface();
+
+  if (!ehi)
+    return FALSE;
   else
   {
     HbaseStr fqTblName;
-    NAString tblName = getTableName().getQualifiedNameAsString();
+
+    CorrName corrName(getTableName());
+
+    NAString tblName = (corrName.isHbaseCell() || corrName.isHbaseRow()) ?
+       corrName.getQualifiedNameObj().getObjectName()
+                :
+       getTableName().getQualifiedNameAsString();
+
     fqTblName.len = tblName.length();
     fqTblName.val = new(STMTHEAP) char[fqTblName.len+1];
     strncpy(fqTblName.val, tblName.data(), fqTblName.len);
     fqTblName.val[fqTblName.len] = '\0';
 
-    retcode = ehi->getRegionsNodeName(fqTblName, partns, nodeNames);
+    Lng32 retcode = ehi->getRegionsNodeName(fqTblName, partns, nodeNames);
 
     NADELETEBASIC(fqTblName.val, STMTHEAP);
     delete ehi;
@@ -7575,30 +7647,10 @@ NABoolean  NATable::getRegionsNodeName(Int32 partns, ARRAY(const char *)& nodeNa
 // Method to get hbase table index levels and block size
 NABoolean  NATable::getHbaseTableInfo(Int32& hbtIndexLevels, Int32& hbtBlockSize) const
 {
-  if (!isHbaseTable() || isSeabaseMDTable() ||
-      getExtendedQualName().getQualifiedNameObj().getObjectName() == HBASE_HISTINT_NAME ||
-      getExtendedQualName().getQualifiedNameObj().getObjectName() == HBASE_HIST_NAME ||
-      getSpecialType() == ExtendedQualName::VIRTUAL_TABLE)
-    return FALSE;
+  ExpHbaseInterface* ehi = getHBaseInterface();
 
-  NADefaults* defs = &ActiveSchemaDB()->getDefaults();
-  const char* server = defs->getValue(HBASE_SERVER);
-  const char* zkPort = defs->getValue(HBASE_ZOOKEEPER_PORT);
-  ExpHbaseInterface* ehi = ExpHbaseInterface::newInstance
-                           (STMTHEAP, server, zkPort);
-
-  Lng32 retcode = ehi->init(NULL);
-  if (retcode < 0)
-  {
-    *CmpCommon::diags()
-              << DgSqlCode(-8448)
-              << DgString0((char*)"ExpHbaseInterface::init()")
-              << DgString1(getHbaseErrStr(-retcode))
-              << DgInt0(-retcode)
-              << DgString2((char*)GetCliGlobals()->getJniErrorStr().data());
-    delete ehi;
+  if (!ehi)
     return FALSE;
-  }
   else
   {
     HbaseStr fqTblName;
@@ -7608,7 +7660,7 @@ NABoolean  NATable::getHbaseTableInfo(Int32& hbtIndexLevels, Int32& hbtBlockSize
     strncpy(fqTblName.val, tblName.data(), fqTblName.len);
     fqTblName.val[fqTblName.len] = '\0';
 
-    retcode = ehi->getHbaseTableInfo(fqTblName,
+    Lng32 retcode = ehi->getHbaseTableInfo(fqTblName,
                                      hbtIndexLevels,
                                      hbtBlockSize);
 
@@ -7618,7 +7670,6 @@ NABoolean  NATable::getHbaseTableInfo(Int32& hbtIndexLevels, Int32& hbtBlockSize
       return FALSE;
   }
   return TRUE;
-
 }
 
 // get details of this NATable cache entry
@@ -7824,7 +7875,8 @@ NATable * NATableDB::get(CorrName& corrName, BindWA * bindWA,
       NABoolean isHbaseRow = corrName.isHbaseRow();
       if (isHbaseCell || isHbaseRow)// explicit cell or row format specification
 	{
-	  if (cmpSBD.existsInHbase(corrName.getQualifiedNameObj().getObjectName()) != 1)
+	  const char* extHBaseName = corrName.getQualifiedNameObj().getObjectName();
+	  if (cmpSBD.existsInHbase(extHBaseName) != 1)
 	    {
 	      *CmpCommon::diags()
 		<< DgSqlCode(-1389)
@@ -7834,11 +7886,17 @@ NATable * NATableDB::get(CorrName& corrName, BindWA * bindWA,
 	      return NULL;
 	    }
 
+          ByteArrayList* bal = NATable::getRegionsBeginKey(extHBaseName);
+
 	  tableDesc = 
 	    HbaseAccess::createVirtualTableDesc
 	    (corrName.getExposedNameAsAnsiString(FALSE, TRUE).data(),
-	     isHbaseRow, isHbaseCell);
+	     isHbaseRow, isHbaseCell, bal);
+
+          delete bal;
+
 	  isSeabase = FALSE;
+
 	}
       else if (corrName.isSeabaseMD())
 	{

--- a/core/sql/optimizer/NATable.h
+++ b/core/sql/optimizer/NATable.h
@@ -62,6 +62,8 @@ class NATableDB;
 struct desc_struct;
 class HbaseCreateOption;
 class PrivMgrUserPrivs;
+class ExpHbaseInterface;
+class ByteArrayList;
 
 typedef QualifiedName* QualifiedNamePtr;
 typedef ULng32 (*HashFunctionPtr)(const QualifiedName&);
@@ -830,6 +832,8 @@ public:
   NABoolean getHbaseTableInfo(Int32& hbtIndexLevels, Int32& hbtBlockSize) const;
   NABoolean getRegionsNodeName(Int32 partns, ARRAY(const char *)& nodeNames) const;
 
+  static ByteArrayList* getRegionsBeginKey(const char* extHBaseName);
+
 private:
   NABoolean getSQLMXAlignedTable() const
   {  return (flags_ & SQLMX_ALIGNED_ROW_TABLE) != 0; }
@@ -839,6 +843,9 @@ private:
 
   void setRecordLength(Int32 recordLength) { recordLength_ = recordLength; }
   void setupPrivInfo();
+
+  ExpHbaseInterface* getHBaseInterface() const;
+  static ExpHbaseInterface* getHBaseInterfaceRaw();
 
   //size of All NATable related data after construction
   //this is used when NATables are cached and only then

--- a/core/sql/optimizer/NodeMap.cpp
+++ b/core/sql/optimizer/NodeMap.cpp
@@ -1294,7 +1294,9 @@ NodeMap::getPopularNodeNumber(CollIndex beginPos, CollIndex endPos) const
   for (Lng32 index = beginPos; index < endPos; index++) {
     CMPASSERT(map_.getUsage(index) != UNUSED_COLL_ENTRY);
     Lng32 currNodeNum = getNodeNumber(index);
-    nodes[currNodeNum] += 1; // keep count regions node number
+
+    if ( currNodeNum != ANY_NODE )
+      nodes[currNodeNum] += 1; // keep count regions node number
   }
 
   Lng32 nodeFrequency = 0; 

--- a/core/sql/optimizer/RelScan.h
+++ b/core/sql/optimizer/RelScan.h
@@ -86,6 +86,7 @@ class QRDescGenerator;
 class RangeSpecRef;
 
 class MVMatch;
+class ByteArrayList;
 
 
 /*************************
@@ -1269,7 +1270,8 @@ public:
   //  virtual desc_struct *createVirtualTableDesc();
   static desc_struct *createVirtualTableDesc(const char * name,
 					     NABoolean isRW = FALSE,
-					     NABoolean isCW = FALSE);
+					     NABoolean isCW = FALSE, 
+                                             ByteArrayList* hbaseKeys = NULL);
 
   static desc_struct *createVirtualTableDesc(const char * name,
 					     NAList<char*> &colNameList,

--- a/core/sql/sqlcat/desc.h
+++ b/core/sql/sqlcat/desc.h
@@ -471,6 +471,12 @@ struct desc_struct {
   Lng32 getLength(void);
 };
 
+// Used by assembleDescs() to populate the fields of each new desc_struct.
+// // buf and len describe the new data extracted from the source (usually from JNI)
+// // target is the new desc_struct object to populate with.
+// // h is the heap from which memory allocation can be done.
+typedef void (*populateFuncT)(char* buf, Int32 len, desc_struct* target, NAMemory* h);
+
 // uses HEAP of CmpCommon!
 desc_struct *readtabledef_allocate_desc(desc_nodetype nodetype);
 

--- a/core/sql/sqlcomp/CmpSeabaseDDL.h
+++ b/core/sql/sqlcomp/CmpSeabaseDDL.h
@@ -1167,8 +1167,6 @@ class CmpSeabaseDDL
      StmtDDLGiveSchema * giveSchemaNode,
      NAString          & currentCatalogName);
 
-  desc_struct * assembleRegionDescs(ByteArrayList* bal, desc_nodetype format);
-
   void glueQueryFragments(Lng32 queryArraySize,
 			  const QString * queryArray,
 			  char * &gluedQuery,
@@ -1246,5 +1244,8 @@ class CmpSeabaseDDL
 
   NABoolean cmpSwitched_;
 };
+
+desc_struct* assembleDescs(ByteArrayList* bal, populateFuncT func, NAMemory* heap);
+
 
 #endif // _CMP_SEABASE_DDL_H_


### PR DESCRIPTION
This request is for the merge of the two fixes to the main branch. 

1425:  represent native HBase tables as partitioned (if so). Previously, all such tables are modeled as single partitioned inside the compiler. 

1432:  compiler crashes when compile LOAD INTO salted trafodion tables