### PR TITLE
[TRAFODION-1868] Compatibility with gcc 4.8

### DIFF
--- a/core/dbsecurity/auth/Makefile
+++ b/core/dbsecurity/auth/Makefile
@@ -73,7 +73,7 @@ INCLUDES	= -I. -I./inc -I ../shared/inc \
 	        -I ../../sql/common
 
 
-LINK_OPTIONS	= -L$(LIBEXPDIR) -lldap -lssl
+LINK_OPTIONS	= -L$(LIBEXPDIR) -lldap -lssl -llber
 LINK_OPTIONS   += $(LNK_FLGS) 
 
 COMMON_LIBS =  -ltdm_sqlcli -larkcmp_dll  

--- a/core/sql/exp/ExpHbaseInterface.h
+++ b/core/sql/exp/ExpHbaseInterface.h
@@ -42,7 +42,6 @@
 
 #include <iostream>
 
-#include <boost/lexical_cast.hpp>
 #include <protocol/TBinaryProtocol.h>
 #include <transport/TSocket.h>
 #include <transport/TTransportUtils.h>

--- a/core/sql/optimizer/RelFastTransport.cpp
+++ b/core/sql/optimizer/RelFastTransport.cpp
@@ -203,7 +203,7 @@ short FastExtract::setOptions(NAList<UnloadOption*> *
 
   for (CollIndex i = 0; i < fastExtractOptionList->entries(); i++)
   {
-    UnloadOption::UnloadOption * feo = (*fastExtractOptionList)[i];
+    UnloadOption * feo = (*fastExtractOptionList)[i];
     switch (feo->option_)
     {
       case UnloadOption::DELIMITER_:

--- a/core/sql/sqlcomp/CmpSeabaseDDLindex.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLindex.cpp
@@ -1969,7 +1969,7 @@ void CmpSeabaseDDL::alterSeabaseTableDisableOrEnableAllIndexes(
     char * catName = NULL;
     char * schName = NULL;
     indexes->position();
-    for (int idx = 0; idx < indexes->numEntries(); idx++)
+    for (int ii = 0; ii < indexes->numEntries(); ii++)
     {
       OutputInfo * idx = (OutputInfo*) indexes->getNext();
 


### PR DESCRIPTION
this is partial changes to Trafodion code base in order to make it compatible with gcc 4.8.
Gcc 4.8 generally is more strict than gcc 4.4, so Trafodion code need to fix all potential issues.
1. variable declared and initialized, but not used anymore
2. suspicious overload of same variable names
3. ld need the required library name to be explicitly added using '-l' option
4. some STL/Boost functions replaced with c++11 features in gcc 4.8, so remove unnecessary call into boost
So there are a lot of changes, to make this process easier, we decided to do this incrementally. Fix small amount of issues each time, easier to code review and test.
It must make sure same code compile and work well under gcc 4.4.

This is the first commit for the whole gcc 4.8 support changes.
We already have a successful gcc 4.8 build prototype, and it works well on CentOS 7. But there are still more changes, so this is a rather proven way to support gcc 4.8.