### PR TITLE
Fix for Phoenix T2 test failures due to missing DTM classes.

### DIFF
--- a/tests/phx/pom.xml.template
+++ b/tests/phx/pom.xml.template
@@ -204,6 +204,14 @@
     </dependency>
 
     <dependency>
+      <groupId>org.trafodion.dtm</groupId>
+      <artifactId>trafodion-dtm</artifactId>
+      <version>${env.TRAFODION_VER}</version>
+      <scope>system</scope>
+      <systemPath>${env.MY_SQROOT}/export/lib/trafodion-dtm-${env.TRAFODION_VER}.jar</systemPath>
+     </dependency>
+
+    <dependency>
       <groupId>org.trafodion.sql</groupId>
       <artifactId>trafodion-sql</artifactId>
       <version>${env.TRAFODION_VER}</version>


### PR DESCRIPTION
The new trafodion-dtm-1.2.0.jar file needed to be added to the
Phoenix tests as well, those are using Maven, not the CLASSPATH
set up in sqenvcom.sh.