### PR TITLE
[[Trafodion 1452]] Cloudera parcel support and EPEL fix

### DIFF
--- a/core/sqf/sqenvcom.sh
+++ b/core/sqf/sqenvcom.sh
@@ -820,5 +820,3 @@ if [[ "$SQ_VERBOSE" == "1" ]]; then
   echo $CLASSPATH | sed -e's/:/ /g' | fmt -w2 | xargs printf '\t%s\n'
   echo
 fi
-export DCS_INSTALL_DIR=/home/trafodion/trafodion-20150807_0830/dcs-1.2.0
-export REST_INSTALL_DIR=/home/trafodion/trafodion-20150807_0830/rest-1.2.0

--- a/core/sqf/sqenvcom.sh
+++ b/core/sqf/sqenvcom.sh
@@ -294,10 +294,55 @@ elif [[ -f $MY_SQROOT/Makefile && -d $TOOLSDIR ]]; then
   export HBASE_CNF_DIR=$MY_SQROOT/sql/local_hadoop/hbase/conf
   export HIVE_CNF_DIR=$MY_SQROOT/sql/local_hadoop/hive/conf
 
+elif [[ -d /opt/cloudera/parcels/CDH ]]; then
+  # we are on a cluster with Cloudera parcels installed
+  # -------------------------------------------
+
+  # native library directories and include directories
+  export HADOOP_LIB_DIR=/opt/cloudera/parcels/CDH/lib/hadoop/lib/native
+  export HADOOP_INC_DIR=/opt/cloudera/parcels/CDH/include
+
+  ### Thrift not supported on Cloudera yet (so use TOOLSDIR download)
+  export THRIFT_LIB_DIR=$TOOLSDIR/thrift-0.9.0/lib
+  export THRIFT_INC_DIR=$TOOLSDIR/thrift-0.9.0/include
+
+
+  export CURL_INC_DIR=/usr/include
+  export CURL_LIB_DIR=/usr/lib64
+
+  # directories with jar files and list of jar files
+  # (could try to reduce the number of jars in the classpath)
+  export HADOOP_JAR_DIRS="/opt/cloudera/parcels/CDH/lib/hadoop
+                          /opt/cloudera/parcels/CDH/lib/hadoop/lib"
+  export HADOOP_JAR_FILES="/opt/cloudera/parcels/CDH/lib/hadoop/client/hadoop-hdfs-*.jar"
+  export HBASE_JAR_FILES="/opt/cloudera/parcels/CDH/lib/hbase/hbase-*-security.jar
+                          /opt/cloudera/parcels/CDH/lib/hbase/hbase-client.jar
+                          /opt/cloudera/parcels/CDH/lib/hbase/hbase-common.jar
+                          /opt/cloudera/parcels/CDH/lib/hbase/hbase-server.jar
+                          /opt/cloudera/parcels/CDH/lib/hbase/hbase-examples.jar
+                          /opt/cloudera/parcels/CDH/lib/hbase/hbase-protocol.jar
+                          /opt/cloudera/parcels/CDH/lib/hbase/lib/htrace-core.jar
+                          /opt/cloudera/parcels/CDH/lib/hbase/lib/zookeeper.jar
+                          /opt/cloudera/parcels/CDH/lib/hbase/lib/$protobuf-*.jar
+                          /opt/cloudera/parcels/CDH/lib/hbase/lib/snappy-java-*.jar
+                          /opt/cloudera/parcels/CDH/lib/hbase/lib/high-scale-lib-*.jar
+                          /opt/cloudera/parcels/CDH/lib/hbase/hbase-hadoop-compat.jar "
+  export HIVE_JAR_DIRS="/opt/cloudera/parcels/CDH/lib/hive/lib"
+  export HIVE_JAR_FILES="/opt/cloudera/parcels/CDH/lib/hadoop-mapreduce/hadoop-mapreduce-client-core.jar"
+
+  # suffixes to suppress in the classpath (set this to ---none--- to add all files)
+  export SUFFIXES_TO_SUPPRESS="-sources.jar -tests.jar"
+
+  # Configuration directories
+
+  export HADOOP_CNF_DIR=/etc/hadoop/conf
+  export HBASE_CNF_DIR=/etc/hbase/conf
+  export HIVE_CNF_DIR=/etc/hive/conf
+
 elif [[ -n "$(ls /usr/lib/hadoop/hadoop-*cdh*.jar 2>/dev/null)" ]]; then
   # we are on a cluster with Cloudera installed
   # -------------------------------------------
-
+  
   # native library directories and include directories
   export HADOOP_LIB_DIR=/usr/lib/hadoop/lib/native
   export HADOOP_INC_DIR=/usr/include
@@ -305,7 +350,7 @@ elif [[ -n "$(ls /usr/lib/hadoop/hadoop-*cdh*.jar 2>/dev/null)" ]]; then
   ### Thrift not supported on Cloudera yet (so use TOOLSDIR download)
   export THRIFT_LIB_DIR=$TOOLSDIR/thrift-0.9.0/lib
   export THRIFT_INC_DIR=$TOOLSDIR/thrift-0.9.0/include
- 
+
 
   export CURL_INC_DIR=/usr/include
   export CURL_LIB_DIR=/usr/lib64
@@ -321,7 +366,7 @@ elif [[ -n "$(ls /usr/lib/hadoop/hadoop-*cdh*.jar 2>/dev/null)" ]]; then
                           /usr/lib/hbase/hbase-server.jar
                           /usr/lib/hbase/hbase-examples.jar
                           /usr/lib/hbase/hbase-protocol.jar
-			  /usr/lib/hbase/lib/htrace-core.jar
+                          /usr/lib/hbase/lib/htrace-core.jar
                           /usr/lib/hbase/lib/zookeeper.jar
                           /usr/lib/hbase/lib/protobuf-*.jar
                          /usr/lib/hbase/lib/snappy-java-*.jar
@@ -775,5 +820,5 @@ if [[ "$SQ_VERBOSE" == "1" ]]; then
   echo $CLASSPATH | sed -e's/:/ /g' | fmt -w2 | xargs printf '\t%s\n'
   echo
 fi
-export DCS_INSTALL_DIR=/home/trafodion/trafodion-20150801_0830/dcs-1.2.0
-export REST_INSTALL_DIR=/home/trafodion/trafodion-20150801_0830/rest-1.2.0
+export DCS_INSTALL_DIR=/home/trafodion/trafodion-20150807_0830/dcs-1.2.0
+export REST_INSTALL_DIR=/home/trafodion/trafodion-20150807_0830/rest-1.2.0

--- a/install/installer/tools/traf_hortonworks_uninstall
+++ b/install/installer/tools/traf_hortonworks_uninstall
@@ -176,6 +176,7 @@ sudo rm -rf /var/spool/mail/mapred
 
 sudo rm -rf /kdump/hadoop
 sudo rm -rf /hadoop
+sudo rm -rf /etc/init.d/ambari*
 
 #==============================================
 #Deleting all userids
@@ -227,5 +228,6 @@ sudo pkill -f zookeeper
 sudo pkill -f hbase
 sudo pkill -f hive
 sudo pkill -f yarn
+sudo pkill -f hdp
 #==============================================
 

--- a/install/installer/tools/traf_hortonworks_uninstall_suse
+++ b/install/installer/tools/traf_hortonworks_uninstall_suse
@@ -175,6 +175,7 @@ sudo rm -rf /var/spool/mail/mapred
 
 sudo rm -rf /kdump/hadoop
 sudo rm -rf /hadoop
+sudo rm -rf /etc/init.d/ambari*
 
 #==============================================
 #Deleting all userids
@@ -226,5 +227,6 @@ sudo pkill -f zookeeper
 sudo pkill -f hbase
 sudo pkill -f hive
 sudo pkill -f yarn
+sudo pkill -f hdp
 #==============================================
 

--- a/install/installer/traf_add_user
+++ b/install/installer/traf_add_user
@@ -183,6 +183,10 @@ if [ "$userid_already_exists" == "Y" ]; then
     fi
 fi
 sudo cp $TRAF_WORKDIR/bashrc_${TRAF_USER}_temp3 $TRAF_USER_DIR/.bashrc
+if [[ -f $TRAF_WORKDIR/installer/sqenvcom.sh ]]; then
+   sudo cp $TRAF_WORKDIR/installer/sqenvcom.sh $TRAF_USER_DIR
+   sudo chown $TRAF_USER.$TRAF_GROUP $TRAF_USER_DIR/sqenvcom.sh
+fi
 sudo chown $TRAF_USER.$TRAF_GROUP $TRAF_USER_DIR/.bashrc
 rm $TRAF_WORKDIR/bashrc_${TRAF_USER}_temp1
 rm $TRAF_WORKDIR/bashrc_${TRAF_USER}_temp2

--- a/install/installer/traf_cloudera_mods98
+++ b/install/installer/traf_cloudera_mods98
@@ -64,16 +64,18 @@ fi
 # if more than one node then copy to all nodes
 echo "***INFO: copying $hbase_trx_jar to all nodes"
 if [ $node_count -ne 1 ]; then
+    
+    $PDSH $MY_HADOOP_NODES $PDSH_SSH_CMD sudo rm -rf $HADOOP_PATH/hbase-trx* 2>/dev/null
     $PDSH $MY_HADOOP_NODES $PDSH_SSH_CMD sudo rm -rf /usr/lib/hbase/lib/hbase-trx* 2>/dev/null
-    $PDSH MY_HADOOP_NODES $PDSH_SSH_CMD sudo rm -rf /usr/share/cmf/lib/plugins/hbase-trx* 2>/dev/null
+    $PDSH $MY_HADOOP_NODES $PDSH_SSH_CMD sudo rm -rf /usr/share/cmf/lib/plugins/hbase-trx* 2>/dev/null
     $PDSH $MY_HADOOP_NODES $PDSH_SSH_CMD sudo rm -rf /usr/lib/hbase/lib/trafodion* 2>/dev/null
     $PDSH $MY_HADOOP_NODES $PDSH_SSH_CMD sudo rm -rf /usr/share/cmf/lib/plugins/trafodion* 2>/dev/null
     $PDSH $MY_NODES $PDSH_SSH_CMD mkdir -p $LOCAL_WORKDIR 2>/dev/null
     $PDSH $MY_HADOOP_NODES $PDSH_SSH_CMD mkdir -p $LOCAL_WORKDIR 2>/dev/null
     cp $UNTAR_DIR/export/lib/$hbase_trx_jar $LOCAL_WORKDIR
     $PDCP $MY_HADOOP_NODES $LOCAL_WORKDIR/$hbase_trx_jar $LOCAL_WORKDIR
-    $PDSH $MY_HADOOP_NODES $PDSH_SSH_CMD sudo cp $LOCAL_WORKDIR/$hbase_trx_jar /usr/lib/hbase/lib
-    $PDSH $MY_HADOOP_NODES $PDSH_SSH_CMD sudo chmod 644 /usr/lib/hbase/lib/$hbase_trx_jar
+    $PDSH $MY_HADOOP_NODES $PDSH_SSH_CMD sudo cp $LOCAL_WORKDIR/$hbase_trx_jar $HADOOP_PATH
+    $PDSH $MY_HADOOP_NODES $PDSH_SSH_CMD sudo chmod 644 $HADOOP_PATH/$hbase_trx_jar
     $PDSH $MY_HADOOP_NODES $PDSH_SSH_CMD rm $LOCAL_WORKDIR/$hbase_trx_jar 2>/dev/null
 else
     for node in $HADOOP_NODES
@@ -82,11 +84,12 @@ else
     ssh -q -n $node sudo rm -rf /usr/share/cmf/lib/plugins/hbase-trx* 2>/dev/null
     ssh -q -n $node sudo rm -rf /usr/lib/hbase/lib/trafodion* 2>/dev/null
     ssh -q -n $node sudo rm -rf /usr/share/cmf/lib/plugins/trafodion* 2>/dev/null
+    ssh -q -n $node sudo rm -rf $HADOOP_PATH/hbase-trx* 2>/dev/null
     ssh -q -n $node sudo mkdir -p $TRAF_WORKDIR 2>/dev/null
     ssh -q -n $node sudo chmod 777 $TRAF_WORKDIR
     scp -q $UNTAR_DIR/export/lib/$hbase_trx_jar $(whoami)@$node:$TRAF_WORKDIR
-    ssh -q -n $node sudo cp $TRAF_WORKDIR/$hbase_trx_jar /usr/lib/hbase/lib
-    ssh -q -n $node sudo chmod 644 /usr/lib/hbase/lib/$hbase_trx_jar
+    ssh -q -n $node sudo cp $TRAF_WORKDIR/$hbase_trx_jar $HADOOP_PATH
+    ssh -q -n $node sudo chmod 644 $HADOOP_PATH/$hbase_trx_jar
     done
 fi
 #=====================================

--- a/install/installer/traf_config_setup
+++ b/install/installer/traf_config_setup
@@ -712,6 +712,7 @@ do
                exit -1
             fi
             nameOfVersion=$(ssh -q -n $node grep "Version" $HOME/hbaseVersion.txt | sed 's/,.*//' | sed 's/-.*//' | grep 2.1.*)
+            HADOOP_PATH="/usr/lib/hbase/lib"
          else
             nameOfVersion=$(ssh -q -n $node grep "Version" $HOME/hbaseVersion.txt | sed 's/,.*//' | sed 's/-.*//' | grep 2.2.*)
          fi
@@ -728,6 +729,7 @@ do
                exit -1
             fi
          fi
+         HADOOP_PATH="/usr/hdp/current/hbase-regionserver/lib"
       fi
 
       if [[ $HADOOP_TYPE == "cloudera" ]]; then
@@ -757,19 +759,20 @@ do
                exit -1
             fi
          fi
+         HADOOP_PATH="/usr/lib/hbase/lib"
          #Check for Cloudera parcels of packages.
          parcelsInstalled=$(ssh -q -n $node sudo ls /opt/cloudera/parcels/ | wc -l)
          if [[ $parcelsInstalled -gt "0" ]]; then
-            echo "***ERROR: Cloudera parcels installed"
-            echo "***ERROR: Trafodion only supports Cloudera packages at this time."
-            exit -1
+            HADOOP_PATH="/opt/cloudera/parcels/CDH/lib/hbase/lib"
          fi
       fi
       echo "***INFO: nameOfVersion=$nameOfVersion"
+      echo "***INFO: HADOOP_PATH=$HADOOP_PATH"
       break;
    fi
 done
 
+echo "export HADOOP_PATH=\"$HADOOP_PATH\"" >> $LOCAL_TRAF_CONFIG
 
 
 

--- a/install/installer/traf_getHadoopNodes
+++ b/install/installer/traf_getHadoopNodes
@@ -12,6 +12,12 @@ if [[ $HADOOP_TYPE == "cloudera" ]]; then
    curlRC=$?
    numberHadoopNodes=$(grep -r "hostname" tempFile | wc -l)
    grep -r "hostname" tempFile > tempFile2
+
+   if [[ -d /opt/cloudera/parcels/CDH ]]; then
+      HADOOP_PATH="/opt/cloudera/parcles/CDH/lib/hbase/lib"
+   else
+      HADOOP_PATH="/usr/lib/hbase/lib"
+   fi
 fi
 
 if [[ $HADOOP_TYPE == "hortonworks" ]]; then
@@ -19,6 +25,12 @@ if [[ $HADOOP_TYPE == "hortonworks" ]]; then
    curlRC=$?
    numberHadoopNodes=$(grep -r "host_name" tempFile | wc -l)
    grep -r "host_name" tempFile > tempFile2
+
+   if [[ -d /usr/lib/hbase/lib ]]; then
+      HADOOP_PATH="/usr/lib/hbase/lib"
+   else
+      HADOOP_PATH="/usr/hdp/current/hbase-regionserver/lib"
+   fi
 fi
 
 if [ $curlRC != 0 ]; then
@@ -65,6 +77,10 @@ sudo chmod 777 $TRAF_CONFIG
 sed -i '/MY_HADOOP_NODES\=/d' $TRAF_CONFIG
 echo "export MY_HADOOP_NODES=\"$MY_HADOOP_NODES\"" >> $TRAF_CONFIG
 sudo chmod 777 $TRAF_CONFIG
+sed -i '/HADOOP_PATH\=/d' $TRAF_CONFIG
+echo "export HADOOP_PATH=\"$HADOOP_PATH\"" >> $TRAF_CONFIG
+sudo chmod 777 $TRAF_CONFIG
+
 
 hadoop_node_count=$(echo $HADOOP_NODES | wc -w)
 

--- a/install/installer/traf_hortonworks_mods98
+++ b/install/installer/traf_hortonworks_mods98
@@ -77,6 +77,7 @@ fi
 # if more than one node then copy to all nodes
 echo "***INFO: copying $hbase_trx_jar to all nodes"
 if [ $node_count -ne 1 ]; then
+    $PDSH $MY_HADOOP_NODES $PDSH_SSH_CMD sudo rm -rf  $HADOOP_PATH/hbase-trx* 2>/dev/null
     $PDSH $MY_HADOOP_NODES $PDSH_SSH_CMD sudo rm -rf /usr/lib/hbase/lib/hbase-trx* 2>/dev/null
     $PDSH $MY_HADOOP_NODES $PDSH_SSH_CMD sudo rm -rf /usr/hdp/current/hbase-regionserver/lib/hbase-trx* 2>/dev/null
     $PDSH $MY_HADOOP_NODES $PDSH_SSH_CMD sudo rm -rf /usr/share/cmf/lib/plugins/hbase-trx* 2>/dev/null
@@ -88,18 +89,14 @@ if [ $node_count -ne 1 ]; then
     cp $UNTAR_DIR/export/lib/$hbase_trx_jar $LOCAL_WORKDIR
     $PDCP $MY_HADOOP_NODES $LOCAL_WORKDIR/$hbase_trx_jar $LOCAL_WORKDIR
 
-    if [[ $CDH_5_3_HDP_2_2_SUPPORT == "N" ]]; then
-       $PDSH $MY_HADOOP_NODES $PDSH_SSH_CMD sudo cp $LOCAL_WORKDIR/$hbase_trx_jar /usr/lib/hbase/lib
-       $PDSH $MY_HADOOP_NODES $PDSH_SSH_CMD sudo chmod 644 /usr/lib/hbase/lib/$hbase_trx_jar
-    else
-       $PDSH $MY_HADOOP_NODES $PDSH_SSH_CMD sudo cp $LOCAL_WORKDIR/$hbase_trx_jar /usr/hdp/current/hbase-regionserver/lib
-       $PDSH $MY_HADOOP_NODES $PDSH_SSH_CMD sudo chmod 644 /usr/hdp/current/hbase-regionserver/lib/$hbase_trx_jar
-    fi
+    $PDSH $MY_HADOOP_NODES $PDSH_SSH_CMD sudo cp $LOCAL_WORKDIR/$hbase_trx_jar $HADOOP_PATH
+    $PDSH $MY_HADOOP_NODES $PDSH_SSH_CMD sudo chmod 644 $HADOOP_PATH/$hbase_trx_jar
 
     $PDSH $MY_HADOOP_NODES $PDSH_SSH_CMD rm $LOCAL_WORKDIR/$hbase_trx_jar 2>/dev/null
 else
     for node in $HADOOP_NODES
-    do
+    do 
+    ssh -q -n $node sudo rm -rf $HADOOP_PATH/hbase-trx* 2>/dev/null
     ssh -q -n $node sudo rm -rf /usr/lib/hbase/lib/hbase-trx* 2>/dev/null
     ssh -q -n $node sudo rm -rf /usr/share/cmf/lib/plugins/hbase-trx* 2>/dev/null
     ssh -q -n $node sudo rm -rf /usr/lib/hbase/lib/trafodion* 2>/dev/null
@@ -108,13 +105,8 @@ else
     ssh -q -n $node sudo chmod 777 $TRAF_WORKDIR
     scp -q $UNTAR_DIR/export/lib/$hbase_trx_jar $(whoami)@$node:$TRAF_WORKDIR
 
-    if [[ $CDH_5_3_HDP_2_2_SUPPORT == "N" ]]; then
-       ssh -q -n $node sudo cp $TRAF_WORKDIR/$hbase_trx_jar /usr/lib/hbase/lib
-       ssh -q -n $node sudo chmod 644 /usr/lib/hbase/lib/$hbase_trx_jar
-    else
-       ssh -q -n $node sudo cp $TRAF_WORKDIR/$hbase_trx_jar /usr/hdp/current/hbase-regionserver/lib
-       ssh -q -n $node sudo chmod 644 /usr/hdp/current/hbase-regionserver/lib/$hbase_trx_jar
-    fi
+    ssh -q -n $node sudo cp $TRAF_WORKDIR/$hbase_trx_jar $HADOOP_PATH
+    ssh -q -n $node sudo chmod 644 $HADOOP_PATH/$hbase_trx_jar
     done
 fi
 

--- a/install/installer/traf_setup
+++ b/install/installer/traf_setup
@@ -128,18 +128,24 @@ if [[ $SUSE_LINUX == "false" ]]; then
       echo "***INFO: ... EPEL rpm"
       if [[ "$EPEL_RPM" != "" ]]; then
          if [ $node_count -ne 1 ]; then
-            $TRAF_PDCP $EPEL_RPM $TRAF_WORKDIR
+            for node in $NODE_LIST
+            do
+               scp -q $EPEL_RPM $(whoami)@$node:$HOME
+            done
          else
-            cp -rf $EPEL_RPM $TRAF_WORKDIR
+            cp -rf $EPEL_RPM $HOME
          fi
       else
          if [[ $internetAccess == "true" ]]; then
             epel_rpm="epel-release-6-8.noarch.rpm"
             wget http://download.fedoraproject.org/pub/epel/6/x86_64/$epel_rpm
             if [ $node_count -ne 1 ]; then
-               $TRAF_PDCP $epel_rpm $TRAF_WORKDIR
+               for node in $NODE_LIST
+               do
+                  scp -q $LOCAL_WORKDIR/$epel_rpm $(whoami)@$node:$HOME
+               done
             else
-               cp -rf $epel_rpm $TRAF_WORKDIR
+               cp -rf $epel_rpm $HOME
             fi
 
             if [ $? != 0 ]; then
@@ -160,7 +166,7 @@ if [[ $SUSE_LINUX == "false" ]]; then
    do
      EPEL_INSTALLED=$( ssh -q -n $node rpm -qa | grep epel | wc -l)
      if [[ $EPEL_INSTALLED == 0 ]]; then
-        ssh -q -n $node sudo rpm -Uvh $TRAF_WORKDIR/epel* 2>> $YUM_LOG >> $YUM_LOG
+        ssh -q -n $node sudo rpm -Uvh $HOME/epel* 2>> $YUM_LOG >> $YUM_LOG
         if [ $? != 0 ]; then
            echo "***ERROR: Can't install EPEL rpm $EPEL_RPM"
            exit -1
@@ -180,13 +186,7 @@ else
    sleep 10
 fi
 
-# first install pdsh on each node so we can use it to install
-# everything else.  don't need pdsh if only a single node
-
-$TRAF_PDSH sudo mkdir -p $TRAF_WORKDIR
-$TRAF_PDSH sudo chmod 777 $TRAF_WORKDIR
-
-
+#install pdsh if not on SUSE Linux
 if [[ $SUSE_LINUX == "false" ]]; then
    if [ $node_count -ne 1 ]; then
       for node in $NODE_LIST
@@ -218,6 +218,9 @@ if [[ $SUSE_LINUX == "false" ]]; then
 
    fi
 fi
+
+$TRAF_PDSH sudo mkdir -p $TRAF_WORKDIR
+$TRAF_PDSH sudo chmod 777 $TRAF_WORKDIR
 
 if [[ $SUSE_LINUX == "false" ]]; then
    # to handle the case where the EPEL rpm was already

--- a/install/installer/traf_start
+++ b/install/installer/traf_start
@@ -73,10 +73,10 @@ fi
 
 #============================================
 echo "***INFO: traf_start" | tee -a $INSTALL_LOG
-echo ******************************************
-echo ******************************************
-echo ******************************************
-echo ******************************************
+echo "******************************************"
+echo "******************************************"
+echo "******************************************"
+echo "******************************************"
 #============================================
 # Check if an existing instance is up
 process_count=$(cstat -noheader 2>/dev/null | wc -l)
@@ -92,6 +92,12 @@ fi
 # Create install directory
 mkdir -p $SQ_ROOT
 echo $SQ_ROOT
+
+if [[ -f $HOME/sqenvcom.sh ]]; then
+   echo "****INFO: Copying over sqenvcom.sh"
+   cp -rf $HOME/sqenvcom.sh $SQ_ROOT
+fi
+
 cd $SQ_ROOT
 
 # untar Trafodion build into install directory
@@ -186,6 +192,10 @@ cd $SQ_ROOT
 if [ "$node_count" -ne "1" ]; then
    echo "***INFO: Creating $SQ_ROOT directory on all nodes" | tee -a $INSTALL_LOG
    $PDSH $MY_NODES -x $HOSTNAME $PDSH_SSH_CMD mkdir -p $SQ_ROOT
+   if [[ -f $HOME/sqenvcom.sh ]]; then
+      echo "****INFO: Copying over sqenvcom.sh"
+      $PDCP $MY_NODES $HOME/sqenvcom.sh $SQ_ROOT
+   fi
 fi
 
 echo "***INFO: starting sqgen" | tee -a $INSTALL_LOG

--- a/install/installer/trafodion_uninstaller
+++ b/install/installer/trafodion_uninstaller
@@ -83,6 +83,10 @@ fi
 timestamp=$(date +%F-%H-%M-%S)
 logsdir="/var/log/trafodion"
 logfile="$logsdir/uninstall_$timestamp.log"
+export PDSH="pdsh -R exec"
+export PDSH_SSH_CMD="ssh -q -n %h"
+export PDCP="pdcp -R ssh"
+
 
 if [ $node_count -eq 1 ]; then
     TRAF_PDSH=""
@@ -90,7 +94,7 @@ else
     # use the -S option to cause pdsh to return largest of
     # the remote command return values so we can tell if one
     # or more of the remote commands failed
-    TRAF_PDSH="pdsh -S $MY_NODES"
+    TRAF_PDSH="pdsh -R exec $MY_NODES $PDSH_SSH_CMD"
 fi
 
 #Check sudo access which is required for "--all" option
@@ -116,10 +120,10 @@ if [ $node_count -eq 1 ]; then
    sudo rm /usr/lib/hbase/lib/$HBASE_TRX 2>/dev/null
    sudo rm /usr/hdp/current/hbase-regionserver/lib/$HBASE_TRX 2>/dev/null
 else
-   pdsh $MY_NODES "sudo rm /etc/security/limits.d/trafodion.conf 2>/dev/null"
-   pdsh $MY_NODES "sudo rm /usr/share/cmf/lib/plugins/$HBASE_TRX 2>/dev/null"
-   pdsh $MY_NODES "sudo rm /usr/lib/hbase/lib/$HBASE_TRX 2>/dev/null"
-   pdsh $MY_NODES "sudo rm /usr/hdp/current/hbase-regionserver/lib/$HBASE_TRX 2>/dev/null" 
+   $TRAF_PDSH "sudo rm /etc/security/limits.d/trafodion.conf 2>/dev/null"
+   $TRAF_PDSH "sudo rm /usr/share/cmf/lib/plugins/$HBASE_TRX 2>/dev/null"
+   $TRAF_PDSH "sudo rm /usr/lib/hbase/lib/$HBASE_TRX 2>/dev/null"
+   $TRAF_PDSH "sudo rm /usr/hdp/current/hbase-regionserver/lib/$HBASE_TRX 2>/dev/null" 
 fi
 
 echo "***INFO remove the Trafodion userid and group"


### PR DESCRIPTION
Trafodion can now be installed on cloudera parcels. 

traf_setup was trying to use pdsh and pdcp for the epel repo 
when it had not been installed.