### PR TITLE
[TRAFODION 1678] Fix DTM error 97 on DROP SCHEMA

### DIFF
--- a/core/sql/arkcmp/CmpContext.cpp
+++ b/core/sql/arkcmp/CmpContext.cpp
@@ -837,7 +837,7 @@ CmpContext::compileDirect(char *data, UInt32 data_len, CollHeap *outHeap,
         // NAMemory.h.
         cmpStatement = new CTXTHEAP CmpStatement(this);
         CmpMessageSQLText sqltext(data, data_len, CTXTHEAP, charset, op);
-        Set_SqlParser_Flags(parserFlags);
+        Assign_SqlParser_Flags(parserFlags);
         rs = cmpStatement->process(sqltext);
         copyFrags = TRUE;
         break;
@@ -848,7 +848,7 @@ CmpContext::compileDirect(char *data, UInt32 data_len, CollHeap *outHeap,
         // request is from ex_control_tcb::work() for setting compiler CQDs
         cmpStatement = new CTXTHEAP CmpStatement(this);
         CmpMessageCompileStmt compileStmt(data, data_len, op, CTXTHEAP, charset);
-        Set_SqlParser_Flags(parserFlags);
+        Assign_SqlParser_Flags(parserFlags);
         rs = cmpStatement->process(compileStmt);
         copyData = TRUE;
         break;
@@ -858,7 +858,7 @@ CmpContext::compileDirect(char *data, UInt32 data_len, CollHeap *outHeap,
         // request is from ContextCli::createMxcmpSession() to set user id
         cmpStatement = new CTXTHEAP CmpStatement(this);
         CmpMessageDatabaseUser databaseUserStmt(data, data_len, CTXTHEAP);
-        Set_SqlParser_Flags(parserFlags);
+        Assign_SqlParser_Flags(parserFlags);
         rs = cmpStatement->process(databaseUserStmt);
         copyData = TRUE;
         break;
@@ -870,7 +870,7 @@ CmpContext::compileDirect(char *data, UInt32 data_len, CollHeap *outHeap,
         CmpMessageDDL ddlStmt(data, data_len, CTXTHEAP, charset,
                              parentQid, parentQidLen);
  
-        Set_SqlParser_Flags(parserFlags);
+        Assign_SqlParser_Flags(parserFlags);
         rs = cmpStatement->process(ddlStmt);
         copyData = TRUE;
         break;
@@ -880,7 +880,7 @@ CmpContext::compileDirect(char *data, UInt32 data_len, CollHeap *outHeap,
         // request is from ExDescribeTcb::work() to get statement explain
         cmpStatement = new CTXTHEAP CmpStatement(this);
         CmpMessageDescribe describeStmt(data, data_len, CTXTHEAP, charset);
-        Set_SqlParser_Flags(parserFlags);
+        Assign_SqlParser_Flags(parserFlags);
         rs = cmpStatement->process(describeStmt);
         copyData = TRUE;
         break;
@@ -890,7 +890,7 @@ CmpContext::compileDirect(char *data, UInt32 data_len, CollHeap *outHeap,
         // request is from ContextCli::endMxcmpSession()
         cmpStatement = new CTXTHEAP CmpStatement(this);
         CmpMessageEndSession endSessionStmt(data, data_len, CTXTHEAP);
-        Set_SqlParser_Flags(parserFlags);
+        Assign_SqlParser_Flags(parserFlags);
         rs = cmpStatement->process(endSessionStmt);
         copyData = TRUE;
         break;
@@ -900,7 +900,7 @@ CmpContext::compileDirect(char *data, UInt32 data_len, CollHeap *outHeap,
         // request is from ExDescribeTcb::work() for getting compiler CQDs
         cmpStatement = new CTXTHEAP CmpStatement(this);
         CmpMessageSetTrans setTransStmt(data, data_len, CTXTHEAP);
-        Set_SqlParser_Flags(parserFlags);
+        Assign_SqlParser_Flags(parserFlags);
         rs = cmpStatement->process(setTransStmt);
         copyData = TRUE;
         break;
@@ -913,7 +913,7 @@ CmpContext::compileDirect(char *data, UInt32 data_len, CollHeap *outHeap,
         //ISP request is passed as data argument
         CMPASSERT(data);
         CmpMessageISPRequest & ispRequest = *(CmpMessageISPRequest *)data;
-        Set_SqlParser_Flags(parserFlags);
+        Assign_SqlParser_Flags(parserFlags);
         //process request
         rs = cmpStatement->process(ispRequest);
         copyData = TRUE;
@@ -937,7 +937,7 @@ CmpContext::compileDirect(char *data, UInt32 data_len, CollHeap *outHeap,
             cmpStatement = new CTXTHEAP CmpStatement(this);
             CMPASSERT(FALSE);
          }
-         Set_SqlParser_Flags(parserFlags);//What is this for??
+         Assign_SqlParser_Flags(parserFlags);//What is this for??
          //process request
          rs = cmpStatement->process(ispGetNext);
          copyData = TRUE;

--- a/core/sql/sqlcomp/CmpDescribe.cpp
+++ b/core/sql/sqlcomp/CmpDescribe.cpp
@@ -563,17 +563,24 @@ short CmpDescribe(const char *query, const RelExpr *queryExpr,
                   char* &outbuf, ULng32 &outbuflen,
                   CollHeap *heap)
 {
+  short rc = 0;  // assume success
+
   // save the current parserflags setting
 
   ULng32 savedParserFlags;
   SQL_EXEC_GetParserFlagsForExSqlComp_Internal(savedParserFlags);
 
+  // OK, folks, we are about to locally change a global variable, so any returns 
+  // must insure that the global variable gets reset back to its original value
+  // (saved above in "savedParserFlags"). So, if you are tempted to code a
+  // "return", don't do it. Set the rc instead and goto the "finally" label.
+
+  Set_SqlParser_Flags(INTERNAL_QUERY_FROM_EXEUTIL);
+  SQL_EXEC_SetParserFlagsForExSqlComp_Internal(INTERNAL_QUERY_FROM_EXEUTIL);
+
  // add an exception handler around all the SQL specific code
  try
  {
-  Set_SqlParser_Flags(INTERNAL_QUERY_FROM_EXEUTIL);
-  SQL_EXEC_SetParserFlagsForExSqlComp_Internal(INTERNAL_QUERY_FROM_EXEUTIL);
- 
   // Display triggers using this object
   NABoolean showUsingTriggers = !!getenv("SQLMX_SHOW_USING_TRIGGERS");
 
@@ -617,64 +624,85 @@ short CmpDescribe(const char *query, const RelExpr *queryExpr,
   if (d->getIsSchema())
     {
       if (!CmpDescribeIsAuthorized())
-        return -1;
+        {
+          rc = -1;
+          goto finally;
+        }
       NAString schemaText;
       QualifiedName objQualName(d->getDescribedTableName().getQualifiedNameObj(),
                                 STMTHEAP);
       if (!CmpSeabaseDDL::describeSchema(objQualName.getCatalogName(),
                                          objQualName.getSchemaName(),
                                          schemaText))
-        return -1;
+        {
+          rc = -1;
+          goto finally;
+        }
         
       outputLine(space, schemaText,0);
       outbuflen = space.getAllocatedSpaceSize();
       outbuf = new (heap) char[outbuflen];
       space.makeContiguous(outbuf, outbuflen);
 
-      return 0;
+      goto finally;  // we are done and rc is already 0
     }
   
   // If SHOWDDL USER, go get description and return
   if (d->getIsUser())
     {
       if (!CmpDescribeIsAuthorized(SQLOperation::MANAGE_USERS))
-        return -1;
+        {
+          rc = -1;
+          goto finally;
+        }
       NAString userText;
       CmpSeabaseDDLuser userInfo;
       if (!userInfo.describe(d->getAuthIDName(), userText))
-        return -1;
+        {
+          rc = -1;
+          goto finally;
+        }
 
       outputLine(space, userText,0);
       outbuflen = space.getAllocatedSpaceSize();
       outbuf = new (heap) char[outbuflen];
       space.makeContiguous(outbuf, outbuflen);
 
-      return 0;
+      goto finally;  // we are done and rc is already 0
     }
 
   // If SHOWDDL ROLE, go get description and return
   if (d->getIsRole())
   {
       if (!CmpDescribeIsAuthorized(SQLOperation::MANAGE_ROLES))
-        return -1;
+        {
+          rc = -1;
+          goto finally;
+        }
       NAString roleText;
       CmpSeabaseDDLrole roleInfo(ActiveSchemaDB()->getDefaults().getValue(SEABASE_CATALOG));
       if (!roleInfo.describe(d->getAuthIDName(),roleText))
-        return -1;
+        {
+          rc = -1;
+          goto finally;
+        }
 
       outputLine(space, roleText,0);
       outbuflen = space.getAllocatedSpaceSize();
       outbuf = new (heap) char[outbuflen];
       space.makeContiguous(outbuf, outbuflen);
 
-      return 0;
+      goto finally;  // we are done and rc is already 0
    }
 
   // If SHOWDDL COMPONENT, go get description and return
   if (d->getIsComponent())
     {
       if (!CmpDescribeIsAuthorized(SQLOperation::MANAGE_COMPONENTS))
-        return -1;
+        {
+          rc = -1;
+          goto finally;
+        }
        std::vector<std::string> outlines;
        std::string privMDLoc = ActiveSchemaDB()->getDefaults().getValue(SEABASE_CATALOG);
        privMDLoc += ".\"";
@@ -685,18 +713,20 @@ short CmpDescribe(const char *query, const RelExpr *queryExpr,
        //get description in REGISTER, CREATE, GRANT statements.
        CmpSeabaseDDL cmpSBD((NAHeap*)heap);
        if (cmpSBD.switchCompiler())
-       {
-         *CmpCommon::diags() << DgSqlCode(-CAT_UNABLE_TO_RETRIEVE_PRIVS);
-         return -1;
-       }
+         {
+           *CmpCommon::diags() << DgSqlCode(-CAT_UNABLE_TO_RETRIEVE_PRIVS);
+           rc = -1;
+           goto finally;
+         }
 
        if(!privMgrInterface.describeComponents(d->getComponentName().data(), outlines))
-       {
+         {
            *CmpCommon::diags() << DgSqlCode(-CAT_TABLE_DOES_NOT_EXIST_ERROR)
                         << DgTableName(d->getComponentName().data());
            cmpSBD.switchBackCompiler();
-           return -1;
-       }
+           rc = -1;
+           goto finally;
+         }
        cmpSBD.switchBackCompiler();
            
        for(int i = 0; i < outlines.size(); i++)
@@ -704,24 +734,30 @@ short CmpDescribe(const char *query, const RelExpr *queryExpr,
        outbuflen = space.getAllocatedSpaceSize();
        outbuf = new (heap) char[outbuflen];
        space.makeContiguous(outbuf, outbuflen);
-       return 0;
+       goto finally;  // we are done and rc is already 0
     }
 
   if (d->getDescribedTableName().getQualifiedNameObj().getObjectNameSpace() == COM_LIBRARY_NAME)
     {
       if (!CmpDescribeLibrary(d->getDescribedTableName(),outbuf,outbuflen,heap))
-         return -1;
+        {
+          rc = -1;
+          goto finally;
+        }
          
-      return 0;
+      goto finally;  // we are done and rc is already 0
     }
 
   if (d->getDescribedTableName().getQualifiedNameObj().getObjectNameSpace() == 
       COM_UDF_NAME)
     {
       if (!CmpDescribeRoutine(d->getDescribedTableName(),outbuf,outbuflen,heap))
-         return -1;
+        {
+          rc = -1;
+          goto finally;
+        }
          
-      return 0;
+      goto finally;  // we are done and rc is already 0
     }
 
   ExtendedQualName::SpecialTableType tType =
@@ -757,7 +793,8 @@ short CmpDescribe(const char *query, const RelExpr *queryExpr,
                         while(query[i] != '\'' && query[i] != '\0') i++;
          i++;
       }
-      return CmpDescribePlan(&query[i], d->getFlags(), outbuf, outbuflen, heap);
+      rc = CmpDescribePlan(&query[i], d->getFlags(), outbuf, outbuflen, heap);
+      goto finally;  // we are done
     }
 
   if (d->getFormat() == Describe::SHAPE_)
@@ -770,19 +807,22 @@ short CmpDescribe(const char *query, const RelExpr *queryExpr,
       for ( ; *query == ' '; query++) ;
 
       // Skip the SHOWSHAPE token (length 9) in front of the input query.
-      return CmpDescribeShape(&query[9], outbuf, outbuflen, heap);
+      rc = CmpDescribeShape(&query[9], outbuf, outbuflen, heap);
+      goto finally;  // we are done
     }
 
   if (d->getFormat() == Describe::SHOWQRYSTATS_)
     {
       // show histogram for root of this query.
-      return CmpDescribeShowQryStats(query, outbuf, outbuflen, heap);
+      rc = CmpDescribeShowQryStats(query, outbuf, outbuflen, heap);
+      goto finally;  // we are done
     }
 
   if (d->getFormat() >= Describe::CONTROL_FIRST_ &&
       d->getFormat() <= Describe::CONTROL_LAST_)
     {
-      return CmpDescribeControl(d, outbuf, outbuflen, heap);
+      rc = CmpDescribeControl(d, outbuf, outbuflen, heap);
+      goto finally;  // we are done
     }
  
   if (d->getFormat() == Describe::LEAKS_)
@@ -797,17 +837,19 @@ short CmpDescribe(const char *query, const RelExpr *queryExpr,
       HEAPLOG_ON();
       HeapLogRoot::pack(outbuf, d->getFlags());
 #endif
-      return 0;
+      goto finally;  // we are done and rc is already 0
     }
 
   if (d->getFormat() == Describe::SHOWSTATS_)
     {
-      return (short)ShowStats(query, outbuf, outbuflen, heap);
+      rc = (short)ShowStats(query, outbuf, outbuflen, heap);
+      goto finally;  // we are done
     }
 
   if (d->getFormat() == Describe::TRANSACTION_)
     {
-      return CmpDescribeTransaction(outbuf, outbuflen, heap);
+      rc = CmpDescribeTransaction(outbuf, outbuflen, heap);
+      goto finally;  // we are done
     }
     
     
@@ -820,17 +862,17 @@ short CmpDescribe(const char *query, const RelExpr *queryExpr,
       (d->getDescribedTableName().isHive()) &&
       (!d->getDescribedTableName().isSpecialTable()))
     {
-      short rc = 
+      rc = 
         CmpDescribeHiveTable(d->getDescribedTableName(), outbuf, outbuflen, heap);
-      return rc;
+      goto finally;  // we are done
     }
 
   if (d->getLabelAnsiNameSpace() == COM_SEQUENCE_GENERATOR_NAME)
     {
-      short rc = 
+      rc = 
         CmpDescribeSequence(d->getDescribedTableName(), 
                             outbuf, outbuflen, heap, NULL);
-      return rc;
+      goto finally;  // we are done
     }
 
   // check if this is an hbase/seabase table. If so, describe using info from NATable.
@@ -839,11 +881,11 @@ short CmpDescribe(const char *query, const RelExpr *queryExpr,
       ((d->getDescribedTableName().isHbase()) ||
        (d->getDescribedTableName().isSeabase())))
     {
-      short rc = 
+      rc = 
         CmpDescribeSeabaseTable(d->getDescribedTableName(), 
                                 (d->getFormat() == Describe::INVOKE_ ? 1 : 2),
                                 outbuf, outbuflen, heap, NULL, TRUE);
-      return rc;
+      goto finally;  // we are done
     }
 
   desc_struct *tabledesc = NULL;
@@ -881,13 +923,17 @@ short CmpDescribe(const char *query, const RelExpr *queryExpr,
         {
           // not supported
           *CmpCommon::diags() << DgSqlCode(-3131);
-          return -1;
+          rc = -1;
+          goto finally;
         }
     }
   
   
   if (!tabledesc)
-    return -1;
+    {
+      rc = -1;
+      goto finally;
+    }
 
   NAString tableName(tabledesc->body.table_desc.tablename) ;
   
@@ -991,7 +1037,7 @@ short CmpDescribe(const char *query, const RelExpr *queryExpr,
 
       NADELETEBASIC(buf, CmpCommon::statementHeap());
       CmpCommon::context()->readTableDef_->deleteTree(tabledesc);
-      return 0;
+      goto finally;  // we are done and rc is already 0
     }
 
    
@@ -1041,22 +1087,13 @@ short CmpDescribe(const char *query, const RelExpr *queryExpr,
 
   NADELETEBASIC(buf, CmpCommon::statementHeap());
   CmpCommon::context()->readTableDef_->deleteTree(tabledesc);
-  // Restore parser flags settings to what they originally were
-  Assign_SqlParser_Flags(savedParserFlags);
-  SQL_EXEC_AssignParserFlagsForExSqlComp_Internal(savedParserFlags);
-  
-  return 0;
- }
+
+ }  // end of try block
 
  // LCOV_EXCL_START
  // exception handling
  catch(...)
  {
-
-   // Restore parser flags settings to what they originally were
-   Assign_SqlParser_Flags(savedParserFlags);
-   SQL_EXEC_AssignParserFlagsForExSqlComp_Internal(savedParserFlags);
-
     // Check diags area, if it doesn't contain an error, add an
     // internal exception
     if (CmpCommon::diags()->getNumber() == 0)
@@ -1066,9 +1103,17 @@ short CmpDescribe(const char *query, const RelExpr *queryExpr,
       *CmpCommon::diags() << DgString1(__FILE__);
       *CmpCommon::diags() << DgInt0(__LINE__);
     }
-    return -1;
+    rc = -1;
  }
  // LCOV_EXCL_STOP
+
+finally:
+
+  // Restore parser flags settings to what they originally were
+  Assign_SqlParser_Flags(savedParserFlags);
+  SQL_EXEC_AssignParserFlagsForExSqlComp_Internal(savedParserFlags);
+  
+  return rc;
 
 } // SHOWDDL
 


### PR DESCRIPTION
This fixes the two bugs mentioned in JIRA TRAFODION-1678. The change to sqlcomp/CmpDescribe.cpp fixes the first bug, that is, some returns from CmpDescribe were failing to restore the SQL parser flags global before exiting. The change to arkcmp/CmpContext.txt fixes the second bug, which is the code was using the wrong API to set the SQL parser flags. Fixing either of these bugs resolves the symptom seen in the JIRA (one bug masks the other); I have chosen to fix both.