### PR TITLE
[TRAFODION-1868] Compatibility with gcc 4.8 , part 2, DTM changes

### DIFF
--- a/core/sqf/src/tm/Makefile
+++ b/core/sqf/src/tm/Makefile
@@ -44,6 +44,9 @@ endif
 DTMOBJS		= -DTMOBJS
 
 
+#gcc 4.8 need explicit set this flag to allow auto search of dependent shared object during link
+LNK_FLGS       += -Xlinker --copy-dt-needed-entries
+
 LIBSTMOBJS = $(OUTDIR)/tmtransid.o \
 			 $(OUTDIR)/tmtransaction.o \
 			 $(OUTDIR)/tmlibtxn.o \

--- a/core/sqf/src/tm/tmaudit.cpp
+++ b/core/sqf/src/tm/tmaudit.cpp
@@ -298,11 +298,11 @@ int32 TM_Audit::write_trans_state(TM_Transid_Type *pv_transid,
 {
     Audit_Transaction_State lv_state_rec;
     char      lv_write_buffer[REC_SIZE];
-    bool      lv_force = true;
+    //bool      lv_force = true;
     int32     lv_notify = 0;
 
     TMTrace(2, ("TM_Audit::write_trans_state: ENTRY \n"));
-    lv_force = prepare_trans_state(&lv_state_rec, lv_write_buffer, pv_transid,
+    prepare_trans_state(&lv_state_rec, lv_write_buffer, pv_transid,
                                    pv_nid, pv_state, pv_abort_flags);
 
 #ifdef USE_FILE_AUDIT
@@ -316,7 +316,7 @@ int32 TM_Audit::write_trans_state(TM_Transid_Type *pv_transid,
 void TM_Audit::write_shutdown(int32 pv_nid, int32 pv_state)
 {
     Audit_TM_Shutdown       lv_rec;
-    int64                   lv_vsn;
+    //int64                   lv_vsn;
     char                    lv_write_buffer[REC_SIZE];
 
     pv_nid = pv_nid; // 810
@@ -334,7 +334,7 @@ void TM_Audit::write_shutdown(int32 pv_nid, int32 pv_state)
 #endif
 
     iv_mutex.lock();
-    lv_vsn = iv_vsn++;
+    iv_vsn++;
     iv_mutex.unlock();
 
 
@@ -481,15 +481,15 @@ void TM_Audit::adp_module_terminate()
 void TM_Audit::adp_activate_cursor()
 {
    // If we're using a TLOG/TM then the index is nid.
-   AuditTrailPosition_Struct lv_low_pos, lv_high_pos;
+   //AuditTrailPosition_Struct lv_low_pos, lv_high_pos;
 
     if (!iv_initialized)
        return; // for now
 
-    lv_low_pos.Sequence = 0;
-    lv_low_pos.rba = 0;
-    lv_high_pos.Sequence = 0;
-    lv_high_pos.rba = 0;
+    //lv_low_pos.Sequence = 0;
+    //lv_low_pos.rba = 0;
+    //lv_high_pos.Sequence = 0;
+    //lv_high_pos.rba = 0;
 
 }
 

--- a/core/sqf/src/tm/tmauditobj.cpp
+++ b/core/sqf/src/tm/tmauditobj.cpp
@@ -207,14 +207,12 @@ void CTmAuditObj::write_buffer()
 {
     TMTrace(2, ("CTmAuditObj::write_buffer : ENTRY.\n"));
 
-    int32 lv_notify = -1;
-
     if (iv_prepared_to_write) // no lock means it was not called appropriately, error TODO
     {
         if (iv_write_buf_size > 0)
         {
             TMTrace(2, ("CTmAuditObj::write_buffer with size of %d: ENTRY.\n", iv_write_buf_size));
-            lv_notify = iv_mat.write_buffer(iv_write_buf_size, ia_write_buffer, iv_highest_fill_vsn);
+            iv_mat.write_buffer(iv_write_buf_size, ia_write_buffer, iv_highest_fill_vsn);
             iv_write_buf_size = 0;
         }
         else
@@ -226,7 +224,7 @@ void CTmAuditObj::write_buffer()
         prepare_to_write(true);
         if (iv_write_buf_size > 0)
         {  
-            lv_notify = iv_mat.write_buffer(iv_write_buf_size, ia_write_buffer, iv_highest_fill_vsn);
+            iv_mat.write_buffer(iv_write_buf_size, ia_write_buffer, iv_highest_fill_vsn);
             iv_write_buf_size = 0;
         }
         iv_double_write = false;

--- a/core/sqf/src/tm/tmddlrequests.cpp
+++ b/core/sqf/src/tm/tmddlrequests.cpp
@@ -36,7 +36,6 @@ using namespace std;
 JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInterface_createTableReq
   (JNIEnv *pp_env, jobject pv_object, jbyteArray pv_tableDescriptor, jobjectArray pv_keys, jint pv_numSplits, jint pv_keyLength, jlong pv_transid, jbyteArray pv_tblname){
 
-   short lv_ret;
    char la_tbldesc[TM_MAX_DDLREQUEST_STRING];
    char la_tblname[TM_MAX_DDLREQUEST_STRING];
    char* str_key;
@@ -76,7 +75,7 @@ JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInter
          pp_env->DeleteLocalRef(jba_keyarray);
       }
 
-      lv_ret = CREATETABLE(la_tbldesc, lv_tbldesc_length, la_tblname, la_keys, lv_numSplits, lv_keyLength, lv_transid);
+      CREATETABLE(la_tbldesc, lv_tbldesc_length, la_tblname, la_keys, lv_numSplits, lv_keyLength, lv_transid);
 
       pp_env->ReleaseByteArrayElements(pv_tableDescriptor, lp_tbldesc, 0);
       pp_env->ReleaseByteArrayElements(pv_tblname, lp_tblname, 0);
@@ -92,7 +91,6 @@ JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInter
 JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInterface_dropTableReq
   (JNIEnv *pp_env, jobject pv_object, jbyteArray pv_tblname, jlong pv_transid) {
 
-   short lv_ret; 
    char la_tblname[TM_MAX_DDLREQUEST_STRING];
 
    int lv_tblname_len = pp_env->GetArrayLength(pv_tblname);
@@ -106,7 +104,7 @@ JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInter
 
       long lv_transid = (long) pv_transid;
 
-      lv_ret = DROPTABLE(la_tblname, lv_tblname_len, lv_transid);
+      DROPTABLE(la_tblname, lv_tblname_len, lv_transid);
       pp_env->ReleaseByteArrayElements(pv_tblname, lp_tblname, 0);
    }
 }
@@ -119,7 +117,6 @@ JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInter
 JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInterface_truncateOnAbortReq
   (JNIEnv *pp_env, jobject pv_object, jbyteArray pv_tblname, jlong pv_transid) {
 
-   short lv_ret;
    char la_tblname[TM_MAX_DDLREQUEST_STRING];
 
    int lv_tblname_len = pp_env->GetArrayLength(pv_tblname);
@@ -133,7 +130,7 @@ JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInter
 
       long lv_transid = (long) pv_transid;
 
-      lv_ret = REGTRUNCATEONABORT(la_tblname, lv_tblname_len, lv_transid);
+      REGTRUNCATEONABORT(la_tblname, lv_tblname_len, lv_transid);
       pp_env->ReleaseByteArrayElements(pv_tblname, lp_tblname, 0);
    }
 }
@@ -146,7 +143,6 @@ JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInter
 JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInterface_alterTableReq
   (JNIEnv *pp_env, jobject pv_object, jbyteArray pv_tblName, jobjectArray pv_tableOptions, jlong pv_transID) {
 
-   short lv_ret;
    int tblopts_len =0;
    char la_tblname[TM_MAX_DDLREQUEST_STRING];
 
@@ -186,7 +182,7 @@ JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInter
       }
 
       long lv_transid = (long) pv_transID;
-      lv_ret = ALTERTABLE(la_tblname, lv_tblname_len, tbl_options, tblopts_len, tbloptions_cnt, lv_transid);
+      ALTERTABLE(la_tblname, lv_tblname_len, tbl_options, tblopts_len, tbloptions_cnt, lv_transid);
       pp_env->ReleaseByteArrayElements(pv_tblName, lp_tblname, 0);
    }
 }

--- a/core/sqf/src/tm/tmlib.cpp
+++ b/core/sqf/src/tm/tmlib.cpp
@@ -2730,21 +2730,20 @@ bool TMLIB::phandle_get(TPT_PTR(pp_phandle), int pv_node)
 
 void TMLIB::phandle_set (TPT_PTR(pp_phandle), int pv_node)
 {
-    short lv_error = 0;
 
     ia_tm_phandle[pv_node].iv_phandle = *pp_phandle;
     ia_tm_phandle[pv_node].iv_open = true;
     
     //call decompose to get out the nid/pid
-    lv_error = XPROCESSHANDLE_DECOMPOSE_(pp_phandle, 
+    XPROCESSHANDLE_DECOMPOSE_(pp_phandle, 
                                           NULL, // node - already know it
                                           &ia_tm_phandle[pv_node].iv_pid, // pid
                                           NULL, // don't care
                                           NULL, // don't care
+                                          0, // don't care
                                           NULL, // don't care
                                           NULL, // don't care
-                                          NULL, // don't care
-                                          NULL, // don't care
+                                          0, // don't care
                                           NULL, // don't care
                                           NULL); //sdon't care
 
@@ -2754,7 +2753,6 @@ void TMLIB::phandle_set (TPT_PTR(pp_phandle), int pv_node)
 
 void TMLIB::initialize()
 {
-   int lv_err = 0;
    msg_mon_get_process_info(NULL, &iv_my_nid,
                                     &iv_my_pid);
 
@@ -2766,7 +2764,7 @@ void TMLIB::initialize()
     //TODO: switch the following call to msg_mon_get_node_info2 when available.
     // This call has been changed so that the node count includes spare nodes, so 
     // will give the wrong value for iv_node_count.
-    lv_err = msg_mon_get_node_info(&iv_node_count, MAX_NODES, NULL);
+    msg_mon_get_node_info(&iv_node_count, MAX_NODES, NULL);
     is_initialized(true);
     // We don't use gv_tmlib_initialized but set it here just to keep things aligned.
     gv_tmlib_initialized = true;
@@ -3142,11 +3140,10 @@ short TMLIB::setupJNI()
 ///////////////////////////////////////////////
 short TMLIB::initConnection(short pv_nid)
 {
-   jboolean jresult = 0;
   jthrowable exc;
   jshort   jdtmid = pv_nid;
   //sleep(30);
-  jresult = _tlp_jenv->CallBooleanMethod(javaObj_, TMLibJavaMethods_[JM_INIT1].methodID, jdtmid);
+  _tlp_jenv->CallBooleanMethod(javaObj_, TMLibJavaMethods_[JM_INIT1].methodID, jdtmid);
   exc = _tlp_jenv->ExceptionOccurred();
   if(exc) {
     _tlp_jenv->ExceptionDescribe();

--- a/core/sqf/src/tm/tmpoolelement.h
+++ b/core/sqf/src/tm/tmpoolelement.h
@@ -46,7 +46,7 @@ protected:
 
 public:
    CTmPoolElement();
-   ~CTmPoolElement();
+   virtual ~CTmPoolElement();
 
    // Required callbacks for CTmPool elements:
    static CTmPoolElement* constructPoolElement(int64);

--- a/core/sqf/src/tm/tmrecov.cpp
+++ b/core/sqf/src/tm/tmrecov.cpp
@@ -1244,7 +1244,6 @@ int32 TM_Recov::resolve_in_doubt_txs(int32 pv_dtm, int_32 delay)
 {
    TM_TX_Info * lp_txn = NULL;
    int64        lv_last_key = 0;
-   int32        lv_error = 0;
 
    // The total number of transactions to recover for this node has already been set when we created the Transaction State List
    //iv_total_txs_to_recover = ip_tm_info->num_active_txs() + txnStateList()->size();
@@ -1261,7 +1260,7 @@ int32 TM_Recov::resolve_in_doubt_txs(int32 pv_dtm, int_32 delay)
 
     while (lp_txn)
     {
-        lv_error = resolveTxn(lp_txn);
+        resolveTxn(lp_txn);
 
         lv_last_key = txnList()->curr_key();
         lp_txn = (TM_TX_Info *) txnList()->get_next();

--- a/core/sqf/src/tm/tmregisterregion.cpp
+++ b/core/sqf/src/tm/tmregisterregion.cpp
@@ -33,7 +33,6 @@ using namespace std;
 JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_TransactionState_registerRegion
 (JNIEnv *pp_env, jobject pv_object, jlong pv_transid, jlong pv_startid, jint pv_port, jbyteArray pv_hostname, jlong pv_startcode, jbyteArray pv_dos)
 {
-   short lv_ret;
    char la_hostname[TM_MAX_REGIONSERVER_STRING];
    char la_dos[TM_MAX_REGIONSERVER_STRING];
    memset(la_hostname, 0, TM_MAX_REGIONSERVER_STRING);
@@ -55,8 +54,7 @@ JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_Transac
           lp_dos,
           lv_dos_length);
 
-   lv_ret = REGISTERREGION(pv_transid, pv_startid, pv_port, la_hostname, lv_hostname_length, pv_startcode, la_dos, lv_dos_length);
-   //cout << "REGISTERREGION Error: " << lv_ret << endl;
+   REGISTERREGION(pv_transid, pv_startid, pv_port, la_hostname, lv_hostname_length, pv_startcode, la_dos, lv_dos_length);
    pp_env->ReleaseByteArrayElements(pv_hostname, lp_hostname, 0);
    pp_env->ReleaseByteArrayElements(pv_dos, lp_dos, 0);
 

--- a/core/sqf/src/tm/tmrmhbase.cpp
+++ b/core/sqf/src/tm/tmrmhbase.cpp
@@ -402,7 +402,6 @@ int32 RM_Info_HBASE::hb_ddl_operation(CTmTxBase *pp_txn, int64 pv_flags, CTmTxMe
 
    int len;
    int len_aligned;
-   int buffer_size;
    int index;
    char *ddlbuffer;
    char **buffer_keys;
@@ -437,7 +436,6 @@ int32 RM_Info_HBASE::hb_ddl_operation(CTmTxBase *pp_txn, int64 pv_flags, CTmTxMe
                          0);
          }
          else {
-            buffer_size = pv_numsplits*pv_keylen;
             buffer_keys = new char *[pv_numsplits];
 
             index = len_aligned;
@@ -480,7 +478,6 @@ int32 RM_Info_HBASE::hb_ddl_operation(CTmTxBase *pp_txn, int64 pv_flags, CTmTxMe
 
          ddlbuffer = pp_msg->getBuffer();
 
-         buffer_size = pv_numtblopts*pv_tbloptslen;
          buffer_opts = new char *[pv_numtblopts];
 
          index = len_aligned;

--- a/core/sqf/src/tm/tmrmtse.cpp
+++ b/core/sqf/src/tm/tmrmtse.cpp
@@ -191,7 +191,6 @@ void RM_Info_TSE::remove_rm_by_index (int32 pv_index)
 int RM_Info_TSE::set_partic_and_transid(TM_Txid_Internal pv_transid, int32 pv_rmid )
 {
     bool lv_found = false;
-    bool lv_partic_added = false;
 
     int lv_idx = 0;
     while (lv_idx <= iv_high_index_used && !lv_found)
@@ -200,7 +199,7 @@ int RM_Info_TSE::set_partic_and_transid(TM_Txid_Internal pv_transid, int32 pv_rm
          // partic to true and set the transid
         if (ia_TSEBranches[lv_idx].rmid() == pv_rmid)
         {
-            lv_partic_added = ia_TSEBranches[lv_idx].add_partic(pv_transid);
+            ia_TSEBranches[lv_idx].add_partic(pv_transid);
             lv_found = true;
             iv_num_rm_partic++;
 

--- a/core/sqf/src/tm/tmtime.h
+++ b/core/sqf/src/tm/tmtime.h
@@ -163,11 +163,10 @@ public:
    }
    static Ctimeval now()
    {  
-      struct timezone lv_tz =  {0, NULL};
       Ctimeval lv_now;
       //char la_buf[DTM_STRING_BUF_SIZE];
 
-      int lv_success = gettimeofday(&lv_now, &lv_tz);
+      int lv_success = gettimeofday(&lv_now, NULL);
       if (lv_success != 0)
       {
          // EMS DTM_GETTIME_FAIL

--- a/core/sqf/src/tm/tmxarmmain.cpp
+++ b/core/sqf/src/tm/tmxarmmain.cpp
@@ -544,7 +544,7 @@ void tm_process_xa_recover(CTmTxMessage * pp_msg)
    lv_recoverReply.iv_end = true;
    lv_recoverReply.iv_count = 0;
    //lv_recoverReply.iv_recovery_index = 0; not found in RM_Recover_Req_Type??
-   memset(&lv_recoverReply.iv_xid, NULL, sizeof(lv_recoverReply.iv_xid));
+   memset(&lv_recoverReply.iv_xid, 0, sizeof(lv_recoverReply.iv_xid));
 
    // Need to handle TMSTATRSCAN, TMENDRSCAN
    pp_msg->reply(XA_OK);

--- a/core/sqf/src/tm/tmxatxn.cpp
+++ b/core/sqf/src/tm/tmxatxn.cpp
@@ -145,7 +145,7 @@ void CTmXaTxn::cleanup()
    iv_txnType = TM_TX_TYPE_XARM;
    iv_txnObj.ip_xaTxn = this;
    iv_rmid = -1;
-   memset(&iv_XID, NULL, sizeof(iv_XID));
+   memset(&iv_XID, 0, sizeof(iv_XID));
    iv_tx_state = TM_TX_STATE_NOTX;
    iv_in_use = false;
    
@@ -175,7 +175,7 @@ void CTmXaTxn::initialize(int32 pv_nid, int64 pv_flags, int32 pv_trace_level,
    iv_txnType = TM_TX_TYPE_XARM;
    iv_txnObj.ip_xaTxn = this;
    iv_rmid = -1;
-   memset(&iv_XID, NULL, sizeof(iv_XID));
+   memset(&iv_XID, 0, sizeof(iv_XID));
 
    CTmTxBase::initialize(pv_nid, pv_flags, pv_trace_level, pv_seq, pv_creator_nid, 
                          pv_creator_pid, pv_rm_wait_time);

--- a/core/sqf/src/tm/tools/Makefile
+++ b/core/sqf/src/tm/tools/Makefile
@@ -48,6 +48,9 @@ endif
 
 #TESTAROBJS        = adp_read_test.o \
 
+#gcc 4.8 need explicit enable flag to search for dependent shared object
+CXXFLAGS       += -Xlinker --copy-dt-needed-entries
+
 PROGS = dtmci \
         tmshutdown 
 

--- a/core/sqf/src/tm/tools/dtmci.cpp
+++ b/core/sqf/src/tm/tools/dtmci.cpp
@@ -142,10 +142,9 @@ void print_transid_str(int32 pv_node, int32 pv_seqnum) {
 
 long now()
 {  
-   struct timezone lv_tz =  {0, NULL};
    timeval lv_now;
 
-   int lv_success = gettimeofday(&lv_now, &lv_tz);
+   int lv_success = gettimeofday(&lv_now, NULL);
    if (lv_success != 0)
    {
       printf("\n** gettimeofday returned error %d.", lv_success);
@@ -502,7 +501,6 @@ void process_tmstats_node(bool pv_reset, int32 pv_nid, bool json)
 
 void process_tmstats(bool pv_reset, int32 pv_node, bool json)
 {
-    int lv_error = 0;
     int lv_dtm_count = 0;
     bool del = false;
 
@@ -513,7 +511,7 @@ void process_tmstats(bool pv_reset, int32 pv_node, bool json)
         process_tmstats_node(pv_reset, pv_node, json);
     else
     {
-        lv_error = msg_mon_get_node_info        ( &lv_dtm_count,
+        msg_mon_get_node_info        ( &lv_dtm_count,
                                                   MAX_NODES,
                                                   NULL);
         
@@ -598,14 +596,13 @@ void process_statusalltransactions_node(int32 pv_node)
 
 void process_statusalltransactions(int32 pv_node)
 {
-  int lv_error = 0;
   int lv_dtm_count = 0;
 
   if(pv_node !=-1)
      cout << "Info specific node: " << pv_node << "\n";
   else
   {
-     lv_error = msg_mon_get_node_info(&lv_dtm_count,
+     msg_mon_get_node_info(&lv_dtm_count,
                                       MAX_NODES,
                                       NULL);
 
@@ -666,14 +663,13 @@ void process_list_node(int32 pv_node)
 
 void process_list(int32 pv_node)
 {
-    int lv_error = 0;
     int lv_dtm_count = 0;
 
     if (pv_node != -1)
         process_list_node(pv_node);
     else
     {
-        lv_error = msg_mon_get_node_info (&lv_dtm_count,
+        msg_mon_get_node_info (&lv_dtm_count,
                                           MAX_NODES,
                                           NULL);
 
@@ -1699,7 +1695,7 @@ int main(int argc, char *argv[])
                 lv_param1 = atoi(lp_nextcmd);
             }
             if (lv_param1 == 0)
-                lv_resume_error= RESUMETRANSACTION(NULL);
+                lv_resume_error= RESUMETRANSACTION(0);
             else
                 lv_resume_error= RESUMETRANSACTION(lv_param1);
                 cout << "RESUMETRANSACTION(" << lv_param1 << ") returned error " << lv_resume_error << endl;

--- a/core/sqf/src/tm/xarmapi.cpp
+++ b/core/sqf/src/tm/xarmapi.cpp
@@ -803,7 +803,7 @@ int xarm_recover_waitReply(int *pp_rmid, XID *pp_xids, int64 *pp_count,
    int32 lv_type = -1;
    bool  lv_retryLink = false;
 
-   if (!pp_rmid || !pp_xids || !pp_count || pp_count <= 0 || !pp_end || !pp_index || !pp_int_error)
+   if (!pp_rmid || !pp_xids || !pp_count || *pp_count <= 0 || !pp_end || !pp_index || !pp_int_error)
    {
       XATrace(XATM_TraceAPIError,("XARM: xarm_recover_waitReply failed with XAER_INVAL "
                                   "(invalid parameter or bad address)\n"));
@@ -1023,7 +1023,6 @@ int xarm_complete_one(int pv_rmid, int *pp_handle)
    char           la_buf[DTM_STRING_BUF_SIZE];
    int            lv_xaError = XA_OK;
    bool           lv_retryLink = false;
-   short          lv_event = 0;
 
    XATrace(XATM_TraceXAAPI,("XARM: xarm_complete_one ENTRY, rmid(%d), handle(%d).\n", 
          pv_rmid, *pp_handle));
@@ -1049,7 +1048,7 @@ int xarm_complete_one(int pv_rmid, int *pp_handle)
    }
 
    // Wait forever for a completion
-   lv_event = XWAIT(LDONE, -1);
+   XWAIT(LDONE, -1);
 
    // It's possible for us to have multiple outstanding requests
    // to the same RM (XARM, so DTM TM process) complete.

--- a/core/sqf/src/tm/xatmapi.cpp
+++ b/core/sqf/src/tm/xatmapi.cpp
@@ -127,7 +127,7 @@ bool tm_XARM_amIaTM()
    msg_mon_get_my_info2(NULL,       // mon node-id
                         NULL,       // mon process-id
                         NULL,       // mon name
-                        NULL,       // mon name-len
+                        0,       // mon name-len
                         &lv_process_type, // mon process-type
                         NULL,       // mon zone-id
                         NULL,       // os process-id
@@ -1075,7 +1075,7 @@ int tm_xa_recover_waitReply(int *pp_rmid, XID *pp_xids, int64 *pp_count,
    int32 lv_type = -1;
    bool  lv_retryLink = false;
 
-   if (!pp_rmid || !pp_xids || !pp_count || pp_count <= 0 || !pp_end || !pp_index || !pp_int_error)
+   if (!pp_rmid || !pp_xids || !pp_count || *pp_count <= 0 || !pp_end || !pp_index || !pp_int_error)
    {
       XATrace(XATM_TraceAPIError,("XATM: tm_xa_recover_waitReply failed with XAER_INVAL "
                                   "(invalid parameter or bad address)\n"));
@@ -1295,7 +1295,6 @@ int complete_one(int pv_rmid, int *pp_handle)
    char           la_buf[DTM_STRING_BUF_SIZE];
    int            lv_xaError = XA_OK;
    bool           lv_retryLink = false;
-   short          lv_event = 0;
 
    XATrace(XATM_TraceXAAPI,("XATM: complete_one ENTRY, rmid(%d), handle(%d).\n", 
          pv_rmid, *pp_handle));
@@ -1321,7 +1320,7 @@ int complete_one(int pv_rmid, int *pp_handle)
    }
 
    // Wait forever for a completion
-   lv_event = XWAIT(LDONE, -1);
+   XWAIT(LDONE, -1);
 
    // It's possible for us to have multiple outstanding requests
    // to the same RM (XARM, so DTM TM process) complete.

--- a/core/sql/optimizer/Stats.h
+++ b/core/sql/optimizer/Stats.h
@@ -965,7 +965,7 @@ public:
   // NB: no need for a dtor
   //
   Interval () :
-      loIndex_(NULL_COLL_INDEX), hist_(NULL)
+      loIndex_(NULL_COLL_INDEX), hist_(0)
   {}
 
   Interval (CollIndex startIndex, const HistogramSharedPtr& hist) :
@@ -1137,10 +1137,10 @@ public:
   inline NABoolean isNull() const { return (hiBound().isNullValue()) ; }
 
   // make sure we don't use Intervals that have been compromised
-  inline void setInvalid() { hist_ = NULL ; }
+  inline void setInvalid() { hist_ = 0; }
   inline NABoolean isValid() const
   {
-    return ( (hist_ != NULL) &&
+    return ( (hist_ != 0) &&
              ((loIndex_+2) <= hist_->entries()) ) ;
   }
   // was loIndex_ <= hist_->entries()-2, but we hate underflow!
@@ -1446,7 +1446,7 @@ public:
   ColStats (ComUID & histid, CostScalar uec = 0, CostScalar rowcount = 0,
             CostScalar baseRowCount = -1,
 	    NABoolean unique = FALSE, NABoolean shapeChanged = FALSE,
-	    const HistogramSharedPtr& desc = NULL, NABoolean modified = FALSE,
+	    const HistogramSharedPtr& desc = 0, NABoolean modified = FALSE,
 	    CostScalar rowRedFactor = 1.0, CostScalar uecRedFactor = 1.0,
                  Int32 avgVarcharSize = 0,  
 	    NAMemory* heap=0, NABoolean allowMinusOne=FALSE);


### PR DESCRIPTION
This is the second part of gcc 4.8 compatibility changes.
Related files are from DTM component.
Major fixed issues:
 - unused var
 - old C++ array init method
 - link options compatible for gcc 4.8
 - use NULL as integer, but NULL is a pointer