### PR TITLE
Fix for JIRA [TRAFODION-1713]

### DIFF
--- a/core/sqf/sql/scripts/genms
+++ b/core/sqf/sql/scripts/genms
@@ -33,6 +33,7 @@ echo "#TM_TLOG_MAX_VERSIONS less than 3 will be ignored"
 echo "TM_TLOG_MAX_VERSIONS=5"
 echo "TM_ENABLE_DDL_TRANS=0"
 echo "TM_USE_SSCC=0"
+echo "TM_IDTMSRV_REFRESH_DELAY_SECONDS=3"
 
 echo "TSE_CONVERT_NOUNDO_TRANS=1"
 


### PR DESCRIPTION
IDs returned from IDTMSRV process should be periodically re-calibrated
so that they are a better approximation of a logical time