### PR TITLE
Trafodion-1612 and Trafodion-1613

### DIFF
--- a/core/bldenvchk.sh
+++ b/core/bldenvchk.sh
@@ -50,7 +50,7 @@ for AVAR in $VARFILELIST; do
       printf '%s =\t%s\n' $AVAR $AVALUE
    fi
    if [[ $RESULT != 0 ]]; then
-      echo "*** Error: $AVAR file not found in PATH."
+      echo "*** Error: $AVAR file not found in PATH or file not fully qualified."
       RETVAL=1
    fi
 done

--- a/core/sqf/sqenvcom.sh
+++ b/core/sqf/sqenvcom.sh
@@ -235,8 +235,12 @@ if [[ -e $MY_SQROOT/sql/scripts/sw_env.sh ]]; then
   # native library directories and include directories
   export HADOOP_LIB_DIR=$YARN_HOME/lib/native
   export HADOOP_INC_DIR=$YARN_HOME/include
-  export THRIFT_LIB_DIR=$TOOLSDIR/thrift-0.9.0/lib
-  export THRIFT_INC_DIR=$TOOLSDIR/thrift-0.9.0/include
+  if [ -z $THRIFT_LIB_DIR ]; then
+    export THRIFT_LIB_DIR=$TOOLSDIR/thrift-0.9.0/lib
+  fi
+  if [ -z $THRIFT_INC_DIR ]; then
+    export THRIFT_INC_DIR=$TOOLSDIR/thrift-0.9.0/include
+  fi
   export CURL_INC_DIR=/usr/include
   export CURL_LIB_DIR=/usr/lib64
   # directories with jar files and list of jar files
@@ -615,8 +619,12 @@ fi
 
 # Common for local workstations, Cloudera, Hortonworks and MapR
 
-export ZOOKEEPER_DIR=$TOOLSDIR/zookeeper-3.4.5
-export MPICH_ROOT=$TOOLSDIR/dest-mpich-3.0.4
+if [ -z $ZOOKEEPER_DIR ]; then
+  export ZOOKEEPER_DIR=$TOOLSDIR/zookeeper-3.4.5
+fi
+if [ -z $MPICH_ROOT ]; then
+  export MPICH_ROOT=$TOOLSDIR/dest-mpich-3.0.4
+fi
 export PROTOBUFS=/usr
 
 # LOG4CXX
@@ -761,27 +769,36 @@ source tools/sqtools.sh
 ######################
 
 # Standard tools expected to be installed and found in PATH
-export ANT="/usr/bin/ant"
-if [[ ! -e $ANT ]]; then
-  ANT="${TOOLSDIR}/bin/ant"
-fi
+# Tool availability are checked during the build (make) step
+export ANT=ant
 export AR=ar
 export FLEX=flex
 export CXX=g++
+
+# Maven may not yet be in the path. Check and report an error
 export MAVEN=mvn
 if [[ -z "$(which $MAVEN 2> /dev/null)" ]]; then
-  export M2_HOME="${TOOLSDIR}/apache-maven-3.0.5"
-  MAVEN="${M2_HOME}/bin/mvn"
+  echo " *** ERROR unable to find mvn (MAVEN) in path"
+  echo " *** please include it in your path before attempting your build"
 fi
 
 # Non-standard or newer version tools
-export BISON="${TOOLSDIR}/bison_3_linux/bin/bison"     # Need 1.3 version or later
-export LLVM="${TOOLSDIR}/dest-llvm-3.2"
-export UDIS86="${TOOLSDIR}/udis86-1.7.2"
-export ICU="${TOOLSDIR}/icu4.4"
+if [ -z $BISON ]; then
+  export BISON="${TOOLSDIR}/bison_3_linux/bin/bison"     # Need 1.3 version or later
+fi
+if [ -z $LLVM ]; then
+  export LLVM="${TOOLSDIR}/dest-llvm-3.2"
+fi
+if [ -z $UDIS86 ]; then
+  export UDIS86="${TOOLSDIR}/udis86-1.7.2"
+fi
+if [ -z $ICU ]; then
+  export ICU="${TOOLSDIR}/icu4.4"
+fi
 
 #######################
 # Developer Local over-rides  (see sqf/LocalSettingsTemplate.sh)
+# Cannot rely on this, the connectivity build overwrites the .trafodion file
 ######################
 if [[ -r ~/.trafodion ]]; then
   [[ $SQ_VERBOSE == 1 ]] && echo "Sourcing local settings file ~/.trafodion"

--- a/core/sqf/src/seatrans/hbase-trx/Makefile
+++ b/core/sqf/src/seatrans/hbase-trx/Makefile
@@ -60,7 +60,7 @@ jdk_1_7_apache:
 	cp -pf target/$(BLD_HBASE_APACHE_TRX_JARNAME) $(MY_SQROOT)/export/lib
 	$(RM) $(VFILE)
 
-build_all: jdk_1_7_apache jdk_1_7_cdh jdk_1_7_hdp jdk_1_7_mapr
+build_all: jdk_1_7_apache jdk_1_7_cdh jdk_1_7_hdp 
 #build_all: jdk_1_7_apache jdk_1_7_cdh
 
 build_chk_apache:

--- a/install/traf_tools_setup.sh
+++ b/install/traf_tools_setup.sh
@@ -397,7 +397,7 @@ echo " *********************************************************** " | tee -a $L
 
 # -----------------------------------------------------------------------------
 # install maven, if version 3 or greater not available already
-#MAVEN_VERSION=`mvn --version 2>/dev/null | grep 'Apache Maven' | cut -f 3 -d ' '`
+MAVEN_VERSION=`mvn --version 2>/dev/null | grep 'Apache Maven' | cut -f 3 -d ' '`
 if [[ ! "$MAVEN_VERSION" =~ "3." ]]; then
   cd $BASEDIR
   echo
@@ -413,6 +413,8 @@ if [[ ! "$MAVEN_VERSION" =~ "3." ]]; then
   fi
     echo "INFO: Maven installation complete" | tee -a $LOGFILE
   echo " *********************************************************** " | tee -a $LOGFILE
+else
+  echo "INFO:  Maven is already installed, skipping to next tool" | tee -a $LOGFILE
 fi
 
 echo


### PR DESCRIPTION
1612: Stop building HBase-trx for MAPR, due to instable Maven repository

- removed mapr from the build_all step in the hbase_trx Makefile, we now create
  6 jar files instead of 7

1613: build failing due to mismatched Maven downloads

When building Trafodion from source objects, Maven is required.  It is not
possible to download Maven from yum, instead it needs to be installed. There
are a few problems related to how Maven is managed with Trafodion builds.

- In many environments, Maven is already installed.  The check to see if Maven
  is already installed is commented out in traf_tools_setup.sh. This has been
  fixed.

- Today, sqenvcom.sh checks to see if mvn is installed, if not, it sets it to
  version 3.0.5 but we install 3.3.3. Changed the code to return an error:
  "ERROR unable to find mvn (MAVEN) in path" to inform the user that mvn needs
  to be added to the path before building. An error is also returned during
  the build (make) if mvn is not found in the path.

- As part of the above change, it was noted that many of the tools were being
  set to the value of $TOOLSDIR when $TOOLSDIR may not be set.  Checks were
  added to see if the environment variable was already set. This allows
  someone to specify a different location for these tools as described in the
  additional build tools wiki page.

- Changed the output returned in bldenvchk.sh.  BISON does not have to be in
  the path but needs to be specified correctly in the environment variable.