### PR TITLE
TRAFODION-1878 Initial commit for adding a portable (docker) build env

### DIFF
--- a/tools/docker/Dockerfile
+++ b/tools/docker/Dockerfile
@@ -1,0 +1,45 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+FROM centos:centos6.6
+MAINTAINER Trafodion Community <dev@trafodion.incubator.apache.org>
+
+LABEL Vendor="Apache Trafodion (incubating)"
+LABEL version=unstable
+
+# download and install environment dependencies
+RUN	yum install -y epel-release alsa-lib-devel ant ant-nodeps boost-devel cmake \
+	     device-mapper-multipath dhcp flex gcc-c++ gd git glibc-devel \
+       glibc-devel.i686 graphviz-perl gzip java-1.7.0-openjdk-devel \
+  		 apr-devel apr-util-devel \
+       libX11-devel libXau-devel libaio-devel \
+       libcurl-devel libibcm.i686 libibumad-devel libibumad-devel.i686 \
+       libiodbc libiodbc-devel librdmacm-devel librdmacm-devel.i686 \
+       libxml2-devel lua-devel lzo-minilzo \
+       net-snmp-devel net-snmp-perl openldap-clients openldap-devel \
+       openldap-devel.i686 openmotif openssl-devel openssl-devel.i686 \
+       openssl-static perl-Config-IniFiles perl-Config-Tiny \
+       perl-DBD-SQLite perl-Expect perl-IO-Tty perl-Math-Calc-Units \
+       perl-Params-Validate perl-Parse-RecDescent perl-TermReadKey \
+       perl-Time-HiRes protobuf-compiler protobuf-devel \
+       readline-devel saslwrapper sqlite-devel \
+       unixODBC unixODBC-devel uuid-perl wget xerces-c-devel xinetd \
+  && yum -y erase pdsh \
+	&& yum clean all
+
+# set environment
+ENV	JAVA_HOME /usr/lib/jvm/java-1.7.0-openjdk.x86_64
+ENV PATH $PATH:$JAVA_HOME/bin

--- a/tools/docker/build-base-docker.sh
+++ b/tools/docker/build-base-docker.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e -x -u
+
+BASE_SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+export DOCKER_ENV_VERSION="0.1"
+export BASE_IMAGE_NAME="trafodion/base:${DOCKER_ENV_VERSION}"
+
+pushd ${BASE_SCRIPT_DIR}
+
+docker build --rm=true -t ${BASE_IMAGE_NAME} .
+
+popd

--- a/tools/docker/start-compile-docker.sh
+++ b/tools/docker/start-compile-docker.sh
@@ -1,0 +1,67 @@
+#!/bin/bash
+
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+set -e -x -u
+
+SCRIPT_DIR=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+source ${SCRIPT_DIR}/build-base-docker.sh
+
+IMAGE_NAME="trafodion/base:${DOCKER_ENV_VERSION}"
+
+if [ "$(uname -s)" == "Linux" ]; then
+  USER_NAME=${SUDO_USER:=$USER}
+  USER_ID=$(id -u "${USER_NAME}")
+  GROUP_ID=$(id -g "${USER_NAME}")
+else # boot2docker uid and gid
+  USER_NAME=$USER
+  USER_ID=1000
+  GROUP_ID=50
+fi
+
+# create user home directory; download and install build tools
+docker build -t "${IMAGE_NAME}-${USER_NAME}" - <<UserSpecificDocker
+FROM ${IMAGE_NAME} 
+RUN groupadd --non-unique -g ${GROUP_ID} ${USER_NAME}
+RUN useradd -g ${GROUP_ID} -u ${USER_ID} -k /root -m ${USER_NAME}
+ENV HOME /home/${USER_NAME}
+RUN cd /home/${USER_NAME} \
+ && mkdir download \
+ && mkdir trafodion-build-tools \
+ && wget https://raw.githubusercontent.com/apache/incubator-trafodion/master/install/traf_tools_setup.sh \
+ && chmod +x traf_tools_setup.sh \
+ && ./traf_tools_setup.sh -d ~/download -i ~/trafodion-build-tools \
+ && rm -fr ./download \
+ && yum install -y qt-devel qt-config
+ENV TOOLSDIR /home/${USER_NAME}/trafodion-build-tools
+ENV PATH $PATH:/home/${USER_NAME}/trafodion-build-tools/apache-maven-3.3.3/bin:/usr/lib64/qt4/bin/
+UserSpecificDocker
+
+# Go to root project folder
+pushd ${SCRIPT_DIR}/../..
+
+docker run -i -t \
+  --rm=true \
+  -w "/home/${USER_NAME}/incubator-trafodion" \
+  -u "${USER_NAME}" \
+  -v "$PWD:/home/${USER_NAME}/incubator-trafodion" \
+  -v "$HOME/.m2:/home/${USER_NAME}/.m2" \
+  --name TrafodionEnv \
+  ${IMAGE_NAME}-${USER_NAME} \
+  bash
+
+popd


### PR DESCRIPTION
Initial commit of docker file.

- The first (base) image downloads all the dependencies, as described on [Create Build Env](https://cwiki.apache.org/confluence/display/TRAFODION/Create+Build+Environment) page 
- The second (user) image downloads and installs all the tools, as described on [Build Source](https://cwiki.apache.org/confluence/display/TRAFODION/Build+Source) page

For testing, please run the two scripts in order:
`cd ./tools/docker`
`./build-base-docker.sh`
`./start-compile-docker.sh`

The second one will take long as it needs to install the tools. Once the second container is up and running, follow the build instructions: **debug** `source ./env.sh` or **release**