### PR TITLE
Stats warnings

### DIFF
--- a/core/sql/optimizer/ScanOptimizer.cpp
+++ b/core/sql/optimizer/ScanOptimizer.cpp
@@ -408,7 +408,7 @@ static NABoolean checkMDAMadditionalRestriction(
         //
         // We will set the set to empty so that the fetching MC UEC logic will not kick in 
         // until a new key column without predicates is seen.
-        if ( currentPredicatelessKeyColumnGroup.entries() > 0 ) {
+        if ( currentPredicatelessKeyColumnGroup.entries() > 1 ) {
 
            // fetch MC UEC from key coluymns for column set currentPredicatelessKeyColumnGroup 
            const MultiColumnUecList* MCUL = hist.getColStatDescList().getUecList();
@@ -416,8 +416,7 @@ static NABoolean checkMDAMadditionalRestriction(
            ValueIdSet theLargestSubset = 
                    MCUL->largestSubset(currentPredicatelessKeyColumnGroup.convertToBaseIds());
 
-           if ( theLargestSubset.entries() > 1 &&
-                theLargestSubset.entries() == currentPredicatelessKeyColumnGroup.entries() ) 
+           if ( theLargestSubset.entries() == currentPredicatelessKeyColumnGroup.entries() ) 
            {
               CostScalar mcUEC = MCUL->lookup(theLargestSubset);
 

--- a/core/sql/regress/compGeneral/TEST062
+++ b/core/sql/regress/compGeneral/TEST062
@@ -43,6 +43,7 @@
 -- @@@ END COPYRIGHT @@@
 
 control query default robust_query_optimization 'minimum';
+cqd HIST_ROWCOUNT_REQUIRING_STATS '50000';
 
 create schema sch;
 set schema sch;

--- a/core/sql/regress/hive/EXPECTED005
+++ b/core/sql/regress/hive/EXPECTED005
@@ -16,6 +16,9 @@
 >>cqd CALL_EMBEDDED_ARKCMP 'OFF';
 
 --- SQL operation complete.
+>>cqd HIST_ROWCOUNT_REQUIRING_STATS '50000';
+
+--- SQL operation complete.
 >>------------------------------------------------------------
 >>-- Testing query plan invalidation in the compiler, but
 >>-- not the executor. Perform DML/DDL operations on a

--- a/core/sql/regress/hive/EXPECTED006
+++ b/core/sql/regress/hive/EXPECTED006
@@ -10,6 +10,9 @@
 >>cqd HIVE_MAX_STRING_LENGTH '25' ;
 
 --- SQL operation complete.
+>>cqd HIST_ROWCOUNT_REQUIRING_STATS '50000';
+
+--- SQL operation complete.
 >>cqd mode_seahive 'ON';
 
 --- SQL operation complete.

--- a/core/sql/regress/hive/EXPECTED020
+++ b/core/sql/regress/hive/EXPECTED020
@@ -13,6 +13,9 @@
 >>cqd traf_enable_orc_format 'ON';
 
 --- SQL operation complete.
+>>cqd HIST_ROWCOUNT_REQUIRING_STATS '50000';
+
+--- SQL operation complete.
 >>
 >>prepare explainIt from
 +>  select substring(cast(SEQ_NUM+100 as char(3)),2,2) s,
@@ -35,7 +38,7 @@
 >>invoke hive.hive.store_orc;
 
 -- Definition of hive table STORE_ORC
--- Definition current  Mon Oct 26 16:10:15 2015
+-- Definition current  Fri Dec  4 19:48:03 2015
 
   (
     S_STORE_SK                       INT

--- a/core/sql/regress/hive/TEST005
+++ b/core/sql/regress/hive/TEST005
@@ -50,6 +50,7 @@ cqd AUTO_QUERY_RETRY 'OFF';
 cqd HIVE_MAX_STRING_LENGTH '25' ;
 cqd mode_seahive 'ON';
 cqd CALL_EMBEDDED_ARKCMP 'OFF';
+cqd HIST_ROWCOUNT_REQUIRING_STATS '50000';
 ------------------------------------------------------------
 -- Testing query plan invalidation in the compiler, but
 -- not the executor. Perform DML/DDL operations on a

--- a/core/sql/regress/hive/TEST006
+++ b/core/sql/regress/hive/TEST006
@@ -35,6 +35,7 @@ set terminal_charset utf8;
 
 cqd AUTO_QUERY_RETRY 'OFF';
 cqd HIVE_MAX_STRING_LENGTH '25' ;
+cqd HIST_ROWCOUNT_REQUIRING_STATS '50000';
 cqd mode_seahive 'ON';
 
 -- Select from the sequence file version of the promotion table

--- a/core/sql/regress/hive/TEST018
+++ b/core/sql/regress/hive/TEST018
@@ -28,6 +28,7 @@ cqd comp_bool_226 'on';
 cqd TRAF_TABLE_SNAPSHOT_SCAN_TABLE_SIZE_THRESHOLD  '0';
 cqd hive_max_string_length '60';
 cqd query_cache '0';
+cqd HIST_ROWCOUNT_REQUIRING_STATS '50000';
 
 obey TEST018(clean_up);
 

--- a/core/sql/regress/hive/TEST020
+++ b/core/sql/regress/hive/TEST020
@@ -35,6 +35,7 @@ set schema hive.hive;
 cqd HIVE_MAX_STRING_LENGTH '20' ;
 cqd mode_seahive 'ON';
 cqd traf_enable_orc_format 'ON';
+cqd HIST_ROWCOUNT_REQUIRING_STATS '50000';
 
 prepare explainIt from
   select substring(cast(SEQ_NUM+100 as char(3)),2,2) s,

--- a/core/sql/regress/tools/runallsb
+++ b/core/sql/regress/tools/runallsb
@@ -42,7 +42,6 @@ export SQLMX_REGRESS=1
 export SEABASE_REGRESS=2
 
 TEST_SUBDIRS="core compGeneral executor seabase fullstack2 charsets qat catman1 udr hive" 
-TEST_SUBDIRS="catman1 udr hive" 
 
 #
 # Make sure we're running from the regress subdir

--- a/core/sql/regress/tools/runallsb
+++ b/core/sql/regress/tools/runallsb
@@ -42,6 +42,7 @@ export SQLMX_REGRESS=1
 export SEABASE_REGRESS=2
 
 TEST_SUBDIRS="core compGeneral executor seabase fullstack2 charsets qat catman1 udr hive" 
+TEST_SUBDIRS="catman1 udr hive" 
 
 #
 # Make sure we're running from the regress subdir

--- a/core/sql/sqlcomp/nadefaults.cpp
+++ b/core/sql/sqlcomp/nadefaults.cpp
@@ -1932,7 +1932,7 @@ SDDkwd__(EXE_DIAGNOSTIC_EVENTS,		"OFF"),
  XDDkwd__(HIST_PREFETCH,                        "ON"),
  XDDkwd__(HIST_REMOVE_TRAILING_BLANKS,          "ON"), // should remove after verifying code is solid
   DDansi_(HIST_ROOT_NODE,                            ""),
- XDDflt1_(HIST_ROWCOUNT_REQUIRING_STATS,        "50000"),
+ XDDflt1_(HIST_ROWCOUNT_REQUIRING_STATS,        "500"),
   DDflt0_(HIST_SAME_TABLE_PRED_REDUCTION,       "0.0"),
   DDvol__(HIST_SCRATCH_VOL,                     ""),
   // control the amount of data in each partition of the sample tble.


### PR DESCRIPTION
Hi,

I updated the regression tests with an increased value for CQD HIST_ROWCOUNT_REQUIRING_STATS to take care of missing stats warnings. 

A minor improvement also included to consider MC uecs only when the # of key columns without predicates is larger than 1. This is for a previous fix JIRA 1665. 

Thanks 