### PR TITLE
Update fix for TRAFODION-1814

### DIFF
--- a/core/rest/src/main/java/org/trafodion/rest/ServerResource.java
+++ b/core/rest/src/main/java/org/trafodion/rest/ServerResource.java
@@ -57,28 +57,6 @@ public class ServerResource extends ResourceBase {
 		cacheControl.setNoTransform(false);
 	}
 
-	/**
-* @@@ START COPYRIGHT @@@
-
-	Licensed to the Apache Software Foundation (ASF) under one
-	or more contributor license agreements.  See the NOTICE file
-	distributed with this work for additional information
-	regarding copyright ownership.  The ASF licenses this file
-	to you under the Apache License, Version 2.0 (the
-	"License"); you may not use this file except in compliance
-	with the License.  You may obtain a copy of the License at
-
-	  http://www.apache.org/licenses/LICENSE-2.0
-
-	Unless required by applicable law or agreed to in writing,
-	software distributed under the License is distributed on an
-	"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-	KIND, either express or implied.  See the License for the
-	specific language governing permissions and limitations
-	under the License.
-
-* @@@ END COPYRIGHT @@@
-	 */
 	public ServerResource() throws IOException {
 		super();
 	}
@@ -246,19 +224,20 @@ public class ServerResource extends ResourceBase {
 	            String line = scanner.nextLine();
 	            if(line.contains("pstack-ing")) {
 	                continue;
-				} else if (line.contains("pstack") || line.startsWith("--")) {
-					if (pstack == true && sb.length() > 0) {
+	       	    } else if (line.contains("pstack") || line.startsWith("--")) {
+                    if (pstack == true && sb.length() > 0) {
 	                    json.put(new JSONObject().put("PROGRAM", sb.toString()));
 	                    sb.setLength(0);
-						if (line.contains("pstack"))
-							sb.append(line + "\n");
-						pstack = false;
+                        if (line.contains("pstack"))
+                            sb.append(line + "\n");
+                        pstack = false;
 	                } else {
 	                    pstack = true;
-	                    sb.append(line + "\n");
+                        if (line.contains("pstack"))
+                            sb.append(line + "\n");
 	                }
 	            } else {
-	                sb.append(line + "\n");
+	                 sb.append(line + "\n");
 	            }
 	        }
             scanner.close();

--- a/core/rest/src/main/java/org/trafodion/rest/VersionResource.java
+++ b/core/rest/src/main/java/org/trafodion/rest/VersionResource.java
@@ -41,26 +41,11 @@ import org.apache.commons.logging.LogFactory;
 import org.trafodion.rest.model.VersionModel;
 
 /**
-* @@@ START COPYRIGHT @@@
-
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
-
-* @@@ END COPYRIGHT @@@
+ * Implements REST software version reporting
+ * <p>
+ * <tt>/version/rest</tt>
+ * <p>
+ * <tt>/version</tt> (alias for <tt>/version/rest</tt>)
  */
 public class VersionResource extends ResourceBase {
 


### PR DESCRIPTION
The fix earlier did not fully work when pstack was requested for a specific program.
The sqpstack output had a line with "--" string between the lines with "pstack-ing" and the "ssh -q <host> pstack <pid>" lines and this was not handled in the logic.
An example sqpstack output:
pstack-ing 24162
–
ssh -q node2 pstack 24162

The new fix ignores adding a new line if the string is just "--"