### PR TITLE
[TRAFODION-1532] TEST042 allowing longer compile time

### DIFF
--- a/core/sql/regress/compGeneral/FILTER042
+++ b/core/sql/regress/compGeneral/FILTER042
@@ -50,6 +50,8 @@ sed "/Elapsed Time.*/d" |
 sed "/Execution Time.*/d" |
 sed "/Table ID.*/d" |
 sed "/Hist ID.*/d" |
+sed "/System load:.*/d" |
+sed "/CPU frequency:.*/d" |
 awk '
 {
 # we are looking for a less than 1 ms compile time
@@ -68,14 +70,8 @@ awk '
      split($3, a, "."); \
      if ( !match(a[1], "00:00:00") ) \
        print "FAIL (at least one second)", $0; \
-     else { \
-              split(a[2], b, ""); \
-              if ((b[1] == 0) && (b[2]==0) &&  \
-                  ((b[3] == 0) || ((b[3] == 1) && ((b[4] < 4) || (ENVIRON["ON_A_VM"] = "yes"))) )) \
-                  print "SUCCESS (less than 1ms)"; \
-              else \
-                  print "FAIL (at least 1ms)", $0; \
-     }; \
+     else \ 
+       print "SUCCESS (less than 1ms)";   \
    } else \
      print; \
 }
@@ -92,5 +88,7 @@ sed "/Execution Time.*/d" |
 sed "/Table ID.*/d" |
 sed "/Hist ID.*/d" |
 sed "/Compile Time.*/d"
+sed "/System load:.*/d" |
+sed "/CPU frequency:.*/d" |
 fi
 

--- a/core/sql/regress/compGeneral/TEST042
+++ b/core/sql/regress/compGeneral/TEST042
@@ -559,6 +559,8 @@ sh rm hqc.log;
 
 -- test compile time
 
+sh more /proc/loadavg  | cut -d' ' -f 1-3 | sed -e 's/^/System load: /';
+sh grep "model name" /proc/cpuinfo | head -1 | cut -d '@' -f 2 | sed -e 's/^/CPU frequency: /';
 set statistics on;
 prepare xx from select * from t042_orderline where ol_o_id = 1 ;
 explain options 'f' xx;


### PR DESCRIPTION
Allowing longer compile time in TEST042, and add system information just before compile time test.
1. Extent success range to is less than 1 second for hybrid query cache.
2. Add and filter out System load: and CPU frequency: information.