### PR TITLE
[TRAFODION-1423] indexes are now created in aligned format by default

### DIFF
--- a/core/sql/executor/HBaseClient_JNI.cpp
+++ b/core/sql/executor/HBaseClient_JNI.cpp
@@ -2875,14 +2875,7 @@ HBC_RetCode HBaseClient_JNI::getHbaseTableInfo(const char* tblName,
   blockSize = arrayElems[1];
   if (isCopy == JNI_TRUE)
      jenv_->ReleaseIntArrayElements(jHtabInfo, arrayElems, JNI_ABORT);
-
-  if (jresult == false)
-  {
-    logError(CAT_SQL_HBASE, "HBaseClient_JNI::getHbaseTableInfo()", getLastError());
-    jenv_->PopLocalFrame(NULL);
-    return HBC_ERROR_GET_HBTI_EXCEPTION;
-  }
-
+  jenv_->PopLocalFrame(NULL);
   return HBC_OK;  // Table exists.
 }
 

--- a/core/sql/generator/GenExpGenerator.cpp
+++ b/core/sql/generator/GenExpGenerator.cpp
@@ -2892,7 +2892,8 @@ short ExpGenerator::generateKeyEncodeExpr(const IndexDesc * indexDesc,
       if (handleSerialization)
 	{
 	  NAColumn * nac = indexDesc->getNAFileSet()->getIndexKeyColumns()[i];
-	  if (CmpSeabaseDDL::isEncodingNeededForSerialization(nac))
+          NABoolean isAlignedRowFormat = indexDesc->getNAFileSet()->isSqlmxAlignedRowFormat();
+	  if ((!isAlignedRowFormat) && CmpSeabaseDDL::isEncodingNeededForSerialization(nac))
 	    {
 	      if (desc_flag)
 		{

--- a/core/sql/generator/GenPreCode.cpp
+++ b/core/sql/generator/GenPreCode.cpp
@@ -9488,7 +9488,7 @@ ItemExpr * IndexColumn::preCodeGen(Generator * generator)
   return i;
 }
 
-ItemExpr * Generator::addCompDecodeForDerialization(ItemExpr * ie)
+ItemExpr * Generator::addCompDecodeForDerialization(ItemExpr * ie, NABoolean isAlignedFormat)
 {
   if (!ie)
     return NULL;
@@ -9496,7 +9496,7 @@ ItemExpr * Generator::addCompDecodeForDerialization(ItemExpr * ie)
   if ((ie->getOperatorType() == ITM_BASECOLUMN) ||
       (ie->getOperatorType() == ITM_INDEXCOLUMN))
     {
-      if (HbaseAccess::isEncodingNeededForSerialization(ie))
+      if (! isAlignedFormat && HbaseAccess::isEncodingNeededForSerialization(ie))
 	{
 	  ItemExpr * newNode = new(wHeap()) CompDecode
 	    (ie, &ie->getValueId().getType(), FALSE, TRUE);
@@ -9516,7 +9516,7 @@ ItemExpr * Generator::addCompDecodeForDerialization(ItemExpr * ie)
 
   for (Lng32 i = 0; i < ie->getArity(); i++)
     {
-      ItemExpr * nie = addCompDecodeForDerialization(ie->child(i));
+      ItemExpr * nie = addCompDecodeForDerialization(ie->child(i), isAlignedFormat);
       if (nie)
 	ie->setChild(i, nie);
     }

--- a/core/sql/generator/GenRelScan.cpp
+++ b/core/sql/generator/GenRelScan.cpp
@@ -302,7 +302,7 @@ int HbaseAccess::createAsciiColAndCastExpr2(Generator * generator,
   asciiValue = new (h) NATypeToItem(newGivenType->newCopy(h));
   castValue = new(h) Cast(asciiValue, newGivenType); 
 
-  if (HbaseAccess::isEncodingNeededForSerialization(colNode))
+  if ((!alignedFormat) && HbaseAccess::isEncodingNeededForSerialization(colNode))
     {
       castValue = new(generator->wHeap()) CompDecode(castValue, 
 						     newGivenType->newCopy(h),

--- a/core/sql/generator/GenRelUpdate.cpp
+++ b/core/sql/generator/GenRelUpdate.cpp
@@ -485,7 +485,7 @@ static short genHbaseUpdOrInsertExpr(
 		"unexpected type of base table column");
       
       const NAColumn *nac = bc->getNAColumn();
-      if (HbaseAccess::isEncodingNeededForSerialization(bc))
+      if ((NOT isAligned) && HbaseAccess::isEncodingNeededForSerialization(bc))
 	{
 	  ie = new(generator->wHeap()) CompEncode
 	    (ie, FALSE, -1, CollationInfo::Sort, TRUE);
@@ -2243,6 +2243,8 @@ short HbaseInsert::codeGen(Generator *generator)
 
   ValueIdList returnRowVIDList;
   NABoolean upsertColsWereSkipped = FALSE;
+  NABoolean isAlignedFormat = getTableDesc()->getNATable()->isAlignedFormat(getIndexDesc());
+
   for (CollIndex ii = 0; ii < newRecExprArray().entries(); ii++)
     {
       const ItemExpr *assignExpr = newRecExprArray()[ii].getItemExpr();
@@ -2274,7 +2276,7 @@ short HbaseInsert::codeGen(Generator *generator)
       ItemExpr * ie = new(generator->wHeap())
 	Cast(child1Expr, &givenType);
 
-      if (HbaseAccess::isEncodingNeededForSerialization
+      if ((NOT isAlignedFormat) && HbaseAccess::isEncodingNeededForSerialization
 	  (assignExpr->child(0)->castToItemExpr()))
 	{
 	  ie = new(generator->wHeap()) CompEncode
@@ -2295,7 +2297,6 @@ short HbaseInsert::codeGen(Generator *generator)
   ULng32 insertRowLen    = 0;
   ExpTupleDesc * tupleDesc   = 0;
   ExpTupleDesc::TupleDataFormat tupleFormat;
-  NABoolean isAlignedFormat = getTableDesc()->getNATable()->isAlignedFormat(getIndexDesc());
 
   if (isAlignedFormat)
     tupleFormat = ExpTupleDesc::SQLMX_ALIGNED_FORMAT;

--- a/core/sql/generator/GenRelUpdate.cpp
+++ b/core/sql/generator/GenRelUpdate.cpp
@@ -2531,7 +2531,7 @@ short HbaseInsert::codeGen(Generator *generator)
 	getCheckConstraints().rebuildExprTree(ITM_AND, TRUE, TRUE);
 
       if (getTableDesc()->getNATable()->hasSerializedEncodedColumn())
-	constrTree = generator->addCompDecodeForDerialization(constrTree);
+	constrTree = generator->addCompDecodeForDerialization(constrTree, isAlignedFormat);
 
       expGen->generateExpr(constrTree->getValueId(), ex_expr::exp_SCAN_PRED,
 			   &insConstraintExpr);

--- a/core/sql/generator/Generator.h
+++ b/core/sql/generator/Generator.h
@@ -1632,7 +1632,7 @@ public:
   void setPlanExpirationTimestamp(Int64 t);
   Int64 getPlanExpirationTimestamp() { return planExpirationTimestamp_; }
 
-  ItemExpr * addCompDecodeForDerialization(ItemExpr * ie);
+  ItemExpr * addCompDecodeForDerialization(ItemExpr * ie, NABoolean isAlignedFormat);
 
   void setHBaseNumCacheRows(double rowsAccessed, 
                             ComTdbHbaseAccess::HbasePerfAttributes * hbpa,

--- a/core/sql/optimizer/NAColumn.h
+++ b/core/sql/optimizer/NAColumn.h
@@ -398,6 +398,14 @@ public:
     return hbaseColFlags_;
   }
 
+  void resetSerialization() {
+     hbaseColFlags_ &= SEABASE_SERIALIZED;
+  }
+
+  enum {
+    SEABASE_SERIALIZED = 0x0001
+  };
+
 private:
   enum referencedState { NOT_REFERENCED, REFERENCED_ANYWHERE, REFERENCED_FOR_MULTI_INTERVAL_HISTOGRAM, REFERENCED_FOR_SINGLE_INTERVAL_HISTOGRAM };
 

--- a/core/sql/optimizer/NATable.cpp
+++ b/core/sql/optimizer/NATable.cpp
@@ -3718,7 +3718,7 @@ NABoolean createNAFileSets(desc_struct * table_desc       /*IN*/,
   NABoolean isVerticalPartition;
   NABoolean hasRemotePartition = FALSE;
   CollIndex numClusteringKeyColumns = 0;
-
+  NABoolean tableAlignedRowFormat = table->isSQLMXAlignedTable();
   // get hbase table index level and blocksize. costing code uses index_level
   // and block size to estimate cost. Here we make a JNI call to read index level
   // and block size. If there is a need to avoid reading from Hbase layer,
@@ -3777,27 +3777,10 @@ NABoolean createNAFileSets(desc_struct * table_desc       /*IN*/,
       // is this an index or is it really a VP?
       isVerticalPartition = indexes_desc->body.indexes_desc.isVerticalPartition;
       NABoolean isPacked = indexes_desc->body.indexes_desc.isPacked;
+      NABoolean indexAlignedRowFormat = (indexes_desc->body.indexes_desc.rowFormat == COM_ALIGNED_FORMAT_TYPE);
 
       NABoolean isNotAvailable =
 	indexes_desc->body.indexes_desc.notAvailable;
-/*
-      RowFormatEnum rowFormat;
-      switch (indexes_desc->body.indexes_desc.rowFormat)
-      {
-        case COM_PACKED_FORMAT_TYPE:
-           rowFormat = SQLMX_ROW_FORMAT;
-           break;
-        case COM_ALIGNED_FORMAT_TYPE:
-           rowFormat = SQLMX_ALIGNED_ROW_FORMAT;
-           break;
-        case COM_HBASE_FORMAT_TYPE:
-           rowFormat = SQLMX_HBASE_FORMAT;
-           break;
-        default:
-           rowFormat = SQLMX_UNKNOWN_FORMAT;
-      }
-*/
-
 
       ItemExprList hbaseSaltColumnList(CmpCommon::statementHeap());
       Int64 numOfSaltedPartitions = 0;
@@ -3833,13 +3816,14 @@ NABoolean createNAFileSets(desc_struct * table_desc       /*IN*/,
           indexColumn = colArray.getColumn(tablecolnumber);
           
           if ((table->isHbaseTable()) &&
-              (indexes_desc->body.indexes_desc.keytag != 0))
+              ((indexes_desc->body.indexes_desc.keytag != 0) || 
+                (indexAlignedRowFormat  && indexAlignedRowFormat != tableAlignedRowFormat)))
             {
               newIndexColumn = new(heap) NAColumn(*indexColumn);
               newIndexColumn->setIndexColName(keys_desc->body.keys_desc.keyname);
               newIndexColumn->setHbaseColFam(keys_desc->body.keys_desc.hbaseColFam);
               newIndexColumn->setHbaseColQual(keys_desc->body.keys_desc.hbaseColQual);
-              
+              newIndexColumn->resetSerialization(); 
               saveNAColumns.insert(indexColumn);
               newColumns.insert(newIndexColumn);
               indexColumn = newIndexColumn;
@@ -3930,14 +3914,15 @@ NABoolean createNAFileSets(desc_struct * table_desc       /*IN*/,
           indexColumn = colArray.getColumn(tablecolnumber);
 
 	  if ((table->isHbaseTable()) &&
-	      (indexes_desc->body.indexes_desc.keytag != 0))
+	      ((indexes_desc->body.indexes_desc.keytag != 0) || 
+               (indexAlignedRowFormat  && indexAlignedRowFormat != tableAlignedRowFormat)))
 	    {
 	      newIndexColumn = new(heap) NAColumn(*indexColumn);
 	      if (non_keys_desc->body.keys_desc.keyname)
 		newIndexColumn->setIndexColName(non_keys_desc->body.keys_desc.keyname);
 	      newIndexColumn->setHbaseColFam(non_keys_desc->body.keys_desc.hbaseColFam);
 	      newIndexColumn->setHbaseColQual(non_keys_desc->body.keys_desc.hbaseColQual);
-	      
+              newIndexColumn->resetSerialization(); 
 	      indexColumn = newIndexColumn;
               newColumns.insert(newIndexColumn);
 	    }

--- a/core/sql/regress/seabase/TEST022
+++ b/core/sql/regress/seabase/TEST022
@@ -20,7 +20,7 @@
 -- under the License.
 --
 -- @@@ END COPYRIGHT @@@
-
+cqd hbase_delete_costing 'off';
 log LOG022 clear;
 
 cqd hbase_native_iud 'ON';

--- a/core/sql/sqlcomp/CmpDescribe.cpp
+++ b/core/sql/sqlcomp/CmpDescribe.cpp
@@ -2283,7 +2283,8 @@ static short cmpDisplayColumn(const NAColumn *nac,
                               Lng32 &ii,
                               NABoolean namesOnly,
                               NABoolean &identityCol,
-                              NABoolean isExternalTable)
+                              NABoolean isExternalTable,
+                              NABoolean isAlignedRowFormat)
 {
   identityCol = FALSE;
   
@@ -2408,9 +2409,10 @@ static short cmpDisplayColumn(const NAColumn *nac,
   if ((! sqlmxRegr) ||
       (type == 3))
     {
-      if (CmpSeabaseDDL::isSerialized(nac->getHbaseColFlags()))
+      if ((NOT isAlignedRowFormat) &&
+            CmpSeabaseDDL::isSerialized(nac->getHbaseColFlags()))
         attrStr += " SERIALIZED";
-      else if  ((CmpCommon::getDefault(HBASE_SERIALIZATION) == DF_ON) ||
+      else if ((CmpCommon::getDefault(HBASE_SERIALIZATION) == DF_ON) ||
                 (type == 3))
         attrStr += " NOT SERIALIZED";
     }
@@ -2439,6 +2441,7 @@ short cmpDisplayColumns(const NAColumnArray & naColArr,
                         NABoolean namesOnly,
                         Lng32 &identityColPos,
                         NABoolean isExternalTable,
+			NABoolean isAlignedRowFormat,
                         char * inColName = NULL,
                         NABoolean isAdd = FALSE,
                         const NAColumn * nacol = NULL)
@@ -2464,7 +2467,7 @@ short cmpDisplayColumns(const NAColumnArray & naColArr,
             continue;
         }
       
-       if (cmpDisplayColumn(nac, type, space, buf, ii, namesOnly, identityCol, isExternalTable))
+       if (cmpDisplayColumn(nac, type, space, buf, ii, namesOnly, identityCol, isExternalTable, isAlignedRowFormat))
         return -1;
 
       if (identityCol)
@@ -2475,7 +2478,7 @@ short cmpDisplayColumns(const NAColumnArray & naColArr,
 
   if ((inColName) && (isAdd) && (nacol))
     {
-      if (cmpDisplayColumn(nacol, type, space, buf, ii, namesOnly, identityCol, isExternalTable))
+      if (cmpDisplayColumn(nacol, type, space, buf, ii, namesOnly, identityCol, isExternalTable, isAlignedRowFormat))
         return -1;
     }
 
@@ -2744,7 +2747,7 @@ short CmpDescribeSeabaseTable (
 		    displaySystemCols, 
 		    FALSE,
                     identityColPos,
-                    isExternalTable,
+                    isExternalTable, naTable->isSQLMXAlignedTable(),
                     colName, isAdd, nacol);
 
   Int32 nonSystemKeyCols = 0;
@@ -3014,6 +3017,7 @@ short CmpDescribeSeabaseTable (
       for (Int32 i = 0; i < indexList.entries(); i++)
 	{
 	  const NAFileSet * naf = indexList[i];
+          isAligned = naf->isSqlmxAlignedRowFormat();
 	  if (naf->getKeytag() == 0)
 	    continue;
 	  
@@ -3069,7 +3073,8 @@ short CmpDescribeSeabaseTable (
 				displaySystemCols,
 				(type == 2),
                                 dummy,
-                                isExternalTable);
+                                isExternalTable,
+                                isAligned);
 	      outputShortLine(space, "  )");
 	      
 	      sprintf(buf,  "  PRIMARY KEY ");
@@ -3087,6 +3092,15 @@ short CmpDescribeSeabaseTable (
 	  cmpDisplayPrimaryKey(naf->getIndexKeyColumns(), numIndexCols, 
 			       displaySystemCols,
 			       space, buf, FALSE, TRUE);
+
+          if ((NOT sqlmxRegr) && isAligned)
+          {
+             char attrs[2000];
+             strcpy(attrs, " ATTRIBUTES ");
+             if (isAligned)
+                strcat(attrs, "ALIGNED FORMAT ");
+             outputShortLine(space, attrs);
+          }
 
           if ((naf->hbaseCreateOptions()) && (type == 2) &&
                (naf->hbaseCreateOptions()->entries() > 0))

--- a/core/sql/sqlcomp/CmpSeabaseDDL.h
+++ b/core/sql/sqlcomp/CmpSeabaseDDL.h
@@ -310,7 +310,7 @@ class CmpSeabaseDDL
 
   static NABoolean isSerialized(ULng32 flags)
   {
-    return (flags & SEABASE_SERIALIZED) != 0;
+    return (flags & NAColumn::SEABASE_SERIALIZED) != 0;
   }
 
   short buildColInfoArray(
@@ -402,13 +402,11 @@ class CmpSeabaseDDL
   
   void deallocEHI(ExpHbaseInterface* &ehi);
   void dropLOBHdfsFiles();
- protected:
-
   enum {
-    SEABASE_SERIALIZED = 0x0001,
     // set if we need to get the hbase snapshot info of the table
     GET_SNAPSHOTS = 0x0002
   };
+ protected:
 
   void setFlags(ULng32 &flags, ULng32 flagbits)
   {

--- a/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
@@ -2665,13 +2665,13 @@ short CmpSeabaseDDL::getTypeInfo(const NAType * naType,
         collationSequence = charType->getCollation();
         if (serializedOption == 1) // option explicitly specified
           {
-            setFlags(hbaseColFlags, SEABASE_SERIALIZED);
+            setFlags(hbaseColFlags, NAColumn::SEABASE_SERIALIZED);
           }
         else if ((serializedOption == -1) && // not specified
                  (CmpCommon::getDefault(HBASE_SERIALIZATION) == DF_ON) &&
                  (NOT alignedFormat))
           {
-            setFlags(hbaseColFlags, SEABASE_SERIALIZED);
+            setFlags(hbaseColFlags, NAColumn::SEABASE_SERIALIZED);
           }
        }
       break;
@@ -2691,7 +2691,7 @@ short CmpSeabaseDDL::getTypeInfo(const NAType * naType,
         if (serializedOption == 1) // option explicitly specified
           {
             if (DFS2REC::isBinary(datatype))
-              setFlags(hbaseColFlags, SEABASE_SERIALIZED);
+              setFlags(hbaseColFlags, NAColumn::SEABASE_SERIALIZED);
             else if (numericType->isEncodingNeeded())
               {
                 *CmpCommon::diags() << DgSqlCode(-1191)
@@ -2704,7 +2704,7 @@ short CmpSeabaseDDL::getTypeInfo(const NAType * naType,
                  (DFS2REC::isBinary(datatype)) &&
                  (NOT alignedFormat))
           {
-            setFlags(hbaseColFlags, SEABASE_SERIALIZED);
+            setFlags(hbaseColFlags, NAColumn::SEABASE_SERIALIZED);
           }
       }
       break;
@@ -2764,7 +2764,7 @@ short CmpSeabaseDDL::getTypeInfo(const NAType * naType,
   if ((serializedOption == 1) && (alignedFormat))
     {
       // ignore serialized option on aligned format tables
-      resetFlags(hbaseColFlags, SEABASE_SERIALIZED);
+      resetFlags(hbaseColFlags, NAColumn::SEABASE_SERIALIZED);
       
       /*
        *CmpCommon::diags()
@@ -2830,7 +2830,7 @@ short CmpSeabaseDDL::getColInfo(ElemDDLColDef * colNode,
 
   if (colName == "SYSKEY")
     {
-      resetFlags(hbaseColFlags, SEABASE_SERIALIZED);
+      resetFlags(hbaseColFlags, NAColumn::SEABASE_SERIALIZED);
     }
 
   if  (collationSequence != CharInfo::DefaultCollation)

--- a/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
@@ -2089,6 +2089,13 @@ NABoolean CmpSeabaseDDL::enabledForSerialization(NAColumn * nac)
   return FALSE;
 }
 
+// NAColumn in memory is expected to have the correct HbaseColFlags for
+// serialization depending on if it belongs to index or table. 
+// Index and Table row format can be different now. However, it is
+// recommended that the function is called only when it is not aligned
+// row format. The existing callers are verified to be working correctly
+// even though some callers don't adhere to this recommendation
+
 NABoolean CmpSeabaseDDL::isEncodingNeededForSerialization(NAColumn * nac)
 {
   const NAType *givenType = nac->getType();

--- a/core/sql/sqlcomp/CmpSeabaseDDLindex.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLindex.cpp
@@ -612,17 +612,22 @@ void CmpSeabaseDDL::createSeabaseIndex(
 
       return;
     }
+  ParDDLFileAttrsCreateIndex &fileAttribs =
+    createIndexNode->getFileAttributes();
 
   NABoolean alignedFormat = FALSE;
-  if (CmpCommon::getDefault(TRAF_INDEX_ALIGNED_ROW_FORMAT) == DF_ON) {
-     if (naTable->hasSerializedColumn())
-        alignedFormat = FALSE;
-     else
-     if (isSeabaseReservedSchema(tableName))
-        alignedFormat = FALSE;
-     else
+  if (fileAttribs.isRowFormatSpecified() == TRUE)
+    {
+      if (fileAttribs.getRowFormat() == ElemDDLFileAttrRowFormat::eALIGNED)
+        {
+          alignedFormat = TRUE;
+        }
+    }
+  else if(CmpCommon::getDefault(TRAF_INDEX_ALIGNED_ROW_FORMAT) == DF_ON)
+    {
+      if ( NOT isSeabaseReservedSchema(tableName))
         alignedFormat = TRUE;
-  }
+    }
   else
   if (naTable->isSQLMXAlignedTable())
     alignedFormat = TRUE;

--- a/core/sql/sqlcomp/nadefaults.cpp
+++ b/core/sql/sqlcomp/nadefaults.cpp
@@ -3315,7 +3315,7 @@ XDDkwd__(SUBQUERY_UNNESTING,			"ON"),
  
  DDkwd__(TRAF_ENABLE_ORC_FORMAT,                 "OFF"),   
 
-  DDkwd__(TRAF_INDEX_ALIGNED_ROW_FORMAT,        "OFF"),   
+  DDkwd__(TRAF_INDEX_ALIGNED_ROW_FORMAT,        "ON"),   
   DDkwd__(TRAF_INDEX_CREATE_OPT,          "OFF"),
   DDkwd__(TRAF_LOAD_ALLOW_RISKY_INDEX_MAINTENANCE,        "OFF"),
   DDkwd__(TRAF_LOAD_CONTINUE_ON_ERROR,          "OFF"),

--- a/core/sql/src/main/java/org/trafodion/sql/HBaseClient.java
+++ b/core/sql/src/main/java/org/trafodion/sql/HBaseClient.java
@@ -1239,6 +1239,9 @@ public class HBaseClient {
         for (int i =0; i < regArr.length; i++) 
           logger.debug("Region Path is " + regArr[i].getPath());
       }
+
+      if (regArr.length == 0)
+         return true;
       // get random region from the region array
       int regInd = 0;
       regInd = tblName.hashCode() % regArr.length;


### PR DESCRIPTION
The indexes row format is now independent of the table. The table
can be in format that aids in pushing down the predicates to
hbase, but the index is now created in aligned format by default.

SHOWDDL <table_name> now shows the row format of the index when it
is in aligned row format.