### PR TITLE
[TRAFODION-1871] Fix error 2006 in UPDATE STATISTICS

### DIFF
--- a/core/sql/ustat/hs_cli.cpp
+++ b/core/sql/ustat/hs_cli.cpp
@@ -4762,7 +4762,7 @@ Lng32 HSinsertEmptyHist::insert()
 #else // NA_USTAT_USE_STATIC not defined, use dynamic query
     char sbuf[25];
     NAString qry = "SELECT HISTOGRAM_ID, COL_POSITION, COLUMN_NUMBER, COLCOUNT, "
-                          "cast(READ_TIME as char(19)), REASON "
+                          "cast(READ_TIME as char(19) character set iso88591), REASON "
                    "FROM ";
     qry.append(histTable_);
     qry.append(    " WHERE TABLE_UID = ");
@@ -5479,7 +5479,7 @@ static char ppStmtText[] =
 "          when LEFT_CHILD_SEQ_NUM is null then"
 "            '.  '"
 "          else"
-"            cast(cast(LEFT_CHILD_SEQ_NUM as numeric(3)) as char(3))"
+"            cast(cast(LEFT_CHILD_SEQ_NUM as numeric(3)) as char(3) character set iso88591)"
 "        end"
 ""
 // RIGHT CHILD
@@ -5487,11 +5487,11 @@ static char ppStmtText[] =
 "          when RIGHT_CHILD_SEQ_NUM is null then"
 "            '.  '"
 "          else"
-"            cast(cast(RIGHT_CHILD_SEQ_NUM as numeric(3)) as char(3))"
+"            cast(cast(RIGHT_CHILD_SEQ_NUM as numeric(3)) as char(3) character set iso88591)"
 "        end"
 ""
 // SEQUENCE NUMBER
-"      , cast(cast(SEQ_NUM as numeric(3)) as char(3))"
+"      , cast(cast(SEQ_NUM as numeric(3)) as char(3) character set iso88591)"
 ""
 // OPERATOR
 "      , cast(substring(lower(OPERATOR) from 1 for 20) as char(20))"
@@ -5722,13 +5722,13 @@ static char ppStmtText[] =
 "            from 1 for 20) as char(20))"
 ""
 // CARDINALITY
-"      , CAST(CARDINALITY AS CHAR(11))"
+"      , CAST(CARDINALITY AS CHAR(11) character set iso88591)"
 ""
 // OPERATOR COST
-"      , CAST(OPERATOR_COST AS CHAR(11))"
+"      , CAST(OPERATOR_COST AS CHAR(11) character set iso88591)"
 ""
 // TOTAL COST
-"      , CAST(TOTAL_COST AS CHAR(11))"
+"      , CAST(TOTAL_COST AS CHAR(11) character set iso88591)"
 ""
 "        FROM TABLE(EXPLAIN(NULL, '";
 

--- a/core/sql/ustat/hs_cli.cpp
+++ b/core/sql/ustat/hs_cli.cpp
@@ -5751,6 +5751,8 @@ Lng32 printPlan(SQLSTMT_ID *stmt)
 
     HSLogMan *LM = HSLogMan::Instance();
 
+    HSFuncExecQuery("CQD DEFAULT_CHARSET 'ISO88591'"); // to avoid buffer overruns in row
+
     NAString ppStmtStr = ppStmtText;
     ppStmtStr.append((char *)stmt->identifier).append("')) ORDER BY SEQ_NUM DESC;");
 
@@ -5794,11 +5796,15 @@ Lng32 printPlan(SQLSTMT_ID *stmt)
             LM->Log(LM->msg);
           }
         else if (retcode != 100)
-          HSLogError(retcode);
+          {
+            HSFuncExecQuery("CQD DEFAULT_CHARSET RESET");
+            HSLogError(retcode);
+          }
       }
 
     // ppStmtId will be closed by ~HSCursor if closeStmtNeeded_ is set.
 
+    HSFuncExecQuery("CQD DEFAULT_CHARSET RESET");
     return retcode;
   }
 

--- a/core/sql/ustat/hs_globals.cpp
+++ b/core/sql/ustat/hs_globals.cpp
@@ -7743,7 +7743,7 @@ Lng32 HSGlobalsClass::groupListFromTable(HSColGroupStruct*& groupList,
 #else // NA_USTAT_USE_STATIC not defined, use dynamic query
     char sbuf[25];
     NAString qry = "SELECT HISTOGRAM_ID, COL_POSITION, COLUMN_NUMBER, COLCOUNT, "
-                          "cast(READ_TIME as char(19)), REASON "
+                          "cast(READ_TIME as char(19) character set iso88591), REASON "
                    "FROM ";
     qry.append(hstogram_table->data());
     qry.append(    " WHERE TABLE_UID = ");

--- a/core/sql/ustat/hs_globals.cpp
+++ b/core/sql/ustat/hs_globals.cpp
@@ -5568,16 +5568,6 @@ Lng32 HSGlobalsClass::CollectStatistics()
     //The result will always be a VARCHAR(len) CHARACTER SET UCS2
     //In most cases, this will reduce the number of fetches.
 
-    //10-040618-7112: temporary workaround for compiler issue
-    //make sure no parallel plans get generated for single partitioned tables
-    //The sample table for SQLMP tables are always single partition. Whereas for
-    //SQLMX, the table may be partitioned based on the HIST_SCRATCH_VOL cqd.
-    if ((sampleTableUsed && tableFormat == SQLMP) ||
-        (NOT sampleTableUsed && objDef->getNumPartitions() == 1))
-      {
-        HSFuncExecQuery("CONTROL QUERY DEFAULT ATTEMPT_ESP_PARALLELISM 'OFF'");
-      }
-
     if (CmpCommon::getDefault(USTAT_ATTEMPT_ESP_PARALLELISM) == DF_OFF)
       HSFuncExecQuery("CONTROL QUERY DEFAULT ATTEMPT_ESP_PARALLELISM 'OFF'");
 
@@ -5734,16 +5724,6 @@ Lng32 HSGlobalsClass::CollectStatistics()
             }
           }
         LM->StopTimer();
-      }
-
-    //10-040618-7112: temporary workaround for compiler issue
-    //make sure no parallel plans get generated for single partitioned tables
-    //The sample table for SQLMP tables are always single partition. Whereas for
-    //SQLMX, the table may be partitioned based on the HIST_SCRATCH_VOL cqd.
-    if ((sampleTableUsed && tableFormat == SQLMP) ||
-        (NOT sampleTableUsed && objDef->getNumPartitions() == 1))
-      {
-        HSFuncExecQuery("CONTROL QUERY DEFAULT ATTEMPT_ESP_PARALLELISM RESET");
       }
 
     if (CmpCommon::getDefault(USTAT_ATTEMPT_ESP_PARALLELISM) == DF_OFF)


### PR DESCRIPTION
Fixes an assertion that happens in UPDATE STATISTICS when: 1. the default character set is UTF8 and 2. statistics already exist on the table.