### PR TITLE
[TRAFODION-1765] trafci would throw an error when set statistics on

### DIFF
--- a/core/conn/trafci/manualtests/README
+++ b/core/conn/trafci/manualtests/README
@@ -1,0 +1,47 @@
+# @@@ START COPYRIGHT @@@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# @@@ END COPYRIGHT @@@
+
+README for TRAFCI manualtests
+=============================
+
+This directory contains manual tests used to validate fixes for trafci. Eventual goal is to automate these tests.
+
+To run any one specfic test, invoke a trafci session and obey the corresponding test file.
+
+statcheck.sql   - TRAFODION-1765 reported that if statistics are on for a 
+                  session, then execution of queries resulted in the following
+                  error:
+                     "*** ERROR[29003] Statement does not exist"
+
+                  This was a regression due to fix for TRAFODION-1709.
+
+                  To check for TRAFODION-1709 do the following while running
+                  this test:
+
+                  cd $MY_SQROOT/export/limited-support-tools/LSO 
+                  ./offender -s active -t 300
+
+                  For direct execute queries the EXECUTE_STATE should be
+                  DEALLOCATED.
+
+                  For prepare/execute queries the EXECUTE_STATE should be
+                  CLOSE.
+

--- a/core/conn/trafci/manualtests/README
+++ b/core/conn/trafci/manualtests/README
@@ -31,7 +31,10 @@ statcheck.sql   - TRAFODION-1765 reported that if statistics are on for a
                   error:
                      "*** ERROR[29003] Statement does not exist"
 
-                  This was a regression due to fix for TRAFODION-1709.
+                  This was a regression due to fix for TRAFODION-1709:
+
+                     When issuing an execdirect sql statement via trafci
+                     the statements are not being deallocated. 
 
                   To check for TRAFODION-1709 do the following while running
                   this test:

--- a/core/conn/trafci/manualtests/statcheck.sql
+++ b/core/conn/trafci/manualtests/statcheck.sql
@@ -1,0 +1,47 @@
+--
+-- @@@ START COPYRIGHT @@@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+-- @@@ END COPYRIGHT @@@
+--
+
+create schema trafci_manual;
+set schema trafci_manual;
+
+-- with statistics off
+
+create table stat_check ( a int );
+insert into stat_check values (1);
+
+select * from stat_check;
+prepare s1 from select * from stat_check;
+execute s1;
+
+-- with statistics on
+set statistics on;
+
+select * from stat_check;
+get statistics;
+prepare s2 from select * from stat_check;
+execute s2;
+get statistics;
+
+set statistics off;
+drop table stat_check;
+drop schema trafci_manual;

--- a/core/conn/trafci/manualtests/statcheck.sql
+++ b/core/conn/trafci/manualtests/statcheck.sql
@@ -29,17 +29,17 @@ set schema trafci_manual;
 create table stat_check ( a int );
 insert into stat_check values (1);
 
-select * from stat_check;
 prepare s1 from select * from stat_check;
 execute s1;
+select * from stat_check;
+get statistics;
 
 -- with statistics on
 set statistics on;
 
-select * from stat_check;
-get statistics;
 prepare s2 from select * from stat_check;
 execute s2;
+select * from stat_check;
 get statistics;
 
 set statistics off;

--- a/core/conn/trafci/src/org/trafodion/ci/DatabaseQuery.java
+++ b/core/conn/trafci/src/org/trafodion/ci/DatabaseQuery.java
@@ -1163,9 +1163,10 @@ public class DatabaseQuery extends QueryWrapper
          super.setQueryRowCount(stmt);
          sessObj.setQryEndTime();
       }
-    
+
       stmt.close();
       sessObj.setStmtObj(sessObj.getConnObj().createStatement());
+      this.stmt=sessObj.getStmtObj();
       resetQryObj();
    }
 

--- a/dcs/bin/stop-dcs.sh
+++ b/dcs/bin/stop-dcs.sh
@@ -41,7 +41,7 @@ fi
 master=`$bin/dcs --config "${DCS_CONF_DIR}" org.trafodion.dcs.zookeeper.ZkUtil /$USER/dcs/master|tail -n 1`
 errCode=$?
 zkerror=`echo $master| grep -i error`
-if ( [ $errCode -ne 0 ] || [ ! -z $zkerror ] );
+if ( [ ${errCode} -ne 0 ] || [ -n "${zkerror}" ] );
 then
   echo "Zookeeper exception occurred, killing all DcsMaster and DcsServers..."
   "$bin"/dcs-daemon.sh --config "${DCS_CONF_DIR}" stop master 

--- a/dcs/src/main/java/org/trafodion/dcs/master/listener/ConnectReply.java
+++ b/dcs/src/main/java/org/trafodion/dcs/master/listener/ConnectReply.java
@@ -279,7 +279,6 @@ class ConnectReply {
                 LOG.error(clientSocketAddress + ": " + "No Available Servers");
             else
                 LOG.error(clientSocketAddress + ": " + "No Available Servers - exception thrown");
-            }
         } else {
             
             if (cc.datasource.length() == 0)

--- a/dcs/src/main/java/org/trafodion/dcs/master/listener/ConnectReply.java
+++ b/dcs/src/main/java/org/trafodion/dcs/master/listener/ConnectReply.java
@@ -1,25 +1,25 @@
-/**
-* @@@ START COPYRIGHT @@@
+//
+// @@@ START COPYRIGHT @@@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
 
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
-
-* @@@ END COPYRIGHT @@@
- */
+// @@@ END COPYRIGHT @@@
+//
 package org.trafodion.dcs.master.listener;
 
 import java.sql.SQLException;
@@ -173,7 +173,7 @@ class ConnectReply {
                 nodeRegisteredPath = registeredPath + "/" + server;
  		if(LOG.isDebugEnabled())
                     LOG.debug(clientSocketAddress + ": " + " index " + index + " server picked " + server );
-                data = isServerAvalible(nodeRegisteredPath);
+                data = isServerAvailable(nodeRegisteredPath);
                 if(data != null){
                 	found = true;
                 	break;
@@ -190,7 +190,7 @@ class ConnectReply {
                         if(LOG.isDebugEnabled())
                             LOG.debug(clientSocketAddress + ": " + "server selected in search 1 " + server );
                             
-                        data = isServerAvalible(nodeRegisteredPath);
+                        data = isServerAvailable(nodeRegisteredPath);
                         if(data != null){
                         	found = true;
                         	break;
@@ -209,7 +209,7 @@ class ConnectReply {
                         if(LOG.isDebugEnabled())
                             LOG.debug(clientSocketAddress + ": " + "server selected in search 2 " + server );
                             
-                        data = isServerAvalible(nodeRegisteredPath);
+                        data = isServerAvailable(nodeRegisteredPath);
                         if(data != null){
                         	found = true;
                         	break;
@@ -275,11 +275,10 @@ class ConnectReply {
         if (found == false || exceptionThrown == true){
             exception.exception_nr = ListenerConstants.DcsMasterNoSrvrHdl_exn; //no available servers
             replyException = true;
-            if(LOG.isDebugEnabled()){
-                if (found == false)
-                    LOG.info(clientSocketAddress + ": " + "No Available Servers");
-                else
-                    LOG.info(clientSocketAddress + ": " + "No Available Servers - exception thrown");
+            if (found == false)
+                LOG.error(clientSocketAddress + ": " + "No Available Servers");
+            else
+                LOG.error(clientSocketAddress + ": " + "No Available Servers - exception thrown");
             }
         } else {
             
@@ -314,7 +313,7 @@ class ConnectReply {
     return replyException;
     }
     
-	private byte[] isServerAvalible(String serverPath) throws KeeperException, InterruptedException {
+	private byte[] isServerAvailable(String serverPath) throws KeeperException, InterruptedException {
         Stat stat = zkc.exists(serverPath,false);
         if(stat != null){
             byte[] data = zkc.getData(serverPath, false, stat);


### PR DESCRIPTION
TRAFODION-1765 - trafci would throw an error when set statistics on 
TRAFODION-1757 - 1) DCS stop script still not handling zookeeper error properly
                              2) No indication in DCS logs for "No Available Servers" unless
                                  debug level is enabled.