### PR TITLE
[TRAFODION-1514] Stop using custom suffix (Nv44) of ICU libs.

### DIFF
--- a/core/conn/unixodbc/odbc/odbcclient/unixcli/makefile.lnx
+++ b/core/conn/unixodbc/odbc/odbcclient/unixcli/makefile.lnx
@@ -29,7 +29,7 @@ VPATH = ./DrvrManager:./trace:./cli:./TCPIPV4:./Interface:./common:./platform:./
 
 C_FLAGS = -m64 -Dunixcli -DVERSION3 -DMXLINUX -DDISABLE_TRACE -DSIZEOF_LONG=8 -DSIZEOF_LONG_INT=8 -Wall -fPIC -w -DASYNCIO -DTRACE_COMPRESSION -I$(ICU)/linux64/include -I/usr/include/openssl
 
-LIBS = -lpthread -lrt -ldl -lz -L$(ICU)/linux64/lib -licuucNv44 -Wl,--hash-style=both /usr/lib64/libssl.a /usr/lib64/libcrypto.a -Wl,--version-script=linux.exports
+LIBS = -lpthread -lrt -ldl -lz -L$(ICU)/linux64/lib -licuuc -Wl,--hash-style=both /usr/lib64/libssl.a /usr/lib64/libcrypto.a -Wl,--version-script=linux.exports
 
 ifeq ($(MAKECMDGOALS),linux64_release)
 	OBJDIR = ./obj/linux64/release/

--- a/core/conn/unixodbc/odbc/odbcclient/unixcli/package/linux64_install.sh
+++ b/core/conn/unixodbc/odbc/odbcclient/unixcli/package/linux64_install.sh
@@ -40,7 +40,7 @@ ETC_DIR=
 INCLUDE_DIR=
 SAMPLE_DIR=
 #package files, excluding this file
-pkgfiles=(libhpodbc_l64.so.?.*.? MXODSN MD5SUM LICENSE hpsqlext.h connect_test.cpp license.txt libicuucNv44.so.44 libicudataNv44.so.44)
+pkgfiles=(libhpodbc_l64.so.?.*.? MXODSN MD5SUM LICENSE hpsqlext.h connect_test.cpp license.txt libicuuc.so.44 libicudata.so.44)
 
 #check whether the package directory has all files (or this script is invoked form "PkgTmp" dir)
 function check_package {
@@ -151,9 +151,9 @@ function install_lib {
       err=0
       mv -f $lib $lib.SAV
       (( err += $? ))
-	  mv -f libicuucNv44.so.44 libicuucNv44.so.44.SAV     
+	  mv -f libicuuc.so.44 libicuuc.so.44.SAV     
       (( err += $? ))   
-	  mv -f libicudataNv44.so.44 libicudataNv44.so.44.SAV     
+	  mv -f libicudata.so.44 libicudata.so.44.SAV     
       (( err += $? ))    
       #remove link
       rm -f libhpodbc_l64.so.$ver
@@ -168,21 +168,21 @@ function install_lib {
    fi
    #copy library
    err=0
-   cp -f $PKG_DIR/libicuucNv44.so.44  .
+   cp -f $PKG_DIR/libicuuc.so.44  .
    (( err += $? ))
-   chmod 555 libicuucNv44.so.44
+   chmod 555 libicuuc.so.44
    (( err += $? ))
-   rm -f libicuucNv44.so
+   rm -f libicuuc.so
    (( err += $? ))
-   ln -s libicuucNv44.so.44 libicuucNv44.so
+   ln -s libicuuc.so.44 libicuuc.so
    (( err += $? ))
-   cp -f $PKG_DIR/libicudataNv44.so.44  .
+   cp -f $PKG_DIR/libicudata.so.44  .
    (( err += $? ))
-   chmod 555 libicudataNv44.so.44
+   chmod 555 libicudata.so.44
    (( err += $? ))       
-   rm -f libicudataNv44.so
+   rm -f libicudata.so
    (( err += $? ))       
-   ln -s libicudataNv44.so.44 libicudataNv44.so
+   ln -s libicudata.so.44 libicudata.so
    (( err += $? ))       
    cp -f $PKG_DIR/libhpodbc_l64.so.?.*.? .
    (( err += $? ))

--- a/core/conn/unixodbc/odbc/odbcclient/unixcli/package/mklnxpkg.sh
+++ b/core/conn/unixodbc/odbc/odbcclient/unixcli/package/mklnxpkg.sh
@@ -95,9 +95,9 @@ then
     let err=0
     cp ../../../libtrafodbc_l64.so ${libname##*/}
     ((err += $?))
-    cp ${ICU}/linux64/lib/libicuucNv44.so.44.0 libicuucNv44.so.44
+    cp ${ICU}/linux64/lib/libicuuc.so.44.0 libicuuc.so.44
     ((err += $?))
-    cp ${ICU}/linux64/lib/libicudataNv44.so.44.0 libicudataNv44.so.44
+    cp ${ICU}/linux64/lib/libicudata.so.44.0 libicudata.so.44
     ((err += $?))
     md5sum ./${libname##*/} >  MD5SUM
     ((err += $?))

--- a/core/conn/unixodbc/odbc/odbcclient/unixcli/package/trafodbclnx_install.sh
+++ b/core/conn/unixodbc/odbc/odbcclient/unixcli/package/trafodbclnx_install.sh
@@ -40,7 +40,7 @@ ETC_DIR=
 #INCLUDE_DIR=
 SAMPLE_DIR=
 #package files, excluding this file
-pkgfiles=(libtrafodbc_l64.so TRAFDSN MD5SUM LICENSE connect_test.cpp license.txt libicuucNv44.so.44 libicudataNv44.so.44)
+pkgfiles=(libtrafodbc_l64.so TRAFDSN MD5SUM LICENSE connect_test.cpp license.txt libicuuc.so.44 libicudata.so.44)
 
 #check whether the package directory has all files (or this script is invoked form "PkgTmp" dir)
 function check_package {
@@ -146,9 +146,9 @@ function install_lib {
       err=0
       mv -f $lib $lib.SAV
       (( err += $? ))
-	  mv -f libicuucNv44.so.44 libicuucNv44.so.44.SAV     
+	  mv -f libicuuc.so.44 libicuuc.so.44.SAV     
       (( err += $? ))   
-	  mv -f libicudataNv44.so.44 libicudataNv44.so.44.SAV     
+	  mv -f libicudata.so.44 libicudata.so.44.SAV     
       (( err += $? ))    
       #remove link
       rm -f libtrafodbc_l64.so.1
@@ -163,21 +163,21 @@ function install_lib {
    fi
    #copy library
    err=0
-   cp -f $PKG_DIR/libicuucNv44.so.44  .
+   cp -f $PKG_DIR/libicuuc.so.44  .
    (( err += $? ))
-   chmod 555 libicuucNv44.so.44
+   chmod 555 libicuuc.so.44
    (( err += $? ))
-   rm -f libicuucNv44.so
+   rm -f libicuuc.so
    (( err += $? ))
-   ln -s libicuucNv44.so.44 libicuucNv44.so
+   ln -s libicuuc.so.44 libicuuc.so
    (( err += $? ))
-   cp -f $PKG_DIR/libicudataNv44.so.44  .
+   cp -f $PKG_DIR/libicudata.so.44  .
    (( err += $? ))
-   chmod 555 libicudataNv44.so.44
+   chmod 555 libicudata.so.44
    (( err += $? ))
-   rm -f libicudataNv44.so
+   rm -f libicudata.so
    (( err += $? ))
-   ln -s libicudataNv44.so.44 libicudataNv44.so
+   ln -s libicudata.so.44 libicudata.so
    (( err += $? ))
    cp -f $PKG_DIR/libtrafodbc_l64.so .
    (( err += $? ))

--- a/install/traf_tools_setup.sh
+++ b/install/traf_tools_setup.sh
@@ -229,7 +229,7 @@ cd $BASEDIR
 wget http://download.icu-project.org/files/icu4c/4.4/icu4c-4_4-src.tgz
 tar -xzf icu4c-4_4-src.tgz
 cd icu/source
-./configure --with-library-suffix=Nv44 --prefix=$TOOLSDIR/icu4.4/linux64
+./configure --prefix=$TOOLSDIR/icu4.4/linux64
 make
 make check
 make install


### PR DESCRIPTION
We keep using our customized suffix from Neoview time, Nv4,
for ICU lib files, this causes confusion to developers who wants
to build Linux ODBC driver. Remove this suffix from the name of
lib files, to get rid of the confusion.