### PR TITLE
[TRAFODION-1779] Non-optimal plan chosen for a query against the crea…

### DIFF
--- a/core/sql/optimizer/NATable.cpp
+++ b/core/sql/optimizer/NATable.cpp
@@ -7864,12 +7864,9 @@ NATable * NATableDB::get(CorrName& corrName, BindWA * bindWA,
       table = NULL;
     }
 
-  if (0) //(table && (corrName.isHbase() || corrName.isSeabase()))
+  if (table && ((table->isHbaseTable() || table->isSeabaseTable()) && !(table->isSeabaseMDTable())))
     {
-      const NAString * val =
-	ActiveControlDB()->getControlSessionValue("SHOWPLAN");
-      if ( ( (val) && (*val == "ON") ) &&
-	   (CmpCommon::getDefault(TRAF_RELOAD_NATABLE_CACHE) == DF_ON))
+      if ((CmpCommon::getDefault(TRAF_RELOAD_NATABLE_CACHE) == DF_ON))
 	{
 	  remove(table->getKey());
 	  table = NULL;

--- a/core/sql/regress/core/EXPECTED005.SB
+++ b/core/sql/regress/core/EXPECTED005.SB
@@ -1568,7 +1568,7 @@ NUM_LOOKUPS  NUM_CACHE_HITS  NUM_ENTRIES  MAX_CACHE_SIZE
 NUM_LOOKUPS  NUM_CACHE_HITS  NUM_ENTRIES  MAX_CACHE_SIZE
 -----------  --------------  -----------  --------------
 
-        170             136            0        20971520
+        165             135            0        20971520
 
 --- 1 row(s) selected.
 >>

--- a/core/sql/sqlcomp/CmpDescribe.cpp
+++ b/core/sql/sqlcomp/CmpDescribe.cpp
@@ -1690,10 +1690,6 @@ static short CmpDescribePlan(
   if (retcode)
     return (short)retcode;
 
-  retcode = exeImmedCQD("TRAF_RELOAD_NATABLE_CACHE", TRUE);
-  if (retcode)
-    return (short)retcode;
-
   // send control session to indicate showplan is being done
   retcode = exeImmedOneStmt("CONTROL SESSION SET 'SHOWPLAN' 'ON';");
   if (retcode)
@@ -1763,8 +1759,6 @@ static short CmpDescribePlan(
   if (retcode)
     goto label_error;
         
-  resetRetcode  = exeImmedCQD("TRAF_RELOAD_NATABLE_CACHE", FALSE);
-
    // free up resources
   retcode = SQL_EXEC_DeallocDesc(&sql_src);
   if (retcode)
@@ -1782,8 +1776,6 @@ static short CmpDescribePlan(
     resetRetcode = exeImmedOneStmt("CONTROL SESSION RESET 'SHOWPLAN';");
 
  label_error:
-    resetRetcode  = exeImmedCQD("TRAF_RELOAD_NATABLE_CACHE", FALSE);
-
     return ((retcode < 0) ? -1 : (short)retcode);
 } // CmpDescribePlan
 

--- a/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
@@ -8859,15 +8859,6 @@ bool CmpSeabaseDDL::dropOneTableorView(
 
 char buf [1000];
 
-Lng32 cliRC = cliInterface.holdAndSetCQD("TRAF_RELOAD_NATABLE_CACHE", "ON");
-
-   if (cliRC < 0)
-   {
-      cliInterface.retrieveSQLDiagnostics(CmpCommon::diags());
-      
-      return false;
-   }
-
 bool someObjectsCouldNotBeDropped = false;
 
 char volatileString[20] = {0};
@@ -8892,7 +8883,8 @@ char objectTypeString[20] = {0};
                volatileString,objectTypeString,objectName);
                
 // Save the current parserflags setting
-ULng32 savedParserFlags = Get_SqlParser_Flags(0xFFFFFFFF);
+   ULng32 savedParserFlags = Get_SqlParser_Flags(0xFFFFFFFF);
+   Lng32 cliRC = 0;
 
    try
    {            
@@ -8913,8 +8905,6 @@ ULng32 savedParserFlags = Get_SqlParser_Flags(0xFFFFFFFF);
    
    if (cliRC < 0 && cliRC != -CAT_OBJECT_DOES_NOT_EXIST_IN_TRAFODION)
       someObjectsCouldNotBeDropped = true;
-
-   cliRC = cliInterface.restoreCQD("TRAF_RELOAD_NATABLE_CACHE");
 
    return someObjectsCouldNotBeDropped;
    

--- a/core/sql/sqlcomp/CmpSeabaseDDLschema.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLschema.cpp
@@ -1010,18 +1010,10 @@ static bool dropOneTable(
 
 char buf [1000];
 
-Lng32 cliRC = cliInterface.holdAndSetCQD("TRAF_RELOAD_NATABLE_CACHE", "ON");
-
-   if (cliRC < 0)
-   {
-      cliInterface.retrieveSQLDiagnostics(CmpCommon::diags());
-      
-      return false;
-   }
-
 bool someObjectsCouldNotBeDropped = false;
 
 char volatileString[20] = {0};
+Lng32 cliRC = 0;
 
    if (isVolatile)
       strcpy(volatileString,"VOLATILE");
@@ -1060,7 +1052,6 @@ ULng32 savedParserFlags = Get_SqlParser_Flags(0xFFFFFFFF);
 
    ActiveSchemaDB()->getNATableDB()->removeNATable(cn,
      NATableDB::REMOVE_FROM_ALL_USERS, COM_BASE_TABLE_OBJECT);
-   cliRC = cliInterface.restoreCQD("TRAF_RELOAD_NATABLE_CACHE");
 
    return someObjectsCouldNotBeDropped;
    

--- a/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
@@ -2904,9 +2904,6 @@ short CmpSeabaseDDL::dropSeabaseTable2(
   else
      verifyName = tableName;
 
-  if (CmpCommon::getDefault(TRAF_RELOAD_NATABLE_CACHE) == DF_OFF)
-    ActiveSchemaDB()->getNATableDB()->useCache();
-
  // save the current parserflags setting
   ULng32 savedParserFlags = Get_SqlParser_Flags (0xFFFFFFFF);
   Set_SqlParser_Flags(ALLOW_VOLATILE_SCHEMA_IN_TABLE_NAME);
@@ -3089,17 +3086,6 @@ short CmpSeabaseDDL::dropSeabaseTable2(
       // drop all constraints referencing me.
       if (uniqConstr->hasRefConstraintsReferencingMe())
         {
-          cliRC = cliInterface->holdAndSetCQD("TRAF_RELOAD_NATABLE_CACHE", "ON");
-          if (cliRC < 0)
-            {
-              cliInterface->retrieveSQLDiagnostics(CmpCommon::diags());
-              
-              deallocEHI(ehi); 
-              processReturn();
-              
-              return -1;
-            }
-
           for (Lng32 j = 0; j < uniqConstr->getNumRefConstraintsReferencingMe(); j++)
             {
               const ComplementaryRIConstraint * rc = 
@@ -3118,9 +3104,6 @@ short CmpSeabaseDDL::dropSeabaseTable2(
               if (cliRC < 0)
                 {
                   cliInterface->retrieveSQLDiagnostics(CmpCommon::diags());
-
-                  cliRC = cliInterface->restoreCQD("TRAF_RELOAD_NATABLE_CACHE");
-                  
                   deallocEHI(ehi); 
                   processReturn();
                   
@@ -3128,9 +3111,6 @@ short CmpSeabaseDDL::dropSeabaseTable2(
                 }
               
             } // for
-          
-          cliRC = cliInterface->restoreCQD("TRAF_RELOAD_NATABLE_CACHE");
-          
         } // if
     } // for
 
@@ -4748,23 +4728,11 @@ void CmpSeabaseDDL::alterSeabaseTableAddColumn(
       (alterAddColNode->getAddConstraintUniqueArray().entries() NEQ 0) OR
       (alterAddColNode->getAddConstraintRIArray().entries() NEQ 0))
     {
-      cliRC = cliInterface.holdAndSetCQD("TRAF_RELOAD_NATABLE_CACHE", "ON");
-      if (cliRC < 0)
-        {
-          cliInterface.retrieveSQLDiagnostics(CmpCommon::diags());
-          
-          processReturn();
-          
-          goto label_return;
-        }
-
       addConstraints(tableName, currCatAnsiName, currSchAnsiName,
                      alterAddColNode->getAddConstraintPK(),
                      alterAddColNode->getAddConstraintUniqueArray(),
                      alterAddColNode->getAddConstraintRIArray(),
                      alterAddColNode->getAddConstraintCheckArray());                 
-
-      cliRC = cliInterface.restoreCQD("TRAF_RELOAD_NATABLE_CACHE");
 
       if (CmpCommon::diags()->getNumber(DgSqlCode::ERROR_))
         return;
@@ -5574,8 +5542,6 @@ void CmpSeabaseDDL::alterSeabaseTableAddPKeyConstraint(
       return;
     }
 
-  if (CmpCommon::getDefault(TRAF_RELOAD_NATABLE_CACHE) == DF_OFF)
-    ActiveSchemaDB()->getNATableDB()->useCache();
 
   BindWA bindWA(ActiveSchemaDB(), CmpCommon::context(), FALSE/*inDDL*/);
   CorrName cn(tableName.getObjectNamePart().getInternalName(),
@@ -5859,9 +5825,6 @@ void CmpSeabaseDDL::alterSeabaseTableAddUniqueConstraint(
       return;
     }
 
-  if (CmpCommon::getDefault(TRAF_RELOAD_NATABLE_CACHE) == DF_OFF)
-    ActiveSchemaDB()->getNATableDB()->useCache();
-
   BindWA bindWA(ActiveSchemaDB(), CmpCommon::context(), FALSE/*inDDL*/);
   CorrName cn(tableName.getObjectNamePart().getInternalName(),
               STMTHEAP,
@@ -6090,9 +6053,6 @@ void CmpSeabaseDDL::alterSeabaseTableAddRIConstraint(
 
       return;
     }
-
-  if (CmpCommon::getDefault(TRAF_RELOAD_NATABLE_CACHE) == DF_OFF)
-    ActiveSchemaDB()->getNATableDB()->useCache();
 
   BindWA bindWA(ActiveSchemaDB(), CmpCommon::context(), FALSE/*inDDL*/);
   CorrName cn(referencingTableName.getObjectNamePart().getInternalName(),
@@ -6826,9 +6786,6 @@ void CmpSeabaseDDL::alterSeabaseTableAddCheckConstraint(
 
       return;
     }
-
-  if (CmpCommon::getDefault(TRAF_RELOAD_NATABLE_CACHE) == DF_OFF)
-    ActiveSchemaDB()->getNATableDB()->useCache();
 
   BindWA bindWA(ActiveSchemaDB(), CmpCommon::context(), FALSE/*inDDL*/);
   CorrName cn(tableName.getObjectNamePart().getInternalName(),


### PR DESCRIPTION
…ted table

in the same session

The CQD TRAF_RELOAD_NATABLE_CACHE can be turned on to invalidate the cache entry.

The usage will be as follows:
create table t1 ..
load into table t1 .. -->This adds the table t1 to NATable cache with estimated row count as 100
cqd traf_reload_natable_cache 'on' ;
select * from t1 -->The non-metadata table accessed by this query will be invalidated from
the NATable cache and reloaded
cqd traf_reload_natable_cache 'off'

Also removed the use of this CQD in the DDL portion of the codes because it was never used.
This CQD was used prior to introduction of query invalidation feature.