### PR TITLE
[TRAFODION-1564]Split/balance is not being delayed

### DIFF
--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/coprocessor/transactional/SplitBalanceHelper.java
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/coprocessor/transactional/SplitBalanceHelper.java
@@ -251,7 +251,7 @@ public class SplitBalanceHelper {
                                         ConcurrentHashMap<Long,TransactionalRegionScannerHolder> scanners,
                                         int pendingDelayLen) throws IOException {
     int count = 1;
-    while(!scannersListClear(scanners) && !pendingListClear(commitPendingTransactions)) {
+    while(!scannersListClear(scanners) || !pendingListClear(commitPendingTransactions)) {
       try {
           if(LOG.isDebugEnabled()) LOG.debug("pendingAndScannersWait() delay, count " + count++ + " on: " + hri.getRegionNameAsString());
           Thread.sleep(pendingDelayLen);


### PR DESCRIPTION
Region split/balance is not being delayed if Trx Scanner obj is present
Fix was to delay on scanners list clear OR pending list clear instead
of AND.