### PR TITLE
fix JIRA461

### DIFF
--- a/core/sql/export/NAStringDef.h
+++ b/core/sql/export/NAStringDef.h
@@ -515,6 +515,8 @@ friend class NASubString;
   
 };
 
+typedef NAString* NAStringPtr;
+
 SQLEXPORT_LIB_FUNC NAString toLower(const NAString&);   // Return lower-case version of argument.
 
 

--- a/core/sql/optimizer/EncodedKeyValue.cpp
+++ b/core/sql/optimizer/EncodedKeyValue.cpp
@@ -305,6 +305,7 @@ short encodeKeyValues(desc_struct   * column_descs,
 		      desc_struct   * key_descs,
 		      NAString      * inValuesArray[],          // INPUT
                       NABoolean isIndex,
+                      NABoolean isMaxKey,                       // INPUT
 		      char * encodedKeyBuffer,                  // OUTPUT
                       CollHeap * h,
 		      ComDiagsArea * diagsArea)
@@ -350,7 +351,7 @@ short encodeKeyValues(desc_struct   * column_descs,
       }
 
       if (inValuesArray[i] == NULL)
-	inValuesArray[i] = getMinMaxValue(column, key, FALSE, h);
+	inValuesArray[i] = getMinMaxValue(column, key, isMaxKey, h);
       
       ItemExpr * itemExpr = buildEncodeTree(column, key, inValuesArray[i],
 					    &generator, diagsArea);

--- a/core/sql/optimizer/EncodedKeyValue.h
+++ b/core/sql/optimizer/EncodedKeyValue.h
@@ -64,6 +64,7 @@ short encodeKeyValues(desc_struct   * column_descs,
 		      desc_struct   * key_descs,
 		      NAString      * inValuesArray[],          // INPUT
                       NABoolean isIndex,
+                      NABoolean isMaxKey,			// INPUT
 		      char * encodedKeyBuffer,                  // OUTPUT
                       CollHeap * h,
 		      ComDiagsArea * diagsArea);

--- a/core/sql/optimizer/ItemColRef.h
+++ b/core/sql/optimizer/ItemColRef.h
@@ -838,6 +838,8 @@ public:
   void setIsCachedParam(NABoolean isCachedParam = TRUE)  
   { isCachedParam_ = isCachedParam; }
 
+  NABoolean isSystemGeneratedOutputHV() const;
+
   NAString& getPrototypeValue() 	   { return prototypeValue_; }
   const NAString& getPrototypeValue() const { return prototypeValue_; } // LCOV_EXCL_LINE
   NABoolean hasPrototypeValue() const	   { return !prototypeValue_.isNull(); }

--- a/core/sql/optimizer/ItemExpr.cpp
+++ b/core/sql/optimizer/ItemExpr.cpp
@@ -14906,3 +14906,80 @@ NABoolean LOBoper::isCovered
   return FALSE;
 }
 
+// Compute the exprssion at compile time. Assume all operands are constants.
+// Return NULL if the computation fails and CmpCommon::diags() may be side-affected.
+ConstValue* ItemExpr::compute(CollHeap* heap)
+{
+  ValueIdList exprs;
+  exprs.insert(getValueId());
+
+  const NAType& dataType = getValueId().getType();
+
+  Lng32 decodedValueLen = dataType.getNominalSize() + dataType.getSQLnullHdrSize();
+
+  char staticDecodeBuf[200];
+  Lng32 staticDecodeBufLen = 200;
+
+  char* decodeBuf = staticDecodeBuf;
+  Lng32 decodeBufLen = staticDecodeBufLen;
+
+  // For character types, multiplying by 8 to deal with conversions between
+  // any two known character sets supported.  
+  Lng32 factor = (DFS2REC::isAnyCharacter(dataType.getFSDatatype())) ? 8 : 1;
+
+  if ( staticDecodeBufLen < decodedValueLen * factor) {
+    decodeBufLen = decodedValueLen * factor;
+    decodeBuf = new (STMTHEAP) char[decodeBufLen];
+  }
+
+  Lng32 resultLength = 0;
+  Lng32 resultOffset = 0;
+
+  // Produce the decoded key. Refer to 
+  // ex_function_encode::decodeKeyValue() for the 
+  // implementation of the decoding logic.
+  ex_expr::exp_return_type rc = exprs.evalAtCompileTime
+    (0, ExpTupleDesc::SQLARK_EXPLODED_FORMAT, decodeBuf, decodeBufLen,
+     &resultLength, &resultOffset, CmpCommon::diags()
+     );
+
+
+  ConstValue* result = NULL;
+
+  if ( rc == ex_expr::EXPR_OK ) {
+    CMPASSERT(resultOffset == dataType.getPrefixSizeWithAlignment());
+    // expect the decodeBuf to have this layout
+    // | null ind. | varchar length ind. | alignment | result |
+    // |<---getPrefixSizeWithAlignment-------------->|
+    // |<----getPrefixSize-------------->|
+
+    // The method getPrefixSizeWithAlignment(), the diagram above,
+    // and this code block assumes that varchar length ind. is
+    // 2 bytes if present. If it is 4 bytes we should fail the 
+    // previous assert
+
+    // Next we get rid of alignment bytes by prepending the prefix
+    // (null ind. + varlen ind.) to the result. ConstValue constr.
+    // will process prefix + result. The assert above ensures that 
+    // there are no alignment fillers at the beginning of the 
+    // buffer. Given the previous assumption about size
+    // of varchar length indicator, alignment bytes will be used by
+    // expression evaluator only if column is of nullable type.
+    // For a description of how alignment is computed, please see
+    // ExpTupleDesc::sqlarkExplodedOffsets() in exp/exp_tuple_desc.cpp
+
+    if (dataType.getSQLnullHdrSize() > 0)
+      memmove(&decodeBuf[resultOffset - dataType.getPrefixSize()], 
+                        decodeBuf, dataType.getPrefixSize());
+    result =
+      new (heap) 
+      ConstValue(&dataType,
+                 (void *) &(decodeBuf[resultOffset - 
+                                      dataType.getPrefixSize()]),
+                 resultLength+dataType.getPrefixSize(),
+                 NULL,
+                 heap);
+  }
+
+  return result;
+}

--- a/core/sql/optimizer/ItemExpr.h
+++ b/core/sql/optimizer/ItemExpr.h
@@ -1048,9 +1048,9 @@ public:
   //  Utility methods
   // ---------------------------------------------------------------------
   
-  // compute the exprssion at compile time. Assume all operands are constants.
+  // Evaluate the exprssion at compile time. Assume all operands are constants.
   // Return NULL if the computation fails and CmpCommon::diags() may be side-affected.
-  ConstValue* compute(CollHeap* heap);
+  ConstValue* evaluate(CollHeap* heap);
 
   // produce an ascii-version of the object (for display or saving into a file)
   virtual void unparse(NAString &result,

--- a/core/sql/optimizer/ItemExpr.h
+++ b/core/sql/optimizer/ItemExpr.h
@@ -1047,6 +1047,10 @@ public:
   // ---------------------------------------------------------------------
   //  Utility methods
   // ---------------------------------------------------------------------
+  
+  // compute the exprssion at compile time. Assume all operands are constants.
+  // Return NULL if the computation fails and CmpCommon::diags() may be side-affected.
+  ConstValue* compute(CollHeap* heap);
 
   // produce an ascii-version of the object (for display or saving into a file)
   virtual void unparse(NAString &result,

--- a/core/sql/optimizer/NAFileSet.cpp
+++ b/core/sql/optimizer/NAFileSet.cpp
@@ -169,7 +169,7 @@ Lng32 NAFileSet::getEncodedKeyLength()
 
 	for(CollIndex i=0;i<indexKeyColumns_.entries();i++)
 	{
-		encodedKeyLength_ += indexKeyColumns_[i]->getType()->getNominalSize();
+		encodedKeyLength_ += indexKeyColumns_[i]->getType()->getEncodedKeyLength();
 	}
 	return encodedKeyLength_;
 }

--- a/core/sql/optimizer/NAFileSet.cpp
+++ b/core/sql/optimizer/NAFileSet.cpp
@@ -109,6 +109,7 @@ NAFileSet::NAFileSet(const QualifiedName & fileSetName,
            resetAfterStatement_(FALSE),
 	   bitFlags_(0),
 	   keyLength_(0),
+	   encodedKeyLength_(0),
            thisRemoteIndexGone_(FALSE),
            isDecoupledRangePartitioned_(isDecoupledRangePartitioned),
            fileCode_(fileCode),
@@ -159,6 +160,18 @@ Lng32 NAFileSet::getKeyLength()
 		keyLength_ += indexKeyColumns_[i]->getType()->getTotalSize();
 	}
 	return keyLength_;
+}
+
+// returns the length of the encoded key in bytes for this index
+Lng32 NAFileSet::getEncodedKeyLength()
+{
+	if(encodedKeyLength_ >0) return encodedKeyLength_;
+
+	for(CollIndex i=0;i<indexKeyColumns_.entries();i++)
+	{
+		encodedKeyLength_ += indexKeyColumns_[i]->getType()->getNominalSize();
+	}
+	return encodedKeyLength_;
 }
 
 Lng32 NAFileSet::getCountOfPartitions() const

--- a/core/sql/optimizer/NAFileSet.h
+++ b/core/sql/optimizer/NAFileSet.h
@@ -160,6 +160,7 @@ public:
   Lng32 getRecordLength() const             { return recordLength_; }
   Lng32 getLockLength() const             { return lockLength_; }
   Lng32 getKeyLength();
+  Lng32 getEncodedKeyLength();
   Lng32 getBlockSize() const                   { return blockSize_; }
 
   Int32 getIndexLevels() const                   { return indexLevels_; }
@@ -329,6 +330,11 @@ private:
   // Key length in bytes.
   //----------------------------------------------------------------------
   Lng32 keyLength_;
+
+  // ---------------------------------------------------------------------
+  // Encoded key length in bytes.
+  //----------------------------------------------------------------------
+  Lng32 encodedKeyLength_;
 
   // ---------------------------------------------------------------------
   // Lock length in bytes.

--- a/core/sql/optimizer/NATable.cpp
+++ b/core/sql/optimizer/NATable.cpp
@@ -1756,7 +1756,7 @@ static ItemExpr * getRangePartitionBoundaryValuesFromEncodedKeys(
 
             keyColVal->synthTypeAndValueId();
 
-            keyColVal = keyColVal->compute(heap);
+            keyColVal = keyColVal->evaluate(heap);
 
             if ( !keyColVal ) 
               return NULL;

--- a/core/sql/optimizer/NATable.cpp
+++ b/core/sql/optimizer/NATable.cpp
@@ -1756,72 +1756,9 @@ static ItemExpr * getRangePartitionBoundaryValuesFromEncodedKeys(
 
             keyColVal->synthTypeAndValueId();
 
-            ValueIdList exprs;
-            exprs.insert(keyColVal->getValueId());
+            keyColVal = keyColVal->compute(heap);
 
-            char staticDecodeBuf[200];
-            Lng32 staticDecodeBufLen = 200;
-
-            char* decodeBuf = staticDecodeBuf;
-            Lng32 decodeBufLen = staticDecodeBufLen;
-
-            // For character types, multiplying by 8 to deal with conversions between
-            // any two known character sets supported.  
-            Lng32 factor = (DFS2REC::isAnyCharacter(pkType->getFSDatatype())) ? 8 : 1;
-
-            if ( staticDecodeBufLen < decodedValueLen * factor) {
-              decodeBufLen = decodedValueLen * factor;
-              decodeBuf = new (STMTHEAP) char[decodeBufLen];
-            }
-
-            Lng32 resultLength = 0;
-            Lng32 resultOffset = 0;
-
-            // Produce the decoded key. Refer to 
-            // ex_function_encode::decodeKeyValue() for the 
-            // implementation of the decoding logic.
-            ex_expr::exp_return_type rc = exprs.evalAtCompileTime
-              (0, ExpTupleDesc::SQLARK_EXPLODED_FORMAT, decodeBuf, decodeBufLen,
-               &resultLength, &resultOffset, CmpCommon::diags()
-               );
-
-
-            if ( rc == ex_expr::EXPR_OK ) {
-              CMPASSERT(resultOffset == pkType->getPrefixSizeWithAlignment());
-              // expect the decodeBuf to have this layout
-              // | null ind. | varchar length ind. | alignment | result |
-              // |<---getPrefixSizeWithAlignment-------------->|
-              // |<----getPrefixSize-------------->|
-
-              // The method getPrefixSizeWithAlignment(), the diagram above,
-              // and this code block assumes that varchar length ind. is
-              // 2 bytes if present. If it is 4 bytes we should fail the 
-              // previous assert
-
-              // Next we get rid of alignment bytes by prepending the prefix
-              // (null ind. + varlen ind.) to the result. ConstValue constr.
-              // will process prefix + result. The assert above ensures that 
-              // there are no alignment fillers at the beginning of the 
-              // buffer. Given the previous assumption about size
-              // of varchar length indicator, alignment bytes will be used by
-              // expression evaluator only if column is of nullable type.
-              // For a description of how alignment is computed, please see
-              // ExpTupleDesc::sqlarkExplodedOffsets() in exp/exp_tuple_desc.cpp
-
-              if (pkType->getSQLnullHdrSize() > 0)
-                memmove(&decodeBuf[resultOffset - pkType->getPrefixSize()], 
-                                  decodeBuf, pkType->getPrefixSize());
-              keyColVal =
-                new (heap) 
-                ConstValue(pkType,
-                           (void *) &(decodeBuf[resultOffset - 
-                                                pkType->getPrefixSize()]),
-                           resultLength+pkType->getPrefixSize(),
-                           NULL,
-                           heap);
-            }
-
-            if ( rc != ex_expr::EXPR_OK ) 
+            if ( !keyColVal ) 
               return NULL;
           }
 

--- a/core/sql/optimizer/PartFunc.cpp
+++ b/core/sql/optimizer/PartFunc.cpp
@@ -5053,7 +5053,7 @@ Int32 RangePartitionBoundaries::findBeginBoundary(char* encodedKey, Int32 keyLen
                                                   compFuncPtrT compFunc) const
 {
    // boundaries are stored in entries in the range [0, partitionCount_] 
-   for (Lng32 i=partitionCount_-1; i>= 0; i--) {
+   for (Lng32 i=0; i<=partitionCount_-1; i++ ) {
 
        const char* low = getBinaryBoundaryValue(i);
        const char* high = getBinaryBoundaryValue(i+1);
@@ -5072,7 +5072,7 @@ Int32 RangePartitionBoundaries::findEndBoundary(char* encodedKey, Int32 keyLen,
                                                 compFuncPtrT compFunc) const
 {
    // boundaries are stored in entries in the range [0, partitionCount_] 
-   for (Lng32 i=0; i<partitionCount_-1; i++ ) {
+   for (Lng32 i=partitionCount_-1; i>= 0; i--) {
 
        const char* low = getBinaryBoundaryValue(i);
        const char* high = getBinaryBoundaryValue(i+1);
@@ -5095,6 +5095,10 @@ RangePartitioningFunction::computeNumOfActivePartitions(SearchKey* skey, const T
    Int32 bIndex = 0;
 
    const NATable* naTable = tDesc->getNATable();
+
+   if ( naTable->isHiveTable() )
+     return origPartitions;  
+
    NABoolean isNativeHbase = (naTable->isHbaseCellTable() || naTable->isHbaseRowTable());
    compFuncPtrT compFuncPtr = ( isNativeHbase ) ? compareAsciiKey: compareEncodedKey;
   

--- a/core/sql/optimizer/PartFunc.h
+++ b/core/sql/optimizer/PartFunc.h
@@ -75,6 +75,7 @@ class NAColumnArray;
 class SearchKey;
 class SkewedValueList;
 typedef LIST(Int64) Int64List;
+typedef NABoolean (*compFuncPtrT)(const char* low, const char* key, const char* high, Int32 keyLen, NABoolean checkLast);
 
 // ----------------------------------------------------------------------
 // literals for special numbers of partitions (don't care, exactly one)
@@ -2035,6 +2036,15 @@ public:
   void completePartitionBoundaries(const ValueIdList& partitioningKeyOrder,
 				   Lng32 encodedBoundaryKeyLength);
 
+
+  // find a boundary pair [low, high) with smallest low value in which keys fall, and return the
+  // // index of the boundary low. Return -1 otherwise, or the key lengths are different.
+  Int32 findBeginBoundary(char* encodedKey, Int32 keyLen, compFuncPtrT compFunc) const;
+
+  // find a boundary pair [low, high) with the largest low value in which keys fall, and return the
+  // // index of the boundary low. Return -1 otherwise, or the key lengths are different.
+  Int32 findEndBoundary(char* encodedKey, Int32 keyLen, compFuncPtrT compFunc) const;
+
   void setupForStatement(NABoolean useStringVersion);
   void resetAfterStatement();
 
@@ -2245,6 +2255,12 @@ public:
 
   NABoolean 
      partFuncAndFuncPushDownCompatible(const PartitioningFunction&) const;
+
+  // ---------------------------------------------------------------------
+  // Compute the number of active partitions. Active partitions are those
+  // that will be accessed applying the search key skey.
+  // ---------------------------------------------------------------------
+  Int32 computeNumOfActivePartitions(SearchKey* skey, const TableDesc* tDesc) const;
 
   virtual const NAString getText() const;
   virtual void print( FILE* ofd = stdout,
@@ -2689,5 +2705,7 @@ private:
 
 }; // class RoundRobinPartitioningFunction
 // LCOV_EXCL_STOP
+//
+
 
 #endif /* PARTFUNC_H */

--- a/core/sql/optimizer/RelExpr.cpp
+++ b/core/sql/optimizer/RelExpr.cpp
@@ -9516,7 +9516,7 @@ FileScan::FileScan(const CorrName& tableName,
      mdamFlag_(UNDECIDED),
      skipRowsToPreventHalloween_(FALSE),
      doUseSearchKey_(TRUE),
-     computedNumOfActivePartiions_(-1)
+     computedNumOfActivePartitions_(-1)
 {
   // Set the filescan properties:
 
@@ -9561,7 +9561,7 @@ FileScan::FileScan(const CorrName& tableName,
          const RangePartitioningFunction* rangePartFunc =
               indexDesc_->getPartitioningFunction()->castToRangePartitioningFunction();
 
-         computedNumOfActivePartiions_ = 
+         computedNumOfActivePartitions_ = 
              rangePartFunc->computeNumOfActivePartitions(partKeys_, tableDescPtr);
       }
     }

--- a/core/sql/optimizer/RelExpr.cpp
+++ b/core/sql/optimizer/RelExpr.cpp
@@ -9515,7 +9515,8 @@ FileScan::FileScan(const CorrName& tableName,
      estRowsAccessed_ (0),
      mdamFlag_(UNDECIDED),
      skipRowsToPreventHalloween_(FALSE),
-     doUseSearchKey_(TRUE)
+     doUseSearchKey_(TRUE),
+     computedNumOfActivePartiions_(-1)
 {
   // Set the filescan properties:
 
@@ -9552,6 +9553,17 @@ FileScan::FileScan(const CorrName& tableName,
                                      dummySet, // needed by interface but not used here
                                      indexDesc_
                                    );
+
+   
+      if ( indexDesc_->getPartitioningFunction() &&
+           indexDesc_->getPartitioningFunction()->castToRangePartitioningFunction() ) 
+      {
+         const RangePartitioningFunction* rangePartFunc =
+              indexDesc_->getPartitioningFunction()->castToRangePartitioningFunction();
+
+         computedNumOfActivePartiions_ = 
+             rangePartFunc->computeNumOfActivePartitions(partKeys_, tableDescPtr);
+      }
     }
   setComputedPredicates(generatedCCPreds);
 

--- a/core/sql/optimizer/RelScan.h
+++ b/core/sql/optimizer/RelScan.h
@@ -813,7 +813,8 @@ public:
     uniqueProbes_(0),
     duplicateSuccProbes_(0),
     failedProbes_(0),
-    tuplesProcessed_(0)
+    tuplesProcessed_(0),
+    computedNumOfActivePartiions_(-1)
   {}
 
   // destructor
@@ -1020,6 +1021,8 @@ public:
            const ValueIdList& partitioningKeyColumnsList,
            const ValueIdList& partitioningKeyColumnsOrder);
 
+  Int32 getComputedNumOfActivePartiions()  const { return computedNumOfActivePartiions_; }
+
 private:
 
 
@@ -1105,6 +1108,10 @@ private:
   CostScalar tuplesProcessed_;
 
   NABoolean doUseSearchKey_;
+
+  // number of active partitions computed only from the Range Part Func
+  // and the search key (partKey_)
+  Int32 computedNumOfActivePartiions_;
 
 }; // class FileScan
 

--- a/core/sql/optimizer/RelScan.h
+++ b/core/sql/optimizer/RelScan.h
@@ -814,7 +814,7 @@ public:
     duplicateSuccProbes_(0),
     failedProbes_(0),
     tuplesProcessed_(0),
-    computedNumOfActivePartiions_(-1)
+    computedNumOfActivePartitions_(-1)
   {}
 
   // destructor
@@ -1021,7 +1021,7 @@ public:
            const ValueIdList& partitioningKeyColumnsList,
            const ValueIdList& partitioningKeyColumnsOrder);
 
-  Int32 getComputedNumOfActivePartiions()  const { return computedNumOfActivePartiions_; }
+  Int32 getComputedNumOfActivePartiions()  const { return computedNumOfActivePartitions_; }
 
 private:
 
@@ -1111,7 +1111,7 @@ private:
 
   // number of active partitions computed only from the Range Part Func
   // and the search key (partKey_)
-  Int32 computedNumOfActivePartiions_;
+  Int32 computedNumOfActivePartitions_;
 
 }; // class FileScan
 

--- a/core/sql/optimizer/ScanOptimizer.cpp
+++ b/core/sql/optimizer/ScanOptimizer.cpp
@@ -2989,6 +2989,9 @@ CollIndex ScanOptimizer::getEstNumActivePartitionsAtRuntime() const
     }
   }
 
+  if ( actParts > 1 ) 
+     actParts = MINOF(actParts, getFileScan().getComputedNumOfActivePartiions());
+
   return actParts;
 }
 
@@ -3022,6 +3025,9 @@ CollIndex ScanOptimizer::getEstNumActivePartitionsAtRuntimeForHbaseRegions() con
   // be one, use that value
   if (estActParts == 1 AND (CmpCommon::getDefault(NCM_HBASE_COSTING) == DF_ON))
     actParts = estActParts;
+
+  if ( actParts > 1 ) 
+     actParts = MINOF(actParts, getFileScan().getComputedNumOfActivePartiions());
 
   return actParts;
 }

--- a/core/sql/optimizer/ValueDesc.cpp
+++ b/core/sql/optimizer/ValueDesc.cpp
@@ -6444,8 +6444,13 @@ ValueIdList::computeEncodedKey(const TableDesc* tDesc, NABoolean isMaxKey,
       ItemExpr* ie = vid.getItemExpr();
 
       if ( ie->getOperatorType() != ITM_CONSTANT ) {
-          ConstValue* value = ie->compute(STMTHEAP);
-          if ( !value )
+          
+          ConstValue* value = NULL;
+          if ( ie->doesExprEvaluateToConstant(TRUE, TRUE) ) {
+             value = ie->evaluate(STMTHEAP);
+             if ( !value )
+                return NULL;
+          } else
              return NULL;
 
           inputStrings[j] = new (STMTHEAP) NAString(value->getConstStr(FALSE));

--- a/core/sql/optimizer/ValueDesc.cpp
+++ b/core/sql/optimizer/ValueDesc.cpp
@@ -59,6 +59,9 @@
 //////////////////////////////
 #include "Analyzer.h"
 //////////////////////////////
+//
+#include "NATable.h"
+#include "EncodedKeyValue.h"
 
 #include "SqlParserGlobals.h"		// must be last #include
 
@@ -639,7 +642,7 @@ void ValueId::getSubExprRootedByVidUnion(ValueIdSet & vs)
 // expression with the given expression.
 // used in Insert::bindNode() to move constraints from the target table
 // to the source table.
-// -----------------------------------------------------------------------
+// ----------------------------------------------------------------------
 void ValueId::replaceBaseColWithExpr(const NAString& colName,
 				     const ValueId & vid)
 {
@@ -6395,5 +6398,113 @@ Lng32 ValueIdList::findPrefixLength(const ValueIdSet& x) const
          break;
     }
   return ct;
+}
+
+// -----------------------------------------------------------------------
+// replace any ColReference (of the given column name) in of this value
+// expression with the given expression.
+// used in ValueId::computeEncodedKey() to assign key values into the
+// salt/DivisionByto expression.
+// ----------------------------------------------------------------------
+void ValueId::replaceColReferenceWithExpr(const NAString& colName,
+                                          const ValueId & vid)
+{
+  ItemExpr* thisItemExpr = getItemExpr();
+  for( Lng32 i = 0; i < thisItemExpr->getArity(); i++ )
+  {
+    ValueId childValueId = thisItemExpr->child(i).getValueId();
+    ItemExpr* childItemExpr = childValueId.getItemExpr();
+
+    if( childItemExpr->getOperatorType() == ITM_REFERENCE)
+    {
+      if( ((ColReference*)childItemExpr)->getColRefNameObj().getColName() == colName )
+        thisItemExpr->setChild( i, vid.getItemExpr() );
+    }
+    childValueId.replaceColReferenceWithExpr( colName, vid );
+  }
+}
+
+
+char*
+ValueIdList::computeEncodedKey(const TableDesc* tDesc, NABoolean isMaxKey, 
+                               char*& encodedKeyBuffer, Int32& keyBufLen) const
+{
+   const NATable*  naTable = tDesc->getNATable();
+
+
+   CollIndex count = entries();
+   NAString** inputStrings = new (STMTHEAP) NAStringPtr[count];
+
+   for (Int32 j=0; j<count; j++ ) 
+       inputStrings[j] = NULL;
+
+   for (Int32 j=0; j<count; j++ ) {
+
+      ValueId vid = (*this)[j];
+      ItemExpr* ie = vid.getItemExpr();
+
+      if ( ie->getOperatorType() != ITM_CONSTANT ) {
+          ConstValue* value = ie->compute(STMTHEAP);
+          if ( !value )
+             return NULL;
+
+          inputStrings[j] = new (STMTHEAP) NAString(value->getConstStr(FALSE));
+      } else  {
+         // no need to prefix with charset prefix.
+         inputStrings[j] = new (STMTHEAP) NAString(((ConstValue*) ie)->getConstStr(FALSE));
+
+         if ( *inputStrings[j] == "<min>" ||  *inputStrings[j] == "<max>" )
+            inputStrings[j] = NULL;
+      }
+   }
+
+   const NAFileSet * naf = naTable->getClusteringIndex();
+   const desc_struct * tableDesc = naTable->getTableDesc();
+   desc_struct * colDescs = tableDesc->body.table_desc.columns_desc;
+   desc_struct * keyDescs = (desc_struct*)naf->getKeysDesc();
+
+   // cast away const since the method may compute and store the length
+   keyBufLen = ((NAFileSet*)naf)->getEncodedKeyLength(); 
+
+   if ( naTable->isHbaseCellTable() || naTable->isHbaseRowTable() ) { 
+      // the encoded key for Native Hbase table is a null-terminated string ('<key>')
+      NAString key;
+      key.append("(");
+
+      size_t idx = inputStrings[0]->index("_ISO88591");
+      if ( idx == 0 )
+         key.append(inputStrings[0]->remove(0, 9));
+      else
+         key.append(*inputStrings[0]);
+
+      key.append(")");
+
+      keyBufLen = inputStrings[0]->length() + 5; // extra 4 bytes for (,', ', ), and one byte for null. 
+
+      if (!encodedKeyBuffer )
+         encodedKeyBuffer = new (STMTHEAP) char[keyBufLen];
+
+      memcpy(encodedKeyBuffer, key.data(), key.length());
+      encodedKeyBuffer[key.length()] = NULL;
+
+      return encodedKeyBuffer;
+
+   } else {
+      keyBufLen = ((NAFileSet*)naf)->getEncodedKeyLength(); 
+
+      if (!encodedKeyBuffer )
+         encodedKeyBuffer = new (STMTHEAP) char[keyBufLen];
+
+      short ok = encodeKeyValues(colDescs, keyDescs,
+                      inputStrings,    // INPUT
+                      FALSE,           // not isIndex
+                      isMaxKey,        
+                      encodedKeyBuffer,// OUTPUT
+                      STMTHEAP, CmpCommon::diags());
+
+      NADELETEARRAY(inputStrings, count, NAStringPtr, STMTHEAP);
+
+      return ( ok == 0 ) ? encodedKeyBuffer : NULL;
+   }
 }
 

--- a/core/sql/optimizer/ValueDesc.h
+++ b/core/sql/optimizer/ValueDesc.h
@@ -81,6 +81,7 @@ class VEGRewritePairs;
 class TableDesc;
 class IndexDesc;
 class ConstValue;
+class NATable;
 
 ////////////////////
 class QueryAnalysis;
@@ -226,6 +227,14 @@ public:
   // to the source table.
   // ---------------------------------------------------------------------
   void replaceBaseColWithExpr(const NAString& colName, const ValueId & vid);
+
+  // -----------------------------------------------------------------------
+  // replace any ColReference (of the given column name) in of this value
+  // expression with the given expression.
+  // used in ValueId::computeEncodedKey() to assign key values into the
+  // salt/DivisionByto expression.
+  // ----------------------------------------------------------------------
+  void replaceColReferenceWithExpr(const NAString& colName, const ValueId & vid);
 
   // ---------------------------------------------------------------------
   // Replace the definition of this valueId to be a new itemexpr
@@ -603,6 +612,14 @@ public:
   // refers to the same VEG as refered to by x, which must be a VEG predicate,
   // or to an equal predicate.
   ValueId extractVEGRefForEquiPredicate(ValueId x) const;
+
+
+  // Encode this list of constants into an encoded key and save the result into
+  // encodedKeyBuffer, and the key length into keyBufLen. Allocate an buffer
+  // if encodedKeyBuffer points at NULL from STMTHEAP. Also return the buffer pointer
+  // if everything is OK.  Return NULL otherwise.
+  char* computeEncodedKey(const TableDesc* tDesc, NABoolean isMaxKey, char*& encodedKeyBuffer, Int32& keyBufLen) const;
+
 
   // ---------------------------------------------------------------------
   // Print

--- a/core/sql/qms/QmsJoinGraph.h
+++ b/core/sql/qms/QmsJoinGraph.h
@@ -71,7 +71,6 @@ typedef NAPtrList<JoinGraphEqualitySetPtr>		EqualitySetList;
 typedef NAPtrList<JoinGraphTablePtr>		        JoinGraphTableList;
 typedef NAPtrArray<JoinGraphTablePtr>			JoinGraphTableArray;
 typedef NASubArray<JoinGraphTablePtr>			JoinGraphTableSubArray;
-typedef NAString*                                       NAStringPtr;
 typedef NAPtrList<QRJoinSubGraphPtr>			SubGraphList;
 typedef NAPtrList<QRJoinSubGraphMapPtr>			SubGraphMapList;
 

--- a/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
@@ -6258,6 +6258,7 @@ short CmpSeabaseDDL::createEncodedKeysBuffer(char** &encodedKeysBuffer,
                                keyDescs,
                                splitValuesAsText, // INPUT
                                isIndex,
+                               FALSE,             // encoding for Min Key
                                encodedKeysBuffer[i],  // OUTPUT
                                STMTHEAP,
                                CmpCommon::diags());


### PR DESCRIPTION
This set contains the fix to JIRA461, which addresses the problem as follows. 

1. For range partition function only, the the begin B and end E partition is identified using the begin key and end contained in the SearchKey generated for the FileScan object.
2. The number of active partitions is the number of partitions contained within B and E. 
3. The work is done for both Trafodion and Native Hbase table, where key comparison is different:  binary key comparison for encoded key in a Traf table, and ASCII key comparison for a Native Hbase table.