### PR TITLE
[TRAFODION-1831] Improved error msg when properties file is absent

### DIFF
--- a/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
@@ -1434,7 +1434,7 @@ short CmpSeabaseDDL::validateVersions(NADefaults *defs,
       if (hbaseErrStr)
         *hbaseErrStr = (char*)GetCliGlobals()->getJniErrorStr().data();
 
-      retcode = -1394;
+      retcode = -1398;
       goto label_return;
     }
   else


### PR DESCRIPTION
When $MY_SQROOT/etc/traf_coprocessor.properties is absent, SQL operations fail with

*** ERROR[1394] Trafodion needs to be reinitialized on this system due to missing or corrupted metadata objects. Do 'initialize trafodion, drop' followed by 'initialize trafodion' to reinitialize Trafodion. This will delete all metadata and user objects from the Trafodion database and recreate metadata.

This is incorrect, and doing the steps described does not solve the problem.

Changed the code to instead raise the following error:

*** ERROR[1398] Error 704 occured while accessing the hbase subsystem. Fix that error and make sure hbase is up and running. Error Details:
java.lang.NullPointerException
java.lang.String.contains(String.java:2076)
org.TRAFODION.sql.CoprocessorUtils.addCoprocessor(CoprocessorUtils.java:76)
org.TRAFODION.sql.CoprocessorUtils.addCoprocessor(CoprocessorUtils.java:88)
org.TRAFODION.sql.HBaseClient.getHTableClient(HBaseClient.java:861)

This at least points to a coprocessor problem.