### PR TITLE
[TRAFODION-25] Fix bug preventing fully parallelized DELETEs

### DIFF
--- a/core/sql/optimizer/OptPhysRelExpr.cpp
+++ b/core/sql/optimizer/OptPhysRelExpr.cpp
@@ -16565,21 +16565,35 @@ HbaseDelete::synthPhysicalProperty(const Context* myContext,
                                    const Lng32     planNumber,
                                    PlanWorkSpace  *pws)
 {
-
-  //----------------------------------------------------------
-  // Create a node map with a single, active, wild-card entry.
-  //----------------------------------------------------------
-  NodeMap* myNodeMap = new(CmpCommon::statementHeap())
-                        NodeMap(CmpCommon::statementHeap(),
-                                1,
-                                NodeMapEntry::ACTIVE);
+  const ReqdPhysicalProperty* rppForMe =
+          myContext->getReqdPhysicalProperty();
+  PartitioningRequirement* partReqForMe =
+    rppForMe->getPartitioningRequirement();
 
   //------------------------------------------------------------
-  // Synthesize a partitioning function with a single partition.
+  // Synthesize a partitioning function with a single partition
+  // unless we have a partitioning requirement that says 
+  // otherwise.
   //------------------------------------------------------------
-  PartitioningFunction* myPartFunc =
-    new(CmpCommon::statementHeap())
-    SinglePartitionPartitioningFunction(myNodeMap);
+  PartitioningFunction* myPartFunc = NULL;
+
+  if (partReqForMe &&
+      partReqForMe->castToRequireReplicateNoBroadcast())
+    {
+      myPartFunc =
+        partReqForMe->castToRequireReplicateNoBroadcast()->
+        getPartitioningFunction()->copy();
+    }
+  else
+    {
+      // Create a node map with a single, active, wild-card entry.
+      NodeMap* myNodeMap = new(CmpCommon::statementHeap())
+                               NodeMap(CmpCommon::statementHeap(),
+                               1,
+                               NodeMapEntry::ACTIVE);
+      myPartFunc = new(CmpCommon::statementHeap())
+      SinglePartitionPartitioningFunction(myNodeMap);
+    }
 
   PhysicalProperty * sppForMe =
     new(CmpCommon::statementHeap())
@@ -16613,21 +16627,35 @@ HbaseUpdate::synthPhysicalProperty(const Context* myContext,
                                    const Lng32     planNumber,
                                    PlanWorkSpace  *pws)
 {
-
-  //----------------------------------------------------------
-  // Create a node map with a single, active, wild-card entry.
-  //----------------------------------------------------------
-  NodeMap* myNodeMap = new(CmpCommon::statementHeap())
-                        NodeMap(CmpCommon::statementHeap(),
-                                1,
-                                NodeMapEntry::ACTIVE);
+  const ReqdPhysicalProperty* rppForMe =
+          myContext->getReqdPhysicalProperty();
+  PartitioningRequirement* partReqForMe =
+    rppForMe->getPartitioningRequirement();
 
   //------------------------------------------------------------
-  // Synthesize a partitioning function with a single partition.
+  // Synthesize a partitioning function with a single partition
+  // unless we have a partitioning requirement that says 
+  // otherwise.
   //------------------------------------------------------------
-  PartitioningFunction* myPartFunc =
-    new(CmpCommon::statementHeap())
-    SinglePartitionPartitioningFunction(myNodeMap);
+  PartitioningFunction* myPartFunc = NULL;
+
+  if (partReqForMe &&
+      partReqForMe->castToRequireReplicateNoBroadcast())
+    {
+      myPartFunc =
+        partReqForMe->castToRequireReplicateNoBroadcast()->
+        getPartitioningFunction()->copy();
+    }
+  else
+    {
+      // Create a node map with a single, active, wild-card entry.
+      NodeMap* myNodeMap = new(CmpCommon::statementHeap())
+                               NodeMap(CmpCommon::statementHeap(),
+                               1,
+                               NodeMapEntry::ACTIVE);
+      myPartFunc = new(CmpCommon::statementHeap())
+      SinglePartitionPartitioningFunction(myNodeMap);
+    }
 
   PhysicalProperty * sppForMe =
     new(CmpCommon::statementHeap())
@@ -16703,27 +16731,30 @@ HbaseInsert::synthPhysicalProperty(const Context* myContext,
   PartitioningRequirement* partReqForMe =
     rppForMe->getPartitioningRequirement();
 
-  //----------------------------------------------------------
-  // Create a node map with a single, active, wild-card entry.
-  //----------------------------------------------------------
-  NodeMap* myNodeMap = new(CmpCommon::statementHeap())
-                        NodeMap(CmpCommon::statementHeap(),
-                                1,
-                                NodeMapEntry::ACTIVE);
-
   //------------------------------------------------------------
-  // Synthesize a partitioning function with a single partition.
+  // Synthesize a partitioning function with a single partition
+  // unless we have a partitioning requirement that says 
+  // otherwise.
   //------------------------------------------------------------
   PartitioningFunction* myPartFunc = NULL;
 
   if (partReqForMe &&
       partReqForMe->castToRequireReplicateNoBroadcast())
-    myPartFunc = 
-      partReqForMe->castToRequireReplicateNoBroadcast()->
-      getPartitioningFunction()->copy();
+    {
+      myPartFunc =
+        partReqForMe->castToRequireReplicateNoBroadcast()->
+        getPartitioningFunction()->copy();
+    }
   else
-    myPartFunc = new(CmpCommon::statementHeap())
-    SinglePartitionPartitioningFunction(myNodeMap);
+    {
+      // Create a node map with a single, active, wild-card entry.
+      NodeMap* myNodeMap = new(CmpCommon::statementHeap())
+                               NodeMap(CmpCommon::statementHeap(),
+                               1,
+                               NodeMapEntry::ACTIVE);
+      myPartFunc = new(CmpCommon::statementHeap())
+      SinglePartitionPartitioningFunction(myNodeMap);
+    }
 
   PhysicalProperty * sppForMe =
     new(CmpCommon::statementHeap())

--- a/core/sql/optimizer/ScmCostMethod.cpp
+++ b/core/sql/optimizer/ScmCostMethod.cpp
@@ -3881,9 +3881,16 @@ CostMethodHbaseDelete::scmComputeOperatorCostInternal(RelExpr* op,
   HbaseDelete* delOp = (HbaseDelete *)op;   // downcast
 
   CMPASSERT(partFunc_ != NULL);
-  CostScalar activePartitions =
-   (CostScalar)
-     (((NodeMap *)(partFunc_->getNodeMap()))->getNumActivePartitions());
+
+  //  Later, if and when we start using NodeMaps to track active regions for 
+  //  Trafodion tables in HBase (or native HBase tables), we can use the
+  //  following to get active partitions.
+  //CostScalar activePartitions =
+  // (CostScalar)
+  //   (((NodeMap *)(partFunc_->getNodeMap()))->getNumActivePartitions());
+  //  But for now, we do the following:
+  CostScalar activePartitions = (CostScalar)(partFunc_->getCountOfPartitions());
+
   const IndexDesc* CIDesc = delOp->getIndexDesc();
   const CostScalar & recordSizeInKb = CIDesc->getRecordSizeInKb();
 


### PR DESCRIPTION
Costing changes merged in a few weeks ago enabled more efficient DELETE plans. For example, in a table with 200,000 rows, formerly we would pick a serial plan for "delete from t". With the costing changes, we would pick a plan that would scan its regions in parallel, forward the keys to the Master, then do a "vsbb delete" in the Master. This is much faster. 

However it is still not ideal. A better plan would  be to skip the forwarding step and do "vsbb delete" in the ESP where we are doing a scan. In this way, the HBase deletes are happening in parallel as well as the scans.

The reason the ideal plan was not chosen was that method HbaseDelete::synthPhysicalProperty() had stub code that always generated a "single partition" partitioning function. So, plans that attempted to do the delete in parallel would not be chosen due to the conflicting physical property.

The fix is to change HbaseDelete::synthPhysicalProperty() to use the input partitioning function if it is a replicate no broadcast function. A similar bug existed in HbaseUpdate::synthPhysicalProperty() which is also fixed in this check-in.