### PR TITLE
Fix for the executor/TEST106 failure caused due to JIRA TRAFODION-1625

### DIFF
--- a/core/sql/generator/GenPreCode.cpp
+++ b/core/sql/generator/GenPreCode.cpp
@@ -4934,8 +4934,9 @@ RelExpr * HbaseDelete::preCodeGen(Generator * generator,
   else
   if (isUnique)
     {
-      // do not cancel unique queries.
-      generator->setMayNotCancel(TRUE);
+      if (!generator->oltOptInfo()->multipleRowsReturned())
+	// do not cancel unique queries.
+	generator->setMayNotCancel(TRUE);
       uniqueHbaseOper() = TRUE;
       canDoCheckAndUpdel() = FALSE;
       if ((NOT producesOutputs()) &&

--- a/core/sql/generator/GenPreCode.cpp
+++ b/core/sql/generator/GenPreCode.cpp
@@ -4934,8 +4934,9 @@ RelExpr * HbaseDelete::preCodeGen(Generator * generator,
   else
   if (isUnique)
     {
+      //If this unique delete is not part of a rowset operation , 
+      //don't allow it to be cancelled. 
       if (!generator->oltOptInfo()->multipleRowsReturned())
-	// do not cancel unique queries.
 	generator->setMayNotCancel(TRUE);
       uniqueHbaseOper() = TRUE;
       canDoCheckAndUpdel() = FALSE;
@@ -5201,8 +5202,10 @@ RelExpr * HbaseUpdate::preCodeGen(Generator * generator,
   else
   if (isUnique)
     {
-      // do not cancel unique queries.
-      generator->setMayNotCancel(TRUE);
+      //If this unique delete is not part of a rowset operation , 
+      //don't allow it to be cancelled.
+      if (!generator->oltOptInfo()->multipleRowsReturned())
+	generator->setMayNotCancel(TRUE);
       uniqueHbaseOper() = TRUE;
 
       canDoCheckAndUpdel() = FALSE;
@@ -11441,10 +11444,11 @@ RelExpr * HbaseAccess::preCodeGen(Generator * generator,
   if (!isUnique)
       generator->oltOptInfo()->setMultipleRowsReturned(TRUE) ;
 
+  // Do not allow cancel of unique queries but allow cancel of queries 
+  // that are part of a rowset operation. 
   if ((isUnique) &&
       (NOT generator->oltOptInfo()->multipleRowsReturned()))
     {
-      // do not cancel unique queries.
       generator->setMayNotCancel(TRUE);
       uniqueHbaseOper() = TRUE;
     }


### PR DESCRIPTION
A delete query on a 200K large table was marked as a unique delete. This was found when the long operation was not being cancelled when a cancel query was issued. Unique queries are typcially not cancelable since they are  short running.   The issue happens when rowset deletes are chosen . This  plan change happened recently due to a costing change. The rowset operation needs to be marked as cancelable. 