### PR TITLE
[TRAFODION-1516] A trafodion infrastructure program mxssmp dumps cor…

### DIFF
--- a/core/sql/executor/ExStats.cpp
+++ b/core/sql/executor/ExStats.cpp
@@ -11127,7 +11127,7 @@ Lng32 ExStatsTcb::str_parse_stmt_name(char *string, Lng32 len, char *nodeName,
        tempNum =  str_atoi(pidTemp, str_len(pidTemp));
        if (tempNum < 0)
           tempNum = -1;
-       *pid = (short)tempNum;
+       *pid = (pid_t)tempNum;
     }
   }
   if (timeTemp != NULL)
@@ -11155,7 +11155,7 @@ Lng32 ExStatsTcb::str_parse_stmt_name(char *string, Lng32 len, char *nodeName,
   if (etTemp != NULL)
   {
     tempNum =  atoi(etTemp);
-    *filter = (short)tempNum;
+    *filter = (Lng32)tempNum;
     retcode = SQLCLI_STATS_REQ_ET_OFFENDER;
   }
   if (nodeNameTemp != NULL)


### PR DESCRIPTION
…e at times

SSMP was dumping core sometimes when the DCS MASTER tries to cancel a query using pid.
When the pid is more than 32767,  the executor was not handling it correctly resulting
in negative number for pid. This resulted in partial junk message being sent to SSMP.
The junk message causes ssmp to dump core sometimes.