### PR TITLE
fix JIRA 1654 for Trafodion

### DIFF
--- a/core/sql/sqlcomp/DefaultConstants.h
+++ b/core/sql/sqlcomp/DefaultConstants.h
@@ -3768,8 +3768,20 @@ enum DefaultConstants
   HBASE_UPDATE_COSTING,
   TRAF_LOAD_FLUSH_SIZE_IN_KB,
 
-  // decide if to apply the additional restriction check (majority of keys with predicates)
+  // Specify whic additional restriction check to apply
+  //  0: no check
+  //  1: apply majority of keys with predicates check
+  //  2: apply total UECs on keyless key columns check
+  //  3: apply both 1) and 2)
   MDAM_APPLY_RESTRICTION_CHECK,
+
+  // A threshold of total UECs on keyless key columns above which MDAM will not be considered.
+  // The threshold is expressed as a percentage of the total RC.
+  MDAM_TOTAL_UEC_CHECK_UEC_THRESHOLD,
+
+  // A threshold of minitmal RC above which the above total UEC check will be applied.
+  MDAM_TOTAL_UEC_CHECK_MIN_RC_THRESHOLD,
+
 
   // This enum constant must be the LAST one in the list; it's a count,
   // not an Attribute (it's not IN DefaultDefaults; it's the SIZE of it)!

--- a/core/sql/sqlcomp/nadefaults.cpp
+++ b/core/sql/sqlcomp/nadefaults.cpp
@@ -2160,7 +2160,7 @@ SDDkwd__(ISO_MAPPING,           (char *)SQLCHARSETSTRING_ISO88591),
   XDDflt__(MC_SKEW_SENSITIVITY_THRESHOLD,        "0.1"),
 
 
-  DDkwd__(MDAM_APPLY_RESTRICTION_CHECK,	"OFF"),
+  DDui___(MDAM_APPLY_RESTRICTION_CHECK,	            "2"),
   DDflt0_(MDAM_CPUCOST_NET_OVH,			"2000."),
 
 
@@ -2180,6 +2180,10 @@ SDDkwd__(ISO_MAPPING,           (char *)SQLCHARSETSTRING_ISO88591),
   XDDkwd__(MDAM_SCAN_METHOD,			"ON"),
 
   DDflt0_(MDAM_SELECTION_DEFAULT,		"0.5"),
+
+  DDflt0_(MDAM_TOTAL_UEC_CHECK_MIN_RC_THRESHOLD, "10000"),
+  DDflt0_(MDAM_TOTAL_UEC_CHECK_UEC_THRESHOLD,	 "0.01"),
+
   DDkwd__(MDAM_TRACING,			        "OFF"),
 
   // controls the max. number of probes at which MDAM under NJ plan will be


### PR DESCRIPTION
Hi,

Could you please review the fix? 

The idea is to compute the product of UECs for key columns without predicates and consider MDAM when that product is within a fraction of the total UEC. 

CQDs re-arranged/created for this new and the existing restriction. 

MDAM_APPLY_RESTRICTION_CHECK:
  // Specify whic additional restriction check to apply
  //  0: no check
  //  1: apply majority of keys with predicates check
  //  2: apply total UECs on keyless key columns check (default)
  //  3: apply both 1) and 2)

MDAM_TOTAL_UEC_CHECK_UEC_THRESHOLD:
 // A threshold of total UECs on keyless key columns above which MDAM will not be considered.
  // The threshold is expressed as a percentage of the total RC.
 Default to 1 percent of the total RC. 

MDAM_TOTAL_UEC_CHECK_MIN_RC_THRESHOLD:
// A threshold of minitmal RC above which the above total UEC check will be applied. Default to 10,000 rows