### PR TITLE
[TRAFODION-1868] Compatibility with gcc 4.8 , part 3, mornitor, odbc …

### DIFF
--- a/core/conn/odbc/src/odbc/nsksrvr/Makefile
+++ b/core/conn/odbc/src/odbc/nsksrvr/Makefile
@@ -130,6 +130,8 @@ LOC_JSIG=$(JAVA_HOME)/jre/lib/i386/server
 endif
 
 
+#gcc 4.8 need explicit enable this flag, otherwise ld must explicitly link with all so using '-l'
+GCCMODE        += -Xlinker --copy-dt-needed-entries
 # Produce mxosrvr
 $(BINEXPDIR)/mxosrvr: $(OBJS) $(LIBEXPDIR)/libzookeeper_mt.so
 	$(CXX) $(GCCMODE) -o $@ $(DBG_FLGS)  -L$(LIBEXPDIR) -D_SQ64 -L$(LOC_JSIG) $(EARLY_LIBS) $(COMMON_LIBS) $(DBT_LIBS) -lzookeeper_mt $(HADOOP_LIBS) $(OBJS) -lz

--- a/core/conn/odbc/src/odbc/nsksrvrcore/csrvrstmt.cpp
+++ b/core/conn/odbc/src/odbc/nsksrvrcore/csrvrstmt.cpp
@@ -129,7 +129,12 @@ SRVR_STMT_HDL::SRVR_STMT_HDL()
 	IRD = NULL;
 	outputDataValue._length = 0;
 	outputDataValue._buffer = NULL;
-	outputDataValue.pad_to_offset_8_ = {'\0', '\0', '\0', '\0'};
+        //outputDataValue.pad_to_offset_8_ = {'\0', '\0', '\0', '\0'};
+        //use trafodional way to initialze array, above is c++11 in gcc 4.8
+        //for gcc 4.4 backward compatibilty, Trafodion now is using c++0x , gcc 4.4 cannot support c++11 mode
+        //once tested with -std=c++11, may recover this coding style
+        memset( outputDataValue.pad_to_offset_8_ , 0, sizeof(outputDataValue.pad_to_offset_8_) );
+
 	inputDataValue._length = 0;
 	inputDataValue._buffer = NULL;
 	delayedOutputDataValue._length = 0;

--- a/core/sqf/monitor/linux/config.cxx
+++ b/core/sqf/monitor/linux/config.cxx
@@ -26,6 +26,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <iostream>
+#include <unistd.h>
 
 using namespace std;
 

--- a/core/sqf/monitor/linux/makefile
+++ b/core/sqf/monitor/linux/makefile
@@ -48,7 +48,7 @@ FLAGS+= -UNDEBUG
 FLAGS+= -Wall -Wextra
 
 # Flags for use in compiling Seabed trace modules
-SBFLAGS = -Wall -Wextra -pedantic -Werror  -Wno-long-long $(DBG_FLGS) $(OPTIM_FLGS)
+SBFLAGS = -Wall -Wextra -pedantic -Werror  -Wno-long-long $(DBG_FLGS) $(OPTIM_FLGS) -Xlinker --copy-dt-needed-entries
 SBDIR = ../../src/seabed/src
 
 COMMONLOGGERDIR = ../../commonLogger
@@ -84,6 +84,7 @@ INCLUDES+= -I$(LOG4CXX_INC_DIR)/log4cxx
 
 LIBS+=  -lsqlite3
 LIBS+=  -llog4cxx
+LIBS+=  -ldl
 
 ifeq ($(USE_TESTPOINTS),1)
    FLAGS+= -DUSE_TESTPOINTS

--- a/core/sqf/monitor/linux/monitor.cxx
+++ b/core/sqf/monitor/linux/monitor.cxx
@@ -35,6 +35,9 @@ using namespace std;
 #include <unistd.h>
 #include <malloc.h>
 #include <sys/ipc.h>
+#include <sys/time.h>
+#include <sys/resource.h> //add for getrlimit, strange centos6/gcc4.4 don't need this
+
 //#include <sys/stat.h>
 #include "monlogging.h"
 #include "monprof.h"

--- a/core/sqf/src/seabed/src/sautil.cpp
+++ b/core/sqf/src/seabed/src/sautil.cpp
@@ -95,11 +95,6 @@ void SB_SA_Util_assert_fun_com(const char *pp_exp,
                                const char *pp_file,
                                unsigned    pv_line,
                                const char *pp_fun) {
-    pid_t lv_pid;
-    pid_t lv_tid;
-
-    lv_pid = getpid();
-    lv_tid = sb_sa_util_gettid();
     gv_sb_sa_util_save_assert.iv_errno = errno;
     gv_sb_sa_util_save_assert.iv_line = pv_line;
     gv_sb_sa_util_save_assert.iv_lhs = pv_lhs;

--- a/core/sqf/src/seabed/src/stream.cpp
+++ b/core/sqf/src/seabed/src/stream.cpp
@@ -353,11 +353,9 @@ void SB_Trans::Trans_Stream::checksum_recv_check(Rd_Type     *pp_rd,
     int   lv_chk;
     int   lv_ctrl_len;
     int   lv_data_len;
-    int   lv_data_off;
     int   lv_inx;
 
     lv_chk = -1;
-    lv_data_off = 0;
     pv_client = pv_client; // touch
     lp_ctrl = pp_rd->ip_ctrl;
     lv_ctrl_len = pp_rd->iv_ctrl_len;


### PR DESCRIPTION
this is part 3 of gcc 4.8 changes.
some changes are very strange, for example:
core/sqf/monitor/linux/monitor.cxx
it will call glibc function getrlimit(), which defined in sys/resource.h 
in gcc 4.4, this code can be compiled, which I don't know why. This is not what I have been taught in school. :-)  If a function is not declared, compiler should report error, but gcc 4.4 not. Maybe there are complex nested header file include, but I cannot trace it.
So simply for code readability, we should add it. I still don't understand why this code can be built without issue for so long time :-) 

After I understand why gcc 4.8 disable '--no-copy-dt-needed-entries'
https://wiki.ubuntu.com/NattyNarwhal/ToolchainTransition
I realize this is just a temp solution for gcc 4.8 build. In the following changes, I will disable it again and fix Makefile link options.
But first let's fix these .cpp and .h issues. Then on Makefile.