### PR TITLE
TRAFODION-1570 and TRAFODION-1667 fixes to sqvers -u display

### DIFF
--- a/core/sqf/build-scripts/genverhdr.ksh
+++ b/core/sqf/build-scripts/genverhdr.ksh
@@ -122,7 +122,8 @@ Implementation-Version-6: date $buildDate
 EOF
 	cat > $TMPFILEJ2 <<EOF
 #!/bin/sh
-echo "Implementation-Version-1: Version \$*"
+VER_PROD=`echo \$TRAFODION_VER_PROD | sed 's/ /_/'`
+echo "Implementation-Version-1: Version \$* \$VER_PROD"
 cat \$MY_SQROOT/export/include/SCMBuildMan.mf
 EOF
 	chmod +x $TMPFILEJ2

--- a/core/sqf/sqenvcom.sh
+++ b/core/sqf/sqenvcom.sh
@@ -649,7 +649,7 @@ fi
 
 
 # for debugging
-export LD_BIND_NOW=true
+# export LD_BIND_NOW=true
 
 export MPI_TMPDIR=$PWD/tmp
 if [[ -d $MPI_TMPDIR ]]; then

--- a/core/sqf/sqvers
+++ b/core/sqf/sqvers
@@ -81,13 +81,28 @@ if ($verbose) {
 my $lr = `uname -r`;
 $lr =~ s/\s+$//;
 
-if ($verbose) {
+my $linuxdistro = "UnknownLinuxDistro";
+my $dr = "?.?";
+if (-r "/etc/redhat-release") {
+    if ($verbose) {
 	printf "v: cmd:cat /etc/redhat-release\n";
-}
-my $rhrel = `cat /etc/redhat-release`;
-my $rr = "?.?";
-if ($rhrel =~ /^.*release ([0-9][0-9]*)\.([0-9][0-9]*)/) {
-	$rr=$1 . "." . $2
+    }
+    $linuxdistro = "redhat";
+    my $linuxrel = `cat /etc/redhat-release`;
+    if ($linuxrel =~ /^.*release ([0-9][0-9]*)\.([0-9][0-9]*)/) {
+	$dr=$1 . "." . $2
+    }
+} elsif (-r "/etc/SuSE-release") {
+    if ($verbose) {
+	printf "v: cmd:cat /etc/SuSE-release\n";
+    }
+    $linuxdistro = "SuSE";
+    my $susevers = `cat /etc/SuSE-release | grep VERSION | cut -f 2 -d '='`;
+    my $susepatch = `cat /etc/SuSE-release | grep PATCH | cut -f 2 -d '='`;
+    # trim white space
+    $susevers =~ s/^\s+|\s+$//g;
+    $susepatch =~ s/^\s+|\s+$//g;
+    $dr=$susevers . "." . $susepatch
 }
 
 print "MY_SQROOT=$my_sqroot\n";
@@ -106,7 +121,7 @@ if (($mtype =~ /32/) || ($btype =~ /debug/)) {
 	print "SQ_MBTYPE=$sq_mbtype ($mtype-$btype)\n";
 }
 print "linux=$lr\n";
-print "redhat=$rr\n";
+print "$linuxdistro=$dr\n";
 
 # deal with elfs
 my $dir_lib = "export/lib" . $sq_mbtype;


### PR DESCRIPTION
Fix sqvers -u to treat all the jars from a build as a single version (JDBC jars not yet integrated).
Add version display for SuSE Linux to sqvers.
Remove LD_BIND_NOW environment variable, should be for debugging only.