### PR TITLE
[TRAFODION-28] Update the copyrights in all Trafodion source files to make them conform to ASF standards.

### DIFF
--- a/core/conn/trafci/src/org/trafodion/ci/SessionDefaults.java
+++ b/core/conn/trafci/src/org/trafodion/ci/SessionDefaults.java
@@ -22,7 +22,7 @@
 package org.trafodion.ci;
 
 public interface SessionDefaults {
-   final String PROD_NAME = "Trafodion Command Interface ";
+   final String PROD_NAME = System.getenv("TRAFODION_VER_PROD")+" Command Interface ";
    final String APP_NAME = "TrafCI";
    final String DRIVER_NAME = "org.trafodion.jdbc.t4.T4Driver"; 
    final String PKG_NAME = "/org/trafodion/ci/";

--- a/core/conn/trafci/src/org/trafodion/ci/UserInterface.java
+++ b/core/conn/trafci/src/org/trafodion/ci/UserInterface.java
@@ -407,7 +407,8 @@ public class UserInterface {
 
 	private static void banner() {
 		System.out.println("\nWelcome to " + SessionDefaults.PROD_NAME);
-		System.out.println("Copyright(C) 2013-2014 Hewlett-Packard Development Company, L.P.");
+		String copyright_str = "Copyright (c) "+System.getenv("PRODUCT_COPYRIGHT_HEADER");
+		System.out.println(copyright_str);
 		System.out.println();
 	}
 }

--- a/core/sqf/build-scripts/genverhdr.ksh
+++ b/core/sqf/build-scripts/genverhdr.ksh
@@ -59,6 +59,8 @@ function usage {
    print_usage_line "-major" "Specifies major number in the version string."
    print_usage_line "-minor" "Specifies minor number in the version string."
    print_usage_line "-update" "Specifies update number in the version string."
+   print_usage_line "-prodver" "Specifies product version(open,Ent,EntAdv) in the version string."
+   
 }
 
 #---------------
@@ -100,6 +102,12 @@ static const char * SCMBuildStr = "";
 
 /* build date */
 #define VERS_DT        $buildDate
+
+/*prodver*/
+#define VERS_PRODVER $prodver
+
+/*copyright*/
+#define COPYRIGHT $copyright
 
 #endif
 
@@ -161,6 +169,8 @@ typeset buildDate=
 typeset major=
 typeset minor=
 typeset update=
+typeset prodver=
+typeset copyright=
 
 while [ $# -gt 0 ]; do
    case $1 in
@@ -196,6 +206,10 @@ while [ $# -gt 0 ]; do
          update="${2}"
          shift
          ;;
+       -prodver|-pv)
+         prodver="${2}"
+         shift
+         ;;       
       -h|*)
          usage
          exit 1
@@ -224,5 +238,7 @@ fi
 [ -z "$major" ]  && major="$( grep TRAFODION_VER_MAJOR=  $VERFILE | cut -f2 -d=)"
 [ -z "$minor" ]  && minor="$( grep TRAFODION_VER_MINOR=  $VERFILE | cut -f2 -d=)"
 [ -z "$update" ] && update="$(grep TRAFODION_VER_UPDATE= $VERFILE | cut -f2 -d=)"
+[ -z "$prodver" ] && prodver="$(grep TRAFODION_VER_PROD= $VERFILE | cut -f2 -d=| sed 's/ /_/' | sed 's/\"//g')"
+[ -z "$copyright" ] && copyright=" Copyright (c) $(grep PRODUCT_COPYRIGHT_HEADER= $VERFILE | cut -f2 -d=)"
 
 writeVerHdr

--- a/core/sqf/export/include/SCMVersHelp.h
+++ b/core/sqf/export/include/SCMVersHelp.h
@@ -41,40 +41,45 @@
 /*
  * internal helpers (i.e. used by SCMVersHelp.h)
  */
-#define INTVERS_PROC_BUILD(comp,cvmaj,cvmin,cvupd,pvmaj,pvmin,pvupd,bv,br,scmbv,dt) \
+#define INTVERS_PROC_BUILD(comp,cvmaj,cvmin,cvupd,pvmaj,pvmin,pvupd,prodver,bv,br,scmbv,dt) \
 VERS_ ## comp ## \
 _CV ## cvmaj ## _ ## cvmin ## _ ## cvupd ## \
 _PV ## pvmaj ## _ ## pvmin ## _ ## pvupd ## \
+_ ## prodver ##\
 _BV ## bv ## \
 _BR ## br ## \
 _DT ## dt ## \
 _SV ## scmbv
-#define INTVERS_PROC_MAC(comp,cvmaj,cvmin,cvupd,pvmaj,pvmin,pvupd,bv,br,scmbv,dt) \
-INTVERS_PROC_BUILD(comp,cvmaj,cvmin,cvupd,pvmaj,pvmin,pvupd,bv,br,scmbv,dt)
+#define INTVERS_PROC_MAC(comp,cvmaj,cvmin,cvupd,pvmaj,pvmin,pvupd,prodver,bv,br,scmbv,dt) \
+  INTVERS_PROC_BUILD(comp,cvmaj,cvmin,cvupd,pvmaj,pvmin,pvupd,prodver,bv,br,scmbv,dt)
 
-#define INTVERS_STR_BUILD(comp,cvmaj,cvmin,cvupd,pvmaj,pvmin,pvupd,bv,scmbv,dt) \
+#define INTVERS_STR_BUILD(comp,cvmaj,cvmin,cvupd,pvmaj,pvmin,pvupd,prodver,bv,scmbv,dt) \
 #comp " " \
 "Version " #cvmaj "." #cvmin "." #cvupd " " \
+#prodver " "\
 "Release " #pvmaj "." #pvmin "." #pvupd " " \
 "(Build " #bv " [" #scmbv "], date " #dt ")"
-#define INTVERS_STR_MAC(comp,cvmaj,cvmin,cvupd,pvmaj,pvmin,pvupd,bv,scmbv,dt) \
-INTVERS_STR_BUILD(comp,cvmaj,cvmin,cvupd,pvmaj,pvmin,pvupd,bv,scmbv,dt)
+#define INTVERS_STR_MAC(comp,cvmaj,cvmin,cvupd,pvmaj,pvmin,pvupd,prodver,bv,scmbv,dt) \
+  INTVERS_STR_BUILD(comp,cvmaj,cvmin,cvupd,pvmaj,pvmin,pvupd,prodver,bv,scmbv,dt)
 #define INTVERS_STR(comp) INTVERS_STR_MAC(comp,\
                                           VERS_CV_MAJ,VERS_CV_MIN,VERS_CV_UPD,\
                                           VERS_PV_MAJ,VERS_PV_MIN,VERS_PV_UPD,\
+                                          VERS_PRODVER,\
                                           VERS_BV,\
                                           VERS_SCMBV,\
                                           VERS_DT)
-#define INTVERS2_STR_BUILD(comp,cvmaj,cvmin,cvupd,pvmaj,pvmin,pvupd,bv,br,scmbv,dt) \
+#define INTVERS2_STR_BUILD(comp,cvmaj,cvmin,cvupd,pvmaj,pvmin,pvupd,prodvers,bv,br,scmbv,dt) \
 #comp " " \
 "Version " #cvmaj "." #cvmin "." #cvupd " " \
+#prodvers " "\
 "Release " #pvmaj "." #pvmin "." #pvupd " " \
 "(Build " #bv " [" #scmbv "], branch " #br ", date " #dt ")"
-#define INTVERS2_STR_MAC(comp,cvmaj,cvmin,cvupd,pvmaj,pvmin,pvupd,bv,br,scmbv,dt) \
-INTVERS2_STR_BUILD(comp,cvmaj,cvmin,cvupd,pvmaj,pvmin,pvupd,bv,br,scmbv,dt)
+#define INTVERS2_STR_MAC(comp,cvmaj,cvmin,cvupd,pvmaj,pvmin,pvupd,prodvers,bv,br,scmbv,dt) \
+  INTVERS2_STR_BUILD(comp,cvmaj,cvmin,cvupd,pvmaj,pvmin,pvupd,prodver,bv,br,scmbv,dt)
 #define INTVERS2_STR(comp) INTVERS2_STR_MAC(comp,\
                                            VERS_CV_MAJ,VERS_CV_MIN,VERS_CV_UPD,\
                                            VERS_PV_MAJ,VERS_PV_MIN,VERS_PV_UPD,\
+                                           VERS_PRODVER,\
                                            VERS_BV,\
                                            VERS_BR,\
                                            VERS_SCMBV,\
@@ -99,6 +104,7 @@ INTVERS2_STR_BUILD(comp,cvmaj,cvmin,cvupd,pvmaj,pvmin,pvupd,bv,br,scmbv,dt)
 #define VERS_PROC(comp) INTVERS_PROC_MAC(comp,\
                                          VERS_CV_MAJ,VERS_CV_MIN,VERS_CV_UPD,\
                                          VERS_PV_MAJ,VERS_PV_MIN,VERS_PV_UPD,\
+                                         VERS_PRODVER,\
                                          VERS_BV,\
                                          VERS_BR2,\
                                          VERS_SCMBV2,\
@@ -107,8 +113,8 @@ INTVERS2_STR_BUILD(comp,cvmaj,cvmin,cvupd,pvmaj,pvmin,pvupd,bv,br,scmbv,dt)
 /*
  * use this to get copyright string
  */
-#define VERS_COPY_STR \
-"(C) Copyright 2011-2013 Hewlett-Packard Development Company, L.P."
+
+#define VERS_COPY_STR  "Copyright (c) $PRODUCT_COPYRIGHT_HEADER"
 
 /*
  * use this to define version proc function for a library

--- a/core/sqf/sqenvcom.sh
+++ b/core/sqf/sqenvcom.sh
@@ -29,7 +29,7 @@
 #  * Add an entry in sqf/LocalSettingsTemplate.sh to make path configurable.
 ##############################################################
 
-#Product version (Trafodion, Enterprise or Enterprise Adv)
+#Product version (Trafodion or derivative product)
 export TRAFODION_VER_PROD="Apache Trafodion "
 # Trafodion version (also update file ../sql/common/copyright.h)
 export TRAFODION_VER_MAJOR=1

--- a/core/sqf/sqenvcom.sh
+++ b/core/sqf/sqenvcom.sh
@@ -29,13 +29,16 @@
 #  * Add an entry in sqf/LocalSettingsTemplate.sh to make path configurable.
 ##############################################################
 
+#Product version (Trafodion, Enterprise or Enterprise Adv)
+export TRAFODION_VER_PROD="Apache Trafodion "
 # Trafodion version (also update file ../sql/common/copyright.h)
 export TRAFODION_VER_MAJOR=1
 export TRAFODION_VER_MINOR=2
 export TRAFODION_VER_UPDATE=0
 export TRAFODION_VER="${TRAFODION_VER_MAJOR}.${TRAFODION_VER_MINOR}.${TRAFODION_VER_UPDATE}"
 
-
+# Product copyright header
+export PRODUCT_COPYRIGHT_HEADER="2015 Apache Software Foundation"
 ##############################################################
 # Trafodion authentication:
 #    Set TRAFODION_ENABLE_AUTHENTICATION to YES to enable

--- a/core/sqf/sqvers
+++ b/core/sqf/sqvers
@@ -283,10 +283,10 @@ sub version_elf ($$) {
 		$ver =~ s/_sl_/\//g;
 		$ver =~ s/_dt_/\./g;
 		$ver =~ s/_dh_/-/g;
-		if ($ver =~ /([a-zA-Z0-9_]*)_CV(\d*)_(\d*)_(\d*)_PV(\d*)_(\d*)_(\d*)_BV(\w*)_BR([\w\-\.\/]*)_DT(\w*)_SV(.*)/) {
+		if ($ver =~ /([a-zA-Z0-9_]*)_CV(\d*)_(\d*)_(\d*)_PV(\d*)_(\d*)_(\d*)_(\w*)_BV(\w*)_BR([\w\-\.\/]*)_DT(\w*)_SV(.*)/) {
 			$has_version = 1;
-			my $verstr = "Release $5.$6.$7 (Build $8 [$11], branch $9, date $10)";
-			my $bldstr = $11;
+			my $verstr = "$8 Release $5.$6.$7 (Build $9 [$12], branch $10, date $11)";
+			my $bldstr = $12;
 			if ($utt) {
 				utt_add($dir, $elf, $verstr, $bldstr);
 			} else {

--- a/core/sql/common/copyright.h
+++ b/core/sql/common/copyright.h
@@ -20,34 +20,12 @@
 //
 // @@@ END COPYRIGHT @@@
 **********************************************************************/
-
-#ifndef COPYRIGHT_H
-
-  #define COPYRIGHT_H \
-  "(c) Copyright 2014 Hewlett-Packard Development Company, LP."
-
-  // The COPYRIGHT_VERSION_H macro is no longer defined here.
-  // Instead, the version is defined in sqenvcom.sh and then passed
-  // via -D compiler directives in a few makefiles: sqlcilib, arkcmplib, sqlc
-
-
-  #define COPYRIGHT_TOP_PRODNAME_H	"Trafodion"
-  #define COPYRIGHT_XTOP_PRODNAME_H	"Trafodion"
-
-  #define COPYRIGHT_ARKCMP_PRODNAME_H	"Trafodion Compiler"
-  #define COPYRIGHT_CATMAN_PRODNAME_H	"Trafodion Catalog Manager"
-  #define COPYRIGHT_SQLCI_PRODNAME_H	"Trafodion Conversational Interface"
-  #define COPYRIGHT_SQLC_PRODNAME_H	"Trafodion C/C++ Preprocessor"
-  #define COPYRIGHT_SQLCO_PRODNAME_H	"Trafodion COBOL Preprocessor"
-  #define COPYRIGHT_UDRSERV_PRODNAME_H	"Trafodion UDR Server"
-
+  #define  COPYRIGHT_XTOP_PRODNAME_H PRODVER
+  #define COPYRIGHT_ARKCMP_PRODNAME_H  "Compiler"
+  #define COPYRIGHT_SQLCI_PRODNAME_H  "Conversational Interface"
+  #define COPYRIGHT_UDRSERV_PRODNAME_H "UDR Server"
+ 
   #define COPYRIGHT_BANNER_1(ostrm,prod) \
-  ostrm << prod " " COPYRIGHT_VERSION_H << endl << COPYRIGHT_H << endl
+    ostrm << PRODVER <<  " " << prod " " << COPYRIGHT_VERSION_H << endl << "Copyright (c) " << COPYRIGHT_HEADER_H<< endl
 
-  #define COPYRIGHT_BANNER_2(ostrm,prod) \
-  COPYRIGHT_BANNER_1(ostrm,prod) << endl
 
-  #define SQLCO_CPYRT COPYRIGHT_SQLCO_PRODNAME_H " " COPYRIGHT_VERSION_H
-  #define SQLC_CPYRT  COPYRIGHT_SQLC_PRODNAME_H  " " COPYRIGHT_VERSION_H
-
-#endif

--- a/core/sql/nskgmake/sqlcilib/Makefile
+++ b/core/sql/nskgmake/sqlcilib/Makefile
@@ -58,10 +58,9 @@ YINC := tdm_sqlmxmsg_intl
 CPPSRC += SqlciRWSimulator.cpp \
 	SqlciCSSimulator.cpp
 
-DEFS += -DSQLCLI_LIB -DCLI_DLL -D_UNICODE -DCOPYRIGHT_VERSION_H=\"$(TRAFODION_VER)\"
+DEFS += -DSQLCLI_LIB -DCLI_DLL -D_UNICODE -DCOPYRIGHT_VERSION_H=\"$(TRAFODION_VER)\" -DCOPYRIGHT_HEADER_H='"$(PRODUCT_COPYRIGHT_HEADER)"' -DPRODVER='"$(TRAFODION_VER_PROD)"'
 
 CPPSRC += vers_libsqlcilib.cpp
-
 
 YSRC := sqlci_yacc.y
 LSRC := sqlci_lex.ll

--- a/core/sql/nskgmake/sqlmsg/Makefile
+++ b/core/sql/nskgmake/sqlmsg/Makefile
@@ -27,4 +27,7 @@ CPPSRC := \
 	ParserMsg.cpp
 
 CPPSRC += vers_libsqlmsg.cpp
-DEFS := -DSQLCLI_LIB
+
+DEFS += -DSQLCLI_LIB -DPRODVER='"$(TRAFODION_VER_PROD)"'
+
+

--- a/core/sql/regress/tools/regress-filter-linux
+++ b/core/sql/regress/tools/regress-filter-linux
@@ -324,6 +324,7 @@ s/^NonStop SQL\/MX \([A-Za-z\/ +]*\) [0-9][0-9]*\.[0-9][0-9]*$/\1 #n.#n/
 /^Copyright (c).*All Rights Reserved. *$/s/Compaq[^.]*\./#CPQ#TDM#./
 /^(c) Copyright [0-9][0-9][0-9][0-9] Hewlett-Packard Development Company.*$/s/^.*$/Copyright (c) ####-#### #CPQ#TDM#\.  All Rights Reserved./
 /^(c) Copyright [0-9][0-9][0-9][0-9]-[0-9][0-9][0-9][0-9] Hewlett-Packard Development Company.*$/s/^.*$/Copyright (c) ####-#### #CPQ#TDM#\.  All Rights Reserved./
+s/^Copyright (c) .*/Copyright (c) ######/
 /^[Hh]istory file .* Access is denied/d
 s/^\(MESSAGEFILE     [ 	]*\).*/\1#f/
 /^MESSAGEFILE VRSN[ 	]*{/s/{.*/#v/

--- a/core/sql/regress/tools/setuplnxenv
+++ b/core/sql/regress/tools/setuplnxenv
@@ -79,7 +79,7 @@ fi
 # Finally, add the regression variables and make sure the directories
 # actually exist
 #
-echo "MY_SQROOt"
+echo "MY_SQROOT"
 echo $MY_SQROOT
 export MY_SQROOT=$MY_SQROOT
 export SQLMX_MODULE_DIR=${MY_SQROOT}/sql/sqlmx/USERMODULES

--- a/core/sql/regress/tools/setuplnxenv
+++ b/core/sql/regress/tools/setuplnxenv
@@ -79,6 +79,8 @@ fi
 # Finally, add the regression variables and make sure the directories
 # actually exist
 #
+echo "MY_SQROOt"
+echo $MY_SQROOT
 export MY_SQROOT=$MY_SQROOT
 export SQLMX_MODULE_DIR=${MY_SQROOT}/sql/sqlmx/USERMODULES
 export SQLMX_SYSMODULE_DIR=${MY_SQROOT}/sql/sqlmx/SYSTEMMODULES

--- a/core/sql/regress/udr/EXPECTED100.SB
+++ b/core/sql/regress/udr/EXPECTED100.SB
@@ -1706,7 +1706,7 @@ OUT2
 >>
 >>obey TEST100(udrtrace);
 >>log;
-Trafodion Conversational Interface @version@
+Conversational Interface @version@
 (c) Copyright 2014 Hewlett-Packard Development Company, LP.
 >>?section udrtrace2
 >>--

--- a/core/sql/regress/udr/FILTER100
+++ b/core/sql/regress/udr/FILTER100
@@ -29,7 +29,8 @@ s/\\[A-Z0-9]\{1,\}\.\$[A-Z0-9][0-9]*:[A-Z0-9][0-9]*/@pid@/g
 s/\\[A-Z0-9]\{1,\}\.\$:[A-Z0-9][0-9]*:[A-Z0-9][0-9]*:[A-Z0-9][0-9]*/@pid@/g
 s/\\[A-Z0-9]\{1,\}\.\$:[A-Z0-9][0-9]*:[A-Z0-9][0-9]*:[A-Z0-9][0-9]*/@pid@/g
 /\[MXUDR\] Container:/s/\(Container: \).*\(\/t100\)/\1@path@\2/
-s/Conversational Interface [0-9][0-9.]*/Conversational Interface @version@/
+#s/Conversational Interface [0-9][0-9.]*/Conversational Interface @version@/
+s/^[A-Za-z ]* Conversational Interface [0-9][0-9.]*/Conversational Interface @version@/
 
 # The following two rules remove JDBC debugging printouts
 # We have these lines because of the internal JDBC version.

--- a/core/sql/sqlmsg/ComDiagsMsg.cpp
+++ b/core/sql/sqlmsg/ComDiagsMsg.cpp
@@ -421,7 +421,6 @@ static const char *returnClassOrigin(Lng32 theSQLCODE, size_t offset)
 {
   char sqlstate[6];
   ComSQLSTATE(theSQLCODE,sqlstate);
-
   // Classes and subclasses starting with letters '0' ... '4', 'A' ... 'H' are
   // defined by ISO/ANSI SQL92. See subclause 18.1, GR 3b) and subclause 22.1.
 
@@ -429,7 +428,7 @@ static const char *returnClassOrigin(Lng32 theSQLCODE, size_t offset)
       (sqlstate[offset] >= 'A' && sqlstate[offset] <= 'H'))
     return "ISO 9075";
   else
-    return COPYRIGHT_XTOP_PRODNAME_H;
+    return (const char *)COPYRIGHT_XTOP_PRODNAME_H;
 }
 
 const char *ComClassOrigin(Lng32 theSQLCODE)


### PR DESCRIPTION
This change addresses the product banners to reflect Apache Trafodion copyright and name.
The copyright and product names have been made envvars in sqencom.sh so we dont' have to touch code in the future to make any updates. 
Changed sqvers output to give detail to show the Apache Trafodion name in it.