### PR TITLE
run-time display methods for Atp, Cri and Tupp.

### DIFF
--- a/core/sql/common/str.cpp
+++ b/core/sql/common/str.cpp
@@ -1588,3 +1588,154 @@ Int32 str_convertToHexAscii(const char * src,               // in
   return computedHexAsciiStrLen;
 }
 
+void printBrief(char* dataPointer, Lng32 keyLen) 
+{
+  // We don't know what the data type is, but we do know how
+  // long the field is. So we will guess the data type.
+
+  // The Generator transforms varchars to chars, so we don't
+  // have to worry about varchar length fields.
+
+  // We might have a null indicator, but we have no way of knowing
+  // that here. So we will ignore that possibility. (Sorry!)
+
+  // If the length is 2 or 4 or 8, we'll guess that it is an
+  // integer and print a signed integer interpretation.
+
+  // If the length is 7 and the first two bytes, when interpreted
+  // as Big Endian, looks like a year within 100 years of 2000,
+  // we'll interpret it as a TIMESTAMP(0).
+
+  // There are other possibilities of course which can be added
+  // over time but a better solution would be to change the 
+  // Generator and Executor to simply give us the data type info.
+
+  char local[1001];  // will assume our length is <= 1000
+  local[0] = '\0';
+
+  if (dataPointer)
+    {
+    bool allNulls = true;
+    bool allFFs = true;
+    bool allPrintable = true;
+    size_t i = 0;
+    while (i < keyLen && (allNulls || allFFs))
+      {
+      if (dataPointer[i] != '\0') allNulls = false;
+      if (dataPointer[i] != -1) allFFs = false;
+      if (!isprint(dataPointer[i])) allPrintable = false;
+      i++;
+      }
+    if (allNulls)
+      {
+      strcpy(local,"*lo*");  // hopefully there won't be a legitimate value of *lo*
+      }
+    else if (allFFs)
+      {
+      strcpy(local,"*hi*");  // hopefully there won't be a legitimate value of *hi*
+      }
+    else if (allPrintable)
+      {
+      size_t lengthToMove = sizeof(local) - 1;
+      if (keyLen < lengthToMove)
+        lengthToMove = keyLen;
+      strncpy(local,dataPointer,lengthToMove);
+      local[lengthToMove] = '\0';
+      }
+    else  
+      {
+      // create a hex representation of the first 498 characters
+      strcpy(local,"hex ");
+      char * nextTarget = local + strlen(local);
+      size_t repdChars = ((sizeof(local) - 1)/2) - 4; // -4 to allow for "hex "
+      if (keyLen < repdChars)
+        repdChars = keyLen;
+
+      for (size_t i = 0; i < repdChars; i++)
+        {
+        unsigned char nibbles[2];
+        nibbles[0] = ((unsigned char)dataPointer[i] & 
+                      (unsigned char)0xf0)/16;
+        nibbles[1] = (unsigned char)dataPointer[i] & (unsigned char)0x0f;
+        for (size_t j = 0; j < 2; j++)
+          {
+          if (nibbles[j] < 10)
+            *nextTarget = '0' + nibbles[j];
+          else
+            *nextTarget = 'a' + (nibbles[j] - 10);
+          nextTarget++;
+          }  // for j
+        }  // for i
+
+      *nextTarget = '\0';         
+      }
+
+    if (keyLen == 2)  // if it might be a short
+      {
+      // append an interpretation as a short (note that there
+      // is room in local for this purpose)
+
+      // the value is big-endian hence the weird computation
+      long value = 256 * dataPointer[0] + 
+                   (unsigned char)dataPointer[1];                  
+      sprintf(local + strlen(local), " (short %ld)",value);
+      }
+    else if (keyLen == 4)  // if it might be a long
+      {
+      // append an interpretation as a long (note that there
+      // is room in local for this purpose)
+
+      // the value is big-endian hence the weird computation
+      long value = 256 * 256 * 256 * dataPointer[0] + 
+                   256 * 256 * (unsigned char)dataPointer[1] +  
+                   256 * (unsigned char)dataPointer[2] + 
+                   (unsigned char)dataPointer[3];           
+      sprintf(local + strlen(local), " (long %ld)",value);
+      }
+    else if (keyLen == 8)  // if it might be a 64-bit integer
+      {
+      // append an interpretation as a short (note that there
+      // is room in local for this purpose)
+
+      // the value is big-endian hence the weird computation
+      long long value = 256 * 256 * 256 * dataPointer[0] + 
+                   256 * 256 * (unsigned char)dataPointer[1] +  
+                   256 * (unsigned char)dataPointer[2] + 
+                   (unsigned char)dataPointer[3]; 
+      value = (long long)256 * 256 * 256 * 256 * value +   
+                   256 * 256 * 256 * (unsigned char)dataPointer[4] + 
+                   256 * 256 * (unsigned char)dataPointer[5] +  
+                   256 * (unsigned char)dataPointer[6] + 
+                   (unsigned char)dataPointer[7];        
+      sprintf(local + strlen(local), " (long long %lld)",value);
+      }
+    else if (keyLen == 7)  // a TIMESTAMP(0) perhaps?
+      {
+      long year = 256 * dataPointer[0] +
+                          (unsigned char)dataPointer[1];
+      if ((year >= 1900) && (year <= 2100))
+        {
+        // looks like a TIMESTAMP(0); look further
+        long month = (unsigned char)dataPointer[2];
+        long day = (unsigned char)dataPointer[3];
+        long hour = (unsigned char)dataPointer[4];
+        long minute = (unsigned char)dataPointer[5];
+        long second = (unsigned char)dataPointer[6];
+
+        if ((month >= 1) && (month <= 12) &&
+            (day >= 1) && (day <= 31) &&
+            (hour >= 0) && (hour <= 23) &&
+            (minute >= 0) && (minute <= 59) &&
+            (second >= 0) && (second <= 59))
+          {
+          sprintf(local + strlen(local), 
+                  " (TIMESTAMP(0) %ld-%02ld-%02ld %02ld:%02ld:%02ld)",
+                  year,month,day,hour,minute,second);
+          }
+        }
+      }
+    }    
+  cout << local;
+  // cout << *(Lng32 *)dataPointer;
+  // End test change
+}

--- a/core/sql/common/str.cpp
+++ b/core/sql/common/str.cpp
@@ -1593,8 +1593,9 @@ void printBrief(char* dataPointer, Lng32 keyLen)
   // We don't know what the data type is, but we do know how
   // long the field is. So we will guess the data type.
 
-  // The Generator transforms varchars to chars, so we don't
-  // have to worry about varchar length fields.
+  // Note that varchar length fields are not handled here. For
+  // certain Tupp such as MdamPoint, this is OK because the Generator 
+  // transforms varchars to chars.
 
   // We might have a null indicator, but we have no way of knowing
   // that here. So we will ignore that possibility. (Sorry!)

--- a/core/sql/common/str.h
+++ b/core/sql/common/str.h
@@ -448,4 +448,7 @@ Int32 str_convertToHexAscii(const char * src,                   // in
                           char *       result,                // out
                           const size_t maxResultSize,         // in - including NULL terminator if addNullAtEnd
                           NABoolean    addNullAtEnd = TRUE);  // in
+
+NA_EIDPROC
+void printBrief(char* dataPointer, Lng32 keyLen); 
 #endif // STR_H

--- a/core/sql/executor/ExSequence.cpp
+++ b/core/sql/executor/ExSequence.cpp
@@ -827,6 +827,8 @@ short ExSequenceTcb::work()
               }
             }
 
+//pentry_up->getAtp()->display("return eval result", myTdb().getCriDescUp());
+
             //
             // Case-10-030724-7963: we are done pointing the tupp at the
             // history buffer, so point it back to the SQL buffer.

--- a/core/sql/executor/MdamPoint.cpp
+++ b/core/sql/executor/MdamPoint.cpp
@@ -47,6 +47,7 @@
 #include "NABoolean.h"
 #include "MdamEndPoint.h"
 #include "MdamPoint.h"
+#include "str.h"
 
 // *****************************************************************************
 // Member functions for class MdamPoint
@@ -132,158 +133,13 @@ void MdamPoint::print(const char * header) const
        << endl;
 }
 
+//void printBrief(char* dataPointer, Lng32 keyLen);
+
 void MdamPoint::printBrief() const
 {
   char * dataPointer = getDataPointer();
   Lng32 keyLen = tupp_.getAllocatedSize();
 
-  // We don't know what the data type is, but we do know how
-  // long the field is. So we will guess the data type.
-
-  // The Generator transforms varchars to chars, so we don't
-  // have to worry about varchar length fields.
-
-  // We might have a null indicator, but we have no way of knowing
-  // that here. So we will ignore that possibility. (Sorry!)
-
-  // If the length is 2 or 4 or 8, we'll guess that it is an
-  // integer and print a signed integer interpretation.
-
-  // If the length is 7 and the first two bytes, when interpreted
-  // as Big Endian, looks like a year within 100 years of 2000,
-  // we'll interpret it as a TIMESTAMP(0).
-
-  // There are other possibilities of course which can be added
-  // over time but a better solution would be to change the 
-  // Generator and Executor to simply give us the data type info.
-
-  char local[1001];  // will assume our length is <= 1000
-  local[0] = '\0';
-
-  if (dataPointer)
-    {
-    bool allNulls = true;
-    bool allFFs = true;
-    bool allPrintable = true;
-    size_t i = 0;
-    while (i < keyLen && (allNulls || allFFs))
-      {
-      if (dataPointer[i] != '\0') allNulls = false;
-      if (dataPointer[i] != -1) allFFs = false;
-      if (!isprint(dataPointer[i])) allPrintable = false;
-      i++;
-      }
-    if (allNulls)
-      {
-      strcpy(local,"*lo*");  // hopefully there won't be a legitimate value of *lo*
-      }
-    else if (allFFs)
-      {
-      strcpy(local,"*hi*");  // hopefully there won't be a legitimate value of *hi*
-      }
-    else if (allPrintable)
-      {
-      size_t lengthToMove = sizeof(local) - 1;
-      if (keyLen < lengthToMove)
-        lengthToMove = keyLen;
-      strncpy(local,dataPointer,lengthToMove);
-      local[lengthToMove] = '\0';
-      }
-    else  
-      {
-      // create a hex representation of the first 498 characters
-      strcpy(local,"hex ");
-      char * nextTarget = local + strlen(local);
-      size_t repdChars = ((sizeof(local) - 1)/2) - 4; // -4 to allow for "hex "
-      if (keyLen < repdChars)
-        repdChars = keyLen;
-
-      for (size_t i = 0; i < repdChars; i++)
-        {
-        unsigned char nibbles[2];
-        nibbles[0] = ((unsigned char)dataPointer[i] & 
-                      (unsigned char)0xf0)/16;
-        nibbles[1] = (unsigned char)dataPointer[i] & (unsigned char)0x0f;
-        for (size_t j = 0; j < 2; j++)
-          {
-          if (nibbles[j] < 10)
-            *nextTarget = '0' + nibbles[j];
-          else
-            *nextTarget = 'a' + (nibbles[j] - 10);
-          nextTarget++;
-          }  // for j
-        }  // for i
-
-      *nextTarget = '\0';         
-      }
-
-    if (keyLen == 2)  // if it might be a short
-      {
-      // append an interpretation as a short (note that there
-      // is room in local for this purpose)
-
-      // the value is big-endian hence the weird computation
-      long value = 256 * dataPointer[0] + 
-                   (unsigned char)dataPointer[1];                  
-      sprintf(local + strlen(local), " (short %ld)",value);
-      }
-    else if (keyLen == 4)  // if it might be a long
-      {
-      // append an interpretation as a long (note that there
-      // is room in local for this purpose)
-
-      // the value is big-endian hence the weird computation
-      long value = 256 * 256 * 256 * dataPointer[0] + 
-                   256 * 256 * (unsigned char)dataPointer[1] +  
-                   256 * (unsigned char)dataPointer[2] + 
-                   (unsigned char)dataPointer[3];           
-      sprintf(local + strlen(local), " (long %ld)",value);
-      }
-    else if (keyLen == 8)  // if it might be a 64-bit integer
-      {
-      // append an interpretation as a short (note that there
-      // is room in local for this purpose)
-
-      // the value is big-endian hence the weird computation
-      long long value = 256 * 256 * 256 * dataPointer[0] + 
-                   256 * 256 * (unsigned char)dataPointer[1] +  
-                   256 * (unsigned char)dataPointer[2] + 
-                   (unsigned char)dataPointer[3]; 
-      value = (long long)256 * 256 * 256 * 256 * value +   
-                   256 * 256 * 256 * (unsigned char)dataPointer[4] + 
-                   256 * 256 * (unsigned char)dataPointer[5] +  
-                   256 * (unsigned char)dataPointer[6] + 
-                   (unsigned char)dataPointer[7];        
-      sprintf(local + strlen(local), " (long long %lld)",value);
-      }
-    else if (keyLen == 7)  // a TIMESTAMP(0) perhaps?
-      {
-      long year = 256 * dataPointer[0] +
-                          (unsigned char)dataPointer[1];
-      if ((year >= 1900) && (year <= 2100))
-        {
-        // looks like a TIMESTAMP(0); look further
-        long month = (unsigned char)dataPointer[2];
-        long day = (unsigned char)dataPointer[3];
-        long hour = (unsigned char)dataPointer[4];
-        long minute = (unsigned char)dataPointer[5];
-        long second = (unsigned char)dataPointer[6];
-
-        if ((month >= 1) && (month <= 12) &&
-            (day >= 1) && (day <= 31) &&
-            (hour >= 0) && (hour <= 23) &&
-            (minute >= 0) && (minute <= 59) &&
-            (second >= 0) && (second <= 59))
-          {
-          sprintf(local + strlen(local), 
-                  " (TIMESTAMP(0) %ld-%02ld-%02ld %02ld:%02ld:%02ld)",
-                  year,month,day,hour,minute,second);
-          }
-        }
-      }
-    }    
-  cout << local;
-  // cout << *(Lng32 *)dataPointer;
-  // End test change
+  printBrief(dataPointer, keyLen);
 }
-#endif /* NA_MDAM_EXECUTOR_DEBUG */
+#endif

--- a/core/sql/executor/MdamPoint.cpp
+++ b/core/sql/executor/MdamPoint.cpp
@@ -133,8 +133,6 @@ void MdamPoint::print(const char * header) const
        << endl;
 }
 
-//void printBrief(char* dataPointer, Lng32 keyLen);
-
 void MdamPoint::printBrief() const
 {
   char * dataPointer = getDataPointer();

--- a/core/sql/executor/MdamPoint.h
+++ b/core/sql/executor/MdamPoint.h
@@ -102,7 +102,10 @@ public:
   NA_EIDPROC void print(const char * header = "") const;
   NA_EIDPROC void printBrief() const;
   #endif /* NA_MDAM_EXECUTOR_DEBUG */
-
+  
+  #ifdef _DEBUG
+  NA_EIDPROC static void printBrief(char* ptr, Lng32 len) ;
+  #endif 
 private:
 
   // The point's value.

--- a/core/sql/exp/ExpAtp.h
+++ b/core/sql/exp/ExpAtp.h
@@ -124,6 +124,15 @@ class SQLEXP_LIB_FUNC  atp_struct
     inline Int32 get_tag() const;
   NA_EIDPROC
     inline void unset_tag();
+
+  // The passed-in cri will be used if it is not NULL. Otherwise
+  // the cri associated with the atp is used.
+  NA_EIDPROC
+  void display(const char* title = "", ex_cri_desc* cri = NULL);
+  //
+  // print the content of a data field, based on the data type dt
+  NA_EIDPROC
+  void print(char* title, Int16 dt, char* ptr, UInt32 len);
   //---------------------------------------------
    
   //  inline              ~atp_struct();	// destructor

--- a/core/sql/exp/ExpCriDesc.cpp
+++ b/core/sql/exp/ExpCriDesc.cpp
@@ -41,6 +41,7 @@
 #include "ExpCriDesc.h"
 #include "exp_space.h"
 #include "exp_tuple_desc.h"
+#include <iostream>
 
 
 ex_cri_desc::ex_cri_desc(const unsigned short numTuples, void * space_) :
@@ -78,3 +79,20 @@ NA_EIDPROC Lng32 ex_cri_desc::unpack(void * base, void * reallocator)
     }
   return NAVersionedObject::unpack(base, reallocator);
 }
+
+NA_EIDPROC void ex_cri_desc::display(const char* title)
+{
+   cout << title << endl;
+
+   unsigned short tuples = noTuples();
+   char buf[100];
+   for (Int32 i=0; i<tuples; i++) {
+      ExpTupleDesc* tDesc = getTupleDescriptor(i);
+      if ( tDesc ) {
+         sprintf(buf, "%dth tuple:", i);
+         tDesc->display(buf);
+      } else
+         cout << i << "th tuple's TupleDesc is NULL" << endl;
+   }
+}
+

--- a/core/sql/exp/ExpCriDesc.h
+++ b/core/sql/exp/ExpCriDesc.h
@@ -98,6 +98,9 @@ NA_EIDPROC
   Long pack(void *);
 NA_EIDPROC
   Lng32 unpack(void *, void * reallocator);
+
+NA_EIDPROC
+  void display(const char* title = "");
   
   // ---------------------------------------------------------------------
   // Redefinition of methods inherited from NAVersionedObject.

--- a/core/sql/exp/ExpSqlTupp.cpp
+++ b/core/sql/exp/ExpSqlTupp.cpp
@@ -39,6 +39,7 @@
 
 #include "ComPackDefs.h"
 #include "ExpSqlTupp.h"
+#include "str.h"
 
 tupp::tupp()			// constructor
 {
@@ -86,3 +87,14 @@ tupp_descriptor::tupp_descriptor()
 {
   init();
 };
+
+#ifdef _DEBUG
+void tupp::display()
+{
+  char * dataPointer = getDataPointer();
+  Lng32 keyLen = getAllocatedSize();
+
+  printBrief(dataPointer, keyLen);
+
+}
+#endif

--- a/core/sql/exp/ExpSqlTupp.h
+++ b/core/sql/exp/ExpSqlTupp.h
@@ -95,6 +95,10 @@ NA_EIDPROC
 NA_EIDPROC
   NABoolean isAllocated(){return (tuppDescPointer ? TRUE : FALSE);};
 
+#ifdef _DEBUG
+NA_EIDPROC
+  void display();
+#endif
 
 };
 

--- a/core/sql/exp/exp_tuple_desc.cpp
+++ b/core/sql/exp/exp_tuple_desc.cpp
@@ -70,7 +70,9 @@ ExpTupleDesc::ExpTupleDesc(UInt32 num_attrs,
       flags_ = 0;
       attrs_ = 0;
   
+#ifndef _DEBUG
       if (tdescF == LONG_FORMAT)
+#endif
 	{
 	  // allocate an array of num_attrs Attributes*. This array follows
 	  // 'this' class.
@@ -963,5 +965,25 @@ void ExpTupleDesc::assignAtpAndIndex(Int16 atp, Int16 atp_index)
 	  attrs_[i]->setAtpIndex(atp_index);
 	}
     }
+}
+
+void ExpTupleDesc::display(const char* title)
+{
+   if (title)
+      cout << title;
+   else
+      cout << "ExpTupleDesc::display()";
+
+   cout << endl;
+
+   UInt32 attrs = numAttrs();
+   cout << "this=" << this << ", num of attrs=" << attrs << endl;
+
+   for (Int32 j=0; j<attrs; j++) {
+       Attributes* attr = getAttr(j);
+       Int16 dt = attr->getDatatype();
+       UInt32 len = attr->getLength();
+       cout << j << "th attr: dt=" << dt << ", len=" << len << endl;
+   }
 }
 

--- a/core/sql/exp/exp_tuple_desc.h
+++ b/core/sql/exp/exp_tuple_desc.h
@@ -907,6 +907,9 @@ public:
     return ( tdf == SQLMX_ALIGNED_FORMAT );
   }
 
+
+  void display(const char* title = NULL);
+
   // ---------------------------------------------------------------------
   // Redefinition of methods inherited from NAVersionedObject.
   // ---------------------------------------------------------------------


### PR DESCRIPTION
Hi,

This is the work to cover JIRA 1833 "Lack of a display method for ATP, CRI, and TUPP in executor".  Please review. 

These display methods can be called from gdb, or hard coded into the executor. 

Thanks 