### PR TITLE
[TRAFODION-1699] Expose in-development manuals on documentation web page

### DIFF
--- a/docs/src/site/markdown/documentation.md
+++ b/docs/src/site/markdown/documentation.md
@@ -25,14 +25,25 @@ Trafodion odb User Guide                       | [Web Book](docs/odb/index.html)
 Trafodion REST Server Reference Guide          | [Web Book](docs/rest_reference/index.html),[API](docs/rest_reference/apidocs/index.html)
 Trafodion SQL Reference Manual                 | [Web Book](docs/sql_reference/index.html),[PDF](docs/sql_reference/Trafodion_SQL_Reference_Manual.pdf)
 
+# 2.0.0 (In Development)
+
+Document                                       | Formats
+-----------------------------------------------|-----------------------------------
+Trafodion Client Installation Guide            | [Web Book](docs/2.0.0/client_install/index.html),[PDF](docs/2.0.0/client_install/Trafodion_Client_Installation_Guide.pdf)
+Trafodion Command Interface Guide              | [Web Book](docs/2.0.0/command_interface/index.html),[PDF](docs/2.0.0/command_interface/Trafodion_Command_Interface_Guide.pdf)
+Trafodion Database Connectivity Services Guide | [Web Book](docs/2.0.0/dcs_reference/index.html),[API](docs/2.0.0/dcs_reference/apidocs/index.html)
+Trafodion odb User Guide                       | [Web Book](docs/2.0.0/odb/index.html),[PDF](docs/2.0.0/odb/Trafodion_odb_User_Guide.pdf)
+Trafodion REST Server Reference Guide          | [Web Book](docs/2.0.0/rest_reference/index.html),[API](docs/2.0.0/rest_reference/apidocs/index.html)
+Trafodion SQL Reference Manual                 | [Web Book](docs/2.0.0/sql_reference/index.html),[PDF](docs/2.0.0/sql_reference/Trafodion_SQL_Reference_Manual.pdf)
+
 # 1.3.0
 
 Document                                       | Formats
 -----------------------------------------------|-----------------------------------
 Trafodion Client Installation Guide            | [Web Book](docs/1.3.0/client_install/index.html),[PDF](docs/1.3.0/client_install/Trafodion_Client_Installation_Guide.pdf)
 Trafodion Command Interface Guide              | [Web Book](docs/1.3.0/command_interface/index.html),[PDF](docs/1.3.0/command_interface/Trafodion_Command_Interface_Guide.pdf)
-Trafodion Database Connectivity Services Guide | [Web Book](docs/1.3.0/dcs_reference/index.html),[API](docs/1.3.0/dcs_reference/apidocs/1.3.0/index.html)
+Trafodion Database Connectivity Services Guide | [Web Book](docs/1.3.0/dcs_reference/index.html),[API](docs/1.3.0/dcs_reference/apidocs/index.html)
 Trafodion odb User Guide                       | [Web Book](docs/1.3.0/odb/index.html),[PDF](docs/1.3.0/odb/Trafodion_odb_User_Guide.pdf)
-Trafodion REST Server Reference Guide          | [Web Book](docs/1.3.0/rest_reference/index.html),[API](docs/1.3.0/rest_reference/apidocs/1.3.0/index.html)
+Trafodion REST Server Reference Guide          | [Web Book](docs/1.3.0/rest_reference/index.html),[API](docs/1.3.0/rest_reference/apidocs/index.html)
 Trafodion SQL Reference Manual                 | [Web Book](docs/1.3.0/sql_reference/index.html),[PDF](docs/1.3.0/sql_reference/Trafodion_SQL_Reference_Manual.pdf)
 


### PR DESCRIPTION
Also fix URL of the 1.3 API docs.