### PR TITLE
Fix reopened JIRA 1736

### DIFF
--- a/core/rest/src/main/java/org/trafodion/rest/RESTServlet.java
+++ b/core/rest/src/main/java/org/trafodion/rest/RESTServlet.java
@@ -164,15 +164,15 @@ public class RESTServlet implements RestConstants {
 	    List<String> children = getChildren(parentZnode + Constants.DEFAULT_ZOOKEEPER_ZNODE_SERVERS_RUNNING, new RunningWatcher());
 
 	    if( ! children.isEmpty()) {
+        	//If dcsstop.sh is executed and rest server is not restarted, the nodes get appended to the
+        	//existing list and we end with duplicate entries for the same servers with different timestamps
+        	//Since the runningServers are only for the DcsServers, it is ok and not expensive to reconstruct 
+        	//the list every time
+			runningServers.clear();
+			
 	        for(String child : children) {
-	        	
-	        	//If dcsstop.sh is executed and rest server is not restarted, the nodes get appended to the
-	        	//existing list and we end with duplicate entries for the same servers with different timestamps
-	        	//Since the runningServers are only for the DcsServers, it is ok and not expensive to reconstruct 
-	        	//the list every time
-	        	runningServers.clear();
-	        	
-	            //If stop-dcs.sh is executed and DCS_MANAGES_ZK then zookeeper is stopped abruptly.
+
+	        	//If stop-dcs.sh is executed and DCS_MANAGES_ZK then zookeeper is stopped abruptly.
 	            //Second scenario is when ZooKeeper fails for some reason regardless of whether DCS
 	            //manages it. When either happens the DcsServer running znodes still exist in ZooKeeper
 	            //and we see them at next startup. When they eventually timeout


### PR DESCRIPTION
The earlier fix caused only the mxosrvrs associated with last DCS servers to be displayed in the REST dcs connections output. This was because the fix was put inside a loop which cleared the dcsservers discovered for the previous nodes.

The fix is now moved outside the for loop and so preserves all the discovered mxosrvrs. Tested and verified this on a 2 node cluster.