### PR TITLE
[TRAFODION-1649]batch error should not stop the process

### DIFF
--- a/core/conn/jdbc_type4/src/org/trafodion/jdbc/t4/InterfaceStatement.java
+++ b/core/conn/jdbc_type4/src/org/trafodion/jdbc/t4/InterfaceStatement.java
@@ -1368,10 +1368,11 @@ class InterfaceStatement {
 			Arrays.fill(stmt.batchRowCount_, -3); // fill with failed
 			HPT4Messages.throwSQLException(stmt_.connection_.props_, er.errorList);
 		}
-	    //3164
-	    if (batchException) {
-	    	HPT4Messages.throwSQLException(stmt_.connection_.props_, er.errorList);
-	    }
+		// 3164
+		// if (batchException) {
+		// HPT4Messages.throwSQLException(stmt_.connection_.props_,
+		// er.errorList);
+		// }
 	}
 
 	protected void setTransactionStatus(TrafT4Connection conn, String sql) {


### PR DESCRIPTION
Got your error rows and messages as follows:
int[] rs = ps.executeBatch();
for (int i = 0; i < rs.length; i++) {
	if (rs[i] < 0 && rs[i] != -2)
		log.info("Error/warning on row " + i);
}
SQLWarning warn = ps.getWarnings();
while (warn != null) {
	log.info("Error " + warn.getMessage());
	warn = warn.getNextWarning();
}