### PR TITLE
TRAFODION-1541 Fix make errors when building outside of git

### DIFF
--- a/core/sqf/build-scripts/build.branch
+++ b/core/sqf/build-scripts/build.branch
@@ -52,9 +52,9 @@ if [[ "$USE_GIT" == "1" ]];then
     branch=$ZUUL_BRANCH;
   fi
 else
-  rev=`svn info .. | grep '^Last Changed Rev:' | sed 's|Last Changed Rev: ||'`
-  url=`svn info .. | grep '^URL:' | sed 's|URL: ||'`
-  reporoot=`svn info .. | grep '^Repository Root:' | sed 's|Repository Root: ||'`
+  rev=`svn info .. 2>/dev/null | grep '^Last Changed Rev:' | sed 's|Last Changed Rev: ||'`
+  url=`svn info .. 2>/dev/null | grep '^URL:' | sed 's|URL: ||'`
+  reporoot=`svn info .. 2>/dev/null | grep '^Repository Root:' | sed 's|Repository Root: ||'`
   branch=`echo $url | sed "s|$reporoot\/||" | sed 's|\/sqf$||'`
 fi
 if [ $f = 1 ]; then

--- a/core/sqf/src/seatrans/.gitignore
+++ b/core/sqf/src/seatrans/.gitignore
@@ -1,3 +1,4 @@
 hbase-trx/target/
 tm/hbasetmlib2/target/
 tm/hbasetmlib2/testrun
+*.jar.mf

--- a/core/sqf/src/seatrans/tm/hbasetmlib2/Makefile
+++ b/core/sqf/src/seatrans/tm/hbasetmlib2/Makefile
@@ -66,7 +66,7 @@ all:  $(PROGS) mavenbuild
 mavenbuild:
         # create a jar manifest file with the correct version information
 	mkdir -p src/main/resources
-	$(MY_SQROOT)/export/include/SCMBuildJava.sh 1.0.1 >src/main/resources/jarmanifest.mf
+	$(MY_SQROOT)/export/include/SCMBuildJava.sh 1.0.1 >src/main/resources/trafodion-dtm.jar.mf
         # run maven
 	set -o pipefail; $(MAVEN) package -DskipTests | tee maven_build.log | grep -e '\[INFO\] Building' -e '\[INFO\] BUILD SUCCESS' -e 'ERROR'
 	cp -pf target/trafodion-dtm-*.jar $(MY_SQROOT)/export/lib

--- a/core/sqf/src/seatrans/tm/hbasetmlib2/Makefile
+++ b/core/sqf/src/seatrans/tm/hbasetmlib2/Makefile
@@ -64,8 +64,12 @@ endif
 all:  $(PROGS) mavenbuild
 
 mavenbuild:
+        # create a jar manifest file with the correct version information
+	mkdir -p src/main/resources
+	$(MY_SQROOT)/export/include/SCMBuildJava.sh 1.0.1 >src/main/resources/jarmanifest.mf
+        # run maven
 	set -o pipefail; $(MAVEN) package -DskipTests | tee maven_build.log | grep -e '\[INFO\] Building' -e '\[INFO\] BUILD SUCCESS' -e 'ERROR'
-	cp -pf target/*.jar $(MY_SQROOT)/export/lib
+	cp -pf target/trafodion-dtm-*.jar $(MY_SQROOT)/export/lib
 
 $(LIBEXPDIR)/libshbasetmlib.so: $(LIBSTMOBJS)
 	$(CXX) $(DTMOBJS) $(LNK_FLGS) $(LIBTMB) -shared -o $@ $(LIBSTMOBJS)
@@ -93,6 +97,7 @@ clean:
 	$(RM) $(PROGS)
 	$(RM) *.gcda *.gcno *.gcov
 	$(RM) -f  $(OUTDIR)/*.o
+	$(RM) -rf $(MY_SQROOT)/export/lib/trafodion-dtm-*.jar
 
 cleanall: clean
 	$(RM) -rf $(BUILD_PLAT)

--- a/core/sqf/src/seatrans/tm/hbasetmlib2/pom.xml
+++ b/core/sqf/src/seatrans/tm/hbasetmlib2/pom.xml
@@ -73,7 +73,7 @@
         <configuration>
           <archive>
             <manifestFile>
-              src/main/resources/jarmanifest.mf
+              src/main/resources/trafodion-dtm.jar.mf
             </manifestFile>
           </archive>
         </configuration>

--- a/core/sqf/src/seatrans/tm/hbasetmlib2/pom.xml
+++ b/core/sqf/src/seatrans/tm/hbasetmlib2/pom.xml
@@ -68,40 +68,13 @@
   <build>
     <plugins>
       <plugin>
-            <groupId>com.github.koraktor</groupId>
-            <artifactId>mavanagaiata</artifactId>
-            <version>0.7.2</version>
-            <configuration>
-                  <dirtyFlag>false</dirtyFlag>
-                  <dirtyIgnoreUntracked>false</dirtyIgnoreUntracked>
-                  <gitDir>${env.MY_SQROOT}/../../.git</gitDir>
-                  <dateFormat>ddMMMyyyy</dateFormat>
-            </configuration>
-            <executions>
-                  <execution>
-                        <id>git-commit</id>
-                        <phase>validate</phase>
-                        <goals>
-                              <goal>commit</goal>
-                              <goal>branch</goal>
-                        </goals>
-                  </execution>
-            </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>
-              <manifestEntries>
-                    <Implementation-Version-1>Version ${project.version}</Implementation-Version-1>
-                    <Implementation-Version-2>Release ${project.version}</Implementation-Version-2>
-                    <Implementation-Version-3>Build ${env.SQ_BUILD_TYPE}</Implementation-Version-3>
-                    <Implementation-Version-4>[${user.name}]</Implementation-Version-4>
-                    <Implementation-Version-5>Branch ${mvngit.commit.abbrev}-${mvngit.branch}</Implementation-Version-5>
-                    <Implementation-Version-6>Date ${maven.build.timestamp}</Implementation-Version-6>
-                    <Product-Name>${project.name}</Product-Name>
-              </manifestEntries>
+            <manifestFile>
+              src/main/resources/jarmanifest.mf
+            </manifestFile>
           </archive>
         </configuration>
       </plugin>

--- a/core/sql/nskgmake/Makerules.mk
+++ b/core/sql/nskgmake/Makerules.mk
@@ -275,7 +275,7 @@ endif
 mavenbuild:
         # create a jar manifest file with the correct version information
 	mkdir -p ../src/main/resources
-	$(MY_SQROOT)/export/include/SCMBuildJava.sh 1.0.1 >../src/main/resources/jarmanifest.mf
+	$(MY_SQROOT)/export/include/SCMBuildJava.sh 1.0.1 >../src/main/resources/trafodion-sql.jar.mf
         # run maven
 	set -o pipefail && cd ..; $(MAVEN) package -DskipTests | tee maven_build.log | grep -e '\[INFO\] Building' -e '\[INFO\] BUILD SUCCESS' -e 'ERROR'
 	cp -pf ../target/trafodion-sql-*.jar $(MY_SQROOT)/export/lib

--- a/core/sql/nskgmake/Makerules.mk
+++ b/core/sql/nskgmake/Makerules.mk
@@ -273,8 +273,12 @@ endif
 
 # Java files get built through Maven
 mavenbuild:
+        # create a jar manifest file with the correct version information
+	mkdir -p ../src/main/resources
+	$(MY_SQROOT)/export/include/SCMBuildJava.sh 1.0.1 >../src/main/resources/jarmanifest.mf
+        # run maven
 	set -o pipefail && cd ..; $(MAVEN) package -DskipTests | tee maven_build.log | grep -e '\[INFO\] Building' -e '\[INFO\] BUILD SUCCESS' -e 'ERROR'
-	cp -pf ../target/*.jar $(MY_SQROOT)/export/lib
+	cp -pf ../target/trafodion-sql-*.jar $(MY_SQROOT)/export/lib
 
 # This is where the top-level is declared to build everything.
 buildall: $(FINAL_LIBS) $(FINAL_DLLS) $(FINAL_INSTALL_OBJS) $(FINAL_EXES) mavenbuild
@@ -291,4 +295,4 @@ clean:
 	@echo "Removing coverage files"
 	@-find $(TOPDIR) -maxdepth 1 -name '*.gcov' -print | xargs rm -f
 	@cd ..; $(MAVEN) clean
-
+	@rm -rf $(MY_SQROOT)/export/lib/trafodion-sql-*.jar

--- a/core/sql/pom.xml
+++ b/core/sql/pom.xml
@@ -90,7 +90,7 @@
         <configuration>
           <archive>
             <manifestFile>
-              src/main/resources/jarmanifest.mf
+              src/main/resources/trafodion-sql.jar.mf
             </manifestFile>
           </archive>
         </configuration>

--- a/core/sql/pom.xml
+++ b/core/sql/pom.xml
@@ -85,40 +85,13 @@
   <build>
     <plugins>
       <plugin>
-            <groupId>com.github.koraktor</groupId>
-            <artifactId>mavanagaiata</artifactId>
-            <version>0.7.2</version>
-            <configuration>
-                  <dirtyFlag>false</dirtyFlag>
-                  <dirtyIgnoreUntracked>false</dirtyIgnoreUntracked>
-                  <gitDir>${env.MY_SQROOT}/../../.git</gitDir>
-                  <dateFormat>ddMMMyyyy</dateFormat>
-            </configuration>
-            <executions>
-                  <execution>
-                        <id>git-commit</id>
-                        <phase>validate</phase>
-                        <goals>
-                              <goal>commit</goal>
-                              <goal>branch</goal>
-                        </goals>
-                  </execution>
-            </executions>
-      </plugin>
-      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
         <configuration>
           <archive>
-              <manifestEntries>
-                    <Implementation-Version-1>Version ${project.version}</Implementation-Version-1>
-                    <Implementation-Version-2>Release ${project.version}</Implementation-Version-2>
-                    <Implementation-Version-3>Build ${env.SQ_BUILD_TYPE}</Implementation-Version-3>
-                    <Implementation-Version-4>[${user.name}]</Implementation-Version-4>
-                    <Implementation-Version-5>Branch ${mvngit.commit.abbrev}-${mvngit.branch}</Implementation-Version-5>
-                    <Implementation-Version-6>Date ${maven.build.timestamp}</Implementation-Version-6>
-                    <Product-Name>${project.name}</Product-Name>
-              </manifestEntries>
+            <manifestFile>
+              src/main/resources/jarmanifest.mf
+            </manifestFile>
           </archive>
         </configuration>
       </plugin>

--- a/install/traf_tools_setup.sh
+++ b/install/traf_tools_setup.sh
@@ -263,11 +263,11 @@ fi
 
 # install maven, if not available already
 MAVEN_VERSION=`mvn --version 2>/dev/null | grep 'Apache Maven' | cut -f 3 -d ' '`
-if [[ "$MAVEN_VERSION" != "3.0.5" ]]; then
+if [[ ! "$MAVEN_VERSION" =~ "3." ]]; then
   # install maven
   cd $BASEDIR
-  wget http://archive.apache.org/dist/maven/maven-3/3.0.5/binaries/apache-maven-3.0.5-bin.tar.gz
+  wget http://archive.apache.org/dist/maven/maven-3/3.3.3/binaries/apache-maven-3.3.3-bin.tar.gz
   cd $TOOLSDIR
   # there is no install, simply extract the files into $TOOLSDIR
-  tar -xzf $BASEDIR/apache-maven-3.0.5-bin.tar.gz
+  tar -xzf $BASEDIR/apache-maven-3.3.3-bin.tar.gz
 fi

--- a/install/traf_tools_setup.sh
+++ b/install/traf_tools_setup.sh
@@ -260,3 +260,14 @@ make install
 if [ $VERBOSE -eq 1 ]; then
   echo "STEP completed:  installation of THRIFT"
 fi
+
+# install maven, if not available already
+MAVEN_VERSION=`mvn --version 2>/dev/null | grep 'Apache Maven' | cut -f 3 -d ' '`
+if [[ "$MAVEN_VERSION" != "3.0.5" ]]; then
+  # install maven
+  cd $BASEDIR
+  wget http://archive.apache.org/dist/maven/maven-3/3.0.5/binaries/apache-maven-3.0.5-bin.tar.gz
+  cd $TOOLSDIR
+  # there is no install, simply extract the files into $TOOLSDIR
+  tar -xzf $BASEDIR/apache-maven-3.0.5-bin.tar.gz
+fi


### PR DESCRIPTION
Removed the Koraktor Maven plugin from SQL and hbasetmlib2 pom files,
since it fails when we build a source tree that is not managed by git.

Additional changes:

- Added "clean" steps to remove the built jar files
- Suppressed "svn not found" error when building outside of git
- Added maven to traf_tools_setup.sh