### PR TITLE
[TRAFODION-1897] dcscheck may fail if one node in zookeeper quorum is down

### DIFF
--- a/dcs/src/main/java/org/trafodion/dcs/zookeeper/DcsQuorumPeer.java
+++ b/dcs/src/main/java/org/trafodion/dcs/zookeeper/DcsQuorumPeer.java
@@ -1,27 +1,4 @@
 /**
-* @@@ START COPYRIGHT @@@
-
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
-
-* @@@ END COPYRIGHT @@@
- */
-/**
- * Copyright 2010 The Apache Software Foundation
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/dcs/src/main/java/org/trafodion/dcs/zookeeper/ZKConfig.java
+++ b/dcs/src/main/java/org/trafodion/dcs/zookeeper/ZKConfig.java
@@ -1,27 +1,4 @@
 /**
-* @@@ START COPYRIGHT @@@
-
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
-
-* @@@ END COPYRIGHT @@@
- */
-/**
- * Copyright 2010 The Apache Software Foundation
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -120,10 +97,17 @@ public class ZKConfig {
 
     final String[] serverHosts = conf.getStrings(Constants.ZOOKEEPER_QUORUM,
                                                  Constants.LOCALHOST);
+    String serverHost;
+    String address;
+    String key;
     for (int i = 0; i < serverHosts.length; ++i) {
-      String serverHost = serverHosts[i];
-      String address = serverHost + ":" + peerPort + ":" + leaderPort;
-      String key = "server." + i;
+      if (serverHosts[i].contains(":")) {
+        serverHost = serverHosts[i].substring(0, serverHosts[i].indexOf(':'));
+      } else {
+        serverHost = serverHosts[i];
+      }
+      address = serverHost + ":" + peerPort + ":" + leaderPort;
+      key = "server." + i;
       zkProperties.put(key, address);
     }
 

--- a/dcs/src/main/java/org/trafodion/dcs/zookeeper/ZKServerTool.java
+++ b/dcs/src/main/java/org/trafodion/dcs/zookeeper/ZKServerTool.java
@@ -1,27 +1,4 @@
 /**
-* @@@ START COPYRIGHT @@@
-
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
-
-* @@@ END COPYRIGHT @@@
- */
-/**
- * Copyright 2010 The Apache Software Foundation
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/dcs/src/main/java/org/trafodion/dcs/zookeeper/ZkClient.java
+++ b/dcs/src/main/java/org/trafodion/dcs/zookeeper/ZkClient.java
@@ -1,27 +1,4 @@
 /**
-* @@@ START COPYRIGHT @@@
-
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
-
-* @@@ END COPYRIGHT @@@
- */
-/**
- * Copyright 2011 The Apache Software Foundation
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/dcs/src/main/java/org/trafodion/dcs/zookeeper/ZkUtil.java
+++ b/dcs/src/main/java/org/trafodion/dcs/zookeeper/ZkUtil.java
@@ -1,27 +1,4 @@
 /**
-* @@@ START COPYRIGHT @@@
-
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
-
-* @@@ END COPYRIGHT @@@
- */
-/**
- * Copyright 2011 The Apache Software Foundation
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file

--- a/dcs/src/main/java/org/trafodion/dcs/zookeeper/ZooKeeperMainServerArg.java
+++ b/dcs/src/main/java/org/trafodion/dcs/zookeeper/ZooKeeperMainServerArg.java
@@ -1,27 +1,4 @@
 /**
-* @@@ START COPYRIGHT @@@
-
-Licensed to the Apache Software Foundation (ASF) under one
-or more contributor license agreements.  See the NOTICE file
-distributed with this work for additional information
-regarding copyright ownership.  The ASF licenses this file
-to you under the Apache License, Version 2.0 (the
-"License"); you may not use this file except in compliance
-with the License.  You may obtain a copy of the License at
-
-  http://www.apache.org/licenses/LICENSE-2.0
-
-Unless required by applicable law or agreed to in writing,
-software distributed under the License is distributed on an
-"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
-KIND, either express or implied.  See the License for the
-specific language governing permissions and limitations
-under the License.
-
-* @@@ END COPYRIGHT @@@
- */
-/**
- * Copyright 2010 The Apache Software Foundation
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -49,32 +26,12 @@ import org.apache.hadoop.conf.Configuration;
 import org.trafodion.dcs.util.DcsConfiguration;
 
 /**
- * Tool for reading a ZooKeeper server from HBase XML configuration producing
- * the '-server host:port' argument to pass ZooKeeperMain.  This program
- * emits either '-server HOST:PORT" where HOST is one of the zk ensemble
- * members plus zk client port OR it emits '' if no zk servers found (Yes,
- * it emits '-server' too).
+ * Tool for running ZookeeperMain from DCS by reading the Zookeeper quorum
+ * from the xml configuration file.
  */
 public class ZooKeeperMainServerArg {
   public String parse(final Configuration c) {
-    // Note that we do not simply grab the property
-    // Constants.ZOOKEEPER_QUORUM from the DcsConfiguration because the
-    // user may be using a zoo.cfg file.
-    Properties zkProps = ZKConfig.makeZKProps(c);
-    String host = null;
-    String clientPort = null;
-    for (Entry<Object, Object> entry: zkProps.entrySet()) {
-      String key = entry.getKey().toString().trim();
-      String value = entry.getValue().toString().trim();
-      if (key.startsWith("server.") && host == null) {
-        String[] parts = value.split(":");
-        host = parts[0];
-      } else if (key.endsWith("clientPort")) {
-        clientPort = value;
-      }
-      if (host != null && clientPort != null) break;
-    }
-    return host != null && clientPort != null? host + ":" + clientPort: null;
+    return ZKConfig.getZKQuorumServersString(c);
   }
 
   /**


### PR DESCRIPTION
dcscheck calls "$DCS_INSTALL_DIR/bin/dcs zkcli" to get znodes associated with dcs. Earlier only one server from the zookeeper quorum was being passed in to ZooKeeperMain. If that node is down then an exception was raised. Now all servers in the quorum are utilized.