### PR TITLE
[TRAFODION-1828] License info for DCS binary distro

### DIFF
--- a/.rat-excludes
+++ b/.rat-excludes
@@ -59,6 +59,7 @@ license*.txt*
 LICENSE.rtf*
 lic-.*-src
 lic-.*-bin
+not-.*-bin
 # win generated
 SetCertificateDirReg_os.vcxproj*
 SetCertificateDirReg_os.vcxproj.*

--- a/dcs/Makefile
+++ b/dcs/Makefile
@@ -52,6 +52,8 @@ LICENSE: ../licenses/LICENSE-dcs
 
 NOTICE: ../NOTICE
 	cp -f $? $@
+	# Add notice file from jython 2.5.3
+	cat ../licenses/not-dcs-bin >> $@
 
 clean:
 	-$(MAVEN) clean | grep ERROR

--- a/dcs/pom.xml
+++ b/dcs/pom.xml
@@ -86,9 +86,9 @@
       </releases>
     </repository>
     <repository>
-      <id>codehaus</id>
-      <name>Codehaus Public</name>
-      <url>http://repository.codehaus.org/</url>
+      <id>codehaus-mule</id>
+      <name>Codehaus Mule Public</name>
+      <url>https://repository-master.mulesoft.org/nexus/content/groups/public/</url>
       <snapshots>
         <enabled>false</enabled>
       </snapshots>

--- a/licenses/lic-dcs-bin
+++ b/licenses/lic-dcs-bin
@@ -1,9 +1,652 @@
 ===============================================================================
-To Do:
-
-Need to investigate and document licenses for software bundled in:
-
-dcs-2.0.0.jar
-lib/*.jar
+The binary distribution of Apache Trafodion DCS bundles Jetty software which is
+available under the Apache License Version 2.0 (ALv2), though developed outside
+of the ASF.  The bundled software includes Jetty Server, Jetty Utilities, and
+Glassfish Jasper API (JSP2.1 API).  http://www.eclipse.org/jetty/
 
 +++++++++++++++++++++++++++++
+
+The binary distribution of Apache Trafodion DCS bundles SLF4J (Simple Logging
+Facade for Java) software which is available under the MIT/X11 License.
+http://www.slf4j.org
+
+ Copyright (c) 2004-2013 QOS.ch
+ All rights reserved.
+
+ Permission is hereby granted, free  of charge, to any person obtaining
+ a  copy  of this  software  and  associated  documentation files  (the
+ "Software"), to  deal in  the Software without  restriction, including
+ without limitation  the rights to  use, copy, modify,  merge, publish,
+ distribute,  sublicense, and/or sell  copies of  the Software,  and to
+ permit persons to whom the Software  is furnished to do so, subject to
+ the following conditions:
+
+ The  above  copyright  notice  and  this permission  notice  shall  be
+ included in all copies or substantial portions of the Software.
+
+ THE  SOFTWARE IS  PROVIDED  "AS  IS", WITHOUT  WARRANTY  OF ANY  KIND,
+ EXPRESS OR  IMPLIED, INCLUDING  BUT NOT LIMITED  TO THE  WARRANTIES OF
+ MERCHANTABILITY,    FITNESS    FOR    A   PARTICULAR    PURPOSE    AND
+ NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE
+ LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+ OF CONTRACT, TORT OR OTHERWISE,  ARISING FROM, OUT OF OR IN CONNECTION
+ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
+
++++++++++++++++++++++++++++++
+
+The binary distribution of Apache Trafodion DCS bundles Display Tag Library
+software which is available under the Artistic License.
+http://displaytag.sf.net
+
+ The Artistic License
+
+ Preamble
+
+  The intent of this document is to state the conditions under which a
+  Package may be copied, such that the Copyright Holder maintains some
+  semblance of artistic control over the development of the package,
+  while giving the users of the package the right to use and distribute
+  the Package in a more-or-less customary fashion, plus the right to make
+  reasonable modifications.
+
+    "Package" refers to the collection of files distributed by the
+    Copyright Holder, and derivatives of that collection of files
+    created through textual modification.
+
+    "Standard Version" refers to such a Package if it has not been
+    modified, or has been modified in accordance with the wishes
+    of the Copyright Holder.
+
+    "Copyright Holder" is whoever is named in the copyright or
+    copyrights for the package.
+
+    "You" is you, if you're thinking about copying or distributing
+    this Package.
+
+    "Reasonable copying fee" is whatever you can justify on the
+    basis of media cost, duplication charges, time of people involved,
+    and so on.  (You will not be required to justify it to the
+    Copyright Holder, but only to the computing community at large
+    as a market that must bear the fee.)
+
+    "Freely Available" means that no fee is charged for the item
+    itself, though there may be fees involved in handling the item.
+    It also means that recipients of the item may redistribute it
+    under the same conditions they received it.
+
+
+  1. You may make and give away verbatim copies of the source form of the
+  Standard Version of this Package without restriction, provided that you
+  duplicate all of the original copyright notices and associated disclaimers.
+
+
+  2. You may apply bug fixes, portability fixes and other modifications
+  derived from the Public Domain or from the Copyright Holder.  A Package
+  modified in such a way shall still be considered the Standard Version.
+
+
+  3. You may otherwise modify your copy of this Package in any way, provided
+  that you insert a prominent notice in each changed file stating how and
+  when you changed that file, and provided that you do at least ONE of the
+  following:
+
+    a) place your modifications in the Public Domain or otherwise make them
+      Freely Available, such as by posting said modifications to Usenet or
+      an equivalent medium, or placing the modifications on a major archive
+      site such as ftp.uu.net, or by allowing the Copyright Holder to include
+      your modifications in the Standard Version of the Package.
+
+    b) use the modified Package only within your corporation or organization.
+
+    c) rename any non-standard executables so the names do not conflict
+      with standard executables, which must also be provided, and provide
+      a separate manual page for each non-standard executable that clearly
+      documents how it differs from the Standard Version.
+
+    d) make other distribution arrangements with the Copyright Holder.
+
+
+  4. You may distribute the programs of this Package in object code or
+  executable form, provided that you do at least ONE of the following:
+
+    a) distribute a Standard Version of the executables and library files,
+      together with instructions (in the manual page or equivalent) on where
+      to get the Standard Version.
+
+    b) accompany the distribution with the machine-readable source of
+      the Package with your modifications.
+
+    c) accompany any non-standard executables with their corresponding
+      Standard Version executables, giving the non-standard executables
+      non-standard names, and clearly documenting the differences in manual
+      pages (or equivalent), together with instructions on where to get
+      the Standard Version.
+
+    d) make other distribution arrangements with the Copyright Holder.
+
+
+  5. You may charge a reasonable copying fee for any distribution of this
+  Package.  You may charge any fee you choose for support of this Package.
+  You may not charge a fee for this Package itself.  However,
+  you may distribute this Package in aggregate with other (possibly
+  commercial) programs as part of a larger (possibly commercial) software
+  distribution provided that you do not advertise this Package as a
+  product of your own.
+
+
+  6. The scripts and library files supplied as input to or produced as
+  output from the programs of this Package do not automatically fall
+  under the copyright of this Package, but belong to whomever generated
+  them, and may be sold commercially, and may be aggregated with this
+  Package.
+
+
+  7. C or perl subroutines supplied by you and linked into this Package
+  shall not be considered part of this Package.
+
+
+  8. The name of the Copyright Holder may not be used to endorse or promote
+  products derived from this software without specific prior written permission.
+
+
+  9. THIS PACKAGE IS PROVIDED "AS IS" AND WITHOUT ANY EXPRESS OR
+  IMPLIED WARRANTIES, INCLUDING, WITHOUT LIMITATION, THE IMPLIED
+  WARRANTIES OF MERCHANTIBILITY AND FITNESS FOR A PARTICULAR PURPOSE.
+
+
+  The End
+
++++++++++++++++++++++++++++++
+
+The binary distribution of Apache Trafodion DCS bundles Jython Standalone
+software which is available under the Python Software License.
+http://www.jython.org
+
+  ====================================
+  The Jython License
+  ====================================
+
+
+  A. TERMS AND CONDITIONS FOR ACCESSING OR OTHERWISE USING JYTHON
+  ==============================================================================================================
+
+  PYTHON SOFTWARE FOUNDATION LICENSE VERSION 2
+  ----------------------------------------------------------------------------------------
+
+  1. This LICENSE AGREEMENT is between the Python Software Foundation
+  ("PSF"), and the Individual or Organization ("Licensee") accessing and
+  otherwise using this software ("Jython") in source or binary form and
+  its associated documentation.
+
+  2. Subject to the terms and conditions of this License Agreement, PSF
+  hereby grants Licensee a nonexclusive, royalty-free, world-wide
+  license to reproduce, analyze, test, perform and/or display publicly,
+  prepare derivative works, distribute, and otherwise use Jython alone
+  or in any derivative version, provided, however, that PSF's License
+  Agreement and PSF's notice of copyright, i.e., "Copyright (c) 2007
+  Python Software Foundation; All Rights Reserved" are retained in
+  Jython alone or in any derivative version prepared by Licensee.
+
+  3. In the event Licensee prepares a derivative work that is based on
+  or incorporates Jython or any part thereof, and wants to make
+  the derivative work available to others as provided herein, then
+  Licensee hereby agrees to include in any such work a brief summary of
+  the changes made to Jython.
+
+  4. PSF is making Jython available to Licensee on an "AS IS"
+  basis.  PSF MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR
+  IMPLIED.  BY WAY OF EXAMPLE, BUT NOT LIMITATION, PSF MAKES NO AND
+  DISCLAIMS ANY REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS
+  FOR ANY PARTICULAR PURPOSE OR THAT THE USE OF JYTHON WILL NOT
+  INFRINGE ANY THIRD PARTY RIGHTS.
+
+  5. PSF SHALL NOT BE LIABLE TO LICENSEE OR ANY OTHER USERS OF JYTHON
+  FOR ANY INCIDENTAL, SPECIAL, OR CONSEQUENTIAL DAMAGES OR LOSS AS
+  A RESULT OF MODIFYING, DISTRIBUTING, OR OTHERWISE USING JYTHON,
+  OR ANY DERIVATIVE THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF.
+
+  6. This License Agreement will automatically terminate upon a material
+  breach of its terms and conditions.
+
+  7. Nothing in this License Agreement shall be deemed to create any
+  relationship of agency, partnership, or joint venture between PSF and
+  Licensee.  This License Agreement does not grant permission to use PSF
+  trademarks or trade name in a trademark sense to endorse or promote
+  products or services of Licensee, or any third party.
+
+  8. By copying, installing or otherwise using Jython, Licensee
+  agrees to be bound by the terms and conditions of this License
+  Agreement.
+
+  Jython 2.0, 2.1 License
+  --------------------------------------------
+
+  Copyright (c) 2000, 2001, 2002, 2003, 2004, 2005, 2006, 2007 Jython Developers
+  All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+
+   - Redistributions of source code must retain the above copyright
+     notice, this list of conditions and the following disclaimer.
+
+   - Redistributions in binary form must reproduce the above copyright
+     notice, this list of conditions and the following disclaimer in
+     the documentation and/or other materials provided with the distribution.
+
+   - Neither the name of the Jython Developers nor the names of
+     its contributors may be used to endorse or promote products
+     derived from this software without specific prior written permission.
+
+  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+  "AS IS'' AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE REGENTS OR
+  CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+  EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+  PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+  PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+  OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+  NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+  SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+
+
+
+  JPython 1.1.x Software License.
+  ______________________________________________________________________
+
+    1. This LICENSE AGREEMENT is between the Corporation for National Research
+       Initiatives, having an office at 1895 Preston White Drive, Reston, VA
+       20191 ("CNRI"), and the Individual or Organization ("Licensee")
+       accessing and using JPython version 1.1.x in source or binary form and
+       its associated documentation as provided herein ("Software").
+
+    2. Subject to the terms and conditions of this License Agreement, CNRI
+       hereby grants Licensee a non-exclusive, non-transferable, royalty-free,
+       world-wide license to reproduce, analyze, test, perform and/or display
+       publicly, prepare derivative works, distribute, and otherwise use the
+       Software alone or in any derivative version, provided, however, that
+       CNRI's License Agreement and CNRI's notice of copyright, i.e.,
+       "Copyright ï¿½1996-1999 Corporation for National Research Initiatives;
+       All Rights Reserved" are both retained in the Software, alone or in any
+       derivative version prepared by Licensee.
+
+       Alternatively, in lieu of CNRI's License Agreement, Licensee may
+       substitute the following text (omitting the quotes), provided, however,
+       that such text is displayed prominently in the Software alone or in any
+       derivative version prepared by Licensee: "JPython (Version 1.1.x) is
+       made available subject to the terms and conditions in CNRI's License
+       Agreement. This Agreement may be located on the Internet using the
+       following unique, persistent identifier (known as a handle):
+       1895.22/1006. The License may also be obtained from a proxy server on
+       the Web using the following URL: http://hdl.handle.net/1895.22/1006."
+
+    3. In the event Licensee prepares a derivative work that is based on or
+       incorporates the Software or any part thereof, and wants to make the
+       derivative work available to the public as provided herein, then
+       Licensee hereby agrees to indicate in any such work, in a prominently
+       visible way, the nature of the modifications made to CNRI's Software.
+
+    4. Licensee may not use CNRI trademarks or trade name, including JPython
+       or CNRI, in a trademark sense to endorse or promote products or
+       services of Licensee, or any third party. Licensee may use the mark
+       JPython in connection with Licensee's derivative versions that are
+       based on or incorporate the Software, but only in the form
+       "JPython-based ___________________," or equivalent.
+
+    5. CNRI is making the Software available to Licensee on an "AS IS" basis.
+       CNRI MAKES NO REPRESENTATIONS OR WARRANTIES, EXPRESS OR IMPLIED. BY WAY
+       OF EXAMPLE, BUT NOT LIMITATION, CNRI MAKES NO AND DISCLAIMS ANY
+       REPRESENTATION OR WARRANTY OF MERCHANTABILITY OR FITNESS FOR ANY
+       PARTICULAR PURPOSE OR THAT THE USE OF THE SOFTWARE WILL NOT INFRINGE
+       ANY THIRD PARTY RIGHTS.
+
+    6. CNRI SHALL NOT BE LIABLE TO LICENSEE OR OTHER USERS OF THE SOFTWARE FOR
+       ANY INCIDENTAL, SPECIAL OR CONSEQUENTIAL DAMAGES OR LOSS AS A RESULT OF
+       USING, MODIFYING OR DISTRIBUTING THE SOFTWARE, OR ANY DERIVATIVE
+       THEREOF, EVEN IF ADVISED OF THE POSSIBILITY THEREOF. SOME STATES DO NOT
+       ALLOW THE LIMITATION OR EXCLUSION OF LIABILITY SO THE ABOVE DISCLAIMER
+       MAY NOT APPLY TO LICENSEE.
+
+    7. This License Agreement may be terminated by CNRI (i) immediately upon
+       written notice from CNRI of any material breach by the Licensee, if the
+       nature of the breach is such that it cannot be promptly remedied; or
+       (ii) sixty (60) days following notice from CNRI to Licensee of a
+       material remediable breach, if Licensee has not remedied such breach
+       within that sixty-day period.
+
+    8. This License Agreement shall be governed by and interpreted in all
+       respects by the law of the State of Virginia, excluding conflict of law
+       provisions. Nothing in this Agreement shall be deemed to create any
+       relationship of agency, partnership, or joint venture between CNRI and
+       Licensee.
+
+    9. By clicking on the "ACCEPT" button where indicated, or by installing,
+       copying or otherwise using the Software, Licensee agrees to be bound by
+       the terms and conditions of this License Agreement.
+
+                                 [ACCEPT BUTTON]
+
+  B. HISTORY OF THE SOFTWARE
+  =======================================================
+
+  JPython was created in late 1997 by Jim Hugunin. Jim was also the
+  primary developer while he was at CNRI. In February 1999 Barry Warsaw
+  took over as primary developer and released JPython version 1.1.
+
+  In October 2000 Barry helped move the software to SourceForge
+  where it was renamed to Jython. Jython 2.0 and 2.1 were developed
+  under the Jython specific license below.
+
+  From the 2.2 release on, Jython contributors have signed
+  Python Software Foundation contributor agreements and releases are
+  covered under the Python Software Foundation license version 2.
+
+  The standard library is covered by the Python Software Foundation
+  license as well. See the Lib/LICENSE file for details.
+
+  The zxJDBC package was written by Brian Zimmer and originally licensed
+  under the GNU Public License.  The package is now covered by the Jython
+  Software License.
+
+  The command line interpreter is covered by the Apache Software
+  License.  See the org/apache/LICENSE file for details.
+
++++++++++++++++++++++++++++++
+
+The binary distribution of Apache Trafodion DCS bundles Glassfish Jasper 2.1
+and Servlet Specification 2.5 API software which is available under the
+CDDL License.
+https://glassfish.dev.java.net
+https://glassfish.dev.java.net/public/CDDLv1.0.html
+
+  COMMON DEVELOPMENT AND DISTRIBUTION LICENSE (CDDL) Version 1.0 1.
+
+  Definitions.
+
+  1.1. Contributor means each individual or entity that creates or contributes
+  to the creation of Modifications.
+
+  1.2. Contributor Version means the combination of the Original Software,
+  prior Modifications used by a Contributor (if any), and the Modifications made
+  by that particular Contributor.
+
+  1.3. Covered Software means (a) the Original Software, or (b) Modifications,
+  or (c) the combination of files containing Original Software with files
+  containing Modifications, in each case including portions thereof.
+
+  1.4. Executable means the Covered Software in any form other than Source Code.
+
+  1.5. Initial Developer means the individual or entity that first makes
+  Original Software available under this License.
+
+  1.6. Larger Work means a work which combines Covered Software or portions
+  thereof with code not governed by the terms of this License.
+
+  1.7. License means this document.
+
+  1.8. Licensable means having the right to grant, to the maximum extent
+  possible, whether at the time of the initial grant or subsequently acquired,
+  any and all of the rights conveyed herein.
+
+  1.9. Modifications means the Source Code and Executable form of any of the
+  following: A. Any file that results from an addition to, deletion from or
+  modification of the contents of a file containing Original Software or previous
+  Modifications; B. Any new file that contains any part of the Original Software
+  or previous Modification; or C. Any new file that is contributed or otherwise
+  made available under the terms of this License.
+
+  1.10. Original Software means the Source Code and Executable form of computer
+  software code that is originally released under this License.
+
+  1.11. Patent Claims means any patent claim(s), now owned or hereafter
+  acquired, including without limitation, method, process, and apparatus claims,
+  in any patent Licensable by grantor.
+
+  1.12. Source Code means (a) the common form of computer software code in
+  which modifications are made and (b) associated documentation included in or
+  with such code.
+
+  1.13. You (or Your) means an individual or a legal entity exercising rights
+  under, and complying with all of the terms of, this License. For legal
+  entities, You includes any entity which controls, is controlled by, or is under
+  common control with You. For purposes of this definition, control means (a) the
+  power, direct or indirect, to cause the direction or management of such entity,
+  whether by contract or otherwise, or (b) ownership of more than fifty percent
+  (50%) of the outstanding shares or beneficial ownership of such entity.
+
+  2. License Grants.
+
+   2.1. The Initial Developer Grant. Conditioned upon Your compliance with
+   Section 3.1 below and subject to third party intellectual property claims, the
+   Initial Developer hereby grants You a world-wide, royalty-free, non-exclusive
+   license:
+
+  (a) under intellectual property rights (other than patent or trademark)
+  Licensable by Initial Developer, to use, reproduce, modify, display, perform,
+  sublicense and distribute the Original Software (or portions thereof), with or
+  without Modifications, and/or as part of a Larger Work; and
+
+  (b) under Patent Claims infringed by the making, using or selling of Original
+  Software, to make, have made, use, practice, sell, and offer for sale, and/or
+  otherwise dispose of the Original Software (or portions thereof);
+
+  (c) The licenses granted in Sections 2.1(a) and (b) are effective on the
+  date Initial Developer first distributes or otherwise makes the Original
+  Software available to a third party under the terms of this License;
+
+  (d) Notwithstanding Section 2.1(b) above, no patent license is granted: (1)
+  for code that You delete from the Original Software, or (2) for infringements
+  caused by: (i) the modification of the Original Software, or (ii) the
+  combination of the Original Software with other software or devices.
+
+  2.2. Contributor Grant. Conditioned upon Your compliance with Section 3.1
+  below and subject to third party intellectual property claims, each Contributor
+  hereby grants You a world-wide, royalty-free, non-exclusive license:
+
+  (a) under intellectual property rights (other than patent or trademark)
+  Licensable by Contributor to use, reproduce, modify, display, perform,
+  sublicense and distribute the Modifications created by such Contributor (or
+  portions thereof), either on an unmodified basis, with other Modifications, as
+  Covered Software and/or as part of a Larger Work; and
+
+  (b) under Patent Claims infringed by the making, using, or selling of
+  Modifications made by that Contributor either alone and/or in combination with
+  its Contributor Version (or portions of such combination), to make, use, sell,
+  offer for sale, have made, and/or otherwise dispose of: (1) Modifications made
+  by that Contributor (or portions thereof); and (2) the combination of
+  Modifications made by that Contributor with its Contributor Version (or
+  portions of such combination).
+
+  (c) The licenses granted in Sections 2.2(a) and 2.2(b) are effective on the
+  date Contributor first distributes or otherwise makes the Modifications
+  available to a third party.
+
+  (d) Notwithstanding Section 2.2(b) above, no patent license is granted: (1)
+  for any code that Contributor has deleted from the Contributor Version; (2) for
+  infringements caused by: (i) third party modifications of Contributor Version,
+  or (ii) the combination of Modifications made by that Contributor with other
+  software (except as part of the Contributor Version) or other devices; or (3)
+  under Patent Claims infringed by Covered Software in the absence of
+  Modifications made by that Contributor.
+
+  3. Distribution Obligations.
+
+  3.1. Availability of Source Code. Any Covered Software that You distribute or
+  otherwise make available in Executable form must also be made available in
+  Source Code form and that Source Code form must be distributed only under the
+  terms of this License. You must include a copy of this License with every copy
+  of the Source Code form of the Covered Software You distribute or otherwise
+  make available. You must inform recipients of any such Covered Software in
+  Executable form as to how they can obtain such Covered Software in Source Code
+  form in a reasonable manner on or through a medium customarily used for
+  software exchange.
+
+  3.2. Modifications. The Modifications that You create or to which You
+  contribute are governed by the terms of this License. You represent that You
+  believe Your Modifications are Your original creation(s) and/or You have
+  sufficient rights to grant the rights conveyed by this License.
+
+  3.3. Required Notices. You must include a notice in each of Your
+  Modifications that identifies You as the Contributor of the Modification. You
+  may not remove or alter any copyright, patent or trademark notices contained
+  within the Covered Software, or any notices of licensing or any descriptive
+  text giving attribution to any Contributor or the Initial Developer.
+
+  3.4. Application of Additional Terms. You may not offer or impose any terms
+  on any Covered Software in Source Code form that alters or restricts the
+  applicable version of this License or the recipients rights hereunder. You may
+  choose to offer, and to charge a fee for, warranty, support, indemnity or
+  liability obligations to one or more recipients of Covered Software. However,
+  you may do so only on Your own behalf, and not on behalf of the Initial
+  Developer or any Contributor. You must make it absolutely clear that any such
+  warranty, support, indemnity or liability obligation is offered by You alone,
+  and You hereby agree to indemnify the Initial Developer and every Contributor
+  for any liability incurred by the Initial Developer or such Contributor as a
+  result of warranty, support, indemnity or liability terms You offer.
+
+  3.5. Distribution of Executable Versions. You may distribute the Executable
+  form of the Covered Software under the terms of this License or under the terms
+  of a license of Your choice, which may contain terms different from this
+  License, provided that You are in compliance with the terms of this License and
+  that the license for the Executable form does not attempt to limit or alter the
+  recipients rights in the Source Code form from the rights set forth in this
+  License. If You distribute the Covered Software in Executable form under a
+  different license, You must make it absolutely clear that any terms which
+  differ from this License are offered by You alone, not by the Initial Developer
+  or Contributor. You hereby agree to indemnify the Initial Developer and every
+  Contributor for any liability incurred by the Initial Developer or such
+  Contributor as a result of any such terms You offer.
+
+  3.6. Larger Works. You may create a Larger Work by combining Covered Software
+  with other code not governed by the terms of this License and distribute the
+  Larger Work as a single product. In such a case, You must make sure the
+  requirements of this License are fulfilled for the Covered Software.
+
+  4. Versions of the License.
+
+  4.1. New Versions. Sun Microsystems, Inc. is the initial license steward and
+  may publish revised and/or new versions of this License from time to time. Each
+  version will be given a distinguishing version number. Except as provided in
+  Section 4.3, no one other than the license steward has the right to modify this
+  License.
+
+  4.2. Effect of New Versions. You may always continue to use, distribute or
+  otherwise make the Covered Software available under the terms of the version of
+  the License under which You originally received the Covered Software. If the
+  Initial Developer includes a notice in the Original Software prohibiting it
+  from being distributed or otherwise made available under any subsequent version
+  of the License, You must distribute and make the Covered Software available
+  under the terms of the version of the License under which You originally
+  received the Covered Software. Otherwise, You may also choose to use,
+  distribute or otherwise make the Covered Software available under the terms of
+  any subsequent version of the License published by the license steward.
+
+  4.3. Modified Versions. When You are an Initial Developer and You want to
+  create a new license for Your Original Software, You may create and use a
+  modified version of this License if You: (a) rename the license and remove any
+  references to the name of the license steward (except to note that the license
+  differs from this License); and (b) otherwise make it clear that the license
+  contains terms which differ from this License.
+
+  5. DISCLAIMER OF WARRANTY. COVERED SOFTWARE IS PROVIDED UNDER THIS LICENSE ON
+  AN AS IS BASIS, WITHOUT WARRANTY OF ANY KIND, EITHER EXPRESSED OR IMPLIED,
+  INCLUDING, WITHOUT LIMITATION, WARRANTIES THAT THE COVERED SOFTWARE IS FREE OF
+  DEFECTS, MERCHANTABLE, FIT FOR A PARTICULAR PURPOSE OR NON-INFRINGING. THE
+  ENTIRE RISK AS TO THE QUALITY AND PERFORMANCE OF THE COVERED SOFTWARE IS WITH
+  YOU. SHOULD ANY COVERED SOFTWARE PROVE DEFECTIVE IN ANY RESPECT, YOU (NOT THE
+  INITIAL DEVELOPER OR ANY OTHER CONTRIBUTOR) ASSUME THE COST OF ANY NECESSARY
+  SERVICING, REPAIR OR CORRECTION. THIS DISCLAIMER OF WARRANTY CONSTITUTES AN
+  ESSENTIAL PART OF THIS LICENSE. NO USE OF ANY COVERED SOFTWARE IS AUTHORIZED
+  HEREUNDER EXCEPT UNDER THIS DISCLAIMER.
+
+  6. TERMINATION.
+
+  6.1. This License and the rights granted hereunder will terminate
+  automatically if You fail to comply with terms herein and fail to cure such
+  breach within 30 days of becoming aware of the breach. Provisions which, by
+  their nature, must remain in effect beyond the termination of this License
+  shall survive.
+
+  6.2. If You assert a patent infringement claim (excluding declaratory
+  judgment actions) against Initial Developer or a Contributor (the Initial
+  Developer or Contributor against whom You assert such claim is referred to as
+  Participant) alleging that the Participant Software (meaning the Contributor
+  Version where the Participant is a Contributor or the Original Software where
+  the Participant is the Initial Developer) directly or indirectly infringes any
+  patent, then any and all rights granted directly or indirectly to You by such
+  Participant, the Initial Developer (if the Initial Developer is not the
+  Participant) and all Contributors under Sections 2.1 and/or 2.2 of this License
+  shall, upon 60 days notice from Participant terminate prospectively and
+  automatically at the expiration of such 60 day notice period, unless if within
+  such 60 day period You withdraw Your claim with respect to the Participant
+  Software against such Participant either unilaterally or pursuant to a written
+  agreement with Participant.
+
+  6.3. In the event of termination under Sections 6.1 or 6.2 above, all end
+  user licenses that have been validly granted by You or any distributor
+  hereunder prior to termination (excluding licenses granted to You by any
+  distributor) shall survive termination.
+
+  7. LIMITATION OF LIABILITY. UNDER NO CIRCUMSTANCES AND UNDER NO LEGAL THEORY,
+  WHETHER TORT (INCLUDING NEGLIGENCE), CONTRACT, OR OTHERWISE, SHALL YOU, THE
+  INITIAL DEVELOPER, ANY OTHER CONTRIBUTOR, OR ANY DISTRIBUTOR OF COVERED
+  SOFTWARE, OR ANY SUPPLIER OF ANY OF SUCH PARTIES, BE LIABLE TO ANY PERSON FOR
+  ANY INDIRECT, SPECIAL, INCIDENTAL, OR CONSEQUENTIAL DAMAGES OF ANY CHARACTER
+  INCLUDING, WITHOUT LIMITATION, DAMAGES FOR LOST PROFITS, LOSS OF GOODWILL, WORK
+  STOPPAGE, COMPUTER FAILURE OR MALFUNCTION, OR ANY AND ALL OTHER COMMERCIAL
+  DAMAGES OR LOSSES, EVEN IF SUCH PARTY SHALL HAVE BEEN INFORMED OF THE
+  POSSIBILITY OF SUCH DAMAGES. THIS LIMITATION OF LIABILITY SHALL NOT APPLY TO
+  LIABILITY FOR DEATH OR PERSONAL INJURY RESULTING FROM SUCH PARTYS NEGLIGENCE TO
+  THE EXTENT APPLICABLE LAW PROHIBITS SUCH LIMITATION. SOME JURISDICTIONS DO NOT
+  ALLOW THE EXCLUSION OR LIMITATION OF INCIDENTAL OR CONSEQUENTIAL DAMAGES, SO
+  THIS EXCLUSION AND LIMITATION MAY NOT APPLY TO YOU.
+
+  8. U.S. GOVERNMENT END USERS. The Covered Software is a commercial item, as
+  that term is defined in 48 C.F.R. 2.101 (Oct. 1995), consisting of commercial
+  computer software (as that term is defined at 48 C.F.R.  252.227-7014(a)(1))
+  and commercial computer software documentation as such terms are used in 48
+  C.F.R. 12.212 (Sept. 1995). Consistent with 48 C.F.R. 12.212 and 48 C.F.R.
+  227.7202-1 through 227.7202-4 (June 1995), all U.S. Government End Users
+  acquire Covered Software with only those rights set forth herein. This U.S.
+  Government Rights clause is in lieu of, and supersedes, any other FAR, DFAR, or
+  other clause or provision that addresses Government rights in computer software
+  under this License.
+
+  9. MISCELLANEOUS. This License represents the complete agreement concerning
+  subject matter hereof. If any provision of this License is held to be
+  unenforceable, such provision shall be reformed only to the extent necessary to
+  make it enforceable. This License shall be governed by the law of the
+  jurisdiction specified in a notice contained within the Original Software
+  (except to the extent applicable law, if any, provides otherwise), excluding
+  such jurisdictions conflict-of-law provisions. Any litigation relating to this
+  License shall be subject to the jurisdiction of the courts located in the
+  jurisdiction and venue specified in a notice contained within the Original
+  Software, with the losing party responsible for costs, including, without
+  limitation, court costs and reasonable attorneys fees and expenses. The
+  application of the United Nations Convention on Contracts for the International
+  Sale of Goods is expressly excluded. Any law or regulation which provides that
+  the language of a contract shall be construed against the drafter shall not
+  apply to this License. You agree that You alone are responsible for compliance
+  with the United States export administration regulations (and the export
+  control laws and regulation of any other countries) when You use, distribute or
+  otherwise make available any Covered Software.
+
+  10. RESPONSIBILITY FOR CLAIMS. As between Initial Developer and the
+  Contributors, each party is responsible for claims and damages arising,
+  directly or indirectly, out of its utilization of rights under this License and
+  You agree to work with Initial Developer and Contributors to distribute such
+  responsibility on an equitable basis. Nothing herein is intended or shall be
+  deemed to constitute any admission of liability.
+
+  NOTICE PURSUANT TO SECTION 9 OF THE COMMON DEVELOPMENT AND DISTRIBUTION
+  LICENSE (CDDL) The code released under the CDDL shall be governed by the laws
+  of the State of California (excluding conflict-of-law provisions). Any
+  litigation relating to this License shall be subject to the jurisdiction of the
+  Federal Courts of the Northern District of California and the state courts of
+  the State of California, with venue lying in Santa Clara County, California.
+
++++++++++++++++++++++++++++++
+

--- a/licenses/not-dcs-bin
+++ b/licenses/not-dcs-bin
@@ -1,0 +1,20 @@
+
+Notices for Jython bundled software:
+
+   =========================================================================
+   ==  NOTICE file corresponding to section 4(d) of the Apache License,   ==
+   ==  Version 2.0, in this case for the Apache Xerces Java distribution. ==
+   =========================================================================
+
+   Apache Xerces Java
+   Copyright 1999-2007 The Apache Software Foundation
+
+   This product includes software developed at
+   The Apache Software Foundation (http://www.apache.org/).
+
+   Portions of this software were originally based on the following:
+     - software copyright (c) 1999, IBM Corporation., http://www.ibm.com.
+     - software copyright (c) 1999, Sun Microsystems., http://www.sun.com.
+     - voluntary contributions made by Paul Eng on behalf of the
+       Apache Software Foundation that were originally developed at iClick, Inc.,
+       software copyright (c) 1999.


### PR DESCRIPTION
DCS build currently bundles 9 dependent jars. This gives license info on those, as well as additional NOTICE file additions that jython pulls in from Xerces.