### PR TITLE
TRAFODION-1736 REST server reports duplicate DCS connections

### DIFF
--- a/core/rest/src/main/java/org/trafodion/rest/GetStatusResponse.java
+++ b/core/rest/src/main/java/org/trafodion/rest/GetStatusResponse.java
@@ -20,7 +20,7 @@
 *
 * @@@ END COPYRIGHT @@@                                                          */
 
-package org.trafodion.dcs.rest;
+package org.trafodion.rest;
 
 import java.io.IOException;
 

--- a/core/rest/src/main/java/org/trafodion/rest/RESTServlet.java
+++ b/core/rest/src/main/java/org/trafodion/rest/RESTServlet.java
@@ -165,6 +165,13 @@ public class RESTServlet implements RestConstants {
 
 	    if( ! children.isEmpty()) {
 	        for(String child : children) {
+	        	
+	        	//If dcsstop.sh is executed and rest server is not restarted, the nodes get appended to the
+	        	//existing list and we end with duplicate entries for the same servers with different timestamps
+	        	//Since the runningServers are only for the DcsServers, it is ok and not expensive to reconstruct 
+	        	//the list every time
+	        	runningServers.clear();
+	        	
 	            //If stop-dcs.sh is executed and DCS_MANAGES_ZK then zookeeper is stopped abruptly.
 	            //Second scenario is when ZooKeeper fails for some reason regardless of whether DCS
 	            //manages it. When either happens the DcsServer running znodes still exist in ZooKeeper

--- a/core/rest/src/main/java/org/trafodion/rest/provider/JAXBContextResolver.java
+++ b/core/rest/src/main/java/org/trafodion/rest/provider/JAXBContextResolver.java
@@ -76,7 +76,6 @@ public class JAXBContextResolver implements ContextResolver<JAXBContext> {
 		  cTypes);
 	}
 
-	@Override
 	public JAXBContext getContext(Class<?> objectType) {
 		return (types.contains(objectType)) ? context : null;
   }

--- a/core/rest/src/main/java/org/trafodion/rest/provider/producer/PlainTextMessageBodyProducer.java
+++ b/core/rest/src/main/java/org/trafodion/rest/provider/producer/PlainTextMessageBodyProducer.java
@@ -66,13 +66,11 @@ public class PlainTextMessageBodyProducer
 
   private ThreadLocal<byte[]> buffer = new ThreadLocal<byte[]>();
 
-  @Override
   public boolean isWriteable(Class<?> arg0, Type arg1, Annotation[] arg2,
       MediaType arg3) {
     return true;
   }
 
-	@Override
 	public long getSize(Object object, Class<?> type, Type genericType,
 			Annotation[] annotations, MediaType mediaType) {
     byte[] bytes = object.toString().getBytes(); 
@@ -80,7 +78,6 @@ public class PlainTextMessageBodyProducer
     return bytes.length;
 	}
 
-	@Override
 	public void writeTo(Object object, Class<?> type, Type genericType,
 			Annotation[] annotations, MediaType mediaType,
 			MultivaluedMap<String, Object> httpHeaders, OutputStream outStream)

--- a/core/rest/src/main/java/org/trafodion/rest/util/ConfTool.java
+++ b/core/rest/src/main/java/org/trafodion/rest/util/ConfTool.java
@@ -21,7 +21,7 @@ under the License.
 * @@@ END COPYRIGHT @@@
  */
 
-package org.trafodion.dcs.util;
+package org.trafodion.rest.util;
 
 import org.apache.hadoop.conf.Configuration;
 import org.trafodion.rest.util.RestConfiguration;

--- a/core/rest/src/main/java/org/trafodion/rest/zookeeper/ZkClient.java
+++ b/core/rest/src/main/java/org/trafodion/rest/zookeeper/ZkClient.java
@@ -173,7 +173,6 @@ public class ZkClient implements Watcher {
 		return zk;
 	}
 	
-	@Override
 	public void process(WatchedEvent event) {
 		if(event.getState() == Watcher.Event.KeeperState.SyncConnected) {
 			connectedSignal.countDown();


### PR DESCRIPTION
Fix for TRAFODION-1736 where REST server was reporting duplicate entries for servers after a dcs restart.

Also fixed these other errors reported by eclipse:
- Fixed the java package name for the GetStatusResponse.java and ConfTool.java
- Removed the @override annotation for some of the methods which were either implementing interface methods or abstract methods with no real implementation in the super class. Touched classes are ZkClient , JAXBContextResolver and PlainTextMessageBodyProducer