### PR TITLE
Add a new case to BatchTest of Phoenix test

### DIFF
--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/BatchTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/BatchTest.java
@@ -44,7 +44,9 @@ public class BatchTest extends BaseTest {
     
     public  static final int ROW_COUNT = 10000;
     private int[] expectedStatusArray = null;
+    private int[] statusArray = null;
 
+    private static final String strInsert = "INSERT INTO " + BATCH_TEST_TABLE + " VALUES (?,?)";
     private static final String strUpsert = "UPSERT USING LOAD INTO " + BATCH_TEST_TABLE + " VALUES (?,?)";
     private static final String strUpdate = "UPDATE " + BATCH_TEST_TABLE + "SET (ID, NAME) = (?,?)";
     private static final String strDelete = "DELETE FROM " + BATCH_TEST_TABLE;
@@ -91,7 +93,7 @@ public class BatchTest extends BaseTest {
             upsertStmt.setString(2, "Traf The World " + i);
             upsertStmt.addBatch();
         }
-        int[] statusArray = upsertStmt.executeBatch();
+        statusArray = upsertStmt.executeBatch();
         long endTime = System.currentTimeMillis();
         System.out.println("Time consumption for batch inserting "
                 + ROW_COUNT + " rows is " + (endTime - startTime)  + " milli seconds");
@@ -110,7 +112,7 @@ public class BatchTest extends BaseTest {
     }
 
     @Test
-    public void testBatchInsertNegative() throws Exception {
+    public void testBatchInsertDuplicate() throws Exception {
         printTestDescription();
 
         createTestTable(BATCH_TEST_TABLE);
@@ -118,69 +120,126 @@ public class BatchTest extends BaseTest {
         // Initialize the expected status array for executeBatch() success for all rows,
         // except for row 2 and row 6, to which we will pass duplicate ID values on
         // purpose in actual insert later to make an unique value conflict error. The
-        // returned status value should be 
+        // returned status value should be
+        String nameSuffix = "Traf The World ";
         expectedStatusArray = new int[10];
+        
         int[] expectedIdArray = new int[8];
         String[] expectedNameArray = new String[8];
-        for(int i=0, j=0; i < 10; ++i, ++j) {
+        int[] idArray = new int[10];
+        String[] nameArray = new String[10];
+        
+        for(int i=0, j=0; i < 10; ++i) {
             expectedStatusArray[i] = -2;
+            idArray[i] = i;
+            nameArray[i] = nameSuffix + i;
+            expectedIdArray[j] = i;
+            expectedNameArray[j] = nameArray[i];
             switch(i) {
-                case 8:
-                case 9:
-                    break;
                 case 1:
-                case 4:
-                    expectedIdArray[i] = ++j;
-                    expectedNameArray[i] = "Traf The World " + j;
+                case 5:
+                    idArray[i] = i-1;
+                    expectedStatusArray[i] = -3;
                     break;
                 default:
-                    expectedIdArray[i] = j;
-                    expectedNameArray[i] = "Traf The World " + j;
+                    j++;
                     break;
             }
         }
         int expectedRowCount = 8;
 
-        // Start to prepare and execute the batch insert
-        PreparedStatement upsertStmt = conn.prepareStatement(strUpsert);
+        // Start to prepare and execute the batch upsert
+        PreparedStatement insertStmt = conn.prepareStatement(strInsert);
         for(int i=0; i < 10; ++i) {
-            switch(i) {
-                case 1:
-                    upsertStmt.setInt(1, 0);
-                    upsertStmt.setString(2, "Traf The World " + 0);
-                    break;
-                case 5:
-                    upsertStmt.setInt(1, 4);
-                    upsertStmt.setString(2, "Traf The World " + 4);
-                    break;
-                default:
-                    upsertStmt.setInt(1, i);
-                    upsertStmt.setString(2, "Traf The World " + i);
-                    break;
-            }
-            upsertStmt.addBatch();
+            insertStmt.setInt(1, idArray[i]);
+            insertStmt.setString(2, nameArray[i]);
+            insertStmt.addBatch();
         }
         
-        int[] statusArray = upsertStmt.executeBatch();
-        
-        assertEquals(expectedStatusArray.length, statusArray.length);
-        for(int i=0; i<10; ++i) {
-            if((i != 1) && (i != 5)) {
-                assertEquals(expectedStatusArray[i], statusArray[i]);
-            }
-            else {
-                assertTrue(statusArray[i] != expectedStatusArray[i]);
-            }
+        try {
+            statusArray = insertStmt.executeBatch();
+        } catch(SQLException sqle) {
+            assertEquals("Batch update failed. See next exception for details", sqle.getMessage());
+            SQLException e = null;
+            e = sqle.getNextException();
+            do {
+                assertTrue(e.getMessage().contains("ERROR[8102] The operation is prevented by a unique constraint"));
+            } while((e = e.getNextException()) != null);
         }
+        
+        //assertArrayEquals(expectedStatusArray, statusArray);
 
         int rowCount = 0;
         ResultSet rs = conn.createStatement().executeQuery(strSelect);
         while(rs.next()) {
-            assertEquals(expectedIdArray[rowCount], rs.getInt(1));
-            assertEquals(expectedNameArray[rowCount], rs.getString(2));
+            //System.out.println("ID = " + rs.getString(1) + ", Name = " + rs.getString(2));
+            //assertEquals(expectedIdArray[rs.getRow()-1], rs.getInt(1));
+            //assertEquals(expectedNameArray[rs.getRow()-1], rs.getString(2));
+            rowCount++;
+        }
+        rs.close();
+        insertStmt.close();
+    }
+
+    @Test
+    public void testBatchUpsertDuplicate() throws Exception {
+        printTestDescription();
+
+        createTestTable(BATCH_TEST_TABLE);
+
+        // Initialize the expected status array for executeBatch() success for all rows,
+        // except for row 2 and row 6, to which we will pass duplicate ID values on
+        // purpose in actual insert later to make an unique value conflict error. The
+        // returned status value should be
+        String nameSuffix = "Traf The World ";
+        expectedStatusArray = new int[10];
+        int[] expectedIdArray = new int[8];
+        String[] expectedNameArray = new String[8];
+        int[] idArray = new int[10];
+        String[] nameArray = new String[10];
+        
+        for(int i=0, j=0; i < 10; ++i) {
+            expectedStatusArray[i] = -2;
+            idArray[i] = i;
+            nameArray[i] = nameSuffix + i;
+            expectedIdArray[j] = i;
+            expectedNameArray[j] = nameArray[i];
+            switch(i) {
+                case 1:
+                case 5:
+                    idArray[i] = i-1;
+                    expectedNameArray[j-1] = nameArray[i];
+                    break;
+                default:
+                    j++;
+                    break;
+            }
+        }
+        int expectedRowCount = 8;
+
+        // Start to prepare and execute the batch upsert
+        PreparedStatement upsertStmt = conn.prepareStatement(strUpsert);
+        for(int i=0; i < 10; ++i) {
+            upsertStmt.setInt(1, idArray[i]);
+            upsertStmt.setString(2, nameArray[i]);
+            upsertStmt.addBatch();
+        }
+        
+        statusArray = upsertStmt.executeBatch();
+        
+        assertArrayEquals(expectedStatusArray, statusArray);
+
+        int rowCount = 0;
+        ResultSet rs = conn.createStatement().executeQuery(strSelect);
+        while(rs.next()) {
+            //System.out.println("ID = " + rs.getString(1) + ", Name = " + rs.getString(2));
+            assertEquals(expectedIdArray[rs.getRow()-1], rs.getInt(1));
+            assertEquals(expectedNameArray[rs.getRow()-1], rs.getString(2));
             rowCount++;
         }
         assertEquals(rowCount, expectedRowCount);
+        rs.close();
+        upsertStmt.close();
     }
 
 }


### PR DESCRIPTION
1. A new test case of inserting duplciate primary key value with
"insert" statement.
2. Changed the initializtion of expected value array of upsert
duplicate primary key values, previous code may cause incorrect test
result.