### PR TITLE
[TRAFODION-1725] Missing license information

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -218,6 +218,7 @@ BSD-4 for files:
 
  Copyright (c) 1990 The Regents of the University of California.
  Copyright (c) 1990, 1993 The Regents of the University of California.
+ This code is derived from software contributed to Berkeley by Chris Torek.
 
 For details see incubator-trafodion/licenses/LICENSE-bsd4
 
@@ -259,6 +260,7 @@ MIT-Expat for files in:
 
  Copyright (c) 2011 Sencha Inc. - Author: Nicolas Garcia Belmonte 
    (http://philogb.github.com/)
+ Copyright (c) 2006-2010 Valerio Proietti
 
 For details see incubator-trafodion/licenses/LICENSE-js
 
@@ -279,8 +281,10 @@ For details see incubator-trafodion/core/sql/qmscommon/expat/COPYING
 
 MIT-Expat for files in:
    incubator-trafodion/dcs/src/main/resources/dcs-webapps/master/jquery-ui
+   incubator-trafodion/dcs/src/main/resources/dcs-webapps/master/js/lib/jquery-1.11.0.js
 
  Copyright 2014 jQuery Foundation and other contributors
+ (c) 2005, 2014 jQuery Foundation, Inc.
 
 For details see incubator-trafodion/licenses/LICENSE-jquery
 

--- a/licenses/LICENSE-bsd4
+++ b/licenses/LICENSE-bsd4
@@ -1,3 +1,6 @@
+ Copyright (c) 1990, 1993
+ The Regents of the University of California.  All rights reserved.
+
  This code is derived from software contributed to Berkeley by
  Chris Torek.
 

--- a/licenses/LICENSE-jquery
+++ b/licenses/LICENSE-jquery
@@ -1,4 +1,5 @@
 Copyright 2014 jQuery Foundation and other contributors
+(c) 2005, 2014 jQuery Foundation, Inc.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 

--- a/licenses/LICENSE-js
+++ b/licenses/LICENSE-js
@@ -1,4 +1,5 @@
 Copyright (c) 2011 Sencha Inc. - Author: Nicolas Garcia Belmonte (http://philogb.github.com/)
+Copyright (c) 2006-2010 Valerio Proietti
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
More updates to license files from the reviews while releasing 1.3.

There was copyright info in code that was not reflected in top-level
license file.