### PR TITLE
[TRAFODION-1865] uninitialized buffer cause Monitor abort in CentOS 7

### DIFF
--- a/core/sqf/monitor/linux/process.cxx
+++ b/core/sqf/monitor/linux/process.cxx
@@ -3353,6 +3353,7 @@ CProcessContainer::CProcessContainer( bool nodeContainer )
    
     //create & initialize existing semaphore
     char sem_name[MAX_PROCESS_PATH];
+    memset(sem_name, 0 , MAX_PROCESS_PATH);  //clear the buffer
     snprintf(sem_name,sizeof(sem_name), "/monitor.sem.%s", getenv("USER"));
     Mutex = sem_open(sem_name,O_CREAT,0644,0);
     if(Mutex == SEM_FAILED)


### PR DESCRIPTION
We tested on CentOS 7.2, by applying this change, sqstart success.