### PR TITLE
[TRAFODION-1575] Avoid transforming update into delete and insert

### DIFF
--- a/core/sql/comexe/ComTdbHbaseAccess.cpp
+++ b/core/sql/comexe/ComTdbHbaseAccess.cpp
@@ -131,6 +131,8 @@ ComTdbHbaseAccess::ComTdbHbaseAccess(
   encodedKeyExpr_(encodedKeyExpr),
   keyColValExpr_(keyColValExpr),
   insDelPreCondExpr_(NULL),
+  insConstraintExpr_(NULL),
+  updConstraintExpr_(NULL),
   hbaseFilterExpr_(hbaseFilterExpr),
 
   asciiRowLen_(asciiRowLen),
@@ -239,6 +241,8 @@ ComTdbHbaseAccess::ComTdbHbaseAccess(
   encodedKeyExpr_(NULL),
   keyColValExpr_(NULL),
   insDelPreCondExpr_(NULL),
+  insConstraintExpr_(NULL),
+  updConstraintExpr_(NULL),
   hbaseFilterExpr_(NULL),
 
   asciiRowLen_(0),
@@ -311,7 +315,7 @@ ComTdbHbaseAccess::~ComTdbHbaseAccess()
 Int32
 ComTdbHbaseAccess::numExpressions() const
 {
-  return(16);
+  return 18;
 }
  
 // Return the expression names of the explain TDB based on some 
@@ -353,6 +357,10 @@ ComTdbHbaseAccess::getExpressionName(Int32 expNum) const
       return "hbaseFilterExpr";
     case 15:
       return "preCondExpr";
+    case 16:
+      return "insConstraintExpr";
+    case 17:
+      return "updConstraintExpr";
     default:
       return 0;
     }  
@@ -397,6 +405,10 @@ ComTdbHbaseAccess::getExpressionNode(Int32 expNum)
       return hbaseFilterExpr_;
     case 15:
       return insDelPreCondExpr_;
+    case 16:
+      return insConstraintExpr_;
+    case 17:
+      return updConstraintExpr_;
     default:
       return NULL;
     }  
@@ -418,6 +430,8 @@ Long ComTdbHbaseAccess::pack(void * space)
   encodedKeyExpr_.pack(space);
   keyColValExpr_.pack(space);
   insDelPreCondExpr_.pack(space);
+  insConstraintExpr_.pack(space);
+  updConstraintExpr_.pack(space);
   hbaseFilterExpr_.pack(space);
   colFamNameList_.pack(space);
   workCriDesc_.pack(space);
@@ -486,6 +500,8 @@ Lng32 ComTdbHbaseAccess::unpack(void * base, void * reallocator)
   if(encodedKeyExpr_.unpack(base, reallocator)) return -1;
   if(keyColValExpr_.unpack(base, reallocator)) return -1;
   if(insDelPreCondExpr_.unpack(base, reallocator)) return -1;
+  if(insConstraintExpr_.unpack(base, reallocator)) return -1;
+  if(updConstraintExpr_.unpack(base, reallocator)) return -1;
   if(hbaseFilterExpr_.unpack(base, reallocator)) return -1;
   if(colFamNameList_.unpack(base, reallocator)) return -1;
   if(workCriDesc_.unpack(base, reallocator)) return -1;

--- a/core/sql/comexe/ComTdbHbaseAccess.h
+++ b/core/sql/comexe/ComTdbHbaseAccess.h
@@ -846,7 +846,12 @@ public:
    void setInsDelPreCondExpr(ExExprPtr exprPtr) {
         insDelPreCondExpr_ = exprPtr;
    }
-
+   void setInsConstraintExpr(ExExprPtr exprPtr) {
+      insConstraintExpr_ = exprPtr;
+   }
+   void setUpdConstraintExpr(ExExprPtr exprPtr) {
+      updConstraintExpr_ = exprPtr;
+   }
  protected:
   enum
   {
@@ -944,6 +949,8 @@ public:
   ExExprPtr keyColValExpr_;
   ExExprPtr insDelPreCondExpr_;
   ExExprPtr hbaseFilterExpr_;
+  ExExprPtr insConstraintExpr_;
+  ExExprPtr updConstraintExpr_;
 
   ExCriDescPtr workCriDesc_;      
 

--- a/core/sql/executor/ExHbaseAccess.cpp
+++ b/core/sql/executor/ExHbaseAccess.cpp
@@ -338,6 +338,10 @@ ExHbaseAccessTcb::ExHbaseAccessTcb(
     keyColValExpr()->fixup(0, getExpressionMode(), this,  space, heap, FALSE, glob);
   if (insDelPreCondExpr())
     insDelPreCondExpr()->fixup(0, getExpressionMode(), this,  space, heap, FALSE, glob);
+  if (insConstraintExpr())
+    insConstraintExpr()->fixup(0, getExpressionMode(), this,  space, heap, FALSE, glob);
+  if (updConstraintExpr())
+    updConstraintExpr()->fixup(0, getExpressionMode(), this,  space, heap, FALSE, glob);
   if (hbaseFilterValExpr())
     hbaseFilterValExpr()->fixup(0, getExpressionMode(), this,  space, heap, FALSE, glob);
   
@@ -1834,6 +1838,26 @@ short ExHbaseAccessTcb::evalInsDelPreCondExpr()
   return 0; 
 }
 
+short ExHbaseAccessTcb::evalConstraintExpr(ex_expr *expr, UInt16 tuppIndex,
+                                  char * tuppRow)
+{
+  if (expr == NULL) {
+     return 1;
+  }
+  ex_queue_entry *pentry_down = qparent_.down->getHeadEntry();
+  ex_expr::exp_return_type exprRetCode = ex_expr::EXPR_OK;
+  if ((tuppRow) && (tuppIndex > 0))
+    workAtp_->getTupp(tuppIndex).setDataPointer(tuppRow);
+  else
+    workAtp_->getTupp(hbaseAccessTdb().convertTuppIndex_).setDataPointer(convertRow_);
+  exprRetCode = expr->eval(pentry_down->getAtp(), workAtp_);
+  if (exprRetCode == ex_expr::EXPR_ERROR)
+     return -1;
+  else if (exprRetCode == ex_expr::EXPR_TRUE)
+     return 1;
+  else
+     return 0;
+}
 
 short ExHbaseAccessTcb::evalRowIdAsciiExpr(const char * inputRowIdVals,
 					   char * rowIdBuf, // input: buffer where rowid is created

--- a/core/sql/executor/ExHbaseAccess.h
+++ b/core/sql/executor/ExHbaseAccess.h
@@ -235,6 +235,12 @@ protected:
   inline ex_expr *insDelPreCondExpr() const
     { return hbaseAccessTdb().insDelPreCondExpr_; }
 
+  inline ex_expr *insConstraintExpr() const
+    { return hbaseAccessTdb().insConstraintExpr_; }
+
+  inline ex_expr *updConstraintExpr() const
+    { return hbaseAccessTdb().updConstraintExpr_; }
+
   inline ex_expr *hbaseFilterValExpr() const 
     { return hbaseAccessTdb().hbaseFilterExpr_; }
 
@@ -299,6 +305,8 @@ protected:
   short extractColFamilyAndName(char * input, Text &colFam, Text &colName);
   short evalKeyColValExpr(HbaseStr &columnToCheck, HbaseStr &colValToCheck);
   short evalInsDelPreCondExpr();
+  short evalConstraintExpr(ex_expr *expr, UInt16 tuppIndex = 0,
+                  char * tuppRow = NULL);
   short evalEncodedKeyExpr();
   short evalRowIdExpr(NABoolean noVarchar = FALSE);
   short evalRowIdAsciiExpr(NABoolean noVarchar = FALSE);
@@ -954,7 +962,8 @@ public:
     , NEXT_ROW
     , CREATE_FETCHED_ROW
     , CREATE_UPDATED_ROW
-    , EVAL_CONSTRAINT
+    , EVAL_INS_CONSTRAINT
+    , EVAL_UPD_CONSTRAINT
     , CREATE_MUTATIONS
     , APPLY_PRED
     , APPLY_MERGE_UPD_SCAN_PRED
@@ -1021,7 +1030,8 @@ public:
     , CREATE_UPDATED_ROW
     , CREATE_MERGE_INSERTED_ROW
     , CREATE_MUTATIONS
-    , EVAL_CONSTRAINT
+    , EVAL_INS_CONSTRAINT
+    , EVAL_UPD_CONSTRAINT
     , APPLY_PRED
     , APPLY_MERGE_UPD_SCAN_PRED
     , RETURN_ROW
@@ -1133,6 +1143,7 @@ public:
     , CREATE_UPDATED_ROW
     , PROCESS_DELETE
     , PROCESS_DELETE_AND_CLOSE
+    , EVAL_CONSTRAINT
     , PROCESS_UPDATE
     , PROCESS_UPDATE_AND_CLOSE
     , PROCESS_SELECT

--- a/core/sql/optimizer/BindRelExpr.cpp
+++ b/core/sql/optimizer/BindRelExpr.cpp
@@ -10535,7 +10535,7 @@ RelExpr *Update::bindNode(BindWA *bindWA)
   NABoolean transformUpdateKey = updatesClusteringKeyOrUniqueIndexKey(bindWA);
   if (bindWA->errStatus()) // error occurred in updatesCKOrUniqueIndexKey()
     return this;
-
+  // To be removed when TRAFODION-1610 is implemented.
   NABoolean xnsfrmHbaseUpdate = FALSE;
   if ((hbaseOper()) && (NOT isMerge()))
     {      
@@ -10543,26 +10543,19 @@ RelExpr *Update::bindNode(BindWA *bindWA)
 	{
 	  xnsfrmHbaseUpdate = TRUE;
 	}
-      else if ((CmpCommon::getDefault(HBASE_TRANSFORM_UPDATE_TO_DELETE_INSERT) == DF_SYSTEM) &&
-	       (getTableDesc()->getNATable()->hasSecondaryIndexes()))
-	{
-	  xnsfrmHbaseUpdate = TRUE;
-	}
-      else if (avoidHalloween())
-	{
-	  xnsfrmHbaseUpdate = TRUE;
-	}
       else if (getCheckConstraints().entries())
-	{
-	  xnsfrmHbaseUpdate = TRUE;
-	}
+       {
+         xnsfrmHbaseUpdate = TRUE;
+       }
      }  
   
   if (xnsfrmHbaseUpdate)
     {
       boundExpr = transformHbaseUpdate(bindWA);
     }
-  else if ((transformUpdateKey) && (NOT isMerge()))
+  else 
+  // till here and remove the function transformHbaseUpdate also
+  if ((transformUpdateKey) && (NOT isMerge()))
     {
       boundExpr = transformUpdatePrimaryKey(bindWA);
     }


### PR DESCRIPTION
commands to improve performance of update statements. When a table has
check constraint the update command is transformed into insert and delete.

Added code to evaluate constraint expressions in all TCBs so that
constraint checking is done correctly. But, the subtask [TRAFODION-1610]
needs to implemented before this change is exercised.