### PR TITLE
TRAFODION-1504 check for environment in sqgen

### DIFF
--- a/core/sqf/sql/scripts/install_local_hadoop
+++ b/core/sqf/sql/scripts/install_local_hadoop
@@ -844,6 +844,9 @@ read YN
 
 if [ "\$YN" = "y" -o "\$YN" = "Y" ]; then
   rm -rf $MY_SW_ROOT
+  # also remove the convenience scripts
+  cds
+  rm sw*
   echo "Removed $MY_SW_ROOT"
 else
   echo "Exiting without removing anything..."

--- a/core/sqf/sql/scripts/sqgen
+++ b/core/sqf/sql/scripts/sqgen
@@ -98,6 +98,23 @@ elif [[ $sq_stat == 2 ]]; then
    exit 1
 fi
 
+# Make sure sqgen uses the latest environment
+cd $MY_SQROOT
+if [ "$SQ_BUILD_TYPE" == "release" -a -f sqenvr.sh ]; then
+  . ./sqenvr.sh
+else
+  . ./sqenv.sh
+fi
+
+if [ -n "$CHANGED_SQ_ENV_RESTART_SHELL" ]; then
+  # This is set by sqenvcom.sh when the environment has changed
+  # in the shell. The CLASSPATH and other variables are not reliable
+  # in such a situation and we should not do an sqgen.
+  echo "A change in environment variables occurred."
+  echo "Please retry sqgen in a new shell. Exiting..."
+  exit 1
+fi
+
 cd $MY_SQROOT/sql/scripts
 
 # Check to make sure this is a real cluster


### PR DESCRIPTION
Avoid the common mistake of doing an sqgen in an environment that
is not clean, where changes to CLASSPATH or other environment variables
have been done after sourcing sqenv.sh.

This commit also fixes TRAFODION-1505, delete the sw* convenience scripts
created by install_local_hadoop when we do swuninstall_local_hadoop.