### PR TITLE
[TRAFODION-1838] Send CQDs down to child process on CREATE TABLE LIKE

### DIFF
--- a/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
@@ -356,6 +356,9 @@ void CmpSeabaseDDL::createSeabaseTableLike(
         query += keyClause;
       }
 
+  // send any user CQDs down 
+  Lng32 retCode = sendAllControls(FALSE, FALSE, TRUE);
+
   ExeCliInterface cliInterface(STMTHEAP, NULL, NULL, 
   CmpCommon::context()->sqlSession()->getParentQid());
 

--- a/core/sql/ustat/hs_update.cpp
+++ b/core/sql/ustat/hs_update.cpp
@@ -355,7 +355,6 @@ Lng32 UpdateStats(char *input, NABoolean requestedByCompiler)
            LM->Log(LM->msg);
         }
 
-        char *buf =  new (CmpCommon::statementHeap()) char[allowedCqdsSize];
         char* filterString = new (STMTHEAP) char[allowedCqdsSize+1];
         // We need to make a copy of the CQD value here since strtok
         // overwrites delims with nulls in stored cqd value.
@@ -377,6 +376,7 @@ Lng32 UpdateStats(char *input, NABoolean requestedByCompiler)
            {
              NAString quotedString;
              ToQuotedString (quotedString, value);
+             char buf[strlen(name)+quotedString.length()+4+1+1+1];  // room for "CQD %s %s;" and null terminator
              sprintf(buf, "CQD %s %s;", name, quotedString.data());
              retcode = HSFuncExecQuery(buf);
 
@@ -387,7 +387,6 @@ Lng32 UpdateStats(char *input, NABoolean requestedByCompiler)
         }
 
         NADELETEBASIC(filterString, STMTHEAP);
-        NADELETEBASIC(buf, STMTHEAP);
      }
      else // size is zero or too large
      {


### PR DESCRIPTION
Fix two bugs:

1. UPDATE STATISTICS on a table with a nullable key column failed, because the CQD ALLOW_NULLABLE_UNIQUE_KEY_CONSTRAINT was not propagated to a child compiler process by the CREATE TABLE LIKE logic. This has been fixed.

2. A buffer overrun can occur when using USTAT_CQDS_ALLOWED_FOR_SPAWNED_COMPILERS with a single CQD. This bug was encountered while debugging the first bug above. This has been fixed.