### PR TITLE
[TRAFODION-1735] Added Apache license header for major mods

### DIFF
--- a/core/sql/parser/ulexer.h
+++ b/core/sql/parser/ulexer.h
@@ -15,6 +15,27 @@
 // of this software.  Neither the name of the University nor the names of
 // its contributors may be used to endorse or promote products derived from
 // this software without specific prior written permission.
+//
+//
+// Later modifications to enable Unicode parsing were granted to ASF.
+//
+// # Licensed to the Apache Software Foundation (ASF) under one
+// # or more contributor license agreements.  See the NOTICE file
+// # distributed with this work for additional information
+// # regarding copyright ownership.  The ASF licenses this file
+// # to you under the Apache License, Version 2.0 (the
+// # "License"); you may not use this file except in compliance
+// # with the License.  You may obtain a copy of the License at
+// #
+// #   http://www.apache.org/licenses/LICENSE-2.0
+// #
+// # Unless required by applicable law or agreed to in writing,
+// # software distributed under the License is distributed on an
+// # "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// # KIND, either express or implied.  See the License for the
+// # specific language governing permissions and limitations
+// # under the License.
+//
 
 
 // ULexer.h -- define interfaces for Unicode lexical analyzer class (tcr)

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/AlterTableTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/AlterTableTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/ArithmeticQueryTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/ArithmeticQueryTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/AutoCommitTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/AutoCommitTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/BaseTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/BaseTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/BinaryRowKeyTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/BinaryRowKeyTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/CoalesceFunctionTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/CoalesceFunctionTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/CompareDecimalToLongTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/CompareDecimalToLongTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/CreateTableTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/CreateTableTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/CustomEntityDataTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/CustomEntityDataTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/DeleteRangeTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/DeleteRangeTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/DescColumnSortOrderTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/DescColumnSortOrderTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/DistinctCountTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/DistinctCountTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/ExecuteStatementsTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/ExecuteStatementsTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/ExtendedQueryExecTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/ExtendedQueryExecTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/FunkyNamesTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/FunkyNamesTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/GroupByCaseTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/GroupByCaseTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/IndexTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/IndexTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/IsNullTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/IsNullTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/KeyOnlyTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/KeyOnlyTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/MultiCfQueryExecTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/MultiCfQueryExecTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/OrderByTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/OrderByTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/ProductMetricsTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/ProductMetricsTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/QueryExecTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/QueryExecTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/QueryExecWithoutSCNTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/QueryExecWithoutSCNTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/QueryPlanTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/QueryPlanTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/ReadIsolationLevelTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/ReadIsolationLevelTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/SaltedTableTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/SaltedTableTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/SaltedTableUpsertSelectTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/SaltedTableUpsertSelectTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/SaltedTableVarLengthRowKeyTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/SaltedTableVarLengthRowKeyTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/ServerExceptionTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/ServerExceptionTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/SkipScanQueryTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/SkipScanQueryTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/StatementHintsTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/StatementHintsTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/StddevTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/StddevTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/ToCharFunctionTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/ToCharFunctionTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/ToNumberFunctionTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/ToNumberFunctionTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/TopNTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/TopNTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/UpsertBigValuesTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/UpsertBigValuesTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/UpsertSelectAutoCommitTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/UpsertSelectAutoCommitTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/UpsertSelectTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/UpsertSelectTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/UpsertValuesTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/UpsertValuesTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE 
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/VariableLengthPKTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/VariableLengthPKTest.java
@@ -25,6 +25,28 @@
  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  ******************************************************************************/
+/**********************************
+ *
+ * Later modifications to test Trafodion instead of Phoenix were granted to ASF.
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+*************************************/
+
 package test.java.org.trafodion.phoenix.end2end;
 
 import static org.junit.Assert.*;


### PR DESCRIPTION
Per advice on legal-discuss mail list, these third-party files
have been modified enough that they need the Apache header as well
as the original copyright info.