### PR TITLE
[TRAFODION-1784]remove closed statement from HashMap

### DIFF
--- a/dcs/src/main/java/org/trafodion/dcs/servermt/serverSql/TrafConnection.java
+++ b/dcs/src/main/java/org/trafodion/dcs/servermt/serverSql/TrafConnection.java
@@ -364,6 +364,7 @@ public class TrafConnection {
                 LOG.debug(serverWorkerName + ". closeTrafStatement.containsKey [" + stmtLabel + "] is found ");
             trafStatement = getTrafStatement(stmtLabel, 0);
             trafStatement.closeTStatement();
+            statements.remove(stmtLabel);
         }
         return trafStatement;
     }

--- a/dcs/src/main/java/org/trafodion/dcs/servermt/serverSql/TrafStatement.java
+++ b/dcs/src/main/java/org/trafodion/dcs/servermt/serverSql/TrafStatement.java
@@ -119,6 +119,7 @@ public class TrafStatement {
         try {
             if (curKey != 0){
                 resultSetList.get(curKey).closeTResultSet();
+                resultSetList.remove(curKey);
              }
         } catch (Exception e){}
     }


### PR DESCRIPTION
[TRAFDOION-1784][MTDCS]statement shoud be removed from HashMap when it's closed.
TrafConnection uses a HashMap to store the statements in MTDCS code.
When a statement is closed, it should be removed from the HashMap,
otherwise the JVM garbage collection couldn't delete the unused objects.