### PR TITLE
[TRAFODION-1818] Parallel build with maven caused error

### DIFF
--- a/core/sqf/Makefile
+++ b/core/sqf/Makefile
@@ -68,7 +68,7 @@ smstub:
 	cd ../smstub/src; $(MAKE) 2>&1 | sed -e "s/$$/	##(SMSTUB)/" ; exit $${PIPESTATUS[0]}
 
 
-make_sql: $(SEAMONSTER_TARGET) win 
+make_sql: $(SEAMONSTER_TARGET) win hbase_utilities
 	cd sql; $(MAKE) WROOT=$(SQL_W) 2>&1 | sed -e "s/$$/	##(SQL)/" ; exit $${PIPESTATUS[0]}
 	cd $(MY_SQROOT)/sql/scripts && ./makemsg.ksh 2>&1 | sed -e "s/$$/	##(SQL)/" ; exit $${PIPESTATUS[0]}
 
@@ -85,7 +85,7 @@ monitor_ib:
 make_sqevlog: 
 	cd sqevlog; $(MAKE) 2>&1 | sed -e "s/$$/	##(SQF)/" ; exit $${PIPESTATUS[0]}
 
-hbase_utilities:
+hbase_utilities: tm
 	cd hbase_utilities; $(MAKE) 2>&1 | sed -e "s/$$/  ##(HBASE_UTIL)/" ; exit $${PIPESTATUS[0]}
 
 .PHONY: conn

--- a/core/sqf/src/seatrans/tm/hbasetmlib2/Makefile
+++ b/core/sqf/src/seatrans/tm/hbasetmlib2/Makefile
@@ -64,10 +64,10 @@ endif
 all:  $(PROGS) mavenbuild
 
 mavenbuild:
-        # create a jar manifest file with the correct version information
+	# create a jar manifest file with the correct version information
 	mkdir -p src/main/resources
 	$(MY_SQROOT)/export/include/SCMBuildJava.sh 1.0.1 >src/main/resources/trafodion-dtm.jar.mf
-        # run maven
+	# run maven
 	set -o pipefail; $(MAVEN) package -DskipTests | tee maven_build.log | grep -e '\[INFO\] Building' -e '\[INFO\] BUILD SUCCESS' -e 'ERROR'
 	cp -pf target/trafodion-dtm-*.jar $(MY_SQROOT)/export/lib
 


### PR DESCRIPTION
Add dependencies in sqf/Makefile to prevent collision of maven
builds downloading dependencies.

Replace spaces in hbasetmlib2/Makefile with tabs. Makefile syntax
requires initial tab for shell commands.