### PR TITLE
[TRAFODION-1836] License info for win-odbc binary dist

### DIFF
--- a/licenses/lic-clients-bin
+++ b/licenses/lic-clients-bin
@@ -1,7 +1,9 @@
 ===============================================================================
 The binary distribution of Apache Trafodion bundles OpenSSL software. Specifically,
-the Linux ODBC driver is statically linked with OpenSSL libraries. OpenSSL is
-available under a BSD like license. (http://www.openssl.org/)
+the Linux ODBC driver is statically linked with OpenSSL libraries. The Windows
+ODBC driver (TFODBC64) also links in OpenSSL libraries.
+
+OpenSSL is available under a BSD like license. (http://www.openssl.org/)
 
 
     LICENSE ISSUES
@@ -166,12 +168,32 @@ MIT like license. (http://site.icu-project.org/)
 
 +++++++++++++++++++++++++++++
 
-To Do:
+The binary distribution of Apache Trafodion bundles zlib software. Specifically,
+the Windows ODBC driver (TFODBC64) links in zlib libraries. Zlib is 
+available under the zlib/libpng license.
 
-Investigate and document third-pary licenses for SW bundled with binaries
-for client component:
+  zlib.h -- interface of the 'zlib' general purpose compression library
+  version 1.2.8, April 28th, 2013
 
-win-odbc
-  TFODBC64-*.exe
+  Copyright (C) 1995-2013 Jean-loup Gailly and Mark Adler
+
+  This software is provided 'as-is', without any express or implied
+  warranty.  In no event will the authors be held liable for any damages
+  arising from the use of this software.
+
+  Permission is granted to anyone to use this software for any purpose,
+  including commercial applications, and to alter it and redistribute it
+  freely, subject to the following restrictions:
+
+  1. The origin of this software must not be misrepresented; you must not
+     claim that you wrote the original software. If you use this software
+     in a product, an acknowledgment in the product documentation would be
+     appreciated but is not required.
+  2. Altered source versions must be plainly marked as such, and must not be
+     misrepresented as being the original software.
+  3. This notice may not be removed or altered from any source distribution.
+
+  Jean-loup Gailly        Mark Adler
+  jloup@gzip.org          madler@alumni.caltech.edu
 
 +++++++++++++++++++++++++++++


### PR DESCRIPTION
win-odbc pulls in openssl and zlib.  These licenses are on the list compatible with Apache2.0.

Closing in on all the license info for binary distribution.