### PR TITLE
[TRAFODION-1890] disable SSCC entirely in current Trafodion

### DIFF
--- a/core/sqf/sql/scripts/install_local_hadoop
+++ b/core/sqf/sql/scripts/install_local_hadoop
@@ -1570,7 +1570,6 @@ else
       <value>
            org.apache.hadoop.hbase.coprocessor.transactional.TrxRegionObserver,
            org.apache.hadoop.hbase.coprocessor.transactional.TrxRegionEndpoint,
-           org.apache.hadoop.hbase.coprocessor.transactional.SsccRegionEndpoint,
            org.apache.hadoop.hbase.coprocessor.AggregateImplementation
       </value>
    </property>


### PR DESCRIPTION
SSCC is long time not maintained and test, and at the time of its writing, it is for HBase 0.98.6.
Remove it for now from install_local_hadoop will help in some times that HBase for no reason to fail to start and just remove it will make it work fine.
Will add it back after more tests of SSCC.