### PR TITLE
[TRAFODION-1819] Disallow UPDATE STATS in a user transaction

### DIFF
--- a/core/sql/bin/SqlciErrors.txt
+++ b/core/sql/bin/SqlciErrors.txt
@@ -1870,6 +1870,7 @@ drop the default context
 9241 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Insufficient privileges to perform the statistics request for table $0~String0.
 9242 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Unable to create schema for Hive statistics.
 9243 ZZZZZ 99999 BEGINNER MAJOR DBADMIN This UPDATE STATISTICS command may take too long. It is recommended to use the SAMPLE clause instead. If you wish to do this without a SAMPLE clause, specify NO SAMPLE explicitly.
+9244 ZZZZZ 99999 BEGINNER MAJOR DBADMIN UPDATE STATISTICS is not allowed in a user transaction.
 9250 ZZZZZ 99999 UUUUUUUU UUUUU UUUUUUU Last UPDATE STATISTICS error.
 10000 ZZZZZ 99999 UUUUUUUU UUUUU UUUUUUU Sort Error: First Sort error
 10001 ZZZZZ 99999 ADVANCED MAJOR DIALOUT Sort Error : No error text defined. Unexpected error. $0~String0

--- a/core/sql/ustat/hs_const.h
+++ b/core/sql/ustat/hs_const.h
@@ -167,6 +167,7 @@ enum USTAT_ERROR_CODES {UERR_SYNTAX_ERROR                    = 15001,
                         UERR_NO_PRIVILEGE                    = 9241,
                         UERR_CANT_CREATE_HIVE_STATS_SCHEMA   = 9242,
                         UERR_YOU_WILL_LIKELY_BE_SORRY        = 9243,
+                        UERR_USER_TRANSACTION                = 9244,
                         UERR_NO_ERROR                        = 9250,
                         UERR_LAST_ERROR                      = 9250
                        };

--- a/core/sql/ustat/hs_update.cpp
+++ b/core/sql/ustat/hs_update.cpp
@@ -189,6 +189,15 @@ Lng32 UpdateStats(char *input, NABoolean requestedByCompiler)
     HSColGroupStruct::allocCount = 1;  // start at 1 for each new statement
 #endif
 
+    // Disallow UPDATE STATS in a user transaction
+    HSTranMan *TM = HSTranMan::Instance();
+    if (TM->InTransaction())
+      {
+        HSFuncMergeDiags(-UERR_USER_TRANSACTION);
+        retcode = -1;
+        HSExitIfError(retcode);
+      }
+
 
                                              /*==============================*/
                                              /*       PARSE STATEMENT        */


### PR DESCRIPTION
UPDATE STATS sometimes does DDL and DML under the covers, and likes to start its own transactions for this purpose. Trafodion doesn't support mixed DDL and DML in the same transaction. Therefore, it makes sense for UPDATE STATS to check for a user transaction up front, and raise an error if there is one running.