### PR TITLE
Fixed 2 date related issues in phoenix tests

### DIFF
--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/DescColumnSortOrderTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/DescColumnSortOrderTest.java
@@ -482,7 +482,7 @@ public class DescColumnSortOrderTest extends BaseTest {
         Object[][] expectedRows = new Object[][]{{2, date(1, 1, 2001)}};
 
         if (tgtPH()) runQueryTest(ddl, upsert("id", "date"), insertedRows, expectedRows, new WhereCondition("date", "<", "TO_DATE('02-02-2001','mm-dd-yyyy')"));
-        else if (tgtSQ()||tgtTR()) runQueryTest(ddl, upsert("id", "date1"), insertedRows, expectedRows, new WhereCondition("date1", "<", "DATE '02-02-2001'"));
+        else if (tgtSQ()||tgtTR()) runQueryTest(ddl, upsert("id", "date1"), insertedRows, expectedRows, new WhereCondition("date1", "<", "DATE '02/02/2001'"));
     }
     
     private void runQueryTest(String ddl, String columnName, Object[][] rows, Object[][] expectedRows) throws Exception {

--- a/tests/phx/src/test/java/org/trafodion/phoenix/end2end/ProductMetricsTest.java
+++ b/tests/phx/src/test/java/org/trafodion/phoenix/end2end/ProductMetricsTest.java
@@ -757,7 +757,7 @@ public class ProductMetricsTest extends BaseTest {
 
         String query = null;
         if (tgtPH()) query = "SELECT round(date,'hour',1),feature,sum(unique_users) FROM PRODUCT_METRICS WHERE organization_id=? GROUP BY round(date,'hour',1),feature";
-        else if (tgtSQ()||tgtTR()) query = "SELECT date_trunc('hour',date_add(date1,interval '30' minute)),feature,sum(unique_users) FROM PRODUCT_METRICS WHERE organization_id=? GROUP BY date_trunc('hour',date_add(date1,interval '30' minute)),feature order by 3";
+        else if (tgtSQ()||tgtTR()) query = "SELECT date_trunc('hour',date_add(date1,interval '30' minute)),feature,sum(unique_users) FROM PRODUCT_METRICS WHERE organization_id=? GROUP BY date_trunc('hour',date_add(date1,interval '30' minute)),feature order by 3, 1";
         try {
             initTableValues();
             PreparedStatement statement = conn.prepareStatement(query);


### PR DESCRIPTION
(1) MM-DD-YYYY format is no longer supported.  Changed it to MM/DD/YYYY
(2) Added an extra order by column to reinforce the row order of a date column.