### PR TITLE
[TRAFODION-1682]MT-DCS protocol issue fix

### DIFF
--- a/dcs/src/main/java/org/trafodion/dcs/servermt/serverDriverInputOutput/Descriptor2List.java
+++ b/dcs/src/main/java/org/trafodion/dcs/servermt/serverDriverInputOutput/Descriptor2List.java
@@ -80,7 +80,7 @@ public class Descriptor2List {
         if (descCount == descNumber){
             Descriptor2 desc = null;
             if (oldFormat == false)
-                descLength = 3 * ServerConstants.INT_FIELD_SIZE;
+                descLength = 2 * ServerConstants.INT_FIELD_SIZE;
             else
                 descLength = ServerConstants.INT_FIELD_SIZE;
             varLength = 0;

--- a/dcs/src/main/java/org/trafodion/dcs/servermt/serverHandler/ServerApiSqlExecDirect.java
+++ b/dcs/src/main/java/org/trafodion/dcs/servermt/serverHandler/ServerApiSqlExecDirect.java
@@ -215,7 +215,7 @@ public class ServerApiSqlExecDirect {
                 throw new SQLException(serverWorkerName + ". Wrong dialogueId sent by the Client [sent/expected] : [" + dialogueId + "/" + clientData.getDialogueId() + "]");
             }
 //=============================================================================
-            sqlQueryType = SqlUtils.getSqlStmtType(sqlStmtType);
+            sqlQueryType = SqlUtils.getSqlStmtType(sqlString);
 
             try {
                 trafConn = clientData.getTrafConnection();


### PR DESCRIPTION
This commit will fix following issues.
1. [TRAFODION-1682][MTDCS] ODBC: SQLFetch returned invalid cursor
state. It's caused by the length of descriptor2List is not correct and
the sqlQueryType is not correct either. For sqlQueryType,
    SqlUtils.getSqlStmtType(String str) will be used instead of
    SqlUtils.getSqlStmtType(int stmtType) since it can't return the
    correct value.
2. [TRAFODION-1653][MTDCS] coast tests core dumped at 'operator new'
when Multithread DCS is on. It's caused by the EndTransaction message
missing a int which indicate 0 excaption when there is no exception.
3. [TRAFODION-1658][MTDCS] with MultiThread DCS on, coast core dumped
at memcpy when there is parameter in prepare statement. It's caused by
the length of the descriptor2List is not correct.