### PR TITLE
[TRAFODION-1453] Improvements in Hive Scan

### DIFF
--- a/core/sql/bin/SqlciErrors.txt
+++ b/core/sql/bin/SqlciErrors.txt
@@ -1447,7 +1447,7 @@ $1~String1 --------------------------------
 6021 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Compiler Optimizer Warning $0~String0.
 7000 ZZZZZ 99999 ADVANCED MAJOR DIALOUT An internal error occurred in the code generator in file $0~string0 at line $1~int0: $2~string1.
 7001 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Default value $0~String0 is not valid for column $1~String1.
-7002 ZZZZZ 99999 BEGINNER MAJOR DBADMIN --- available ---
+7002 ZZZZZ 99999 BEGINNER MAJOR DBADMIN The input row format of the hive table is not yet supported.
 7003 42000 99999 BEGINNER MAJOR DBADMIN A plan using cluster sampling could not be produced for this query.
 7004 ZZZZZ 99999 BEGINNER MAJOR DBADMIN A parallel extract plan could not be produced. Possible causes include an incompatible Control Query Shape (CQS) specification, use of rowset expressions, or use of SQL features that cannot be parallelized such as [FIRST/LAST N], table-valued functions, stream access to tables, and embedded updates or deletes.
 7005 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Use of selection predicates in parallel extract consumer queries is not allowed.

--- a/core/sql/executor/ExHdfsScan.h
+++ b/core/sql/executor/ExHdfsScan.h
@@ -282,6 +282,7 @@ protected:
 
   NABoolean exception_;
   ComCondition * lastErrorCnd_;
+  NABoolean checkRangeDelimiter_;
 };
 
 class ExOrcScanTcb  : public ExHdfsScanTcb
@@ -428,14 +429,14 @@ protected:
 
 #define RANGE_DELIMITER '\002'
 
-inline char *hdfs_strchr(const char *s, int c, const char *end)
+inline char *hdfs_strchr(const char *s, int c, const char *end, NABoolean checkRangeDelimiter)
 {
   char *curr = (char *)s;
 
   while (curr < end) {
     if (*curr == c)
        return curr;
-    if (*curr == RANGE_DELIMITER)
+    if (checkRangeDelimiter &&*curr == RANGE_DELIMITER)
        return NULL;
     curr++;
   }
@@ -443,7 +444,7 @@ inline char *hdfs_strchr(const char *s, int c, const char *end)
 }
 
 
-inline char *hdfs_strchr(const char *s, int rd, int cd, const char *end, NABoolean *rdSeen)
+inline char *hdfs_strchr(const char *s, int rd, int cd, const char *end, NABoolean checkRangeDelimiter, NABoolean *rdSeen)
 {
   char *curr = (char *)s;
 
@@ -458,7 +459,7 @@ inline char *hdfs_strchr(const char *s, int rd, int cd, const char *end, NABoole
        return curr;
     }
     else
-    if (*curr == RANGE_DELIMITER) {
+    if (checkRangeDelimiter && *curr == RANGE_DELIMITER) {
        *rdSeen = TRUE;
        return NULL;
     }

--- a/core/sql/executor/ExHdfsScan.h
+++ b/core/sql/executor/ExHdfsScan.h
@@ -426,4 +426,48 @@ protected:
   char * aggrRow_;
 };
 
+#define RANGE_DELIMITER '\002'
+
+inline char *hdfs_strchr(const char *s, int c, const char *end)
+{
+  char *curr = (char *)s;
+
+  while (curr < end) {
+    if (*curr == c)
+       return curr;
+    if (*curr == RANGE_DELIMITER)
+       return NULL;
+    curr++;
+  }
+  return NULL;
+}
+
+
+inline char *hdfs_strchr(const char *s, int rd, int cd, const char *end, NABoolean *rdSeen)
+{
+  char *curr = (char *)s;
+
+  while (curr < end) {
+    if (*curr == rd) {
+       *rdSeen = TRUE;
+       return curr;
+    }
+    else
+    if (*curr == cd) {
+       *rdSeen = FALSE;
+       return curr;
+    }
+    else
+    if (*curr == RANGE_DELIMITER) {
+       *rdSeen = TRUE;
+       return NULL;
+    }
+    curr++;
+  }
+  *rdSeen = FALSE;
+  return NULL;
+}
+
+
+
 #endif

--- a/core/sql/generator/GenRelScan.cpp
+++ b/core/sql/generator/GenRelScan.cpp
@@ -1072,7 +1072,11 @@ short FileScan::codeGenForHive(Generator * generator)
     type = (short)ComTdbHdfsScan::SEQUENCE_;
   else if (hTabStats->isOrcFile())
     type = (short)ComTdbHdfsScan::ORC_;
-
+  else {
+    *CmpCommon::diags() << DgSqlCode(-7002);
+      GenExit();
+    return -1;
+  }
   ULng32 buffersize = getDefault(GEN_DPSO_BUFFER_SIZE);
   queue_index upqueuelength = (queue_index)getDefault(GEN_DPSO_SIZE_UP);
   queue_index downqueuelength = (queue_index)getDefault(GEN_DPSO_SIZE_DOWN);


### PR DESCRIPTION
The null byte is now skipped over to look for the column and record delimiter while scanning the hdfs row buffer. The null byte will be part of the column value. The behavior of null byte in the column value is unknown. Skipping over null byte is now in sync with other tool's behavior.

Also, improved the code to scan the buffer for both record and column delimiter once. Earlier, the buffer was scanned twice; once for the record delimiter and another for column delimiter.

No errors are returned when null byte is found.

A sql error 7002 is now reported when a unsupported row format type is accessed from Trafodion.

*** ERROR[7002] The input row format of the hive table is not yet supported.