### PR TITLE
[TRAFODION-1492] Allow specification of MaxHeapSize for JVM started by UDR server

### DIFF
--- a/core/sqf/conf/install_features
+++ b/core/sqf/conf/install_features
@@ -1,6 +1,28 @@
 #!/bin/bash
 #
-# Install feature file ($MY_SQROOT/etc/install_features)
+# @@@ START COPYRIGHT @@@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# @@@ END COPYRIGHT @@@
+#
+
+# Install feature file ($MY_SQROOT/conf/install_features)
 #
 # This file allows specific Trafodion core builds to signal to
 # the installer the presence of a new feature that requires

--- a/core/sqf/conf/trafodion.udr.config
+++ b/core/sqf/conf/trafodion.udr.config
@@ -1,0 +1,52 @@
+# @@@ START COPYRIGHT @@@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# @@@ END COPYRIGHT @@@
+#
+
+# Configuration file for TDM_UDRSERV process
+# Located at $MY_SQROOT/conf/trafodion.udr.config
+# Location of property file can be specified through TRAFUDRCFG env variable
+# TRAFUDRCFG will override this default implementation of the property file.
+# Properties specfied are passed on to the JVM created by the TDM_UDRSERV
+# Can be overridden by env variable TRAF_UDR_JAVA_OPTIONS in 
+# $MY_SQROOT/etc/ms.env
+# Incorrect property values or specification syntax can result in TDM_UDRSERV
+# not being able to initialize a JVM.
+# Properties must be specified in a section titled "java".
+# Section titles are enclosed in "[" paranthesis.
+# For example "[java]"
+# Each line contains a separate property.
+# Optional comments can follow the property if they are preceeded by a ";".
+# Maximum allowed length of a line is 1024 characters.
+# For example "-Xmx750m ; max java heap size" is valid (without quotes)
+# "-Xmx-750m" is valid
+# "-Xmx=750m" is not valid
+# "-Xmx750m" /* max java heap size */" is not valid
+# The end of a section is indicated with the same line as it's title, i.e. 
+# "[java]". The line indicating section end is optional
+# At present the only section heading TDM_UDRSERV will process is "[java]"
+# Place any required property specfication between the section title and
+# end below.
+[java]
+
+[java]
+
+
+

--- a/core/sql/executor/JavaObjectInterface.cpp
+++ b/core/sql/executor/JavaObjectInterface.cpp
@@ -27,8 +27,8 @@
 #include "ComUser.h"
 
 // Changed the default to 512 to limit java heap size used by SQL processes.
+// Keep this define in sync with udrserv/udrserv.cpp
 #define DEFAULT_JVM_MAX_HEAP_SIZE 512
-#define USE_JVM_DEFAULT_MAX_HEAP_SIZE 0
 #define TRAF_DEFAULT_JNIHANDLE_CAPACITY 32
 // ===========================================================================
 // ===== Class JavaObjectInterface

--- a/core/sql/udrserv/UdrCfgParser.cpp
+++ b/core/sql/udrserv/UdrCfgParser.cpp
@@ -44,22 +44,15 @@ NABoolean UdrCfgParser::cfgFileIsOpen(NAString &errorText)
 
    NABoolean envFound = FALSE;
 
-   if(cfgFileName = getenv("MXUDRCFG"))
+   if(cfgFileName = getenv("TRAFUDRCFG"))
    {
       envFound = TRUE;
-      UDR_DEBUG1("UdrCfgParser(): MXUDRCFG cfgFileName is %s", cfgFileName);
+      UDR_DEBUG1("UdrCfgParser(): TRAFUDRCFG cfgFileName is %s", cfgFileName);
    }
    else
    {
-     NAString s("c:/tdm_sql/udr/mxudrcfg");
-     char installdir[1024];
-     Lng32 resultlength = 0;
-     Int32 res = ComRtGetInstallDir(installdir, 1024, &resultlength);
-     if (res == 0)
-     {
-       s = installdir;
-       s += "/mxudrcfg";
-     }
+     NAString s(getenv("MY_SQROOT"));
+     s += "/conf/trafodion.udr.config";
      cfgFileName = strdup(s.data());
      UDR_DEBUG1("UdrCfgParser(): default cfgFileName is %s", cfgFileName);
    }
@@ -73,7 +66,7 @@ NABoolean UdrCfgParser::cfgFileIsOpen(NAString &errorText)
          errorText += cfgFileName;
          errorText += ": ";
          errorText += strerror(errno);
-         errorText += ". Check envvar MXUDRCFG setting.\n";
+         errorText += ". Check envvar TRAFUDRCFG setting.\n";
       }
 
       return FALSE;

--- a/core/sql/udrserv/udrserv.cpp
+++ b/core/sql/udrserv/udrserv.cpp
@@ -170,24 +170,28 @@ static Int32 invokeUdrMethod(const char *method,
 // LCOV_EXCL_START
 // Dead Code
 // These methods are not used, and the interface has not been tested for a long time.
-// Andy is of the opinion that we might want to retire them
+// We might want to retire them
 static Int32 processCommandsFromFile(const char *filename, UdrGlobals &glob);
 static Int32 processSingleCommandFromFile(FILE *f, UdrGlobals &glob);
 // LCOV_EXCL_STOP
+
+// Changed the default to 512 to limit java heap size used by SQL processes.
+// Keep this define in sync with executor/JavaObjectInterface.cpp
+#define DEFAULT_JVM_MAX_HEAP_SIZE 512
 
 static NAString initErrText("");
 /*************************************************************************
    Helper function to propagate all Java-related environment settings
    found in an optional configuration file into an LmJavaOptions instance.
 
-   File must be in location indicated by envvar MXUDRCFG, or if not found, use
-   default of /usr/tandem/sqlmx/udr/mxudrcfg (NT default is c:/tdm_sql/udr/mxudrcfg)
+   File must be in location indicated by envvar TRAFUDRCFG, or if not found, 
+   use default of $MY_SQROOT/conf/trafodion.udr.config
 *************************************************************************/
 void readCfgFileSection ( const char *section, LmJavaOptions &javaOptions )
 {
    char *p = NULL;
    char buffer [BUFFMAX+1];
-   
+
    while ((UdrCfgParser::readSection(section, buffer, sizeof(buffer), initErrText )) > 0)
    {
       UDR_DEBUG2("[%s] entry: %s", section, buffer);
@@ -227,7 +231,11 @@ void InitializeJavaOptionsFromEnvironment(LmJavaOptions &javaOptions
    {
       javaOptions.addSystemProperty("java.class.path", val);
    }
-
+   char maxHeapOption[64];
+   int maxHeapEnvvarMB = DEFAULT_JVM_MAX_HEAP_SIZE;
+   sprintf(maxHeapOption, "-Xmx%dm", maxHeapEnvvarMB);
+   javaOptions.addOption((const char *)maxHeapOption, TRUE);
+   
    /* Look for java startup options and envvars in configuration file */
    if (UdrCfgParser::cfgFileIsOpen(initErrText))
    {
@@ -236,7 +244,7 @@ void InitializeJavaOptionsFromEnvironment(LmJavaOptions &javaOptions
       UdrCfgParser::closeCfgFile();
    }
 
-   if ((val = getenv("SQLMX_JAVA_OPTIONS")))
+   if ((val = getenv("TRAF_UDR_JAVA_OPTIONS")))
    {
       const char *delimiters = " \t";
       bool newlineIsPresent = (strchr(val, '\n') ? true : false);


### PR DESCRIPTION
This is a fix for the second of the two issues described in this JIRA. The first 
has been addressed by narendra in a separate checkin. 

In this checkin we allow multiple methods to specify JVM startup options for the 
UDR server process. There are three methods applied in this order with the last 
specification for each property superceeding previous specifications.
1. A default default of 512MB for UDR JVM's max heap size
2. Specify any desired property including -Xmx in a new configuration file
3. Specify any desired property using TRAF_UDR_JAVA_OPTIONS env variable

The new configuration file is at $MY_SQROT/conf/trafodion.udr.config. It has 
detailed comments on how properties should be specified in the file. The location 
(including name) of the configuration file can be overridden with the env variable
TRAFUDRCFG.

The TRAF_UDR_JAVA_OPTIONS env variable must be specified in $MY_SQROOT/etc/ms.env 
for it to be visible to the UDR server. Multiple properties can be separated by a 
'\t' (TAB) chracater or the '\n' (newline) character