### PR TITLE
[TRAFODION-1749] Bundle log4cxx library in Trafodion build

### DIFF
--- a/core/conn/odbc/src/odbc/nsksrvr/Makefile
+++ b/core/conn/odbc/src/odbc/nsksrvr/Makefile
@@ -121,7 +121,7 @@ DBT_LIBS =
 
 EARLY_LIBS = -ljsig
 
-COMMON_LIBS = -lsbfs -lsbms -levlsq -lwin -ltdm_sqlcli -larkcmp_dll -L../nsksrvrcore -lmxocore -L$(LOG4CXX_LIB_DIR) -llog4cxx
+COMMON_LIBS = -lsbfs -lsbms -levlsq -lwin -ltdm_sqlcli -larkcmp_dll -L../nsksrvrcore -lmxocore -llog4cxx
 
 ifeq ($(SQ_MTYPE),64)
 LOC_JSIG=$(JAVA_HOME)/jre/lib/amd64/server

--- a/core/sqf/LocalSettingsTemplate.sh
+++ b/core/sqf/LocalSettingsTemplate.sh
@@ -61,6 +61,9 @@ MPICH_ROOT="$TOOLSDIR/dest-mpich-3.0.4"
 ZOOKEEPER_DIR="$TOOLSDIR/zookeeper-3.4.5"
 THRIFT_LIB_DIR="$TOOLSDIR/thrift-0.9.0/lib"
 THRIFT_INC_DIR="$TOOLSDIR/thrift-0.9.0/include"
+LOG4CXX_LIB_DIR="$TOOLSDIR/apache-log4cxx-0.10.0/lib"
+LOG4CXX_INC_DIR="$TOOLSDIR/apache-log4cxx-0.10.0/include"
+
 
 # Explicitly set QT_TOOLKIT here if Qt is installed and you want to build the SqlCompilerDebugger
 # QT_TOOLKIT="$TOOLSDIR/Qt-4.8.5-64"

--- a/core/sqf/monitor/linux/makefile
+++ b/core/sqf/monitor/linux/makefile
@@ -83,7 +83,7 @@ INCLUDES+= -I$(LOG4CXX_INC_DIR)
 INCLUDES+= -I$(LOG4CXX_INC_DIR)/log4cxx
 
 LIBS+=  -lsqlite3
-LIBS+=  -L$(LOG4CXX_LIB_DIR) -llog4cxx
+LIBS+=  -llog4cxx
 
 ifeq ($(USE_TESTPOINTS),1)
    FLAGS+= -DUSE_TESTPOINTS

--- a/core/sqf/sqenvcom.sh
+++ b/core/sqf/sqenvcom.sh
@@ -634,7 +634,7 @@ then
   export LOG4CXX_LIB_DIR=$TOOLSDIR/apache-log4cxx-0.10.0/lib
   export LOG4CXX_INC_DIR=$TOOLSDIR/apache-log4cxx-0.10.0/include
 else
-  export LOG4CXX_LIB_DIR=/lib64:/usr/lib64
+  export LOG4CXX_LIB_DIR=/usr/lib64
   export LOG4CXX_INC_DIR=/usr/include/log4cxx
 fi
 

--- a/core/sqf/sqvers
+++ b/core/sqf/sqvers
@@ -171,7 +171,7 @@ sub find_elfs ($$) {
 		if ($file =~ /libQtGuiCmpDbg.so.4/) {
 			$dochk = 0;
 		}
-		if ($file =~ /libhdfs.so|libhadoop.so|libmysql|libthrift|libzookeeper|libcurl/) {
+		if ($file =~ /libhdfs.so|libhadoop.so|libmysql|libthrift|libzookeeper|libcurl|^liblog4cxx/) {
 			$dochk = 0;
 		}
 		if ($file =~ /mpirun|hydra_pmi_proxy/) {

--- a/core/sqf/src/tm/Makefile
+++ b/core/sqf/src/tm/Makefile
@@ -146,7 +146,7 @@ all:  $(LIBEXPDIR)/libsxatmlib.so $(LIBEXPDIR)/libstmlib.so $(PROGS) $(LIBEXPDIR
 
 $(OUTDIR)/tm: $(TMOBJS) $(LIBEXPDIR)/libsxatmlib.so $(LIBEXPDIR)/libshbasetmlib.so $(PROGS) $(LIBEXPDIR)/libxarm.so cp_trx_jar
 	@echo "USE_THREADED_IO = " $(USE_THREADED_IO)
-	$(CXX) $(LNK_FLGS) $(LIBJVM) -o $@ $(TMOBJS) $(LIBSTM) -L$(LIBEXPDIR) -L$(LOG4CXX_LIB_DIR) -llog4cxx -DTM_BUILD_
+	$(CXX) $(LNK_FLGS) $(LIBJVM) -o $@ $(TMOBJS) $(LIBSTM) -L$(LIBEXPDIR) -llog4cxx -DTM_BUILD_
 
 	cp -fup $(OUTDIR)/tm $(BINEXPDIR)
 
@@ -158,17 +158,17 @@ $(OUTDIR)/idtmsrv: $(IDSRVOBJS)
 	cp -fup $(OUTDIR)/idtmsrv $(BINEXPDIR)
 
 $(LIBEXPDIR)/libstmlib.so: $(LIBSTMOBJS) 
-	$(CXX) $(DTMOBJS) $(LNK_FLGS) $(LIBSBMSX) $(LIBJVM) -L$(LIBEXPDIR) -L$(LOG4CXX_LIB_DIR) -llog4cxx -shared -o $@ $(LIBSTMOBJS)  
+	$(CXX) $(DTMOBJS) $(LNK_FLGS) $(LIBSBMSX) $(LIBJVM) -L$(LIBEXPDIR) -llog4cxx -shared -o $@ $(LIBSTMOBJS)  
 
 $(LIBEXPDIR)/libsxatmlib.so: $(LIBSXATMOBJS) 
-	$(CXX) $(LNK_FLGS) -shared -o $@ $(LIBSXATMOBJS) $(LIBSTMX) -L$(LIBEXPDIR) -L$(LOG4CXX_LIB_DIR) -llog4cxx
+	$(CXX) $(LNK_FLGS) -shared -o $@ $(LIBSXATMOBJS) $(LIBSTMX) -L$(LIBEXPDIR) -llog4cxx
 
 $(LIBEXPDIR)/libshbasetmlib.so: $(LIBSXATMOBJS) cp_trx_jar
 	cd $(HBASETMLIB); $(MAKE)
 
 
 $(LIBEXPDIR)/libxarm.so: $(LIBXARMOBJS) 
-	$(CXX) $(LNK_FLGS) -shared -o $@ $(LIBXARMOBJS) -L$(LIBEXPDIR) -L$(LOG4CXX_LIB_DIR) -llog4cxx -DXARM_BUILD_
+	$(CXX) $(LNK_FLGS) -shared -o $@ $(LIBXARMOBJS) -L$(LIBEXPDIR) -llog4cxx -DXARM_BUILD_
 
 $(OUTDIR)/CommonLogger.o: $(MY_SQROOT)/commonLogger/CommonLogger.cpp
 	$(CXX) $(CXXFLAGS) $(INCLUDES) -c -o $@ $<

--- a/core/sql/nskgmake/Makerules.linux
+++ b/core/sql/nskgmake/Makerules.linux
@@ -131,7 +131,7 @@ THRIFT_LIB=-lthrift
 THRIFT_SO=libthrift-*.so
 
 LOG4CXX_INC=-I$(LOG4CXX_INC_DIR) -I$(LOG4CXX_INC_DIR)/log4cxx
-LOG4CXX_LIB=-L$(LOG4CXX_LIB_DIR) -llog4cxx
+LOG4CXX_LIB=-llog4cxx
 LOG4CXX_SO=liblog4cxx*.so
 
 # for now, include these libs (copied to our local lib dir) everywhere
@@ -420,7 +420,8 @@ copytoolslibs:
 	mkdir -p $(LIBROOT)
 	-(for i in $(HADOOP_LIB_DIR)/$(LIBHDFS_SO) \
 	           $(HADOOP_LIB_DIR)/$(LIBHADOOP_SO) \
-	           $(THRIFT_LIB_DIR)/$(THRIFT_SO); \
+	           $(THRIFT_LIB_DIR)/$(THRIFT_SO) \
+	           $(LOG4CXX_LIB_DIR)/$(LOG4CXX_SO); \
 	 do\
 	   cp -Pf $$i* $(LIBROOT); \
 	 done\

--- a/install/installer/traf_package_setup
+++ b/install/installer/traf_package_setup
@@ -160,7 +160,7 @@ if [[ $SUSE_LINUX == "false" ]]; then
    # it doesn't hurt if it was already enabled and we try to enable it again
    $TRAF_PDSH sudo yum-config-manager --enable RedHat-6-x86_64-Fedora-EPEL 2>> $YUM_LOG >> $YUM_LOG
 
-   package_list="log4cxx sqlite expect perl-DBD-SQLite* protobuf xerces-c perl-Params-Validate perl-Time-HiRes gzip"
+   package_list="sqlite expect perl-DBD-SQLite* protobuf xerces-c perl-Params-Validate perl-Time-HiRes gzip"
    if [[ $internetAccess == "true" ]]; then
       for package in $package_list
       do
@@ -201,7 +201,7 @@ else
    echo
    echo 
    echo "***WARNING: All needed RPM's must be installed in advance to install Trafodion on SUSE."
-   echo "***WARNING: log4cxx sqlite expect perl-DBD-SQLite* protobuf xerces-c perl-Params-Validate perl-Time-HiRes gzip"
+   echo "***WARNING: sqlite expect perl-DBD-SQLite* protobuf xerces-c perl-Params-Validate perl-Time-HiRes gzip"
    echo "***WARNING: If any of these packages have not been installed. Stop Trafodion installation and install."
    echo 
    echo 


### PR DESCRIPTION
Since log4cxx is not available in all Linux distros, we make it a
build-time dependency only, and bundle the shared library for runtime.
This eliminates the installer dependency to check log4cxx package.

The build-time dependency can be satisfied either by installing log4cxx
and log4cxx-devel RPM packages, if available, or by building library
from source.  The traf_tools_setup.sh script is enhanced to download
source code and build this dependency.

@robertamarton @amandamoran 