### PR TITLE
[TRAFODION-1728]MT-DCS communication link failure

### DIFF
--- a/dcs/src/main/java/org/trafodion/dcs/servermt/serverSql/TrafConnection.java
+++ b/dcs/src/main/java/org/trafodion/dcs/servermt/serverSql/TrafConnection.java
@@ -384,7 +384,7 @@ public class TrafConnection {
             while (keySetIterator.hasNext()) {
                 key = keySetIterator.next();
                 tstmt = statements.get(key);
-                if (tstmt.getStmtHandle() == stmtHandle);
+                if (tstmt.getStmtHandle() == stmtHandle)
                     return tstmt;
             }
             throw new SQLException("getTrafStatement stmtHandle [" + stmtHandle + "] returns null");


### PR DESCRIPTION
[TRAFODION-1728][MT-DCS]ODBC: SQLExecute ran into communication link
failure when mtdcs is on.