### PR TITLE
[TRAFODION-1417] Reduce locations to change release version number

### DIFF
--- a/core/rest/pom.xml
+++ b/core/rest/pom.xml
@@ -401,7 +401,7 @@
   	<jython-standalone.version>2.5.3</jython-standalone.version>
   	<jettison.version>1.3.5</jettison.version>
   	<displaytag.version>1.1.1</displaytag.version>
-  	<jdbct4.version>2.0.0</jdbct4.version>
+  	<jdbct4.version>${project.version}</jdbct4.version>
    	
     <!-- Plugin Dependencies -->
     <maven.antrun.plugin.version>1.6</maven.antrun.plugin.version>
@@ -415,8 +415,7 @@
     <maven.project.info.reports.plugin.version>2.1.2</maven.project.info.reports.plugin.version>
     <build.helper.maven.plugin.version>1.5</build.helper.maven.plugin.version>
 
-    <!-- also must update this when we bump version -->
-    <package.version>2.0.0</package.version>
+    <package.version>${project.version}</package.version>
   	<final.name>${project.artifactId}-${project.version}</final.name>
   	
   	<!-- Test inclusion patterns used by failsafe configuration -->

--- a/core/rest/pom.xml
+++ b/core/rest/pom.xml
@@ -33,7 +33,7 @@
   <groupId>org.trafodion</groupId>
   <artifactId>rest</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.0</version>
+  <version>${env.TRAFODION_VER}</version>
   <name>rest</name>
   <url>http://wiki.trafodion.org</url>
   

--- a/core/sqf/sql/scripts/install_traf_components
+++ b/core/sqf/sql/scripts/install_traf_components
@@ -431,7 +431,7 @@ else
 # command to run JDBC tests
 cd $JDBCTEST_DIR
 ./jdbc_test.py --appid=jdbc_test --user=SOMEUSER --pw=SOMEPASSWORD --javahome=\$JAVA_HOME \\
-  --target=localhost:$MY_DCS_MASTER_PORT \\
+  --target=localhost:$MY_DCS_MASTER_PORT --dbmaj=\$TRAFODION_VER_MAJOR --dbmin=\$TRAFODION_VER_MINOR \\
   --jdbctype=T4 --jdbccp=\$MY_SQROOT/export/lib/jdbcT4.jar "\$@"
 EOF
     chmod +x $MY_SQROOT/sql/scripts/swjdbc

--- a/dcs/pom.xml
+++ b/dcs/pom.xml
@@ -484,8 +484,8 @@
   	<jython-standalone.version>2.5.3</jython-standalone.version>
   	<jettison.version>1.3.5</jettison.version>
   	<displaytag.version>1.1.1</displaytag.version>
-    <jdbct4.version>2.0.0</jdbct4.version>
-    <jdbct2.version>2.0.0</jdbct2.version>
+    <jdbct4.version>${project.version}</jdbct4.version>
+    <jdbct2.version>${project.version}</jdbct2.version>
     
     <!-- Plugin Dependencies -->
     <maven.antrun.plugin.version>1.6</maven.antrun.plugin.version>
@@ -501,8 +501,7 @@
     <build.helper.maven.plugin.version>1.5</build.helper.maven.plugin.version>
     <maven.assembly.plugin.version>2.5.3</maven.assembly.plugin.version>
 
-    <!-- also must update this when we bump version -->
-    <package.version>2.0.0</package.version>
+    <package.version>${project.version}</package.version>
   	<final.name>${project.artifactId}-${project.version}</final.name>
   	
   	<!-- Test inclusion patterns used by failsafe configuration -->

--- a/dcs/pom.xml
+++ b/dcs/pom.xml
@@ -34,7 +34,7 @@
   <groupId>org.trafodion</groupId>
   <artifactId>dcs</artifactId>
   <packaging>jar</packaging>
-  <version>2.0.0</version>
+  <version>${env.TRAFODION_VER}</version>
   <name>dcs</name>
   <url>http://wiki.trafodion.org</url>
   

--- a/dcs/src/test/jdbc_test/jdbc_test.py
+++ b/dcs/src/test/jdbc_test/jdbc_test.py
@@ -56,6 +56,8 @@ def ArgList():
     _export_str5 = None
     _jdbc_type = None
     _tests = None
+    _dbmaj = None
+    _dbmin = None
 
 #----------------------------------------------------------------------------
 # Tracking all of the global variables in here.
@@ -153,7 +155,7 @@ def generate_pom_xml(appid, jdbccp, jdbc_version):
 #----------------------------------------------------------------------------
 # Generate propfile
 #----------------------------------------------------------------------------
-def generate_t4_propfile(propfile, target, user, pw, role, dsn, schema, appname, jdbc_version):
+def generate_t4_propfile(propfile, target, user, pw, role, dsn, schema, appname, jdbc_version, db_maj, db_min):
     fd = open(propfile, 'w')
     fd.write('url=jdbc:t4jdbc://' + target + '/\n')
     fd.write('user=' + user + '\n')
@@ -163,13 +165,15 @@ def generate_t4_propfile(propfile, target, user, pw, role, dsn, schema, appname,
     fd.write('schema=' + schema + '\n')
     fd.write('serverDataSource=' + dsn + '\n')
     fd.write('trafjdbc_version=' + jdbc_version + '\n')
+    fd.write('db_major=' + db_maj + '\n')
+    fd.write('db_minor=' + db_min + '\n')
     fd.write('sessionName=' + appname + '\n')
     fd.write('applicationName=' + appname + '\n')
     fd.write('batchBinding=500\n')
 
     fd.close()
 
-def generate_t2_propfile(propfile, user, pw, role, dsn, schema, appname, jdbc_version):
+def generate_t2_propfile(propfile, user, pw, role, dsn, schema, appname, jdbc_version, db_maj, db_min):
     fd = open(propfile, 'w')
     fd.write('url=jdbc:sql:\n')
     fd.write('user=' + user + '\n')
@@ -179,6 +183,8 @@ def generate_t2_propfile(propfile, user, pw, role, dsn, schema, appname, jdbc_ve
     fd.write('schema=' + schema + '\n')
     fd.write('serverDataSource=' + dsn + '\n')
     fd.write('trafjdbc_version=' + jdbc_version + '\n')
+    fd.write('db_major=' + db_maj + '\n')
+    fd.write('db_minor=' + db_min + '\n')
     fd.write('sessionName=' + appname + '\n')
     fd.write('applicationName=' + appname + '\n')
     fd.write('batchBinding=500\n')
@@ -242,6 +248,12 @@ def prog_parse_args():
         optparse.make_option('', '--jdbctype', action='store', type='string',
           dest='jdbctype', default='T4',
           help='jdbctype, defaulted to T4'),
+        optparse.make_option('', '--dbmaj', action='store', type='string',
+          dest='dbmaj', default='2',
+          help='DB major version, defaulted to 2'),
+        optparse.make_option('', '--dbmin', action='store', type='string',
+          dest='dbmin', default='0',
+          help='DB minor version, defaulted to 0'),
         optparse.make_option('', '--export1', action='store', type='string',
           dest='exportstr1', default='NONE',
           help='any export string, defaulted to NONE'),
@@ -311,6 +323,8 @@ def prog_parse_args():
     ArgList._jdbc_classpath = options.jdbccp
     ArgList._prop_file = os.path.abspath(options.propfile)
     ArgList._jdbc_type = options.jdbctype
+    ArgList._dbmaj = options.dbmaj
+    ArgList._dbmin = options.dbmin
     ArgList._export_str1 = options.exportstr1
     ArgList._export_str2 = options.exportstr2
     ArgList._export_str3 = options.exportstr3
@@ -321,9 +335,9 @@ def prog_parse_args():
     # Automatically generate the prop file if the user did not specify one
     if options.propfile == DEFAULT_PROP_FILE:
         if options.jdbctype == 'T2':
-            generate_t2_propfile(ArgList._prop_file, ArgList._user, ArgList._pw, ArgList._role, ArgList._dsn, ArgList._schema, ArgList._appid, ArgList._jdbc_version)
+            generate_t2_propfile(ArgList._prop_file, ArgList._user, ArgList._pw, ArgList._role, ArgList._dsn, ArgList._schema, ArgList._appid, ArgList._jdbc_version, ArgList._dbmaj, ArgList._dbmin)
         elif options.jdbctype == 'T4':
-            generate_t4_propfile(ArgList._prop_file, ArgList._target, ArgList._user, ArgList._pw, ArgList._role, ArgList._dsn, ArgList._schema, ArgList._appid, ArgList._jdbc_version)
+            generate_t4_propfile(ArgList._prop_file, ArgList._target, ArgList._user, ArgList._pw, ArgList._role, ArgList._dsn, ArgList._schema, ArgList._appid, ArgList._jdbc_version, ArgList._dbmaj, ArgList._dbmin)
 
     # Generate the pom.xml file from the template according to target type
     generate_pom_xml(ArgList._appid, ArgList._jdbc_classpath, ArgList._jdbc_version)
@@ -340,6 +354,7 @@ def prog_parse_args():
     print 'prop file:             ', ArgList._prop_file
     print 'jdbc type:             ', ArgList._jdbc_type
     print 'jdbc version:          ', ArgList._jdbc_version
+    print 'DB version:            ', ArgList._dbmaj + "." + ArgList._dbmin
     print 'export string 1:       ', ArgList._export_str1
     print 'export string 2:       ', ArgList._export_str2
     print 'export string 3:       ', ArgList._export_str3

--- a/dcs/src/test/jdbc_test/src/test/java/org/trafodion/jdbc_test/TestCat.java
+++ b/dcs/src/test/jdbc_test/src/test/java/org/trafodion/jdbc_test/TestCat.java
@@ -604,9 +604,10 @@ public class TestCat
         try
         {
             Connection connection = Utils.getUserConnection();
+            String db = Utils.dbmaj_version + "." + Utils.dbmin_version;
             String s = connection.getMetaData().getDatabaseProductVersion();
             System.out.println((new StringBuilder()).append("DB product version : ").append(s).toString());
-            assertEquals("DB Product Version", "2.0", s);
+            assertEquals("DB Product Version", db, s);
             connection.close();
             System.out.println("JDBC Get DB product version : Passed");
         }
@@ -626,8 +627,9 @@ public class TestCat
         try
         {
             Connection connection = Utils.getUserConnection();
+            int maj = Integer.parseInt(Utils.dbmaj_version);
             int i = connection.getMetaData().getDatabaseMajorVersion();
-            assertEquals("DB major Version", 2L, i);
+            assertEquals("DB major Version", maj, i);
             connection.close();
             System.out.println("JDBC Get DB major version : Passed");
         }
@@ -647,8 +649,9 @@ public class TestCat
         try
         {
             Connection connection = Utils.getUserConnection();
+            int min = Integer.parseInt(Utils.dbmin_version);
             int i = connection.getMetaData().getDatabaseMinorVersion();
-            assertEquals("DB Minor Version", 0L, i);
+            assertEquals("DB Minor Version", min, i);
             connection.close();
             System.out.println("JDBC Get DB minor version : Passed");
         }

--- a/dcs/src/test/jdbc_test/src/test/java/org/trafodion/jdbc_test/Utils.java
+++ b/dcs/src/test/jdbc_test/src/test/java/org/trafodion/jdbc_test/Utils.java
@@ -52,6 +52,8 @@ public class Utils
 {
 	public static String url;
     public static String trafjdbc_version;
+    public static String dbmaj_version;
+    public static String dbmin_version;
     public static String usr;
     public static String pwd;
     public static String catalog;
@@ -82,6 +84,10 @@ public class Utils
                 System.out.println("schema: " + schema);
                 trafjdbc_version=props.getProperty("trafjdbc_version");
                 System.out.println("trafjdbc_version : " + trafjdbc_version);
+                dbmaj_version=props.getProperty("db_major");
+                System.out.println("dbmaj_version : " + dbmaj_version);
+                dbmin_version=props.getProperty("db_minor");
+                System.out.println("dbmin_version : " + dbmin_version);
             } else {
                 System.out.println("Error: prop is not set. Exiting.");
                 System.exit(0);


### PR DESCRIPTION
To change the trafodion release version major/minor number, there were about a dozen locations in four different files that needed to be modified.

This set of changes eliminates all those places except for the single place in core/sqf/sqenvcom.sh.

It does add maven warnings in DCS and REST build logs, same as in other components that already use maven with environment variable version number.

jdbc_test.py script now takes additional options to pass in correct version numbers. If you use swjdbc script, then it is taken care of. Other environments that call jdbc_test.py directly (e.g., jenkins test automation) should also be changed. But the default values match the current release, so the change is not urgent.