### PR TITLE
[TRAFODION-1494] UPD STATS used serial plans for sample table

### DIFF
--- a/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
@@ -1663,7 +1663,7 @@ void CmpSeabaseDDL::restoreAllControlsAndFlags()
   cliRC = cliInterface.executeImmediate("control query shape restore;");
 
   if (CmpCommon::context()->getCntlCount() > 0 &&
-      CmpCommon::context()->getCntlCount() < CQD_SENT_MAX)
+      CmpCommon::context()->getCntlCount() <= CQD_SENT_MAX)
     {
   cliRC = cliInterface.restoreCQD("volatile_schema_in_use");
 


### PR DESCRIPTION
Fixes a bug in UPDATE STATS. UPDATE STATS when used with the SAMPLE clause creates a sample of data from a table. If the sample is too large to fit in memory, it writes that sample to a temporary table. It uses an UPSERT or LOAD statement to do so. The bug is that the plan chosen for this UPSERT/LOAD was a serial plan, when a parallel plan should have been selected. For details on the bug, see the JIRA.