### PR TITLE
[TRAFODION-1700]  [TRAFODION-1847] fixes Upsert with omitted default value columns leave the …

### DIFF
--- a/core/sql/comexe/ComTdbHbaseAccess.cpp
+++ b/core/sql/comexe/ComTdbHbaseAccess.cpp
@@ -282,6 +282,7 @@ ComTdbHbaseAccess::ComTdbHbaseAccess(
   listOfUpDeldColNames_(NULL),
   listOfMergedColNames_(NULL),
   listOfIndexesAndTable_(NULL),
+  listOfOmittedColNames_(NULL),
 
   keyInfo_(NULL),
   keyColName_(NULL),
@@ -438,6 +439,7 @@ Long ComTdbHbaseAccess::pack(void * space)
   listOfFetchedColNames_.pack(space);
   listOfUpDeldColNames_.pack(space);
   listOfMergedColNames_.pack(space);
+  listOfOmittedColNames_.pack(space);
   listOfIndexesAndTable_.pack(space);
   keyInfo_.pack(space);
   keyColName_.pack(space);
@@ -508,6 +510,7 @@ Lng32 ComTdbHbaseAccess::unpack(void * base, void * reallocator)
   if(listOfFetchedColNames_.unpack(base, reallocator)) return -1;
   if(listOfUpDeldColNames_.unpack(base, reallocator)) return -1;
   if(listOfMergedColNames_.unpack(base, reallocator)) return -1;
+  if(listOfOmittedColNames_.unpack(base, reallocator)) return -1;
   if(listOfIndexesAndTable_.unpack(base, reallocator)) return -1;
   if(keyInfo_.unpack(base, reallocator)) return -1;
   if(keyColName_.unpack(base)) return -1;

--- a/core/sql/comexe/ComTdbHbaseAccess.h
+++ b/core/sql/comexe/ComTdbHbaseAccess.h
@@ -610,8 +610,9 @@ public:
   Queue* listOfDeletedColNames() { return listOfUpDeldColNames_; }
   Queue* listOfMergedColNames() { return listOfMergedColNames_; }
   Queue* listOfIndexesAndTable() { return listOfIndexesAndTable_; }
-
+  Queue* listOfOmittedColNames() { return listOfOmittedColNames_; }
   void setListOfIndexesAndTable(Queue* val) {listOfIndexesAndTable_ = val; }
+  void setListOfOmittedColNames(Queue* val) {listOfOmittedColNames_ = val; }
 
   // overloading listOfUpdatedColNames and listOfMergedColNames...for now.
   Queue* listOfHbaseFilterColNames() { return listOfUpDeldColNames_; }
@@ -977,6 +978,7 @@ public:
   QueuePtr listOfUpDeldColNames_;
   QueuePtr listOfMergedColNames_;
   QueuePtr listOfIndexesAndTable_; // used by bulk load
+  QueuePtr listOfOmittedColNames_;
 
   // information about key ranges
   keyRangeGenPtr keyInfo_;                             

--- a/core/sql/executor/ExHbaseAccess.cpp
+++ b/core/sql/executor/ExHbaseAccess.cpp
@@ -2510,6 +2510,7 @@ short ExHbaseAccessTcb::copyRowIDToDirectBuffer(HbaseStr &rowID)
 short ExHbaseAccessTcb::createDirectRowBuffer( UInt16 tuppIndex, 
                  char * tuppRow,
                   Queue * listOfColNames, 
+                  Queue * listOfOmittedColNames,
                   NABoolean isUpdate,
                   std::vector<UInt32> * posVec,
                   double samplingRate )
@@ -2548,7 +2549,8 @@ short ExHbaseAccessTcb::createDirectRowBuffer( UInt16 tuppIndex,
   Attributes * attr;
   int numCols = 0;
   short *numColsPtr;
-
+  char *str_1;
+  NABoolean omittedColFound;
   allocateDirectRowBufferForJNI(rowTD->numAttrs());
 
   BYTE *rowCurPtr = (BYTE *)row_.val;
@@ -2556,9 +2558,12 @@ short ExHbaseAccessTcb::createDirectRowBuffer( UInt16 tuppIndex,
   row_.len += sizeof(short);
   rowCurPtr += sizeof(short);
   listOfColNames->position();
+
   for (Lng32 i = 0; i <  rowTD->numAttrs(); i++)
     {
+       
     Attributes * attr;
+   
       if (!posVec)
         attr = rowTD->getAttr(i);
       else
@@ -2572,6 +2577,21 @@ short ExHbaseAccessTcb::createDirectRowBuffer( UInt16 tuppIndex,
          {
            extractColNameFields((char*)listOfColNames->getCurr(),
                                 colNameLen, colName);
+           if (listOfOmittedColNames != NULL) {
+              omittedColFound = FALSE;            
+              listOfOmittedColNames->position();
+              while ((str_1 = (char *)listOfOmittedColNames->getNext()) != NULL) {
+                 str = (char*)listOfColNames->getCurr();
+                 if (memcmp(str, str_1, colNameLen+2) == 0) {
+                    omittedColFound = TRUE;
+                    break;
+                 }
+              }
+              if (omittedColFound) {
+                 listOfColNames->advance();
+                 continue ;
+              }
+           }
          }
          else
          {

--- a/core/sql/executor/ExHbaseAccess.h
+++ b/core/sql/executor/ExHbaseAccess.h
@@ -329,6 +329,7 @@ protected:
 
   short createDirectRowBuffer(UInt16 tuppIndex, char * tuppRow, 
                         Queue * listOfColNames,
+                        Queue * listOfOmittedColNames,
 			NABoolean isUpdate = FALSE,
 			std::vector<UInt32> * posVec = NULL,
 			double sampleRate = 0.0);

--- a/core/sql/executor/ExHbaseIUD.cpp
+++ b/core/sql/executor/ExHbaseIUD.cpp
@@ -494,6 +494,7 @@ ExWorkProcRetcode ExHbaseAccessInsertSQTcb::work()
 	    retcode = createDirectRowBuffer( hbaseAccessTdb().convertTuppIndex_,
                                              convertRow_,
                                              hbaseAccessTdb().listOfUpdatedColNames(),
+                                             hbaseAccessTdb().listOfOmittedColNames(),
                                              (hbaseAccessTdb().hbaseSqlIUD() ? FALSE : TRUE));
 
 	    if (retcode == -1)
@@ -880,6 +881,7 @@ ExWorkProcRetcode ExHbaseAccessUpsertVsbbSQTcb::work()
 				      hbaseAccessTdb().convertTuppIndex_,
 				      convertRow_,
 				      hbaseAccessTdb().listOfUpdatedColNames(),
+				      hbaseAccessTdb().listOfOmittedColNames(),
 				      TRUE);
 	    if (retcode == -1)
 	      {
@@ -1492,6 +1494,7 @@ ExWorkProcRetcode ExHbaseAccessBulkLoadPrepSQTcb::work()
                                       hbaseAccessTdb().convertTuppIndex_,
                                       convertRow_,
                                       hbaseAccessTdb().listOfUpdatedColNames(),
+                                      hbaseAccessTdb().listOfOmittedColNames(),
                                       FALSE, //TRUE,
                                       &posVec_,
                                       samplingRate);
@@ -2001,6 +2004,7 @@ ExWorkProcRetcode ExHbaseUMDtrafUniqueTaskTcb::work(short &rc)
 	    retcode = tcb_->createDirectRowBuffer( tcb_->hbaseAccessTdb().updateTuppIndex_,
 					    tcb_->updateRow_, 
 					    tcb_->hbaseAccessTdb().listOfUpdatedColNames(),
+                                            tcb_->hbaseAccessTdb().listOfOmittedColNames(),
 					    TRUE);
 	    if (retcode == -1)
 	      {
@@ -2059,7 +2063,8 @@ ExWorkProcRetcode ExHbaseUMDtrafUniqueTaskTcb::work(short &rc)
 
 	    retcode = tcb_->createDirectRowBuffer( tcb_->hbaseAccessTdb().mergeInsertTuppIndex_,
 					    tcb_->mergeInsertRow_,
-					    tcb_->hbaseAccessTdb().listOfMergedColNames());
+					    tcb_->hbaseAccessTdb().listOfMergedColNames(),
+				            tcb_->hbaseAccessTdb().listOfOmittedColNames());
 	    if (retcode == -1)
 	      {
 		step_ = HANDLE_ERROR;
@@ -2934,6 +2939,7 @@ ExWorkProcRetcode ExHbaseUMDtrafSubsetTaskTcb::work(short &rc)
 				 tcb_->hbaseAccessTdb().updateTuppIndex_,
 				 tcb_->updateRow_,
 				 tcb_->hbaseAccessTdb().listOfUpdatedColNames(),
+				 tcb_->hbaseAccessTdb().listOfOmittedColNames(),
 				 TRUE);
 	    if (retcode == -1)
 	      {
@@ -4166,7 +4172,8 @@ ExWorkProcRetcode ExHbaseAccessSQRowsetTcb::work()
 	    retcode = createDirectRowBuffer(
 				      hbaseAccessTdb().updateTuppIndex_,
 				      updateRow_,
-				      hbaseAccessTdb().listOfUpdatedColNames(),
+			  	      hbaseAccessTdb().listOfUpdatedColNames(),
+				      hbaseAccessTdb().listOfOmittedColNames(),
 				      TRUE);
 	    if (retcode == -1) {
 		step_ = HANDLE_ERROR;

--- a/core/sql/generator/GenPreCode.cpp
+++ b/core/sql/generator/GenPreCode.cpp
@@ -4504,19 +4504,6 @@ RelExpr * UpdateCursor::preCodeGen(Generator * generator,
     {
       ItemExpr * item_expr = val_id.getItemExpr();
 
-      if (isMerge())
-	{
-	  // column being updated must be from the same table that is being
-	  // updated.
-	  if (((BaseColumn *)(item_expr->child(0)->castToItemExpr()))->getTableDesc() !=
-	      getTableDesc())
-	    {
-	      *CmpCommon::diags() << DgSqlCode(-3241)
-				  << DgString0("Invalid column being updated.");
-	      GenExit();
-	    }
-	}
-
       for (short i = 0; i < getTableDesc()->getNATable()->getKeyCount(); i++)
 	{
 	  const char * key_colname = key_column_array[i]->getColName();

--- a/core/sql/generator/GenRelUpdate.cpp
+++ b/core/sql/generator/GenRelUpdate.cpp
@@ -469,7 +469,8 @@ static short genHbaseUpdOrInsertExpr(
   listOfUpdatedColNames = NULL;
   if (updRecExprArray.entries() > 0)
     listOfUpdatedColNames = new(space) Queue(space);
- 
+
+
   for (CollIndex ii = 0; ii < updRecExprArray.entries(); ii++)
     {
       const ItemExpr *assignExpr = updRecExprArray[ii].getItemExpr();
@@ -559,7 +560,6 @@ static short genHbaseUpdOrInsertExpr(
       Attributes * updValAttr = (generator->getMapInfo(updValId, 0))->getAttr();      
       assignAttr->copyLocationAttrs(updValAttr);
     }
-
   for (CollIndex ii = 0; ii < updRecExprArray.entries(); ii++)
     {
       const ItemExpr *assignExpr = updRecExprArray[ii].getItemExpr();
@@ -832,8 +832,8 @@ short HbaseDelete::codeGen(Generator * generator)
   ValueIdList srcVIDlist;
   ValueIdList dupVIDlist;
   HbaseAccess::sortValues(retColRefSet_, 
-                          columnList,
-                          srcVIDlist, dupVIDlist,
+			  columnList,
+			  srcVIDlist, dupVIDlist,
 			  (getTableDesc()->getNATable()->getExtendedQualName().getSpecialType() == ExtendedQualName::INDEX_TABLE));
 
   const CollIndex numColumns = columnList.entries();
@@ -906,7 +906,7 @@ short HbaseDelete::codeGen(Generator * generator)
 						    givenType,         // [IN] Actual type of HDFS column
 						    asciiValue,         // [OUT] Returned expression for ascii rep.
 						    castValue,        // [OUT] Returned expression for binary rep.
-                                                    isAlignedFormat 
+						    isAlignedFormat 
 						    );
       
       GenAssert(res == 1 && asciiValue != NULL && castValue != NULL,
@@ -939,9 +939,9 @@ short HbaseDelete::codeGen(Generator * generator)
 			   asciiTuppIndex,                        // [IN] index into atp
 			   &asciiTupleDesc,                       // [optional OUT] tuple desc
 			   ExpTupleDesc::LONG_FORMAT,             // [optional IN] desc format
-                           0,
-                           NULL,
-                           (NAColumnArray*)colArray);
+			   0,
+			   NULL,
+			   (NAColumnArray*)colArray);
    
   work_cri_desc->setTupleDescriptor(asciiTuppIndex, asciiTupleDesc);
   
@@ -1033,10 +1033,10 @@ short HbaseDelete::codeGen(Generator * generator)
   if (addDefaultValues) //hasAddedColumns)
     {
       expGen->addDefaultValues(columnList,
-                               getIndexDesc()->getAllColumns(),
-                               tuple_desc,
-                               TRUE);
-      
+		       getIndexDesc()->getAllColumns(),
+		       tuple_desc,
+		       TRUE);
+
       if (asciiRowFormat == ExpTupleDesc::SQLMX_ALIGNED_FORMAT)
         {
           expGen->addDefaultValues(columnList,
@@ -1814,6 +1814,8 @@ short HbaseUpdate::codeGen(Generator * generator)
   ULng32 returnedFetchedRowLen = 0;
   ULng32 returnedUpdatedRowLen = 0;
   ULng32 returnedMergeInsertedRowLen = 0;
+  Queue *listOfOmittedColNames = NULL;
+
   if (returnRow)
     {
       const ValueIdList &fetchedOutputs =
@@ -1968,18 +1970,35 @@ short HbaseUpdate::codeGen(Generator * generator)
       expGen->assignAtpAndAtpIndex(getScanIndexDesc()->getIndexColumns(),
 				   0, returnedFetchedTuppIndex); 
       */
-
+      NAColumn *col;
       if (isMerge())
 	{
 	  ValueIdList mergeInsertOutputs;
 
 	  for (CollIndex ii = 0; ii < mergeInsertRecExprArray().entries(); ii++)
-	    {
+	  {
 	      const ItemExpr *assignExpr = mergeInsertRecExprArray()[ii].getItemExpr();
 	      ValueId tgtValueId = assignExpr->child(0)->castToItemExpr()->getValueId();
-	      
+              col = tgtValueId.getNAColumn( TRUE );
+
+              if ((NOT isAlignedFormat) &&
+                 (((Assign*)assignExpr)->canBeSkipped()) &&
+                 (NOT col->isSystemColumn()) &&
+                 (NOT col->isClusteringKey()) &&
+                 (NOT col->isIdentityColumn()))
+              {
+                 if (listOfOmittedColNames == NULL)
+                    listOfOmittedColNames = new(space) Queue(space);
+                 NAString cnInList;
+                 HbaseAccess::createHbaseColId(col, cnInList);
+
+                 char * colNameInList = 
+                    space->AllocateAndCopyToAlignedSpace(cnInList, 0);
+          
+                 listOfOmittedColNames->insert(colNameInList);
+              }
 	      mergeInsertOutputs.insert(tgtValueId);
-	    }
+	  }
 	  
 	  MapTable * returnedMergeInsertedMapTable = 0;
 	  ExpTupleDesc * returnedMergeInsertedTupleDesc = NULL;
@@ -2136,6 +2155,7 @@ short HbaseUpdate::codeGen(Generator * generator)
 		      );
 
   generator->initTdbFields(hbasescan_tdb);
+  hbasescan_tdb->setListOfOmittedColNames(listOfOmittedColNames);
 
   if (getTableDesc()->getNATable()->isHbaseRowTable()) 
     hbasescan_tdb->setRowwiseFormat(TRUE);
@@ -2256,7 +2276,6 @@ short HbaseInsert::codeGen(Generator *generator)
 
   ULng32 loggingRowLen = 0;
 
-  NABoolean addDefaultValues = TRUE;
   NABoolean hasAddedColumns = FALSE;
   if (getTableDesc()->getNATable()->hasAddedColumn())
     hasAddedColumns = TRUE;
@@ -2267,34 +2286,37 @@ short HbaseInsert::codeGen(Generator *generator)
   NAColumn *col;
 
   ValueIdList returnRowVIDList;
-  NABoolean upsertColsWereSkipped = FALSE;
+  Queue *listOfOmittedColNames = NULL;
+
   NABoolean isAlignedFormat = getTableDesc()->getNATable()->isAlignedFormat(getIndexDesc());
 
   for (CollIndex ii = 0; ii < newRecExprArray().entries(); ii++)
-    {
+  {
       const ItemExpr *assignExpr = newRecExprArray()[ii].getItemExpr();
       ValueId tgtValueId = assignExpr->child(0)->castToItemExpr()->getValueId();
       ValueId srcValueId = assignExpr->child(1)->castToItemExpr()->getValueId();
 
       col = tgtValueId.getNAColumn( TRUE );
+      if ((NOT isAlignedFormat) &&
+         (((Assign*)assignExpr)->canBeSkipped()) && 
+         (NOT col->isSystemColumn()) &&
+         (NOT col->isClusteringKey()) &&
+         (NOT col->isIdentityColumn()))
+      {
+          if (listOfOmittedColNames == NULL)
+             listOfOmittedColNames = new(space) Queue(space);
+          NAString cnInList;
+          HbaseAccess::createHbaseColId(col, cnInList);
 
-      // if upsert stmt and this assign was not specified by user, skip it. 
-      // If used, it will overwrite existing values if this row exists in the table.
-      if ((isUpsert()) &&
-	  (NOT ((Assign*)assignExpr)->isUserSpecified()) &&
-	  (NOT col->isSystemColumn()) &&
-          (NOT col->isIdentityColumn()))
-	{
-	  upsertColsWereSkipped = TRUE;
-	  continue;
-	}
+          char * colNameInList = 
+             space->AllocateAndCopyToAlignedSpace(cnInList, 0);
+          listOfOmittedColNames->insert(colNameInList);
+      }
+      colArray.insert( col );
 
       if (returnRow)
-	returnRowVIDList.insert(tgtValueId);
+           returnRowVIDList.insert(tgtValueId);
 
-      if ( col != NULL )
-	colArray.insert( col );
-       
       ItemExpr * child1Expr = assignExpr->child(1);
       const NAType &givenType = tgtValueId.getType();
       
@@ -2313,9 +2335,8 @@ short HbaseInsert::codeGen(Generator *generator)
 	{ 
 	  GenAssert(0,"bindNode failed");
 	}
- 
       insertVIDList.insert(ie->getValueId());
-    }
+  }
 
   const NATable *naTable = getTableDesc()->getNATable();
 
@@ -2345,13 +2366,6 @@ short HbaseInsert::codeGen(Generator *generator)
 				     NULL,
 				     NULL,
 				     &colArray);
-  
-  if (addDefaultValues) 
-    {
-      expGen->addDefaultValues(insertVIDList,
-			       (upsertColsWereSkipped ? colArray : getIndexDesc()->getAllColumns()),
-			       tupleDesc);
-    }
 
   ex_expr * loggingDataExpr = NULL;
   ExpTupleDesc * loggingDataTupleDesc = NULL;
@@ -2417,24 +2431,13 @@ short HbaseInsert::codeGen(Generator *generator)
   NAList<Attributes*> savedInputAttrsList;
 
   const ValueIdList &indexVIDlist = getIndexDesc()->getIndexColumns();
-  CollIndex jj = 0;
   for (CollIndex ii = 0; ii < newRecExprArray().entries(); ii++)
     {
       const ItemExpr *assignExpr = newRecExprArray()[ii].getItemExpr();
       const ValueId &tgtValueId = assignExpr->child(0)->castToItemExpr()->getValueId();
       const ValueId &indexValueId = indexVIDlist[ii];
       col = tgtValueId.getNAColumn( TRUE );
-      
-      if ((isUpsert()) &&
-	  (NOT ((Assign*)assignExpr)->isUserSpecified()) &&
-	  (NOT col->isSystemColumn()) &&
-          (NOT col->isIdentityColumn()))
-	{
-	  continue;
-	}
-      
-      ValueId &srcValId = insertVIDList[jj];
-      jj++;
+      ValueId &srcValId = insertVIDList[ii];
       
       Attributes * colAttr = (generator->addMapInfo(tgtValueId, 0))->getAttr();
       Attributes * indexAttr = (generator->addMapInfo(indexValueId, 0))->getAttr();
@@ -2815,6 +2818,7 @@ short HbaseInsert::codeGen(Generator *generator)
 		      );
 
   generator->initTdbFields(hbasescan_tdb);
+  hbasescan_tdb->setListOfOmittedColNames(listOfOmittedColNames);
 
   if ((CmpCommon::getDefault(HBASE_ASYNC_OPERATIONS) == DF_ON)
            && getInliningInfo().isIMGU())

--- a/core/sql/optimizer/BindRelExpr.cpp
+++ b/core/sql/optimizer/BindRelExpr.cpp
@@ -10265,6 +10265,9 @@ RelExpr* Insert::xformUpsertToMerge(BindWA *bindWA)
       ValueId tgtValueId = assignExpr->child(0)->castToItemExpr()->getValueId();
       NAColumn *col = tgtValueId.getNAColumn( TRUE );
       NABoolean copySetAssign = FALSE;
+      if (col->isSystemColumn())
+         continue;
+      else
       if (! col->isClusteringKey()) 
       {
          // In case of aligned format we need to bind in the new = old values
@@ -10287,7 +10290,7 @@ RelExpr* Insert::xformUpsertToMerge(BindWA *bindWA)
             setAssign = (ItemExpr *)assignExpr;
             setCount++;
             if (setCount > 1) 
-               setAssign = new(bindWA->wHeap()) ItemList(setAssign,setAssignPrev);
+               setAssign = new(bindWA->wHeap()) ItemList(setAssignPrev, setAssign);
          }
      }
   }

--- a/core/sql/optimizer/ItemOther.h
+++ b/core/sql/optimizer/ItemOther.h
@@ -80,6 +80,7 @@ public:
 	 NABoolean userSpecified = TRUE) :
 	 ItemExpr(ITM_ASSIGN, target, source),
 	 userSpecified_(userSpecified),
+         canBeSkipped_(FALSE),
 	 onRollback_(FALSE)
 	 {}
 
@@ -90,6 +91,10 @@ public:
   virtual Int32 getArity() const;
 
   NABoolean isUserSpecified() const	{ return userSpecified_; }
+  void setUserSpecified(NABoolean userSpecified) { userSpecified_ = userSpecified; }
+
+  NABoolean canBeSkipped() const	{ return canBeSkipped_; }
+  void setToBeSkipped(NABoolean canBeSkipped) { canBeSkipped_ = canBeSkipped; }
 
   ValueId getTarget() const { return child(0)->getValueId(); }
   ValueId getSource() const { return child(1)->getValueId(); }
@@ -164,6 +169,8 @@ private:
   // Do the actual type propagation, to be called by the public synthesizeType methods.
   const NAType *doSynthesizeType(ValueId & targetId, ValueId & sourceId);
 
+  // Assign with omitted default value columns other than COM_CURRENT_DEFAULT class types
+  NABoolean canBeSkipped_;
 
 }; // class Assign
 

--- a/core/sql/optimizer/RelExpr.cpp
+++ b/core/sql/optimizer/RelExpr.cpp
@@ -12797,7 +12797,7 @@ MergeUpdate::MergeUpdate(const CorrName &name,
 			 ItemExpr *where)
      : Update(name,tabId,otype,child,setExpr,NULL,oHeap),
        insertCols_(insertCols), insertValues_(insertValues),
-       where_(where)
+       where_(where), xformedUpsert_(FALSE)
 {
   setCacheableNode(CmpMain::BIND);
   

--- a/core/sql/optimizer/RelExpr.cpp
+++ b/core/sql/optimizer/RelExpr.cpp
@@ -12797,7 +12797,7 @@ MergeUpdate::MergeUpdate(const CorrName &name,
 			 ItemExpr *where)
      : Update(name,tabId,otype,child,setExpr,NULL,oHeap),
        insertCols_(insertCols), insertValues_(insertValues),
-       where_(where),xformedUpsert_(FALSE)
+       where_(where)
 {
   setCacheableNode(CmpMain::BIND);
   

--- a/core/sql/optimizer/RelUpdate.h
+++ b/core/sql/optimizer/RelUpdate.h
@@ -143,8 +143,7 @@ GenericUpdate(const CorrName &name,
     noIMneeded_(FALSE),
     useMVCC_(FALSE),
     useSSCC_(FALSE),
-    preconditionTree_(NULL),
-    xformedUpsert_(FALSE) 
+    preconditionTree_(NULL)
   {}
 
   // copy ctor
@@ -542,8 +541,6 @@ GenericUpdate(const CorrName &name,
            { precondition_ = pc; exprsInDerivedClasses_ += precondition_; }
 
   virtual ItemExpr * insertValues() { return NULL;}
-  NABoolean xformedUpsert() {return xformedUpsert_;}
-  void setXformedUpsert() {xformedUpsert_ = TRUE;}
 
 protected:
 
@@ -932,7 +929,6 @@ private:
   ItemExpr *preconditionTree_;
   ValueIdSet precondition_;
  
-  NABoolean xformedUpsert_;
 
 };
 
@@ -1446,10 +1442,14 @@ public:
 
   ItemExpr * insertCols() {return insertCols_;}
   virtual ItemExpr * insertValues() { return insertValues_;}
+
+  NABoolean xformedUpsert() {return xformedUpsert_;}
+  void setXformedUpsert() {xformedUpsert_ = TRUE;}
 private:
   ItemExpr *insertCols_;
   ItemExpr *insertValues_;
   ItemExpr *where_;
+  NABoolean xformedUpsert_;
 };
 
 

--- a/core/sql/optimizer/RelUpdate.h
+++ b/core/sql/optimizer/RelUpdate.h
@@ -143,7 +143,8 @@ GenericUpdate(const CorrName &name,
     noIMneeded_(FALSE),
     useMVCC_(FALSE),
     useSSCC_(FALSE),
-    preconditionTree_(NULL)
+    preconditionTree_(NULL),
+    xformedUpsert_(FALSE) 
   {}
 
   // copy ctor
@@ -541,6 +542,8 @@ GenericUpdate(const CorrName &name,
            { precondition_ = pc; exprsInDerivedClasses_ += precondition_; }
 
   virtual ItemExpr * insertValues() { return NULL;}
+  NABoolean xformedUpsert() {return xformedUpsert_;}
+  void setXformedUpsert() {xformedUpsert_ = TRUE;}
 
 protected:
 
@@ -928,6 +931,8 @@ private:
   // LeafDelete (IM). Only insert/delete if TRUE
   ItemExpr *preconditionTree_;
   ValueIdSet precondition_;
+ 
+  NABoolean xformedUpsert_;
 
 };
 
@@ -1441,13 +1446,10 @@ public:
 
   ItemExpr * insertCols() {return insertCols_;}
   virtual ItemExpr * insertValues() { return insertValues_;}
-  NABoolean xformedUpsert() {return xformedUpsert_;}
-  void setXformedUpsert() {xformedUpsert_ = TRUE;}
 private:
   ItemExpr *insertCols_;
   ItemExpr *insertValues_;
   ItemExpr *where_;
-  NABoolean xformedUpsert_;
 };
 
 

--- a/core/sql/regress/charsets/DIFF012.KNOWN.SB
+++ b/core/sql/regress/charsets/DIFF012.KNOWN.SB
@@ -1,0 +1,2 @@
+125d124
+< good day_suffix

--- a/core/sql/regress/core/EXPECTED056.SB
+++ b/core/sql/regress/core/EXPECTED056.SB
@@ -2025,6 +2025,9 @@ T056T56_COL            T056T56_COL2  T056T56_COL3  T056T56_COL4
 
 --- 1 row(s) selected.
 >>
+>>cqd hbase_filter_preds 'on' ;
+
+--- SQL operation complete.
 >>create table t056t57 (a1 numeric(2,2) signed default 0 not null);
 
 --- SQL operation complete.
@@ -2149,6 +2152,9 @@ A1
     .00
 
 --- 1 row(s) selected.
+>>cqd hbase_filter_preds '2' ;
+
+--- SQL operation complete.
 >>
 >>obey TEST056(tests4);
 >>obey test056(test4OLTops);

--- a/core/sql/regress/core/TEST029
+++ b/core/sql/regress/core/TEST029
@@ -39,7 +39,7 @@ obey TEST029(ddbMX);
 drop   table MT;
 create table MT(a int);		-- empty table, for NULL data source
 #ifMX
-
+cqd hbase_filter_preds 'on' ;
 log  LOG029 clear;
 obey TEST029(tests);
 obey TEST029(ddbMXMP);

--- a/core/sql/regress/core/TEST056
+++ b/core/sql/regress/core/TEST056
@@ -806,6 +806,7 @@ alter table t056t56 add column t056t56_col3 pic 9 default +00;
 alter table t056t56 add column t056t56_col4 decimal default 0;
 select * from t056t56;
 
+cqd hbase_filter_preds 'on' ;
 create table t056t57 (a1 numeric(2,2) signed default 0 not null);
 showddl t056t57;
 insert into t056t57 default values;
@@ -830,6 +831,7 @@ create table t056t61 (a1 numeric(2,2) default -0.0 not null);
 showddl t056t61;
 insert into t056t61 default values;
 select * from t056t61;
+cqd hbase_filter_preds '2' ;
 
 ?section test4ddl
 ------------------------------------------------

--- a/core/sql/regress/seabase/EXPECTED020
+++ b/core/sql/regress/seabase/EXPECTED020
@@ -3263,4 +3263,237 @@ C@           A
 
 --- 3 row(s) selected.
 >>
+>>obey TEST020(trafodion_1700_and_1847);
+>>set parserflags 1;
+
+--- SQL operation complete.
+>>--test for timestamp column default value
+>>cqd traf_aligned_row_format 'off' ;
+
+--- SQL operation complete.
+>>create table test020t41(a largeint not null primary key, b char(10),
++>c timestamp(6) default current , d int , e int default 3);
+
+--- SQL operation complete.
+>>-- check if the timestamp is inserted with the recent timestamp
+>>insert into test020t41 (a,b) values (1,'a'), (2,'b');
+
+--- 2 row(s) inserted.
+>>select a,b,d,e from test020t41 where current_timestamp-c < cast(10 as interval second);
+
+A                     B           D            E          
+--------------------  ----------  -----------  -----------
+
+                   1  a                     ?            3
+                   2  b                     ?            3
+
+--- 2 row(s) selected.
+>>-- check to ensure the timestamp column is not updated with upsert
+>>upsert into test020t41 (a,b,e) values (1, 'c', 5);
+
+--- 1 row(s) inserted.
+>>select a,b,d,e from test020t41 where a = 1 and c = (select c from test020t41 where a = 2);
+
+A                     B           D            E          
+--------------------  ----------  -----------  -----------
+
+                   1  c                     ?            5
+
+--- 1 row(s) selected.
+>>-- check to ensure the value for column d is retained
+>>upsert into test020t41 (a,b) values (1, 'd');
+
+--- 1 row(s) inserted.
+>>select a,b,d,e from test020t41 where a = 1 and c = (select c from test020t41 where a = 2);
+
+A                     B           D            E          
+--------------------  ----------  -----------  -----------
+
+                   1  d                     ?            5
+
+--- 1 row(s) selected.
+>>-- upsert with non-matching rows  
+>>upsert into test020t41 (a,b) values (3, 'e'), (4, 'f');
+
+--- 2 row(s) inserted.
+>>select a,b,d,e from test020t41 ;
+
+A                     B           D            E          
+--------------------  ----------  -----------  -----------
+
+                   1  d                     ?            5
+                   2  b                     ?            3
+                   3  e                     ?            3
+                   4  f                     ?            3
+
+--- 4 row(s) selected.
+>>upsert into test020t41 (a,b) values (3, 'g');
+
+--- 1 row(s) inserted.
+>>select a,b,d,e from test020t41 where a = 3 and c = (select c from test020t41 where a = 4);
+
+A                     B           D            E          
+--------------------  ----------  -----------  -----------
+
+                   3  g                     ?            3
+
+--- 1 row(s) selected.
+>>create index test020t41ix on test020t41(e);
+
+--- SQL operation complete.
+>>select * from table(index_table test020t41ix) ;
+
+E@           A                   
+-----------  --------------------
+
+          3                     2
+          3                     3
+          3                     4
+          5                     1
+
+--- 4 row(s) selected.
+>>upsert into test020t41 (a,b,e) values (5,'h',6);
+
+--- 1 row(s) inserted.
+>>select * from table(index_table test020t41ix) ;
+
+E@           A                   
+-----------  --------------------
+
+          3                     2
+          3                     3
+          3                     4
+          5                     1
+          6                     5
+
+--- 5 row(s) selected.
+>>-- check if the updated d column is reflected in the index
+>>upsert into test020t41 (a,b,e) values (1, 'c', 4);
+
+--- 1 row(s) inserted.
+>>select * from table(index_table test020t41ix) ;
+
+E@           A                   
+-----------  --------------------
+
+          3                     2
+          3                     3
+          3                     4
+          4                     1
+          6                     5
+
+--- 5 row(s) selected.
+>>
+>>create table test020t42(a largeint not null primary key, b char(10),
++>c timestamp(6) default current , d int , e int default 3) attribute aligned format;
+
+--- SQL operation complete.
+>>-- check if the timestamp is inserted with the recent timestamp
+>>insert into test020t42 (a,b) values (1,'a'), (2,'b');
+
+--- 2 row(s) inserted.
+>>select a,b,d,e from test020t42 where current_timestamp-c < cast(10 as interval second);
+
+A                     B           D            E          
+--------------------  ----------  -----------  -----------
+
+                   1  a                     ?            3
+                   2  b                     ?            3
+
+--- 2 row(s) selected.
+>>-- check to ensure the timestamp column is not updated with upsert
+>>upsert into test020t42 (a,b,e) values (1, 'c', 5);
+
+--- 1 row(s) inserted.
+>>select a,b,d,e from test020t42 where a = 1 and c = (select c from test020t42 where a = 2);
+
+A                     B           D            E          
+--------------------  ----------  -----------  -----------
+
+                   1  c                     ?            5
+
+--- 1 row(s) selected.
+>>-- check to ensure the value for column d is retained
+>>upsert into test020t42 (a,b) values (1, 'd');
+
+--- 1 row(s) inserted.
+>>select a,b,d,e from test020t42 where a = 1 and c = (select c from test020t42 where a = 2);
+
+A                     B           D            E          
+--------------------  ----------  -----------  -----------
+
+                   1  d                     ?            5
+
+--- 1 row(s) selected.
+>>-- upsert with non-matching rows  
+>>upsert into test020t42 (a,b) values (3, 'e'), (4, 'f');
+
+--- 2 row(s) inserted.
+>>select a,b,d,e from test020t42 ;
+
+A                     B           D            E          
+--------------------  ----------  -----------  -----------
+
+                   1  d                     ?            5
+                   2  b                     ?            3
+                   3  e                     ?            3
+                   4  f                     ?            3
+
+--- 4 row(s) selected.
+>>upsert into test020t42 (a,b) values (3, 'g');
+
+--- 1 row(s) inserted.
+>>select a,b,d,e from test020t42 where a = 3 and c = (select c from test020t42 where a = 4);
+
+A                     B           D            E          
+--------------------  ----------  -----------  -----------
+
+                   3  g                     ?            3
+
+--- 1 row(s) selected.
+>>create index test020t42ix on test020t42(e);
+
+--- SQL operation complete.
+>>select * from table(index_table test020t42ix) ;
+
+E@           A                   
+-----------  --------------------
+
+          3                     2
+          3                     3
+          3                     4
+          5                     1
+
+--- 4 row(s) selected.
+>>upsert into test020t42 (a,b,e) values (5,'h',6);
+
+--- 1 row(s) inserted.
+>>select * from table(index_table test020t42ix) ;
+
+E@           A                   
+-----------  --------------------
+
+          3                     2
+          3                     3
+          3                     4
+          5                     1
+          6                     5
+
+--- 5 row(s) selected.
+>>-- check if the updated d column is reflected in the index
+>>upsert into test020t42 (a,b,e) values (1, 'c', 4);
+
+--- 1 row(s) inserted.
+>>select * from table(index_table test020t42ix) ;
+
+E@           A                   
+-----------  --------------------
+
+          3                     2
+          3                     3
+          3                     4
+          4                     1
+          6                     5
+
+--- 5 row(s) selected.
 >>log;

--- a/core/sql/regress/seabase/TEST020
+++ b/core/sql/regress/seabase/TEST020
@@ -39,6 +39,7 @@ obey TEST020(tests);
 obey TEST020(test_10_020913_3920);
 obey TEST020(test_10_030916_9668);
 obey TEST020(test_LP_1360493);
+obey TEST020(trafodion_1700_and_1847);
 log;
 obey TEST020(clean_up);
 exit;
@@ -87,6 +88,8 @@ drop table test020_LP_1360493;
 drop table test020_t34 cascade;
 drop table test020_t33 cascade;
 drop table test020t40 cascade;
+drop table test020t41 cascade;
+drop table test020t42 cascade;
 
 ?section tests
 create table  test020t1 (c1 int not null primary key,
@@ -761,3 +764,54 @@ insert into test020t40 values (3,3);
 select * from test020t40;
 select * from table(index_table test020t40i1);
 
+?section trafodion_1700_and_1847
+set parserflags 1;
+--test for timestamp column default value
+cqd traf_aligned_row_format 'off' ;
+create table test020t41(a largeint not null primary key, b char(10),
+c timestamp(6) default current , d int , e int default 3);
+-- check if the timestamp is inserted with the recent timestamp
+insert into test020t41 (a,b) values (1,'a'), (2,'b');
+select a,b,d,e from test020t41 where current_timestamp-c < cast(10 as interval second);
+-- check to ensure the timestamp column is not updated with upsert
+upsert into test020t41 (a,b,e) values (1, 'c', 5);
+select a,b,d,e from test020t41 where a = 1 and c = (select c from test020t41 where a = 2);
+-- check to ensure the value for column d is retained
+upsert into test020t41 (a,b) values (1, 'd');
+select a,b,d,e from test020t41 where a = 1 and c = (select c from test020t41 where a = 2);
+-- upsert with non-matching rows  
+upsert into test020t41 (a,b) values (3, 'e'), (4, 'f');
+select a,b,d,e from test020t41 ;
+upsert into test020t41 (a,b) values (3, 'g');
+select a,b,d,e from test020t41 where a = 3 and c = (select c from test020t41 where a = 4);
+create index test020t41ix on test020t41(e);
+select * from table(index_table test020t41ix) ;
+upsert into test020t41 (a,b,e) values (5,'h',6);
+select * from table(index_table test020t41ix) ;
+-- check if the updated d column is reflected in the index
+upsert into test020t41 (a,b,e) values (1, 'c', 4);
+select * from table(index_table test020t41ix) ;
+
+create table test020t42(a largeint not null primary key, b char(10),
+c timestamp(6) default current , d int , e int default 3) attribute aligned format;
+-- check if the timestamp is inserted with the recent timestamp
+insert into test020t42 (a,b) values (1,'a'), (2,'b');
+select a,b,d,e from test020t42 where current_timestamp-c < cast(10 as interval second);
+-- check to ensure the timestamp column is not updated with upsert
+upsert into test020t42 (a,b,e) values (1, 'c', 5);
+select a,b,d,e from test020t42 where a = 1 and c = (select c from test020t42 where a = 2);
+-- check to ensure the value for column d is retained
+upsert into test020t42 (a,b) values (1, 'd');
+select a,b,d,e from test020t42 where a = 1 and c = (select c from test020t42 where a = 2);
+-- upsert with non-matching rows  
+upsert into test020t42 (a,b) values (3, 'e'), (4, 'f');
+select a,b,d,e from test020t42 ;
+upsert into test020t42 (a,b) values (3, 'g');
+select a,b,d,e from test020t42 where a = 3 and c = (select c from test020t42 where a = 4);
+create index test020t42ix on test020t42(e);
+select * from table(index_table test020t42ix) ;
+upsert into test020t42 (a,b,e) values (5,'h',6);
+select * from table(index_table test020t42ix) ;
+-- check if the updated d column is reflected in the index
+upsert into test020t42 (a,b,e) values (1, 'c', 4);
+select * from table(index_table test020t42ix) ;

--- a/core/sql/sqlcomp/DefaultConstants.h
+++ b/core/sql/sqlcomp/DefaultConstants.h
@@ -3796,6 +3796,9 @@ enum DefaultConstants
   // real charset in the HIVE table
   HIVE_FILE_CHARSET,
 
+  // if ON, upsert into the table will use the default value for the omitted columns
+  // with default value 
+  TRAF_UPSERT_WITH_INSERT_DEFAULT_SEMANTICS,
   // This enum constant must be the LAST one in the list; it's a count,
   // not an Attribute (it's not IN DefaultDefaults; it's the SIZE of it)!
   __NUM_DEFAULT_ATTRIBUTES

--- a/core/sql/sqlcomp/nadefaults.cpp
+++ b/core/sql/sqlcomp/nadefaults.cpp
@@ -3400,6 +3400,7 @@ XDDkwd__(SUBQUERY_UNNESTING,			"ON"),
   DDkwd__(TRAF_UPSERT_ADJUST_PARAMS,                   "OFF"),
   DDkwd__(TRAF_UPSERT_AUTO_FLUSH,                      "OFF"),
   DDint__(TRAF_UPSERT_WB_SIZE,                         "2097152"),
+  DDkwd__(TRAF_UPSERT_WITH_INSERT_DEFAULT_SEMANTICS,   "OFF"),
   DDkwd__(TRAF_UPSERT_WRITE_TO_WAL,                    "OFF"),
 
   DDkwd__(TRAF_USE_RWRS_FOR_MD_INSERT,                   "ON"),


### PR DESCRIPTION
[TRAFODION-1700] Upsert with omitted default value columns leave thealigned format table in corrupted state.
[TRAFODION-1847] Upsert with omitted timestamp columns having current_timestamp as default in a non-aligned format
table returns wrong value for this column

For TRAFODION-1847, the upsert is transformed into merge.
For TRAFODION-1700, the upsert is transformed into merge when the CQD
TRAF_UPSERT_WITH_INSERT_DEFAULT_SEMANTICS is set to OFF. By default this CQD is
set to OFF. When this CQD is ON, the upsert will add a new row with the omitted
columns filled with default values always.