### PR TITLE
Fix symbolic link for cextdecs.h

### DIFF
--- a/core/sqf/Makefile
+++ b/core/sqf/Makefile
@@ -196,7 +196,7 @@ setupdir:
 	-ln -sf $(SQL_W)/sqludr/sqludr.h $(EXPORTINCSQL_DIR)
 	@#
 	mkdir -p export/include/nsk
-	-ln -sf inc/cextdecs/cextdecs.h export/include/nsk
+	-ln -sf $(MY_SQROOT)/inc/cextdecs/cextdecs.h export/include/nsk
 	@# USTAT
 	-mkdir -p export/lib/mx_ustat
 	-ln -sf $(SQL_W)/ustat/USAS.sh export/lib/mx_ustat


### PR DESCRIPTION
Cluster install failed with invalid symbolic link for cextdecs.h . This commit addresses that.