### PR TITLE
[TRAFODION-1799] create index failed with ERROR[3047]

### DIFF
--- a/core/sql/optimizer/ItemExpr.cpp
+++ b/core/sql/optimizer/ItemExpr.cpp
@@ -10519,8 +10519,11 @@ ConstValue * ConstValue::castToConstValue(NABoolean & negate_it)
 
 Int32 ConstValue::getArity() const { return 0; }
 
-NAString ConstValue::getConstStr(NABoolean transformeNeeded) const
+NAString ConstValue::getConstStr(NABoolean transformNeeded) const
 {
+  if ((*text_ == "<min>") || (*text_ == "<max>"))
+    return *text_ ;
+
   if (getType()->getTypeQualifier() == NA_DATETIME_TYPE &&
       getType()->getPrecision() != SQLDTCODE_MPDATETIME)
   {
@@ -10532,7 +10535,7 @@ NAString ConstValue::getConstStr(NABoolean transformeNeeded) const
 
     // 4/8/96: added the Boolean switch so that displayable
     // and non-displayable version can be differed.
-    if ( transformeNeeded )
+    if ( transformNeeded )
       return chType->getCharSetAsPrefix() + getText();
     else
       return chType->getCharSetAsPrefix() + getTextForQuery(QUERY_FORMAT);

--- a/core/sql/optimizer/NormRelExpr.cpp
+++ b/core/sql/optimizer/NormRelExpr.cpp
@@ -7071,32 +7071,32 @@ void RelRoot::recomputeOuterReferences()
   // been pulled up.
   // ---------------------------------------------------------------------
   if (NOT getGroupAttr()->getCharacteristicInputs().isEmpty())
-    {
-      ValueIdSet leafValues, emptySet;
-      GroupAttributes emptyGA;
-      child(0)->getGroupAttr()->getCharacteristicInputs().
-                  getLeafValuesForCoverTest(leafValues, emptyGA, emptySet);
-      CMPASSERT((getGroupAttr()->getCharacteristicInputs().contains
-		 (child(0)->getGroupAttr()->getCharacteristicInputs())) || 
-                (getGroupAttr()->getCharacteristicInputs().contains (leafValues))); 
-      ValueIdSet outerRefs = getGroupAttr()->getCharacteristicInputs(); 
-
-      // Remove from outerRefs those valueIds that are not needed
-      // by my selection predicate or by my computed expression list.
-      // Need to add the orderby list since it is not a subset of the
-      // computed expression list.
-      ValueIdSet allMyExpr(getSelectionPred());
-      allMyExpr.insertList(compExpr());
-      allMyExpr.insertList(reqdOrder());
-
-      allMyExpr.weedOutUnreferenced(outerRefs);
-
-      // Add to outerRefs those that my child need.
-      outerRefs += child(0).getPtr()->getGroupAttr()->getCharacteristicInputs();
-
-      // set my Character Inputs to this new minimal set.
-      getGroupAttr()->setCharacteristicInputs(outerRefs);
-    }
+  {
+    ValueIdSet leafValues, emptySet;
+    GroupAttributes emptyGA;
+    child(0)->getGroupAttr()->getCharacteristicInputs().
+      getLeafValuesForCoverTest(leafValues, emptyGA, emptySet);
+    CMPASSERT((getGroupAttr()->getCharacteristicInputs().contains
+               (child(0)->getGroupAttr()->getCharacteristicInputs())) || 
+              (getGroupAttr()->getCharacteristicInputs().contains (leafValues))); 
+    ValueIdSet outerRefs = getGroupAttr()->getCharacteristicInputs(); 
+    
+    // Remove from outerRefs those valueIds that are not needed
+    // by my selection predicate or by my computed expression list.
+    // Need to add the orderby list since it is not a subset of the
+    // computed expression list.
+    ValueIdSet allMyExpr(getSelectionPred());
+    allMyExpr.insertList(compExpr());
+    allMyExpr.insertList(reqdOrder());
+    
+    allMyExpr.weedOutUnreferenced(outerRefs);
+    
+    // Add to outerRefs those that my child need.
+    outerRefs += child(0).getPtr()->getGroupAttr()->getCharacteristicInputs();
+    
+    // set my Character Inputs to this new minimal set.
+    getGroupAttr()->setCharacteristicInputs(outerRefs);
+  }
 } // RelRoot::recomputeOuterReferences()  
 
 // -----------------------------------------------------------------------

--- a/core/sql/regress/executor/EXPECTED015.SB
+++ b/core/sql/regress/executor/EXPECTED015.SB
@@ -163,6 +163,13 @@
 
 --- SQL operation complete.
 >>
+>>prepare explainIt from
++>select substring(operator,1,16) operator
++>from table (explain(NULL,'XX')) t
++>where operator LIKE '%TRAFODION_MERGE%' ;
+
+--- SQL command prepared.
+>>
 >>insert into t015t1 values (1,1), (2,2);
 
 --- 2 row(s) inserted.
@@ -1800,35 +1807,67 @@ A            B                     C
 --- 1 row(s) selected.
 >>
 >>-- guarding against error 7000 and compiler asserts
->>prepare s1 from UPSERT INTO DEC1 
+>>prepare XX from UPSERT INTO DEC1 
 +>(ID, codeValue, title , description, path, synonyms, objectClassCode, propertyCode)  
 +>VALUES  (NVL((select a.id from DEC1 a where a.codeValue = ?a[10]), DEFAULT), 
 +>?b[10], ?c[10], ?d[10], ?e[10], null, ?f[10], null) ;
 
 --- SQL command prepared.
+>>execute explainIt;
+
+OPERATOR        
+----------------
+
+TRAFODION_MERGE 
+
+--- 1 row(s) selected.
 >>
->>prepare s2 from UPSERT INTO DEC1 
+>>prepare XX from UPSERT INTO DEC1 
 +>(ID, codeValue, title , description, path, synonyms, objectClassCode, propertyCode)  
 +>VALUES  (?a, ?b, ?c, ?d, ?e, null, ?f, null) ;
 
 --- SQL command prepared.
+>>execute explainIt;
+
+OPERATOR        
+----------------
+
+TRAFODION_MERGE 
+
+--- 1 row(s) selected.
 >>
->>prepare s3 from UPSERT INTO DEC1 
+>>prepare XX from UPSERT INTO DEC1 
 +>(ID, codeValue, title , description, path, synonyms, objectClassCode, propertyCode)  
 +>VALUES  (NVL((select a.id from DEC1 a where a.codeValue = ?a), DEFAULT), 
 +>?b, ?c, ?d, ?e, null, ?f, null) ;
 
 --- SQL command prepared.
+>>execute explainIt;
+
+OPERATOR        
+----------------
+
+TRAFODION_MERGE 
+
+--- 1 row(s) selected.
 >>
->>prepare s4 from UPSERT INTO DE 
+>>prepare XX from UPSERT INTO DE 
 +>(ID, dataElementConceptID, valueDomainID)  VALUES  
 +>(NVL((select a.id from DE a where a.dataElementConceptID = 
 +>(select b.id from DEC1 b where b.codeValue = ?) and a.valueDomainID = ? ), DEFAULT),  
 +>NVL((select d.id from DEC1 d where d.codeValue = ?), NULL),  ? ) ;
 
 --- SQL command prepared.
+>>execute explainIt;
+
+OPERATOR        
+----------------
+
+TRAFODION_MERGE 
+
+--- 1 row(s) selected.
 >>
->>prepare s5 from UPSERT INTO ODT 
+>>prepare XX from UPSERT INTO ODT 
 +>(ID, objectTypeID, dataElementID, objectCategoryTypeCode)  
 +>VALUES  (NVL((select a.id from ODT a where a.objectTypeID = 
 +>(select b.id from OT b where b.objectCode = ? and b.version = ?) and  
@@ -1840,29 +1879,68 @@ A            B                     C
 +>(select i.id from DEC1 i where i.codeValue = ?) and h.valueDomainID = ? ), NULL), ? );
 
 --- SQL command prepared.
+>>execute explainIt;
+
+OPERATOR        
+----------------
+
+TRAFODION_MERGE 
+
+--- 1 row(s) selected.
 >>
->>prepare s6 from UPSERT INTO DE 
+>>prepare XX from UPSERT INTO DE 
 +>(ID, dataElementConceptID, valueDomainID)  VALUES  
 +>(NVL((select a.id from DE a where a.dataElementConceptID = 
 +>(select b.id from DEC1 b where b.codeValue = ?) and a.valueDomainID = ? ), DEFAULT),  
 +>(select d.id from DEC1 d where d.codeValue = ?),  ? ) ;
 
 --- SQL command prepared.
+>>execute explainIt;
+
+OPERATOR        
+----------------
+
+TRAFODION_MERGE 
+
+--- 1 row(s) selected.
 >>
->>prepare s7 from UPSERT INTO DE (ID, dataElementConceptID, valueDomainID)  
+>>prepare XX from UPSERT INTO DE (ID, dataElementConceptID, valueDomainID)  
 +>VALUES  (1,  (select d.id from DEC1 d where d.codeValue = ?),  3 ) ;
 
 --- SQL command prepared.
+>>execute explainIt;
+
+OPERATOR        
+----------------
+
+TRAFODION_MERGE 
+
+--- 1 row(s) selected.
 >>
->>prepare s8 from UPSERT INTO DE (ID, dataElementConceptID, valueDomainID)  
+>>prepare XX from UPSERT INTO DE (ID, dataElementConceptID, valueDomainID)  
 +>VALUES  (?[10], ?[10], ?[10] ) ;
 
 --- SQL command prepared.
+>>execute explainIt;
+
+OPERATOR        
+----------------
+
+TRAFODION_MERGE 
+
+--- 1 row(s) selected.
 >>
->>prepare s9 from UPSERT INTO DE (ID, dataElementConceptID, valueDomainID)  
+>>prepare XX from UPSERT INTO DE (ID, dataElementConceptID, valueDomainID)  
 +>VALUES  (1,  (select d.id from DEC1 d where d.codeValue = 'aa'),  3 ) ;
 
 --- SQL command prepared.
->>
+>>execute explainIt;
+
+OPERATOR        
+----------------
+
+TRAFODION_MERGE 
+
+--- 1 row(s) selected.
 >>
 >>log;

--- a/core/sql/regress/executor/TEST015
+++ b/core/sql/regress/executor/TEST015
@@ -260,6 +260,11 @@ PRIMARY KEY (ID)
 ALTER TABLE OT 
 ADD CONSTRAINT UI1_OT UNIQUE (objectCode, version);
 
+prepare explainIt from
+select substring(operator,1,16) operator
+from table (explain(NULL,'XX')) t
+where operator LIKE '%TRAFODION_MERGE%' ;
+
 insert into t015t1 values (1,1), (2,2);
 insert into t015t3 values (1,1,1), (2,2,2), (3,3,3);
 insert into t015t5 values (1,2,3,4,5);
@@ -801,27 +806,31 @@ upsert into t015t7 values (1, NVL((select b+1 from t015t7 where a = 1),DEFAULT),
 select * from t015t7;
 
 -- guarding against error 7000 and compiler asserts
-prepare s1 from UPSERT INTO DEC1 
+prepare XX from UPSERT INTO DEC1 
 (ID, codeValue, title , description, path, synonyms, objectClassCode, propertyCode)  
 VALUES  (NVL((select a.id from DEC1 a where a.codeValue = ?a[10]), DEFAULT), 
 ?b[10], ?c[10], ?d[10], ?e[10], null, ?f[10], null) ;
+execute explainIt;
 
-prepare s2 from UPSERT INTO DEC1 
+prepare XX from UPSERT INTO DEC1 
 (ID, codeValue, title , description, path, synonyms, objectClassCode, propertyCode)  
 VALUES  (?a, ?b, ?c, ?d, ?e, null, ?f, null) ;
+execute explainIt;
 
-prepare s3 from UPSERT INTO DEC1 
+prepare XX from UPSERT INTO DEC1 
 (ID, codeValue, title , description, path, synonyms, objectClassCode, propertyCode)  
 VALUES  (NVL((select a.id from DEC1 a where a.codeValue = ?a), DEFAULT), 
 ?b, ?c, ?d, ?e, null, ?f, null) ;
+execute explainIt;
 
-prepare s4 from UPSERT INTO DE 
+prepare XX from UPSERT INTO DE 
 (ID, dataElementConceptID, valueDomainID)  VALUES  
 (NVL((select a.id from DE a where a.dataElementConceptID = 
 (select b.id from DEC1 b where b.codeValue = ?) and a.valueDomainID = ? ), DEFAULT),  
 NVL((select d.id from DEC1 d where d.codeValue = ?), NULL),  ? ) ;
+execute explainIt;
 
-prepare s5 from UPSERT INTO ODT 
+prepare XX from UPSERT INTO ODT 
 (ID, objectTypeID, dataElementID, objectCategoryTypeCode)  
 VALUES  (NVL((select a.id from ODT a where a.objectTypeID = 
 (select b.id from OT b where b.objectCode = ? and b.version = ?) and  
@@ -831,22 +840,26 @@ a.objectCategoryTypeCode = ? and  a.dataElementID =
 NVL((select g.id from OT g where g.objectCode = ? and g.version = ?), NULL),   
 NVL((select h.id from DE h where h.dataElementConceptID = 
 (select i.id from DEC1 i where i.codeValue = ?) and h.valueDomainID = ? ), NULL), ? );
+execute explainIt;
 
-prepare s6 from UPSERT INTO DE 
+prepare XX from UPSERT INTO DE 
 (ID, dataElementConceptID, valueDomainID)  VALUES  
 (NVL((select a.id from DE a where a.dataElementConceptID = 
 (select b.id from DEC1 b where b.codeValue = ?) and a.valueDomainID = ? ), DEFAULT),  
 (select d.id from DEC1 d where d.codeValue = ?),  ? ) ;
+execute explainIt;
 
-prepare s7 from UPSERT INTO DE (ID, dataElementConceptID, valueDomainID)  
+prepare XX from UPSERT INTO DE (ID, dataElementConceptID, valueDomainID)  
 VALUES  (1,  (select d.id from DEC1 d where d.codeValue = ?),  3 ) ;
+execute explainIt;
 
-prepare s8 from UPSERT INTO DE (ID, dataElementConceptID, valueDomainID)  
+prepare XX from UPSERT INTO DE (ID, dataElementConceptID, valueDomainID)  
 VALUES  (?[10], ?[10], ?[10] ) ;
+execute explainIt;
 
-prepare s9 from UPSERT INTO DE (ID, dataElementConceptID, valueDomainID)  
+prepare XX from UPSERT INTO DE (ID, dataElementConceptID, valueDomainID)  
 VALUES  (1,  (select d.id from DEC1 d where d.codeValue = 'aa'),  3 ) ;
-
+execute explainIt;
 
 log;
 


### PR DESCRIPTION
Create index was failing when bulk load is used to populate the newly created index
Bulk load uses RangePartitionFunction on source table. We get an error when 
source table has timestamp column in key and rangepartitionfunction is used.
Fix is to avoid casting <min>/<max> used internally to TIMESTAMP type.
Change in ItemExpr.cpp

Change in NormRelExpr.cpp (tabs) and executor/test015 is rework for previous PR.