### PR TITLE
[TRAFODION-9] Non-blocking hbase operation to smoothen the data flow …

### DIFF
--- a/core/sql/executor/ExHbaseAccess.cpp
+++ b/core/sql/executor/ExHbaseAccess.cpp
@@ -451,6 +451,7 @@ ExHbaseAccessTcb::ExHbaseAccessTcb(
   colVal_.val = 0;
   colVal_.len = 0;
   asyncCompleteRetryCount_ = 0;
+  asyncOperation_ = FALSE;
   asyncOperationTimeout_ = 2;
   resultArray_ = NULL;
 }

--- a/core/sql/executor/ExHbaseAccess.h
+++ b/core/sql/executor/ExHbaseAccess.h
@@ -483,6 +483,7 @@ protected:
   Lng32 colValEntry_;
   Int16 asyncCompleteRetryCount_;
   NABoolean *resultArray_;
+  NABoolean asyncOperation_;
   Int32 asyncOperationTimeout_;
 
   // Redefined and used by ExHbaseAccessBulkLoadPrepSQTcb.
@@ -1144,7 +1145,7 @@ public:
     , CREATE_ROW
     , APPLY_PRED
     , RETURN_ROW
-    , ASYNC_INSERT_COMPLETE
+    , ASYNC_OPERATION_COMPLETE
   } step_;
 
   ExHbaseAccessSQRowsetTcb( const ExHbaseAccessTdb &tdb,

--- a/core/sql/executor/ExHbaseAccess.h
+++ b/core/sql/executor/ExHbaseAccess.h
@@ -836,7 +836,7 @@ public:
     , HANDLE_ERROR
     , DONE
     , ALL_DONE
-    , ASYNC_INSERT_COMPLETE
+    , COMPLETE_ASYNC_INSERT
 
   } step_;
 
@@ -1145,7 +1145,7 @@ public:
     , CREATE_ROW
     , APPLY_PRED
     , RETURN_ROW
-    , ASYNC_OPERATION_COMPLETE
+    , COMPLETE_ASYNC_OPERATION
   } step_;
 
   ExHbaseAccessSQRowsetTcb( const ExHbaseAccessTdb &tdb,

--- a/core/sql/executor/HBaseClient.java
+++ b/core/sql/executor/HBaseClient.java
@@ -1526,7 +1526,7 @@ public class HBaseClient {
                                  Object[] columns,
                                  long timestamp, boolean asyncOperation) throws IOException {
       HTableClient htc = getHTableClient(jniObject, tblName, useTRex);
-      boolean ret = htc.deleteRow(transID, rowID, columns, timestamp);
+      boolean ret = htc.deleteRow(transID, rowID, columns, timestamp, asyncOperation);
       if (asyncOperation == true)
          htc.setJavaObject(jniObject);
       else
@@ -1538,7 +1538,7 @@ public class HBaseClient {
                       long timestamp, 
                       boolean asyncOperation) throws IOException, InterruptedException, ExecutionException {
       HTableClient htc = getHTableClient(jniObject, tblName, useTRex);
-      boolean ret = htc.deleteRows(transID, rowIDLen, rowIDs, timestamp);
+      boolean ret = htc.deleteRows(transID, rowIDLen, rowIDs, timestamp, asyncOperation);
       if (asyncOperation == true)
          htc.setJavaObject(jniObject);
       else

--- a/core/sql/executor/HBaseClient_JNI.cpp
+++ b/core/sql/executor/HBaseClient_JNI.cpp
@@ -3570,7 +3570,7 @@ HTC_RetCode HTableClient_JNI::init()
     JavaMethods_[JM_SCAN_OPEN  ].jm_name      = "startScan";
     JavaMethods_[JM_SCAN_OPEN  ].jm_signature = "(J[B[B[Ljava/lang/Object;JZI[Ljava/lang/Object;[Ljava/lang/Object;[Ljava/lang/Object;FZZILjava/lang/String;Ljava/lang/String;II)Z";
     JavaMethods_[JM_DELETE     ].jm_name      = "deleteRow";
-    JavaMethods_[JM_DELETE     ].jm_signature = "(J[B[Ljava/lang/Object;J)Z";
+    JavaMethods_[JM_DELETE     ].jm_signature = "(J[B[Ljava/lang/Object;JZ)Z";
     JavaMethods_[JM_COPROC_AGGR     ].jm_name      = "coProcAggr";
     JavaMethods_[JM_COPROC_AGGR     ].jm_signature = "(JI[B[B[B[BZI)[B";
     JavaMethods_[JM_GET_NAME   ].jm_name      = "getTableName";
@@ -3851,8 +3851,9 @@ HTC_RetCode HTableClient_JNI::deleteRow(Int64 transID, HbaseStr &rowID, const LI
   if (hbs_)
     hbs_->getTimer().start();
   tsRecentJMFromJNI = JavaMethods_[JM_DELETE].jm_full_name;
+  jboolean j_asyncOperation = FALSE;
   jboolean jresult = jenv_->CallBooleanMethod(javaObj_, 
-          JavaMethods_[JM_DELETE].methodID, j_tid, jba_rowID, j_cols, j_ts);
+          JavaMethods_[JM_DELETE].methodID, j_tid, jba_rowID, j_cols, j_ts, j_asyncOperation);
   if (hbs_)
     {
       hbs_->incMaxHbaseIOTime(hbs_->getTimer().stop());

--- a/core/sql/exp/ExpHbaseInterface.cpp
+++ b/core/sql/exp/ExpHbaseInterface.cpp
@@ -42,8 +42,6 @@
 #include "CmpCommon.h"
 #include "CmpContext.h"
 
-extern Int64 getTransactionIDFromContext();
-
 // ===========================================================================
 // ===== Class ExpHbaseInterface
 // ===========================================================================
@@ -728,11 +726,11 @@ Lng32 ExpHbaseInterface_JNI::deleteRow(
 	  HbaseStr row, 
 	  const LIST(HbaseStr) *columns,
 	  NABoolean noXn,
-	  const int64_t timestamp)
+	  const int64_t timestamp,
+          NABoolean asyncOperation)
 
 {
   HTableClient_JNI *htc;
-  bool asyncOperation = false;
   Int64 transID;
 
   if (noXn)
@@ -756,10 +754,10 @@ Lng32 ExpHbaseInterface_JNI::deleteRows(
           short rowIDLen,
 	  HbaseStr rowIDs,
 	  NABoolean noXn,
-	  const int64_t timestamp)
+	  const int64_t timestamp,
+          NABoolean asyncOperation)
 {
   HTableClient_JNI *htc;
-  bool asyncOperation = false;
   Int64 transID;
 
   if (noXn)

--- a/core/sql/exp/ExpHbaseInterface.h
+++ b/core/sql/exp/ExpHbaseInterface.h
@@ -61,6 +61,8 @@ class ex_globals;
 class CliGlobals;
 class ExHbaseAccessStats;
 
+Int64 getTransactionIDFromContext();
+
 using namespace apache::thrift;
 using namespace apache::thrift::protocol;
 using namespace apache::thrift::transport;
@@ -219,7 +221,8 @@ class ExpHbaseInterface : public NABasicObject
 		  HbaseStr row, 
 		  const LIST(HbaseStr) *columns,
 		  NABoolean noXn,
-		  const int64_t timestamp) = 0;
+		  const int64_t timestamp,
+                  NABoolean asyncOperation) = 0;
 
 
 
@@ -228,7 +231,8 @@ class ExpHbaseInterface : public NABasicObject
                   short rowIDLen,
 		  HbaseStr rowIDs,
 		  NABoolean noXn,
-		  const int64_t timestamp) = 0;
+		  const int64_t timestamp,
+                  NABoolean asyncOperation) = 0;
 
 
   virtual Lng32 checkAndDeleteRow(
@@ -518,7 +522,8 @@ class ExpHbaseInterface_JNI : public ExpHbaseInterface
 		  HbaseStr row, 
 		  const LIST(HbaseStr) *columns,
 		  NABoolean noXn,
-		  const int64_t timestamp);
+		  const int64_t timestamp,
+                  NABoolean asyncOperation);
 
 
   virtual Lng32 deleteRows(
@@ -526,7 +531,8 @@ class ExpHbaseInterface_JNI : public ExpHbaseInterface
                   short rowIDLen,
 		  HbaseStr rowIDs,
 		  NABoolean noXn,		 		  
-		  const int64_t timestamp);
+		  const int64_t timestamp,
+                  NABoolean asyncOperation);
 
 
   virtual Lng32 checkAndDeleteRow(

--- a/core/sql/generator/GenPreCode.cpp
+++ b/core/sql/generator/GenPreCode.cpp
@@ -4925,17 +4925,26 @@ RelExpr * HbaseDelete::preCodeGen(Generator * generator,
 	       (listOfDelUniqueRows_[0].rowIds_.entries() == 1))
 	isUnique = TRUE;
     }
-
+ 
+  if (getInliningInfo().isIMGU()) {
+     // There is no need to do checkAndDelete for IM
+     canDoCheckAndUpdel() = FALSE;
+     uniqueHbaseOper() = FALSE;
+     if ((generator->oltOptInfo()->multipleRowsReturned()) &&
+	  (CmpCommon::getDefault(HBASE_ROWSET_VSBB_OPT) == DF_ON) &&
+	  (NOT generator->isRIinliningForTrafIUD()))
+	 uniqueRowsetHbaseOper() = TRUE;
+  }
+  else
   if (isUnique)
     {
       // do not cancel unique queries.
       generator->setMayNotCancel(TRUE);
       uniqueHbaseOper() = TRUE;
-
       canDoCheckAndUpdel() = FALSE;
       if ((NOT producesOutputs()) &&
 	  (NOT  inlinedActions) &&
-	  (executorPred().isEmpty()))
+          (executorPred().isEmpty()))
 	{
 	  if ((generator->oltOptInfo()->multipleRowsReturned()) &&
 	      (CmpCommon::getDefault(HBASE_ROWSET_VSBB_OPT) == DF_ON) &&
@@ -5183,7 +5192,16 @@ RelExpr * HbaseUpdate::preCodeGen(Generator * generator,
 	       (listOfUpdUniqueRows_[0].rowIds_.entries() == 1))
 	isUnique = TRUE;
     }
-
+  if (getInliningInfo().isIMGU()) {
+     // There is no need to checkAndPut for IM
+     canDoCheckAndUpdel() = FALSE;
+     uniqueHbaseOper() = FALSE;
+     if ((generator->oltOptInfo()->multipleRowsReturned()) &&
+	      (CmpCommon::getDefault(HBASE_ROWSET_VSBB_OPT) == DF_ON) &&
+	      (NOT generator->isRIinliningForTrafIUD()))
+	 uniqueRowsetHbaseOper() = TRUE;
+  }
+  else
   if (isUnique)
     {
       // do not cancel unique queries.
@@ -5882,7 +5900,7 @@ RelExpr * MergeUnion::preCodeGen(Generator * generator,
   condExpr().replaceVEGExpressions(availableValues,
 				   getGroupAttr()->getCharacteristicInputs());
 
-  if (!getUnionForIF())
+  if (!getUnionForIF() && !getInliningInfo().isIMUnion())
     generator->oltOptInfo()->setMultipleRowsReturned(TRUE);
 
   markAsPreCodeGenned();

--- a/core/sql/generator/GenRelUpdate.cpp
+++ b/core/sql/generator/GenRelUpdate.cpp
@@ -2658,8 +2658,16 @@ short HbaseInsert::codeGen(Generator *generator)
 
   if (getInsertType() == Insert::VSBB_INSERT_USER &&
               generator->oltOptInfo()->multipleRowsReturned())
-    downqueuelength = 400;
-
+  {
+    downqueuelength = getDefault(HBASE_ROWSET_VSBB_SIZE);
+    queue_index dq = 1;
+    queue_index bits = downqueuelength;
+    while (bits && dq < downqueuelength) {
+        bits = bits  >> 1;
+        dq = dq << 1;
+    }
+    downqueuelength = dq;
+  }
   char * tablename = NULL;
   if ((getTableDesc()->getNATable()->isHbaseRowTable()) ||
       (getTableDesc()->getNATable()->isHbaseCellTable()))

--- a/core/sql/generator/GenRelUpdate.cpp
+++ b/core/sql/generator/GenRelUpdate.cpp
@@ -1281,6 +1281,10 @@ short HbaseDelete::codeGen(Generator * generator)
 
   generator->initTdbFields(hbasescan_tdb);
 
+  if ((CmpCommon::getDefault(HBASE_ASYNC_OPERATIONS) == DF_ON)
+           && getInliningInfo().isIMGU())
+     hbasescan_tdb->setAsyncOperations(TRUE);
+
   if (getTableDesc()->getNATable()->isHbaseRowTable()) //rowwiseHbaseFormat())
     hbasescan_tdb->setRowwiseFormat(TRUE);
 
@@ -2652,7 +2656,8 @@ short HbaseInsert::codeGen(Generator *generator)
   queue_index downqueuelength = (queue_index)getDefault(GEN_DP2I_SIZE_DOWN);
   Int32 numBuffers = getDefault(GEN_DP2I_NUM_BUFFERS);
 
-  if (getInsertType() == Insert::VSBB_INSERT_USER)
+  if (getInsertType() == Insert::VSBB_INSERT_USER &&
+              generator->oltOptInfo()->multipleRowsReturned())
     downqueuelength = 400;
 
   char * tablename = NULL;
@@ -2765,8 +2770,8 @@ short HbaseInsert::codeGen(Generator *generator)
 
   generator->initTdbFields(hbasescan_tdb);
 
-  if (CmpCommon::getDefault(HBASE_ASYNC_OPERATIONS) == DF_ON
-           && t == ComTdbHbaseAccess::INSERT_)
+  if ((CmpCommon::getDefault(HBASE_ASYNC_OPERATIONS) == DF_ON)
+           && getInliningInfo().isIMGU())
      hbasescan_tdb->setAsyncOperations(TRUE);
 
   if (getTableDesc()->getNATable()->isSeabaseTable())
@@ -2783,8 +2788,10 @@ short HbaseInsert::codeGen(Generator *generator)
 	  (noCheck()))
 	hbasescan_tdb->setHbaseSqlIUD(FALSE);
 
-      if ((getInsertType() == Insert::VSBB_INSERT_USER) ||
-	  (getInsertType() == Insert::UPSERT_LOAD)) {
+      if (((getInsertType() == Insert::VSBB_INSERT_USER) && 
+                   generator->oltOptInfo()->multipleRowsReturned()) ||
+	  (getInsertType() == Insert::UPSERT_LOAD))
+      {
 	hbasescan_tdb->setVsbbInsert(TRUE);
         hbasescan_tdb->setHbaseRowsetVsbbSize(getDefault(HBASE_ROWSET_VSBB_SIZE));
       }

--- a/core/sql/optimizer/Inlining.cpp
+++ b/core/sql/optimizer/Inlining.cpp
@@ -1841,6 +1841,7 @@ RelExpr *GenericUpdate::createIMTree(BindWA *bindWA,
               Union(imTree, createIMNodes(bindWA, useInternalSyskey, index),
                     NULL, NULL, REL_UNION, CmpCommon::statementHeap(), TRUE, TRUE);
             imTree->setBlockStmt(isinBlockStmt());
+            imTree->getInliningInfo().setFlags(II_isIMUnion);
           } // not bulk load
           else {
             RelExpr * oldIMTree = imTree;
@@ -2007,6 +2008,9 @@ static RelExpr *createIMNode(BindWA *bindWA,
 
   // Do not collect STOI info for security checks.
   imNode->getInliningInfo().setFlags(II_AvoidSecurityChecks);
+  
+  // Set the flag that this GU is part of IM
+  imNode->getInliningInfo().setFlags(II_isIMGU);
 
   if (bindWA->isTrafLoadPrep())
     return imNode;
@@ -2101,6 +2105,9 @@ RelExpr *GenericUpdate::createIMNodes(BindWA *bindWA,
 
     // Add a root just to be consistent, so all returns from this method
     // are topped with a RelRoot.
+
+    // Set this Union is part of IM
+    indexOp->getInliningInfo().setFlags(II_isIMUnion);
     indexOp = new (bindWA->wHeap()) RelRoot(indexOp);
   }
 

--- a/core/sql/optimizer/Inlining.h
+++ b/core/sql/optimizer/Inlining.h
@@ -63,71 +63,76 @@ class ForceCardinalityInfo;
 
 enum InliningInfoEnum {
   // this TSJ's child(1) is a temp Insert.
-  II_DrivingTempInsert		= 0x00000001, 
+  II_DrivingTempInsert		= 0x0000000000000001LL, 
+                                 
   // this TSJ's child(1) is a tree of row triggers and RI.
-  II_DrivingPipelinedActions	= 0x00000002,
+  II_DrivingPipelinedActions	= 0x0000000000000002LL,
   // this TSJ's child(1) is a tree of row triggers.
-  II_DrivingRowTrigger		= 0x00000004,
+  II_DrivingRowTrigger		= 0x0000000000000004LL,
   // this Ordered Union's child(1) is a tree of statement triggers.
-  II_DrivingStatementTrigger	= 0x00000008,
+  II_DrivingStatementTrigger	= 0x0000000000000008LL,
   // this Ordered Union's child(1) is a temp Delete.
-  II_DrivingTempDelete		= 0x00000010,
+  II_DrivingTempDelete		= 0x0000000000000010LL,
   // this Union has before triggers on child(0), after triggers on child(1).
-  II_DrivingBeforeTriggers	= 0x00000020,
+  II_DrivingBeforeTriggers	= 0x0000000000000020LL,
   // this Union's child(0) is an RI tree.
-  II_DrivingRI			= 0x00000040,
+  II_DrivingRI			= 0x0000000000000040LL,
   // this TSJ's child(1) is an IM tree.
-  II_DrivingIM			= 0x00000080,
+  II_DrivingIM			= 0x0000000000000080LL,
   // this Union is the IF node of a trigger root.
-  II_TriggerRoot		= 0x00000100,
+  II_TriggerRoot		= 0x0000000000000100LL,
   // located on a DrivingTempDelete node, when before triggers are present.
-  II_BeforeTriggersExist	= 0x00000200,
+  II_BeforeTriggersExist	= 0x0000000000000200LL,
   // Access Sets should be saved in this node.
-  II_AccessSetNeeded		= 0x00000400,
+  II_AccessSetNeeded		= 0x0000000000000400LL,
   // this Tuple node should be removed during transformation.
-  II_DummyStatement		= 0x00000800,
+  II_DummyStatement		= 0x0000000000000800LL,
   // this EffectiveGU has also row triggers, RI or IM to
   // pipeline values to.
-  II_hasPipelinedActions	= 0x00001000,
+  II_hasPipelinedActions	= 0x0000000000001000LL,
   // this GenericUpdate is the Effective GU of a before trigger. 
   // Do not do inlining again.
-  II_EffectiveGU		= 0x00002000,
+  II_EffectiveGU		= 0x0000000000002000LL,
   // This RelRoot node is on top of the RI action.
-  II_ActionOfRI			= 0x00004000,
+  II_ActionOfRI			= 0x0000000000004000LL,
   // avoid security checks
-  II_AvoidSecurityChecks		= 0x00008000,
+  II_AvoidSecurityChecks		= 0x0000000000008000LL,
   // Does the outputs of this GU go to an MV log (CurrentEpoch required)?
-  II_isMVLoggingInlined		= 0x00010000,
+  II_isMVLoggingInlined		= 0x0000000000010000LL,
   // Marks the MV log insert TSJ for the push-to-DP2 transformation rule.
-  II_DrivingMvLogInsert		= 0x00020000,
+  II_DrivingMvLogInsert		= 0x0000000000020000LL,
   // VSBB Insert drives MV range logging and also IM etc.
-  II_ProjectMidRangeRows        = 0x00040000,
+  II_ProjectMidRangeRows        = 0x0000000000040000LL,
   // Need to project the OLD/NEW outputs from the GU node, for other purposes.
-  II_NeedGuOutputs              = 0x00080000,
+  II_NeedGuOutputs              = 0x0000000000080000LL,
   // Don't apply join commutativity rule
-  II_JoinChildsOrder		= 0x00100000,
+  II_JoinChildsOrder		= 0x0000000000100000LL,
   // Force MDAM on the table
-  II_MdamForcedByInlining	= 0x00200000,
+  II_MdamForcedByInlining	= 0x0000000000200000LL,
   // Force Single execution for TSJ
-  II_SingleExecutionForTSJ	= 0x00400000,
+  II_SingleExecutionForTSJ	= 0x0000000000400000LL,
   // Enable the use of First N Rows for Mvlog
-  II_EnableFirstNRows		= 0x00800000,
+  II_EnableFirstNRows		= 0x0000000000800000LL,
   // Do not implement using the Materialize node
-  II_MaterializeNodeForbidden	= 0x01000000,
+  II_MaterializeNodeForbidden	= 0x0000000001000000LL,
   // this GU has IM
-  II_hasIM	                = 0x02000000,
+  II_hasIM	                = 0x0000000002000000LL,
   // this GU has some inlined actions(IM, RI, triggers, MV logging...)
-  II_hasInlinedActions          = 0x04000000,
+  II_hasInlinedActions          = 0x0000000004000000LL,
   // this GU has RI
-  II_hasRI                      = 0x08000000,
+  II_hasRI                      = 0x0000000008000000LL,
   // this GU has Triggers
-  II_hasTriggers                = 0x10000000,
+  II_hasTriggers                = 0x0000000010000000LL,
   // Force Single execution for TSJ driving row Triggers
-  II_SingleExecutionForTriggersTSJ	= 0x20000000,
+  II_SingleExecutionForTriggersTSJ	= 0x0000000020000000LL,
   // this update operator is part of an action of a row trigger
-  II_InActionOfRowTrigger     	= 0x40000000,
+  II_InActionOfRowTrigger     	= 0x0000000040000000LL,
   // Is this RelRoot, Union, or Insert used in MV logging -- ONLY USED FOR PUSH DOWN
-  II_isUsedForMvLogging         = 0x80000000
+  II_isUsedForMvLogging         = 0x0000000080000000LL,
+  // Is this generic update a part of IM
+  II_isIMGU                     = 0x0000000100000000LL,
+  // is this Union a part of IM
+  II_isIMUnion                  = 0x0000000200000000LL,
   
 };
 
@@ -219,6 +224,11 @@ public:
     return ( isDrivingBeforeTriggers() ||
 	     (isDrivingTempDelete() && !isDrivingBeforeTriggers() ) );
   }
+  inline NABoolean
+  isIMGU()	      const { return forceBool(II_isIMGU); }
+
+  inline NABoolean
+  isIMUnion()	      const { return forceBool(II_isIMUnion); }
 
   inline NABoolean isSystemGenerated() const { return flags_ ? TRUE: FALSE; }
 
@@ -241,8 +251,8 @@ public:
   // LCOV_EXCL_STOP
   
   // Mutators
-  inline void setFlags(Int32 flags)                {flags_ |= flags;}
-  inline void resetFlags(Int32 flags)              {flags_ &= ~flags;}
+  inline void setFlags(Int64 flags)                {flags_ |= flags;}
+  inline void resetFlags(Int64 flags)              {flags_ &= ~flags;}
   inline void setTriggerObject(Trigger *trigger) {triggerObject_ = trigger;}
 
   void merge(InliningInfo *other);
@@ -261,7 +271,7 @@ private:
   inline NABoolean forceBool(InliningInfoEnum bitToTest) const
     { return (flags_ & bitToTest) ? TRUE : FALSE; }
 
-  Int32	     flags_;
+  Int64	     flags_;
   Trigger   *triggerObject_;
 
   //++MV

--- a/core/sql/sqlcomp/nadefaults.cpp
+++ b/core/sql/sqlcomp/nadefaults.cpp
@@ -1734,7 +1734,7 @@ SDDkwd__(EXE_DIAGNOSTIC_EVENTS,		"OFF"),
   // HBASE_SQL_IUD_SEMANTICS:      Off: Don't check for existing rows for insert/update
 
   DDkwd__(HBASE_ASYNC_DROP_TABLE,		"OFF"),
-  DDkwd__(HBASE_ASYNC_OPERATIONS,		"OFF"),
+  DDkwd__(HBASE_ASYNC_OPERATIONS,		"ON"),
  // HBASE_CACHE_BLOCKS, ON => cache every scan, OFF => cache no scan
  // SYSTEM => cache scans which take less than 1 RS block cache mem.
  DDui___(HBASE_BLOCK_SIZE,                      "65536"),

--- a/core/sql/sqlcomp/nadefaults.cpp
+++ b/core/sql/sqlcomp/nadefaults.cpp
@@ -1770,7 +1770,7 @@ SDDkwd__(EXE_DIAGNOSTIC_EVENTS,		"OFF"),
  DDui___(HBASE_REGION_SERVER_MAX_HEAP_SIZE,     "1024"), // in units of MB
 
   DDkwd__(HBASE_ROWSET_VSBB_OPT,		"ON"),
-  DDusht_(HBASE_ROWSET_VSBB_SIZE,        	"1000"),
+  DDusht_(HBASE_ROWSET_VSBB_SIZE,        	"1024"),
   DDflt0_(HBASE_SALTED_TABLE_MAX_FILE_SIZE,	"0"),
   DDkwd__(HBASE_SALTED_TABLE_SET_SPLIT_POLICY,	"ON"),
   DD_____(HBASE_SCHEMA,                         "HBASE"),

--- a/dcs/src/main/java/org/trafodion/dcs/zookeeper/ZkClient.java
+++ b/dcs/src/main/java/org/trafodion/dcs/zookeeper/ZkClient.java
@@ -160,8 +160,8 @@ public class ZkClient implements Watcher {
 			
 			if(this.zk.getState() != ZooKeeper.States.CONNECTED) {
 				this.zk.close();
-				this.zk=null;
 				LOG.error("Zookeeper.State [" + this.zk.getState() + "]");
+				this.zk=null;
 				throw new IOException("Cannot connect to Zookeeper");
 			}
 			


### PR DESCRIPTION
…in trafodion engine

The non-blocking Hbase operation for the index maintenance operators is now enabled by
default for IUD, merge and update commands.

The Hbase operations put, checkAndPut and delete operations from the trafodion engine
for the index maintenance is done using Executor Services to make it non-blocking and the
data flow in the trafodion operators can continue up to the point till it needs to pause for completion.

checkAndDelete is never used for index maintenance now.

Also, ensured that index maintenance uses rowset or single row operators when it should.