### PR TITLE
[TRAFODION-1775][TRAFODION-1777] UPDATE STATS usability improvements

### DIFF
--- a/core/sql/bin/SqlciErrors.txt
+++ b/core/sql/bin/SqlciErrors.txt
@@ -1869,6 +1869,7 @@ drop the default context
 9240 ZZZZZ 99999 BEGINNER MINOR DBADMIN ON EVERY KEY option is not yet implemented for Update Statistics on $0~string0 tables.
 9241 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Insufficient privileges to perform the statistics request for table $0~String0.
 9242 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Unable to create schema for Hive statistics.
+9243 ZZZZZ 99999 BEGINNER MAJOR DBADMIN This UPDATE STATISTICS command may take too long. It is recommended to use the SAMPLE clause instead. If you wish to do this without a SAMPLE clause, specify NO SAMPLE explicitly.
 9250 ZZZZZ 99999 UUUUUUUU UUUUU UUUUUUU Last UPDATE STATISTICS error.
 10000 ZZZZZ 99999 UUUUUUUU UUUUU UUUUUUU Sort Error: First Sort error
 10001 ZZZZZ 99999 ADVANCED MAJOR DIALOUT Sort Error : No error text defined. Unexpected error. $0~String0

--- a/core/sql/sqlcomp/DefaultConstants.h
+++ b/core/sql/sqlcomp/DefaultConstants.h
@@ -709,6 +709,7 @@ enum DefaultConstants
                                             // CQDs are delimited by ","
   USTAT_MIN_CHAR_UEC_FOR_IS,     // minimum UEC for char type to use internal sort
   USTAT_MIN_DEC_BIN_UEC_FOR_IS,  // minimum UEC for binary types to use internal sort
+  USTAT_YOULL_LIKELY_BE_SORRY, // minimum row count where explicit NO SAMPLE clause is required
 
 
   // -------------------------------------------------------------------------

--- a/core/sql/sqlcomp/nadefaults.cpp
+++ b/core/sql/sqlcomp/nadefaults.cpp
@@ -3587,6 +3587,7 @@ XDDkwd__(SUBQUERY_UNNESTING,			"ON"),
   DDkwd__(USTAT_USE_SIDETREE_INSERT,            "ON"),
   DDkwd__(USTAT_USE_SLIDING_SAMPLE_RATIO,       "ON"), // Trend sampling rate down w/increasing table size, going
                                                        //   flat at 1%.
+ XDDui1__(USTAT_YOULL_LIKELY_BE_SORRY,          "100000000"),  // guard against unintentional long-running UPDATE STATS
   DDkwd__(VALIDATE_RFORK_REDEF_TS,	        "OFF"),
 
   DDkwd__(VALIDATE_VIEWS_AT_OPEN_TIME,		"OFF"),

--- a/core/sql/ustat/hs_const.h
+++ b/core/sql/ustat/hs_const.h
@@ -97,6 +97,7 @@ enum hs_table_type { UNKNOWN_TYPE = 0,
 #define SAMPLE_PERIODIC   0x00010000               /* SAMPLE PERIODIC         */
 #define SAMPLE_REQUESTED  0x0001F000               /* 'OR' sampling options   */
 #define SAMPLE_ALL        0x00020000               /* For REMOVE SAMPLE       */
+#define NO_SAMPLE         0x00200000               /* NO SAMPLE (explicit)    */
 
                                                    /*===    IUS OPTIONS    ===*/
 #define IUS_OPT           0x00040000               /* INCREMENTAL UPDATE STATS*/
@@ -104,6 +105,7 @@ enum hs_table_type { UNKNOWN_TYPE = 0,
 
                                                    /*=== SHOWSTATS OPTIONS ===*/
 #define SHOWSTATS_OPT     0x00100000               /* SHOWSTATS COMMAND       */
+//  note 0x00200000 taken above
 #define DETAIL_OPT        0x00000001               /* DETAILS                 */
 
 
@@ -164,6 +166,7 @@ enum USTAT_ERROR_CODES {UERR_SYNTAX_ERROR                    = 15001,
                         UERR_NO_ONEVERYKEY                   = 9240,
                         UERR_NO_PRIVILEGE                    = 9241,
                         UERR_CANT_CREATE_HIVE_STATS_SCHEMA   = 9242,
+                        UERR_YOU_WILL_LIKELY_BE_SORRY        = 9243,
                         UERR_NO_ERROR                        = 9250,
                         UERR_LAST_ERROR                      = 9250
                        };

--- a/core/sql/ustat/hs_globals.cpp
+++ b/core/sql/ustat/hs_globals.cpp
@@ -3026,6 +3026,24 @@ Lng32 HSGlobalsClass::Initialize()
 
     HS_ASSERT(actualRowCount >= 0);
 
+    Int64 youWillLikelyBeSorry = 
+      ActiveSchemaDB()->getDefaults().getAsDouble(USTAT_YOULL_LIKELY_BE_SORRY);
+    if ((actualRowCount >= youWillLikelyBeSorry) &&
+       !(optFlags & SAMPLE_REQUESTED) &&
+       !(optFlags & IUS_OPT))
+      {
+        // attempt to do UPDATE STATISTICS on a big table without sampling,
+        // which could take a really long time
+        if ((optFlags & NO_SAMPLE) == 0)  // if explicit NO SAMPLE is missing
+          {
+            // raise an error on the chance that omitting the SAMPLE clause
+            // was accidental
+            HSFuncMergeDiags(-UERR_YOU_WILL_LIKELY_BE_SORRY);
+            retcode = -1;
+            HSHandleError(retcode);
+          }
+      }
+
 
                                              /*===================================*/
                                              /*=  DETERMINE "NECESSARY" COLUMNS  =*/

--- a/core/sql/ustat/hs_lex.ll
+++ b/core/sql/ustat/hs_lex.ll
@@ -312,6 +312,10 @@ CMNT_START              "/*"
                           return(VALUES);
                         }
 
+[Nn][Oo]                {
+                          return(NO);
+                        }
+
 {R_IDENTIFIER}          {
                           yylval->stringval = new(STMTHEAP) NAString(STMTHEAP);
                           *yylval->stringval = yytext;

--- a/core/sql/ustat/hs_yacc.y
+++ b/core/sql/ustat/hs_yacc.y
@@ -92,7 +92,7 @@ extern int yylex(YYSTYPE * lvalp, void* scanner);
 %token  ON TOK_OFF EVERY COLUMN KEY TO CLEAR VIEWONLY GENERATE INTERVALS
 %token  TOK_SET ROWCOUNT SAMPLE ROWS RANDOM PERIODIC TOK_PERCENT CLUSTERS BLOCKS OF
 %token  EXISTING COLUMNS NECESSARY CREATE REMOVE ALL WITH SKEWED VALUES 
-%token  INCREMENTAL WHERE WHERE_CONDITION PERSISTENT
+%token  INCREMENTAL WHERE WHERE_CONDITION PERSISTENT NO
 %%
 
 /*
@@ -509,6 +509,13 @@ interval_clause :   GENERATE int_number INTERVALS
 ;
 
 sample_clause : sample_clause_init sample_clause_body
+
+              | NO SAMPLE
+                 {
+                   // explicit NO SAMPLE, to override error 
+                   // UERR_YOU_WILL_LIKELY_BE_SORRY on large tables
+                   hs_globals_y->optFlags |= NO_SAMPLE;
+                 }
 ;
 
 sample_clause_init : { 


### PR DESCRIPTION
For [TRAFODION-1775], added a check to UPDATE STATISTICS to return a new error (9243) if UPDATE STATISTICS is attempted on a large table (100,000,000 or more rows) without a SAMPLE clause. Added an explicit NO SAMPLE clause to the syntax to override this check. The value 100,000,000 is not hard-coded; it can be changed via CQD USTAT_YOULL_LIKELY_BE_SORRY.

For [TRAFODION-1777], fixed a minor annoyance. UPDATE STATISTICS on a non-existing object would return three error messages that the object doesn't exist. Changed it to return just one.