### PR TITLE
[TRAFODION-1867] Allow parallel plans for non-partitioned tables in U…

### DIFF
--- a/core/sql/ustat/hs_globals.cpp
+++ b/core/sql/ustat/hs_globals.cpp
@@ -5568,16 +5568,6 @@ Lng32 HSGlobalsClass::CollectStatistics()
     //The result will always be a VARCHAR(len) CHARACTER SET UCS2
     //In most cases, this will reduce the number of fetches.
 
-    //10-040618-7112: temporary workaround for compiler issue
-    //make sure no parallel plans get generated for single partitioned tables
-    //The sample table for SQLMP tables are always single partition. Whereas for
-    //SQLMX, the table may be partitioned based on the HIST_SCRATCH_VOL cqd.
-    if ((sampleTableUsed && tableFormat == SQLMP) ||
-        (NOT sampleTableUsed && objDef->getNumPartitions() == 1))
-      {
-        HSFuncExecQuery("CONTROL QUERY DEFAULT ATTEMPT_ESP_PARALLELISM 'OFF'");
-      }
-
     if (CmpCommon::getDefault(USTAT_ATTEMPT_ESP_PARALLELISM) == DF_OFF)
       HSFuncExecQuery("CONTROL QUERY DEFAULT ATTEMPT_ESP_PARALLELISM 'OFF'");
 
@@ -5734,16 +5724,6 @@ Lng32 HSGlobalsClass::CollectStatistics()
             }
           }
         LM->StopTimer();
-      }
-
-    //10-040618-7112: temporary workaround for compiler issue
-    //make sure no parallel plans get generated for single partitioned tables
-    //The sample table for SQLMP tables are always single partition. Whereas for
-    //SQLMX, the table may be partitioned based on the HIST_SCRATCH_VOL cqd.
-    if ((sampleTableUsed && tableFormat == SQLMP) ||
-        (NOT sampleTableUsed && objDef->getNumPartitions() == 1))
-      {
-        HSFuncExecQuery("CONTROL QUERY DEFAULT ATTEMPT_ESP_PARALLELISM RESET");
       }
 
     if (CmpCommon::getDefault(USTAT_ATTEMPT_ESP_PARALLELISM) == DF_OFF)


### PR DESCRIPTION
…PD STATS.

The problem is for large non-partitioned tables, UPDATE STATS will do a series of SELECTs to compute statistics for sets of columns. The plans for these SELECTs are presently forced to be serial for non-partitioned tables as a workaround for a long-ago compiler bug which seems to have been fixed. It's time to remove this workaround and thereby speed up UPDATE STATS.