### PR TITLE
[TRAFODION-1641] Fix MDAM costing bugs

### DIFF
--- a/core/sql/regress/seabase/EXPECTED010
+++ b/core/sql/regress/seabase/EXPECTED010
@@ -10097,7 +10097,7 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 ---- ---- ---- --------------------  --------  --------------------  ---------
 
 1    .    2    root                                                  1.00E+009
-.    .    1    trafodion_index_scan            T010IX1               1.00E+009
+.    .    1    trafodion_scan                  T010T4                1.00E+009
 
 --- SQL operation complete.
 >>execute s;


### PR DESCRIPTION
This set of changes is a partial fix to [TRAFODION-1641]. It does resolve the issue described in the JIRA (that is, the query now gets a better choice of MDAM plans), however as in many Optimizer changes, there are side effects that still remain to be fully evaluated. Follow-on work will address these if judged to be significant.

JIRA 1641 describes two bugs. This set of changes fixes bug #1: MDAM costing now takes into account the cumulative cost of each key column materialized. This set of changes partially fixes bug #2: It removes a bit of code that set the stop column for all MDAM plans to the last column (which caused MDAM plans to always traverse all keys, which can be grossly inefficient).

For queries not containing RangeSpec predicates with OR subtrees, these changes will allow MDAM to traverse a leading proper subset of columns, which often will be far more efficient. (For RangeSpec predicates containing OR subtrees, there is a heuristic in the code that presently causes all key columns to be traversed. This could be improved, and is part of the follow-on work.)

A side effect of these changes is that the cost computed for MDAM plans of 2 or more key columns will be somewhat higher (and much higher when traversing key columns with high UEC). This may cause MDAM to be chosen less often than previously.

One example of this occurs in the regression test suites (seabase/TEST010): A single query there now chooses a full table scan instead of an index scan using MDAM. Not using MDAM is a good decision for this particular plan. I have not investigated, however, why a full table scan is chosen over a full index scan.