### PR TITLE
[TRAFODION-1900] Optimize MDAM scans with small scanner

### DIFF
--- a/core/sql/comexe/ComTdbHbaseAccess.h
+++ b/core/sql/comexe/ComTdbHbaseAccess.h
@@ -269,19 +269,38 @@ public:
     {(v ? flags_ |= USE_SMALL_SCANNER :
       flags_ &= ~USE_SMALL_SCANNER); };
     NABoolean useSmallScanner()
-    { return (flags_ & USE_SMALL_SCANNER) != 0; };
+    { return (flags_ & (USE_SMALL_SCANNER | USE_SMALL_SCANNER_FOR_MDAM)) != 0; };
+    void setUseSmallScannerForProbes(NABoolean v)
+    {(v ? flags_ |= USE_SMALL_SCANNER_FOR_PROBES :
+      flags_ &= ~USE_SMALL_SCANNER_FOR_PROBES); };
+    NABoolean useSmallScannerForProbes()
+    { return (flags_ & USE_SMALL_SCANNER_FOR_PROBES) != 0; };
 
+    void setUseSmallScannerForMDAMifNeeded(UInt32 numRowRetrieved){
+        //if last scan of mdam fitted in one block, and small scanner CQD is either ON or SYSTEM (this is summarized in USE_SMALL_SCANNER_FOR_PROBES)
+        //then next MDAM scan can use small scanner. Most likely it is about same size as previous one.
+        if ((numRowRetrieved < maxNumRowsPerHBaseBlock_) && ((flags_ & USE_SMALL_SCANNER_FOR_PROBES) != 0))
+            flags_ |= USE_SMALL_SCANNER_FOR_MDAM;
+        else
+            flags_ &= ~USE_SMALL_SCANNER_FOR_MDAM;
+    }
+
+    void setMaxNumRowsPerHbaseBlock(UInt32 n) { maxNumRowsPerHBaseBlock_ = n;}
+    UInt32 maxNumRowsPerHbaseBlock() { return maxNumRowsPerHBaseBlock_; }
 
   private:
     enum
     {
-      CACHE_BLOCKS               = 0x0001,
-      USE_MIN_MDAM_PROBE_SIZE    = 0x0002,
-      USE_SMALL_SCANNER          = 0x0004
+      CACHE_BLOCKS                 = 0x0001,
+      USE_MIN_MDAM_PROBE_SIZE      = 0x0002,
+      USE_SMALL_SCANNER            = 0x0004,
+      USE_SMALL_SCANNER_FOR_PROBES = 0x0008,
+      USE_SMALL_SCANNER_FOR_MDAM   = 0x0010
     };
     
     UInt32 flags_;
     UInt32 numCacheRows_;
+    UInt32 maxNumRowsPerHBaseBlock_;
   };
 
   // ---------------------------------------------------------------------

--- a/core/sql/generator/Generator.cpp
+++ b/core/sql/generator/Generator.cpp
@@ -3143,9 +3143,15 @@ void Generator::setHBaseSmallScanner(Int32 hbaseRowSize, double estRowsAccessed,
 {
   if (CmpCommon::getDefault(HBASE_SMALL_SCANNER) == DF_SYSTEM)
   {
-    if((hbaseRowSize*estRowsAccessed)<hbaseBlockSize)
+    if(((hbaseRowSize*estRowsAccessed)<hbaseBlockSize) && (estRowsAccessed>0))//added estRowsAccessed > 0 because MDAM costing is not populating this field correctly
         hbpa->setUseSmallScanner(TRUE);
+    hbpa->setUseSmallScannerForProbes(TRUE);
   }else if (CmpCommon::getDefault(HBASE_SMALL_SCANNER) == DF_ON)
+  {
       hbpa->setUseSmallScanner(TRUE);
+      hbpa->setUseSmallScannerForProbes(TRUE);
+  }
+  hbpa->setMaxNumRowsPerHbaseBlock(hbaseBlockSize/hbaseRowSize);
 }
+
 


### PR DESCRIPTION
When doing MDAM scans, we are performing interlaced scan for PROBE and for real scan. The probes always return only 1 row, then we close the scanner immediately, therefore should use always small scanner. I will make it conditional on the existing CQD HBASE_SMALL_SCANNER (ether SYSTEM or ON). In addition, caching of blocks retrieved by probe should always we at least receiving one succesfull cache hit on the next MDAM scan, therefore forcing caching ON for MDAM prob is a good idea. Again, will make this forcing conditional on HBASE_SMALL_SCANNER SYSTEM or ON.
Then for the real scan part of MDAM, I will use the following heuristic: If previous scan fitted in one hbase block, then it is likelly than next will also fit in one hbase block, therefore enable small scanner for next scan. Again all this only if CQD above is ON or SYSTEM.
Also includes a fix where SMALL_SCANNER would be turned on for MDAM scan because the compiler for MDAM is not polulating the expected number of rows returned.
Results of using small scanner on MDAM when it make sense showed a 1.39X speed improvement...