### PR TITLE
[TRAFODION-1460] Enable EXPLAIN IN RMS feature by default

### DIFF
--- a/core/sql/cli/SessionDefaults.cpp
+++ b/core/sql/cli/SessionDefaults.cpp
@@ -139,7 +139,6 @@ SessionDefaults::SessionDefaults(CollHeap * heap)
        cancelLogging_(TRUE),
        suspendLogging_(TRUE),
        aqrWarn_(0),
-       explainInRMS_(FALSE),
        redriveCTAS_(FALSE),
        callEmbeddedArkcmp_(FALSE),
        exsmTraceLevel_(0),
@@ -226,7 +225,6 @@ SessionDefaults::SessionDefaults(CollHeap * heap)
   setParentQidSystem(NULL, 0);
   setWmsProcess(FALSE);
   aqrInfo_ = new(heap) AQRInfo(heap);
-  setExplainInRMS(FALSE);
   setRtsTimeout(rtsTimeout_);
   setStatisticsViewType(SQLCLI_PERTABLE_STATS);
   setReclaimTotalMemorySize(DEFAULT_RECLAIM_MEMORY_AFTER);
@@ -1689,7 +1687,6 @@ void SessionDefaults::beginSession()
   setParentQid(NULL, 0);
   setParentQidSystem(NULL, 0);
   setWmsProcess(FALSE);
-  setExplainInRMS(FALSE);
   setStatisticsViewType(SQLCLI_PERTABLE_STATS);
   setReclaimTotalMemorySize(DEFAULT_RECLAIM_MEMORY_AFTER);
   setReclaimFreeMemoryRatio(DEFAULT_RECLAIM_FREE_MEMORY_RATIO);

--- a/core/sql/cli/SessionDefaults.h
+++ b/core/sql/cli/SessionDefaults.h
@@ -571,13 +571,6 @@ public:
 
   AQRInfo * aqrInfo() { return aqrInfo_; }
 
-  void setExplainInRMS(NABoolean v = TRUE)
-  {
-    explainInRMS_ = v;
-  }
-
-  NABoolean isExplainInRMS() { return explainInRMS_; }
-
   Lng32 getStatisticsViewType() { return statisticsViewType_; }
   void setStatisticsViewType(Lng32 type) 
   { 
@@ -766,8 +759,6 @@ private:
   NABoolean suspendLogging_;              // suspended's session
   NABoolean callEmbeddedArkcmp_;       // call the procedural interface and don't send a message to the arkcmp process.
   AQRInfo * aqrInfo_;
-  NABoolean explainInRMS_;  // Flag to trigger copying of explain fragment to the RMS shared
-                            // segment
   Lng32 statisticsViewType_;     // Statistics view type which could be different from the collection statistics type
 /*
   Memory manager will start to reclaim space when the below conditions are met

--- a/core/sql/cli/Statement.cpp
+++ b/core/sql/cli/Statement.cpp
@@ -1973,11 +1973,12 @@ Lng32 Statement::unpackAndInit(ComDiagsArea &diagsArea,
   SessionDefaults *sessionDefaults =
        context_->getSessionDefaults();
   if (statsGlobals != NULL && stmtStats_ != NULL && root_tdb != NULL 
-        && getUniqueStmtId() != NULL 
-        && sessionDefaults->isExplainInRMS())
+        && getUniqueStmtId() != NULL) 
   {
     ex_root_tdb *rootTdb = getRootTdb();
-    if (rootTdb->explainInRms() &&
+    //root_tdb is not unpacked for SHOWPLAN and 
+    // explain fragment can't be obtained for such prepared queries
+    if (!rootTdb->isPacked() && rootTdb->explainInRms() &&
         rootTdb->getFragDir()->getExplainFragDirEntry
                  (fragOffset, fragLen, topNodeOffset) == 0)
     {

--- a/core/sql/executor/ExExplain.cpp
+++ b/core/sql/executor/ExExplain.cpp
@@ -1503,6 +1503,7 @@ RtsExplainFrag *ExExplainTcb::sendToSsmp()
   RtsExplainReq *explainReq;
   CliGlobals *cliGlobals = getGlobals()->castToExExeStmtGlobals()->
                         castToExMasterStmtGlobals()->getCliGlobals();
+  ContextCli *context = cliGlobals->currContext();
   if (cliGlobals->getStatsGlobals() == NULL)
   {
     // Runtime Stats not running.
@@ -1510,6 +1511,14 @@ RtsExplainFrag *ExExplainTcb::sendToSsmp()
     IpcAllocateDiagsArea(diagsArea_, getHeap());
     (*diagsArea_) << DgSqlCode(-EXE_RTS_NOT_STARTED);
     return NULL;
+  }
+
+  ExMasterStats *masterStats;
+
+  if (strcasecmp(qid_, "CURRENT") == 0) {
+     if (context->getStats() != NULL && (masterStats = context->getStats()->getMasterStats()) != NULL) {
+        setQid(masterStats->getQueryId(), masterStats->getQueryIdLen()); 
+     }
   }
 
   // Verify that we have valid parameters for each kind of request. If not, fill in the diagsArea

--- a/core/sql/executor/ex_control.cpp
+++ b/core/sql/executor/ex_control.cpp
@@ -366,13 +366,6 @@ short ExControlTcb::work()
                           currContext->getSessionDefaults()->setStatisticsViewType(SQLCLI_PERTABLE_STATS);
                         }
 		      }
-		    else if (strcmp(value[1], "EXPLAIN_IN_RMS") == 0)
-		      {
-                        NABoolean explainInRMS = TRUE;
-			if (strcmp(value[2], "OFF") == 0)
-                            explainInRMS = FALSE;
-			currContext->getSessionDefaults()->setExplainInRMS(explainInRMS);
-                      }
 		    else if (strcmp(value[1], "MARIAQUEST_PROCESS") == 0)
 		      {
 			if (strcmp(value[2], "ON") == 0)

--- a/core/sql/sqlcomp/nadefaults.cpp
+++ b/core/sql/sqlcomp/nadefaults.cpp
@@ -1374,7 +1374,7 @@ SDDkwd__(EXE_DIAGNOSTIC_EVENTS,		"OFF"),
 
   DDkwd__(EXPLAIN_DISPLAY_FORMAT,		"EXTERNAL"),
 
-  DDkwd__(EXPLAIN_IN_RMS, 		        "OFF"),
+  DDkwd__(EXPLAIN_IN_RMS, 		        "ON"),
 
   DDui___(EXPLAIN_OUTPUT_ROW_SIZE,   "80"),
 


### PR DESCRIPTION
EXPLAIN_IN_RMS is now enabled by default. The explain plan
can now be obtained from a different session using

explain for qid <qid>
explain options 'f' for qid <qid>

The explain fragment in packed format is retained in RMS shared
segment till the query is deallocated.