### PR TITLE
JIRA TRAFODION-1901 Default clause can appear in any order during create

### DIFF
--- a/core/sql/bin/SqlciErrors.txt
+++ b/core/sql/bin/SqlciErrors.txt
@@ -801,7 +801,7 @@ $1~String1 --------------------------------
 3049 42000 99999 BEGINNER MAJOR DBADMIN Host variables, such as $0~string0, are not allowed in a dynamic compilation.
 3050 42000 99999 BEGINNER MAJOR DBADMIN The constraint must have the same catalog and schema as the specified table.
 3051 42000 99999 BEGINNER MAJOR DBADMIN Duplicate HEADING clauses were specified in column definition $0~ColumnName.
-3052 42000 99999 BEGINNER MAJOR DBADMIN Duplicate NOT NULL clauses were specified in column definition $0~ColumnName.
+3052 42000 99999 BEGINNER MAJOR DBADMIN Duplicate $0~String0 clauses were specified in column definition $0~ColumnName.
 3053 42000 99999 BEGINNER MAJOR DBADMIN Duplicate PRIMARY KEY clauses were specified in column definition $0~ColumnName.
 3054 42000 99999 BEGINNER MAJOR DBADMIN The NOT DROPPABLE clause is allowed only in PRIMARY KEY and NOT NULL constraint definitions.
 3055 42000 99999 BEGINNER MAJOR DBADMIN Duplicate DELETE rules were specified.

--- a/core/sql/parser/ElemDDLCol.cpp
+++ b/core/sql/parser/ElemDDLCol.cpp
@@ -59,7 +59,6 @@ ElemDDLColDef::ElemDDLColDef(
      const NAString *columnFamily,
      const NAString *columnName,
      NAType * pColumnDataType,
-     ElemDDLNode * pColDefaultNode,
      ElemDDLNode * pColAttrList,
      CollHeap * heap)
 : ElemDDLNode(ELM_COL_DEF_ELEM),
@@ -88,7 +87,8 @@ ElemDDLColDef::ElemDDLColDef(
   isLobAttrsSpec_(FALSE),
   lobStorage_(Lob_Invalid_Storage),
   isSeabaseSerializedSpec_(FALSE),
-  seabaseSerialized_(FALSE)
+  seabaseSerialized_(FALSE),
+  isColDefaultSpec_(FALSE)
 {
   //  ComASSERT(pColumnDataType NEQ NULL);
 
@@ -152,251 +152,11 @@ ElemDDLColDef::ElemDDLColDef(
     }
   }
 
-  setChild(INDEX_ELEM_DDL_COL_DEFAULT_VALUE, pColDefaultNode);
   setChild(INDEX_ELEM_DDL_COL_ATTR_LIST, pColAttrList);
 
   // initialize data member pDefault_
 
-  ElemDDLColDefault * pColDefault = NULL;
   ComBoolean isIdentityColumn = FALSE;
-
-  if (pColDefaultNode NEQ NULL)
-  {
-    ComASSERT(pColDefaultNode->castToElemDDLColDefault() NEQ NULL);
-    pColDefault = pColDefaultNode->castToElemDDLColDefault();
-  }
-  if (pColDefault NEQ NULL)
-  {
-    switch (pColDefault->getColumnDefaultType())
-    {
-    case ElemDDLColDefault::COL_NO_DEFAULT:
-      defaultClauseStatus_ = NO_DEFAULT_CLAUSE_SPEC;
-      break;
-    case ElemDDLColDefault::COL_DEFAULT:
-      {
-	defaultClauseStatus_ = DEFAULT_CLAUSE_SPEC;
-
-        if (pColDefault->getSGOptions())
-          {
-            isIdentityColumn = TRUE;
-            pSGOptions_ = pColDefault->getSGOptions();
-            pSGLocation_ = pColDefault->getSGLocation();
-          }
-        else
-          {
-            ComASSERT(pColDefault->getDefaultValueExpr() NEQ NULL);
-            pDefault_ = pColDefault->getDefaultValueExpr();
-          }
-
-	// The cast ItemExpr to ConstValue for (ConstValue *)pDefault_; 
-	// statement below sets arbitary value for the isNULL_. 
-	// Bypass these checks for ID column (basically ITM_IDENTITY).
-	ConstValue *cvDef = (ConstValue *)pDefault_;
-	if ((cvDef && !cvDef->isNull()) && (!isIdentityColumn))
-	  {
-	    const NAType *cvTyp = cvDef->getType();
-            NABoolean isAnErrorAlreadyIssued = FALSE;
-
-            if ( cvTyp->getTypeQualifier() == NA_CHARACTER_TYPE )
-            {
-              CharInfo::CharSet defaultValueCS = ((const CharType *)cvTyp)->getCharSet();
-              // Always check for INFER_CHARSET setting before the ICAT setting.
-              NAString inferCharSetFlag;
-              if (getCharSetInferenceSetting(inferCharSetFlag) == TRUE &&
-                  NOT cvDef->isStrLitWithCharSetPrefixSpecified())
-              {
-                if (pColumnDataType->getTypeQualifier() == NA_CHARACTER_TYPE
-                    && ((const CharType *)pColumnDataType)->getCharSet() == CharInfo::UCS2
-                    && SqlParser_DEFAULT_CHARSET == CharInfo::UCS2
-                    && defaultValueCS == CharInfo::ISO88591
-                    )
-                {
-                  *SqlParser_Diags << DgSqlCode(-1186)
-                                   << DgColumnName(ToAnsiIdentifier(getColumnName()))
-                                   << DgString0(pColumnDataType->getTypeSQLname(TRUE/*terse*/))
-                                   << DgString1(cvTyp->getTypeSQLname(TRUE/*terse*/));
-                  isAnErrorAlreadyIssued = TRUE;
-                }
-                else
-                {
-                  cvTyp = cvDef -> pushDownType(*columnDataType_, NA_CHARACTER_TYPE);
-                }
-              }
-              else if (CmpCommon::getDefault(ALLOW_IMPLICIT_CHAR_CASTING) == DF_ON &&
-                       NOT cvDef->isStrLitWithCharSetPrefixSpecified() &&
-                       cvTyp->getTypeQualifier() == NA_CHARACTER_TYPE &&
-                       SqlParser_DEFAULT_CHARSET == CharInfo::ISO88591 &&
-                       defaultValueCS == CharInfo::UnknownCharSet)
-              {
-                cvTyp = cvDef -> pushDownType(*columnDataType_, NA_CHARACTER_TYPE);
-              }
-
-            } // column default value has character data type
-
-            if (NOT isAnErrorAlreadyIssued &&
-                pColumnDataType->getTypeQualifier() == NA_CHARACTER_TYPE &&
-                cvTyp->getTypeQualifier() == NA_CHARACTER_TYPE &&
-                (
-                 CmpCommon::getDefault(ALLOW_IMPLICIT_CHAR_CASTING) == DF_ON ||
-                 NOT cvDef->isStrLitWithCharSetPrefixSpecified()))
-            {
-              const CharType *cdCharType = (const CharType *)pColumnDataType;
-              const CharType *cvCharType = (const CharType *)cvTyp;
-              CharInfo::CharSet cdCharSet = cdCharType->getCharSet(); // cd = column definition
-              CharInfo::CharSet cvCharSet = cvCharType->getCharSet(); // cv = constant value
-              if (cvCharSet == CharInfo::ISO88591)  // default value is a _ISO88591 str lit
-              {
-
-              }
-              else if ( (cvCharSet == CharInfo::UNICODE ||  // default value is a _UCS2 string literal
-                         cvCharSet == CharInfo::UTF8)   &&  // or a _UTF8 string literal
-                         cdCharSet != cvCharSet )
-              {
-                //
-                // Check to see if all characters in the specified column default
-                // string literal value can be successfully converted/translated
-                // to the actual character set of the column.
-                //
-                char buf[2032];  // the output buffer - should be big enough
-                buf[0] = '\0';
-                enum cnv_charset eCnvCS = convertCharsetEnum( cdCharSet );
-                const char * pInStr = cvDef->getRawText()->data();
-                Int32 inStrLen = cvDef->getRawText()->length();
-                char * p1stUnstranslatedChar = NULL;
-                UInt32 outStrLenInBytes = 0;
-                unsigned charCount = 0;  // number of characters translated/converted
-                Int32 cnvErrStatus = 0;
-                char *pSubstitutionChar = NULL;
-                Int32 convFlags = 0;
-
-                if ( cvCharSet == CharInfo::UNICODE )
-                {
-                cnvErrStatus =
-                  UTF16ToLocale
-                    ( cnv_version1            // in  - const enum cnv_version version
-                    , pInStr                  // in  - const char *in_bufr
-                    , inStrLen                // in  - const int in_len
-                    , buf                     // out - const char *out_bufr
-                    , 2016                    // in  - const int out_len
-                    , eCnvCS                  // in  - enum cnv_charset charset
-                    , p1stUnstranslatedChar   // out - char * & first_untranslated_char
-                    , &outStrLenInBytes       // out - unsigned int *output_data_len_p
-                    , convFlags               // in  - const int cnv_flags
-                    , (Int32)TRUE               // in  - const int addNullAtEnd_flag
-                    , (Int32)FALSE              // in  - const int allow_invalids
-                    , &charCount              // out - unsigned int * translated_char_cnt_p
-                    , pSubstitutionChar       // in  - const char *substitution_char
-                    );
-                }
-                else // cvCharSet must be CharInfo::UTF8
-                {
-                cnvErrStatus =
-                  UTF8ToLocale
-                    ( cnv_version1            // in  - const enum cnv_version version
-                    , pInStr                  // in  - const char *in_bufr
-                    , inStrLen                // in  - const int in_len
-                    , buf                     // out - const char *out_bufr
-                    , 2016                    // in  - const int out_len
-                    , eCnvCS                  // in  - enum cnv_charset charset
-                    , p1stUnstranslatedChar   // out - char * & first_untranslated_char
-                    , &outStrLenInBytes       // out - unsigned int *output_data_len_p
-                    , (Int32)TRUE               // in  - const int addNullAtEnd_flag
-                    , (Int32)FALSE              // in  - const int allow_invalids
-                    , &charCount              // out - unsigned int * translated_char_cnt_p
-                    , pSubstitutionChar       // in  - const char *substitution_char
-                    );
-                }
-                switch (cnvErrStatus)
-                {
-                case 0: // success
-                case CNV_ERR_NOINPUT: // an empty input string will get this error code
-                  {
-                    ConstValue *pMBStrLitConstValue ;
-                    // convert the string literal saved in cvDef (column default value)
-                    // from UNICODE (e.g. UTF16) to the column character data type
-                    if ( cdCharSet != CharInfo::UNICODE)
-                    {
-                      NAString mbs2(buf, PARSERHEAP());  // note that buf is NULL terminated
-                      pMBStrLitConstValue =
-                        new(PARSERHEAP()) ConstValue ( mbs2
-                                                   , cdCharSet // use this for str lit prefix
-                                                   , CharInfo::DefaultCollation
-                                                   , CharInfo::COERCIBLE
-                                                   , PARSERHEAP()
-                                                   );
-                    }
-                    else
-                    {
-                      NAWString mbs2((NAWchar*)buf, PARSERHEAP());  // note that buf is NULL terminated
-                      pMBStrLitConstValue = 
-                        new(PARSERHEAP()) ConstValue ( mbs2
-                                                   , cdCharSet // use this for str lit prefix
-                                                   , CharInfo::DefaultCollation
-                                                   , CharInfo::COERCIBLE
-                                                   , PARSERHEAP()
-                                                   );
-                    }
-                    delete pDefault_; // deallocate the old ConstValue object
-                    cvDef = NULL;     // do not use cvDef anymore
-                    pDefault_ = pMBStrLitConstValue;
-                    pColDefault->setDefaultValueExpr(pDefault_);
-                  }
-                  break;
-                case CNV_ERR_INVALID_CHAR:
-                  {
-                    // 1401 ==  CAT_UNABLE_TO_CONVERT_COLUMN_DEFAULT_VALUE_TO_CHARSET
-                    *SqlParser_Diags << DgSqlCode(-1401)
-                                     << DgColumnName(ToAnsiIdentifier(getColumnName()))
-                                     << DgString0(CharInfo::getCharSetName(cdCharSet));
-                  }
-                  break;
-                case CNV_ERR_BUFFER_OVERRUN: // output buffer not big enough
-                case CNV_ERR_INVALID_CS:
-                default:
-                  CMPABORT_MSG("Parser internal logic error");
-                  break;
-                } // switch
-              }
-              else if(!pColumnDataType->isCompatible(*cvTyp))
-              {
-                if (NOT isAnErrorAlreadyIssued)
-                {
-                  *SqlParser_Diags << DgSqlCode(-1186)
-                                   << DgColumnName(ToAnsiIdentifier(getColumnName()))
-                                   << DgString0(pColumnDataType->getTypeSQLname(TRUE/*terse*/))
-                                   << DgString1(cvTyp->getTypeSQLname(TRUE/*terse*/));
-                  isAnErrorAlreadyIssued = TRUE;
-                }
-              }
-            } // column has character data type
-            else
-	    // if interval data type, the default value must have the same
-	    // interval qualifier as the column.
-            if (NOT isAnErrorAlreadyIssued &&
-                (!pColumnDataType->isCompatible(*cvTyp) ||
-                 (pColumnDataType->getTypeQualifier() == NA_INTERVAL_TYPE &&
-                  pColumnDataType->getFSDatatype() != cvTyp->getFSDatatype())))
-            {
-              *SqlParser_Diags << DgSqlCode(-1186)
-                               << DgColumnName(ToAnsiIdentifier(getColumnName()))
-                               << DgString0(pColumnDataType->getTypeSQLname(TRUE/*terse*/))
-                               << DgString1(cvTyp->getTypeSQLname(TRUE/*terse*/));
-              isAnErrorAlreadyIssued = TRUE;
-            }
-	  }
-	}
-      break;
-    case ElemDDLColDefault::COL_COMPUTED_DEFAULT:
-      {
-	defaultClauseStatus_ = DEFAULT_CLAUSE_SPEC;
-        computedDefaultExpr_ = pColDefault->getComputedDefaultExpr();
-      }
-      break;
-    default:
-      CMPABORT_MSG("Parser internal logic error");
-      break;
-    }
-  }
 
   //
   // Traverse the list of column attributes to check for duplicate
@@ -415,12 +175,12 @@ ElemDDLColDef::ElemDDLColDef(
   // has specified NOT NULL NOT DROPPABLE for IDENTITY
   // column. If not specified, then automatically add
   // it. 
-  if (isIdentityColumn)
+  if (pSGOptions_) //isIdentityColumn
     {
       // if NOT NULL not specified, then specify it here.
       if(NOT getIsConstraintNotNullSpecified())
 	isNotNullSpec_ = TRUE;
-
+      
       // [NOT] DROPPABLE is the only attribute for NOT NULL.
       if (pConstraintNotNull_)
 	{
@@ -431,12 +191,12 @@ ElemDDLColDef::ElemDDLColDef(
 			       << DgColumnName(ToAnsiIdentifier(getColumnName()));
 	      return;
 	    }
-		else
-		{
-		// add the NOT DROPPABLE attribute to the NOT NULL .
-		pConstraintNotNull_->setConstraintAttributes
-	    (new (PARSERHEAP()) ElemDDLConstraintAttrDroppable(FALSE)); 
-		}
+          else
+            {
+              // add the NOT DROPPABLE attribute to the NOT NULL .
+              pConstraintNotNull_->setConstraintAttributes
+                (new (PARSERHEAP()) ElemDDLConstraintAttrDroppable(FALSE)); 
+            }
 	}
       else
 	{
@@ -446,7 +206,7 @@ ElemDDLColDef::ElemDDLColDef(
 	    (new (PARSERHEAP()) ElemDDLConstraintAttrDroppable(FALSE)); 
 	}
     } //if isIdentityColumn
- 
+  
   //
   // All column attributes has been checked and saved.
   // If there exists a NOT NULL NONDROPPABLE constraint
@@ -530,6 +290,255 @@ ElemDDLColDef::setChild(Lng32 index, ExprNode * pChildNode)
 }
 
 void
+ElemDDLColDef::setDefaultAttribute(ElemDDLNode * pColDefaultNode)
+{
+  ElemDDLColDefault * pColDefault = NULL;
+  ComBoolean isIdentityColumn = FALSE;
+
+  NAType * pColumnDataType = columnDataType_;
+
+  if (pColDefaultNode NEQ NULL)
+    {
+      ComASSERT(pColDefaultNode->castToElemDDLColDefault() NEQ NULL);
+      pColDefault = pColDefaultNode->castToElemDDLColDefault();
+    }
+
+  if (pColDefault NEQ NULL)
+    {
+      switch (pColDefault->getColumnDefaultType())
+        {
+        case ElemDDLColDefault::COL_NO_DEFAULT:
+          defaultClauseStatus_ = NO_DEFAULT_CLAUSE_SPEC;
+          break;
+        case ElemDDLColDefault::COL_DEFAULT:
+          {
+            defaultClauseStatus_ = DEFAULT_CLAUSE_SPEC;
+            
+            if (pColDefault->getSGOptions())
+              {
+                isIdentityColumn = TRUE;
+                pSGOptions_ = pColDefault->getSGOptions();
+                pSGLocation_ = pColDefault->getSGLocation();
+              }
+            else
+              {
+                ComASSERT(pColDefault->getDefaultValueExpr() NEQ NULL);
+                pDefault_ = pColDefault->getDefaultValueExpr();
+              }
+            
+            // The cast ItemExpr to ConstValue for (ConstValue *)pDefault_; 
+            // statement below sets arbitary value for the isNULL_. 
+            // Bypass these checks for ID column (basically ITM_IDENTITY).
+            ConstValue *cvDef = (ConstValue *)pDefault_;
+            if ((cvDef && !cvDef->isNull()) && (!isIdentityColumn))
+              {
+                const NAType *cvTyp = cvDef->getType();
+                NABoolean isAnErrorAlreadyIssued = FALSE;
+                
+                if ( cvTyp->getTypeQualifier() == NA_CHARACTER_TYPE )
+                  {
+                    CharInfo::CharSet defaultValueCS = ((const CharType *)cvTyp)->getCharSet();
+                    // Always check for INFER_CHARSET setting before the ICAT setting.
+                    NAString inferCharSetFlag;
+                    if (getCharSetInferenceSetting(inferCharSetFlag) == TRUE &&
+                        NOT cvDef->isStrLitWithCharSetPrefixSpecified())
+                      {
+                        if (pColumnDataType->getTypeQualifier() == NA_CHARACTER_TYPE
+                            && ((const CharType *)pColumnDataType)->getCharSet() == CharInfo::UCS2
+                            && SqlParser_DEFAULT_CHARSET == CharInfo::UCS2
+                            && defaultValueCS == CharInfo::ISO88591
+                            )
+                          {
+                            *SqlParser_Diags << DgSqlCode(-1186)
+                                             << DgColumnName(ToAnsiIdentifier(getColumnName()))
+                                             << DgString0(pColumnDataType->getTypeSQLname(TRUE/*terse*/))
+                                             << DgString1(cvTyp->getTypeSQLname(TRUE/*terse*/));
+                            isAnErrorAlreadyIssued = TRUE;
+                          }
+                        else
+                          {
+                            cvTyp = cvDef -> pushDownType(*columnDataType_, NA_CHARACTER_TYPE);
+                          }
+                      }
+                    else if (CmpCommon::getDefault(ALLOW_IMPLICIT_CHAR_CASTING) == DF_ON &&
+                             NOT cvDef->isStrLitWithCharSetPrefixSpecified() &&
+                             cvTyp->getTypeQualifier() == NA_CHARACTER_TYPE &&
+                             SqlParser_DEFAULT_CHARSET == CharInfo::ISO88591 &&
+                             defaultValueCS == CharInfo::UnknownCharSet)
+                      {
+                        cvTyp = cvDef -> pushDownType(*columnDataType_, NA_CHARACTER_TYPE);
+                      }
+                    
+                  } // column default value has character data type
+                
+                if (NOT isAnErrorAlreadyIssued &&
+                    pColumnDataType->getTypeQualifier() == NA_CHARACTER_TYPE &&
+                    cvTyp->getTypeQualifier() == NA_CHARACTER_TYPE &&
+                    (
+                         CmpCommon::getDefault(ALLOW_IMPLICIT_CHAR_CASTING) == DF_ON ||
+                         NOT cvDef->isStrLitWithCharSetPrefixSpecified()))
+                  {
+                    const CharType *cdCharType = (const CharType *)pColumnDataType;
+                    const CharType *cvCharType = (const CharType *)cvTyp;
+                    CharInfo::CharSet cdCharSet = cdCharType->getCharSet(); // cd = column definition
+                    CharInfo::CharSet cvCharSet = cvCharType->getCharSet(); // cv = constant value
+                    if (cvCharSet == CharInfo::ISO88591)  // default value is a _ISO88591 str lit
+                      {
+                        
+                      }
+                    else if ( (cvCharSet == CharInfo::UNICODE ||  // default value is a _UCS2 string literal
+                               cvCharSet == CharInfo::UTF8)   &&  // or a _UTF8 string literal
+                              cdCharSet != cvCharSet )
+                      {
+                        //
+                        // Check to see if all characters in the specified column default
+                        // string literal value can be successfully converted/translated
+                        // to the actual character set of the column.
+                        //
+                        char buf[2032];  // the output buffer - should be big enough
+                        buf[0] = '\0';
+                        enum cnv_charset eCnvCS = convertCharsetEnum( cdCharSet );
+                        const char * pInStr = cvDef->getRawText()->data();
+                        Int32 inStrLen = cvDef->getRawText()->length();
+                        char * p1stUnstranslatedChar = NULL;
+                        UInt32 outStrLenInBytes = 0;
+                        unsigned charCount = 0;  // number of characters translated/converted
+                        Int32 cnvErrStatus = 0;
+                        char *pSubstitutionChar = NULL;
+                        Int32 convFlags = 0;
+                        
+                        if ( cvCharSet == CharInfo::UNICODE )
+                          {
+                            cnvErrStatus =
+                              UTF16ToLocale
+                              ( cnv_version1            // in  - const enum cnv_version version
+                                , pInStr                  // in  - const char *in_bufr
+                                , inStrLen                // in  - const int in_len
+                                , buf                     // out - const char *out_bufr
+                                , 2016                    // in  - const int out_len
+                                , eCnvCS                  // in  - enum cnv_charset charset
+                                , p1stUnstranslatedChar   // out - char * & first_untranslated_char
+                                , &outStrLenInBytes       // out - unsigned int *output_data_len_p
+                                , convFlags               // in  - const int cnv_flags
+                                , (Int32)TRUE               // in  - const int addNullAtEnd_flag
+                                , (Int32)FALSE              // in  - const int allow_invalids
+                                , &charCount              // out - unsigned int * translated_char_cnt_p
+                                , pSubstitutionChar       // in  - const char *substitution_char
+                                );
+                          }
+                        else // cvCharSet must be CharInfo::UTF8
+                          {
+                            cnvErrStatus =
+                              UTF8ToLocale
+                              ( cnv_version1            // in  - const enum cnv_version version
+                                , pInStr                  // in  - const char *in_bufr
+                                , inStrLen                // in  - const int in_len
+                                , buf                     // out - const char *out_bufr
+                                , 2016                    // in  - const int out_len
+                                , eCnvCS                  // in  - enum cnv_charset charset
+                                , p1stUnstranslatedChar   // out - char * & first_untranslated_char
+                                , &outStrLenInBytes       // out - unsigned int *output_data_len_p
+                                , (Int32)TRUE               // in  - const int addNullAtEnd_flag
+                                , (Int32)FALSE              // in  - const int allow_invalids
+                                , &charCount              // out - unsigned int * translated_char_cnt_p
+                                , pSubstitutionChar       // in  - const char *substitution_char
+                                );
+                          }
+                        switch (cnvErrStatus)
+                          {
+                          case 0: // success
+                          case CNV_ERR_NOINPUT: // an empty input string will get this error code
+                            {
+                              ConstValue *pMBStrLitConstValue ;
+                              // convert the string literal saved in cvDef (column default value)
+                              // from UNICODE (e.g. UTF16) to the column character data type
+                              if ( cdCharSet != CharInfo::UNICODE)
+                                {
+                                  NAString mbs2(buf, PARSERHEAP());  // note that buf is NULL terminated
+                                  pMBStrLitConstValue =
+                                    new(PARSERHEAP()) ConstValue ( mbs2
+                                                                   , cdCharSet // use this for str lit prefix
+                                                                   , CharInfo::DefaultCollation
+                                                                   , CharInfo::COERCIBLE
+                                                                   , PARSERHEAP()
+                                                                   );
+                                }
+                              else
+                                {
+                                  NAWString mbs2((NAWchar*)buf, PARSERHEAP());  // note that buf is NULL terminated
+                                  pMBStrLitConstValue = 
+                                    new(PARSERHEAP()) ConstValue ( mbs2
+                                                                   , cdCharSet // use this for str lit prefix
+                                                                   , CharInfo::DefaultCollation
+                                                                   , CharInfo::COERCIBLE
+                                                                   , PARSERHEAP()
+                                                                   );
+                                }
+                              delete pDefault_; // deallocate the old ConstValue object
+                              cvDef = NULL;     // do not use cvDef anymore
+                              pDefault_ = pMBStrLitConstValue;
+                              pColDefault->setDefaultValueExpr(pDefault_);
+                            }
+                            break;
+                          case CNV_ERR_INVALID_CHAR:
+                            {
+                              // 1401 ==  CAT_UNABLE_TO_CONVERT_COLUMN_DEFAULT_VALUE_TO_CHARSET
+                              *SqlParser_Diags << DgSqlCode(-1401)
+                                               << DgColumnName(ToAnsiIdentifier(getColumnName()))
+                                               << DgString0(CharInfo::getCharSetName(cdCharSet));
+                            }
+                            break;
+                          case CNV_ERR_BUFFER_OVERRUN: // output buffer not big enough
+                          case CNV_ERR_INVALID_CS:
+                          default:
+                            CMPABORT_MSG("Parser internal logic error");
+                            break;
+                          } // switch
+                      }
+                    else if(!pColumnDataType->isCompatible(*cvTyp))
+                      {
+                        if (NOT isAnErrorAlreadyIssued)
+                          {
+                            *SqlParser_Diags << DgSqlCode(-1186)
+                                             << DgColumnName(ToAnsiIdentifier(getColumnName()))
+                                             << DgString0(pColumnDataType->getTypeSQLname(TRUE/*terse*/))
+                                             << DgString1(cvTyp->getTypeSQLname(TRUE/*terse*/));
+                            isAnErrorAlreadyIssued = TRUE;
+                          }
+                      }
+                  } // column has character data type
+                else
+                  // if interval data type, the default value must have the same
+                  // interval qualifier as the column.
+                  if (NOT isAnErrorAlreadyIssued &&
+                      (!pColumnDataType->isCompatible(*cvTyp) ||
+                       (pColumnDataType->getTypeQualifier() == NA_INTERVAL_TYPE &&
+                        pColumnDataType->getFSDatatype() != cvTyp->getFSDatatype())))
+                    {
+                      *SqlParser_Diags << DgSqlCode(-1186)
+                                       << DgColumnName(ToAnsiIdentifier(getColumnName()))
+                                       << DgString0(pColumnDataType->getTypeSQLname(TRUE/*terse*/))
+                                       << DgString1(cvTyp->getTypeSQLname(TRUE/*terse*/));
+                      isAnErrorAlreadyIssued = TRUE;
+                    }
+              }
+          }
+          break;
+        case ElemDDLColDefault::COL_COMPUTED_DEFAULT:
+          {
+            defaultClauseStatus_ = DEFAULT_CLAUSE_SPEC;
+            computedDefaultExpr_ = pColDefault->getComputedDefaultExpr();
+          }
+          break;
+        default:
+          CMPABORT_MSG("Parser internal logic error");
+          break;
+        }
+    }
+
+}
+
+void
 ElemDDLColDef::setColumnAttribute(ElemDDLNode * pColAttr)
 {
   switch(pColAttr->getOperatorType())
@@ -564,6 +573,7 @@ ElemDDLColDef::setColumnAttribute(ElemDDLNode * pColAttr)
     {
       // Duplicate NOT NULL clauses in column definition.
       *SqlParser_Diags << DgSqlCode(-3052)
+                       << DgString0("NOT NULL")
                        << DgColumnName(ToAnsiIdentifier(getColumnName()));
     }
     isNotNullSpec_ = TRUE;
@@ -692,8 +702,9 @@ ElemDDLColDef::setColumnAttribute(ElemDDLNode * pColAttr)
 	if(TRUE == isLobAttrsSpec_)
 	  {
 	    // Duplicate LOB attrs in column definition.
-	    *SqlParser_Diags << DgSqlCode(-12064)
-			     << DgColumnName(ToAnsiIdentifier(getColumnName()));
+            *SqlParser_Diags << DgSqlCode(-3052)
+                             << DgString0("LOB")
+                             << DgColumnName(ToAnsiIdentifier(getColumnName()));
 	  }
       
       isLobAttrsSpec_ = TRUE;
@@ -706,13 +717,30 @@ ElemDDLColDef::setColumnAttribute(ElemDDLNode * pColAttr)
       ComASSERT( NULL NEQ pColAttr->castToElemDDLSeabaseSerialized())
 	if(TRUE == isSeabaseSerializedSpec_)
 	  {
-	    // Duplicate attrs in column definition.
-	    *SqlParser_Diags << DgSqlCode(-12064)
-			     << DgColumnName(ToAnsiIdentifier(getColumnName()));
+	    // Duplicate SERIALIZED attrs in column definition.
+            *SqlParser_Diags << DgSqlCode(-3052)
+                             << DgString0("SERIALIZED")
+                             << DgColumnName(ToAnsiIdentifier(getColumnName()));
 	  }
       
       isSeabaseSerializedSpec_ = TRUE;
       seabaseSerialized_ =  pColAttr->castToElemDDLSeabaseSerialized()->serialized();
+    }
+    break;
+
+  case ELM_COL_DEFAULT_ELEM:
+    {
+      ComASSERT( NULL NEQ pColAttr->castToElemDDLColDefault());
+	if(TRUE == isColDefaultSpec_)
+	  {
+	    // Duplicate DEFAULT attrs in column definition.
+            *SqlParser_Diags << DgSqlCode(-3052)
+                             << DgString0("DEFAULT")
+                             << DgColumnName(ToAnsiIdentifier(getColumnName()));
+	  }
+      
+      isColDefaultSpec_ = TRUE;
+      setDefaultAttribute(pColAttr->castToElemDDLColDefault());
     }
     break;
 
@@ -1555,7 +1583,7 @@ ElemProxyColDef::ElemProxyColDef(QualifiedName *tableName,
                                  NAType *type,
                                  ElemDDLNode *colAttrs,
                                  CollHeap *heap)
-     : ElemDDLColDef(NULL, &colName, type, NULL, colAttrs, heap),
+     : ElemDDLColDef(NULL, &colName, type, colAttrs, heap),
        tableName_(tableName)
 {
 }

--- a/core/sql/parser/ElemDDLColDef.h
+++ b/core/sql/parser/ElemDDLColDef.h
@@ -74,13 +74,14 @@ public:
   enum defaultClauseStatusType { DEFAULT_CLAUSE_NOT_SPEC = 0,
                                  NO_DEFAULT_CLAUSE_SPEC = 1,
                                  DEFAULT_CLAUSE_SPEC = 2};
-  
+  enum { INDEX_ELEM_DDL_COL_ATTR_LIST = 0,
+         MAX_ELEM_DDL_COL_DEF_ARITY = 1};
+
   // default constructor
   ElemDDLColDef(
        const NAString * columnFamily,
        const NAString * columnName,
        NAType * pColumnDataType,
-       ElemDDLNode * pColDefaultValue = NULL,
        ElemDDLNode * pColAttrList = NULL,
        CollHeap * heap = PARSERHEAP());
 
@@ -115,6 +116,8 @@ public:
 
   void setDefaultClauseStatus(defaultClauseStatusType d)
   { defaultClauseStatus_ = d; }
+
+  void setDefaultAttribute(ElemDDLNode * pColDefaultNode);
 
   inline const defaultClauseStatusType getDefaultClauseStatus() const;
 
@@ -200,6 +203,8 @@ public:
 
   NABoolean isSerializedSpecified() { return isSeabaseSerializedSpec_; }
   inline NABoolean isSeabaseSerialized() { return seabaseSerialized_; }
+
+  NABoolean isColDefaultSpecified() { return isColDefaultSpec_; }
 
   //
   // methods for tracing
@@ -292,10 +297,6 @@ private:
   //   Column Attributes list includes column constraint definitions
   //   and column heading specification (HEADING clause).
   //
-  enum { INDEX_ELEM_DDL_COL_DEFAULT_VALUE = 0,
-         INDEX_ELEM_DDL_COL_ATTR_LIST,
-         MAX_ELEM_DDL_COL_DEF_ARITY };
-
   ElemDDLNode * children_[MAX_ELEM_DDL_COL_DEF_ARITY];
 
   ComColumnDirection direction_;  // IN / OUT / INOUT
@@ -307,6 +308,7 @@ private:
   NABoolean isSeabaseSerializedSpec_;
   NABoolean seabaseSerialized_;
 
+  NABoolean isColDefaultSpec_;
 }; // class ElemDDLColDef
 
 // -----------------------------------------------------------------------

--- a/core/sql/parser/StmtDDLCreate.cpp
+++ b/core/sql/parser/StmtDDLCreate.cpp
@@ -4418,9 +4418,9 @@ StmtDDLCreateTable::synthesize()
 	  col->setColumnAttribute(pk);
 
 	  ElemDDLNode * pColAttrList = NULL;
-	  if (col->getChild(1))
+	  if (col->getChild(ElemDDLColDef::INDEX_ELEM_DDL_COL_ATTR_LIST))
 	    pColAttrList =
-	      col->getChild(1)->castToElemDDLNode(); //INDEX_ELEM_DDL_COL_ATTR_LIST);
+	      col->getChild(ElemDDLColDef::INDEX_ELEM_DDL_COL_ATTR_LIST)->castToElemDDLNode();
 	  
 	  ElemDDLNode * newColAttrList = NULL;
 	  if (pColAttrList)
@@ -4428,7 +4428,8 @@ StmtDDLCreateTable::synthesize()
 	      new (PARSERHEAP()) ElemDDLList(pColAttrList, pk);
 	  else
 	    newColAttrList = pk;
-	  col->setChild(1 /*INDEX_ELEM_DDL_COL_ATTR_LIST*/, newColAttrList);
+	  col->setChild(ElemDDLColDef::INDEX_ELEM_DDL_COL_ATTR_LIST, 
+                        newColAttrList);
 
 	  userSpecifiedPKey = TRUE;
 	}

--- a/core/sql/parser/sqlparser.y
+++ b/core/sql/parser/sqlparser.y
@@ -2553,7 +2553,6 @@ static void enableMakeQuotedStringISO88591Mechanism()
 %type <pElemDDL>  		column_attributes
 %type <pElemDDL>  		column_attribute
 %type <tokval>    		constraints_keyword
-%type <pElemDDL>  		optional_col_def_default_clause
 %type <pElemDDL>  		col_def_default_clause
 %type <pElemDDL>  		col_def_default_clause_argument
 %type <pElemDDL>                alter_col_default_clause_arg
@@ -24930,8 +24929,7 @@ reset_in_column_defn :
                   }
 
 /* type pElemDDL */
-column_definition : qualified_name data_type optional_col_def_default_clause
-                                optional_column_attributes
+column_definition : qualified_name data_type optional_column_attributes
                                 {
                                   NAType * type = $2;
 
@@ -24995,8 +24993,7 @@ column_definition : qualified_name data_type optional_col_def_default_clause
                                          colFam /* column family */,
                                          colNam /*column_name*/,
                                          type /*data_type*/,
-                                         $3 /*optional_col_def_default_clause*/,
-                                         $4 /*optional_column_attributes*/);
+                                         $3 /*optional_column_attributes*/);
                                   delete $1 /*column_name*/;
                                 }
 
@@ -25030,7 +25027,6 @@ column_definition : qualified_name
 				    ElemDDLColDef(
                                          colFam /* column family */,
                                          colNam /*column_name*/,
-                                          NULL,
                                          NULL,
                                          NULL);
                                   delete $1 /*column_name*/;
@@ -25038,14 +25034,6 @@ column_definition : qualified_name
 
 /* type stringval */
 column_name : identifier
-
-/* type pElemDDL */
-optional_col_def_default_clause : empty
-                                {
-                                  $$ = NULL;
-                                }
-
-                      | col_def_default_clause
 
 /* type pElemDDL */
 col_def_default_clause : TOK_DEFAULT enableCharsetInferenceInColDefaultVal col_def_default_clause_argument
@@ -25164,6 +25152,7 @@ column_attribute : column_constraint_definition
                     | optional_lobattrs
                     | heading
                     | serialized
+                    | col_def_default_clause
 
 /* type pElemDDL */
 column_constraint_definition :  constraint_name_definition

--- a/core/sql/regress/seabase/EXPECTED010
+++ b/core/sql/regress/seabase/EXPECTED010
@@ -10383,7 +10383,7 @@ _SALT_      A            B           C            D
 >>drop table if exists minotaur.events_load75;
 
 --- SQL operation complete.
->>create schema minotaur;
+>>create schema if not exists minotaur;
 
 --- SQL operation complete.
 >>CREATE TABLE if not exists TRAFODION.MINOTAUR.EVENTS_LOAD75

--- a/core/sql/regress/seabase/EXPECTED027
+++ b/core/sql/regress/seabase/EXPECTED027
@@ -12,7 +12,7 @@
 >>invoke t027t01;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T01
--- Definition current  Sat Mar 12 02:58:49 2016
+-- Definition current  Mon Mar 21 01:06:26 2016
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -40,7 +40,7 @@ CREATE TABLE TRAFODION.SCH027.T027T01
 >>invoke t027t01;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T01
--- Definition current  Sat Mar 12 02:58:59 2016
+-- Definition current  Mon Mar 21 01:06:35 2016
 
   (
     "cf".A                           INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -69,7 +69,7 @@ CREATE TABLE TRAFODION.SCH027.T027T01
 >>invoke t027t01;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T01
--- Definition current  Sat Mar 12 02:59:05 2016
+-- Definition current  Mon Mar 21 01:06:41 2016
 
   (
     "cf".A                           INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -101,7 +101,7 @@ CREATE TABLE TRAFODION.SCH027.T027T01
 >>invoke t027t01;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T01
--- Definition current  Sat Mar 12 02:59:14 2016
+-- Definition current  Mon Mar 21 01:06:46 2016
 
   (
     "cf".A                           INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -131,7 +131,7 @@ CREATE TABLE TRAFODION.SCH027.T027T01
 >>invoke t027t01;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T01
--- Definition current  Sat Mar 12 02:59:16 2016
+-- Definition current  Mon Mar 21 01:06:54 2016
 
   (
     "cf".A                           INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -196,7 +196,7 @@ A            B            C
 >>invoke t027t01;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T01
--- Definition current  Sat Mar 12 02:59:22 2016
+-- Definition current  Mon Mar 21 01:06:59 2016
 
   (
     "cf".A                           INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -234,7 +234,7 @@ CREATE INDEX T027T01I1 ON TRAFODION.SCH027.T027T01
 >>invoke t027t01;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T01
--- Definition current  Sat Mar 12 02:59:26 2016
+-- Definition current  Mon Mar 21 01:07:06 2016
 
   (
     "cf".A                           INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -274,7 +274,7 @@ CREATE INDEX T027T01I1 ON TRAFODION.SCH027.T027T01
 >>invoke t027t01;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T01
--- Definition current  Sat Mar 12 02:59:31 2016
+-- Definition current  Mon Mar 21 01:07:11 2016
 
   (
     "cf".A                           INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -312,7 +312,7 @@ CREATE INDEX T027T01I1 ON TRAFODION.SCH027.T027T01
 >>invoke t027t01;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T01
--- Definition current  Sat Mar 12 02:59:32 2016
+-- Definition current  Mon Mar 21 01:07:12 2016
 
   (
     "cf".A                           INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -352,7 +352,7 @@ CREATE INDEX T027T01I1 ON TRAFODION.SCH027.T027T01
 >>invoke t027t011;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T011
--- Definition current  Sat Mar 12 02:59:40 2016
+-- Definition current  Mon Mar 21 01:07:15 2016
 
   (
     "cf".A                           INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -397,7 +397,7 @@ A            B            C            E            D
 >>invoke t027t011;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T011
--- Definition current  Sat Mar 12 02:59:43 2016
+-- Definition current  Mon Mar 21 01:07:19 2016
 
   (
     "cf".A                           INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -437,7 +437,7 @@ CREATE TABLE TRAFODION.SCH027.T027T011
 >>invoke t027t011;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T011
--- Definition current  Sat Mar 12 02:59:53 2016
+-- Definition current  Mon Mar 21 01:07:28 2016
 
   (
     SYSKEY                           LARGEINT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -472,7 +472,7 @@ CREATE TABLE TRAFODION.SCH027.T027T011
 >>invoke t027t011;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T011
--- Definition current  Sat Mar 12 02:59:57 2016
+-- Definition current  Mon Mar 21 01:07:32 2016
 
   (
     SYSKEY                           LARGEINT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -504,7 +504,7 @@ CREATE TABLE TRAFODION.SCH027.T027T011
 >>invoke t027t03;
 
 -- Definition of Trafodion volatile table T027T03
--- Definition current  Sat Mar 12 03:00:03 2016
+-- Definition current  Mon Mar 21 01:07:38 2016
 
   (
     "cf1".A                          INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -536,7 +536,7 @@ CREATE VOLATILE TABLE T027T03
 >>invoke t027t03;
 
 -- Definition of Trafodion volatile table T027T03
--- Definition current  Sat Mar 12 03:00:24 2016
+-- Definition current  Mon Mar 21 01:07:58 2016
 
   (
     "cf1".A                          INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -585,7 +585,7 @@ CREATE VOLATILE TABLE T027T03
 >>invoke t027t02;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T02
--- Definition current  Sat Mar 12 03:00:45 2016
+-- Definition current  Mon Mar 21 01:08:18 2016
 
   (
     "cf".SYSKEY                      LARGEINT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -637,7 +637,7 @@ CREATE VOLATILE TABLE T027T03
 >>invoke t027t03;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T03
--- Definition current  Sat Mar 12 03:01:07 2016
+-- Definition current  Mon Mar 21 01:08:40 2016
 
   (
     "cf1".A                          INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -674,7 +674,7 @@ A            B            C            D
 >>invoke t027t02;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T02
--- Definition current  Sat Mar 12 03:01:20 2016
+-- Definition current  Mon Mar 21 01:08:53 2016
 
   (
     OBJECT_UID                       LARGEINT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -787,7 +787,7 @@ create index t027t01i2 on t027t01("cf2".b);
 >>invoke t027t7;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T7
--- Definition current  Sat Mar 12 03:01:46 2016
+-- Definition current  Mon Mar 21 01:09:19 2016
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -819,7 +819,7 @@ A            B   C                 Z
 >>invoke t027t7;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T7
--- Definition current  Sat Mar 12 03:01:54 2016
+-- Definition current  Mon Mar 21 01:09:28 2016
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -840,7 +840,7 @@ A            B   C                 Z
 >>invoke t027t7;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T7
--- Definition current  Sat Mar 12 03:02:19 2016
+-- Definition current  Mon Mar 21 01:09:51 2016
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -861,7 +861,7 @@ A            B   C                 Z
 >>invoke t027t7;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T7
--- Definition current  Sat Mar 12 03:02:42 2016
+-- Definition current  Mon Mar 21 01:10:14 2016
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -883,7 +883,7 @@ A            B   C                 Z
 >>invoke t027t7;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T7
--- Definition current  Sat Mar 12 03:03:05 2016
+-- Definition current  Mon Mar 21 01:10:35 2016
 
   (
     A                                LARGEINT DEFAULT NULL /*altered_col*/
@@ -904,7 +904,7 @@ A            B   C                 Z
 >>invoke t027t7;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T7
--- Definition current  Sat Mar 12 03:03:25 2016
+-- Definition current  Mon Mar 21 01:10:55 2016
 
   (
     A                                LARGEINT DEFAULT NULL /*altered_col*/
@@ -925,7 +925,7 @@ A            B   C                 Z
 >>invoke t027t7;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T7
--- Definition current  Sat Mar 12 03:03:42 2016
+-- Definition current  Mon Mar 21 01:11:16 2016
 
   (
     A                                LARGEINT DEFAULT NULL /*altered_col*/
@@ -946,7 +946,7 @@ A            B   C                 Z
 >>invoke t027t7;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T7
--- Definition current  Sat Mar 12 03:04:05 2016
+-- Definition current  Mon Mar 21 01:11:35 2016
 
   (
     A                                LARGEINT DEFAULT NULL /*altered_col*/
@@ -967,7 +967,7 @@ A            B   C                 Z
 >>invoke t027t7;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T7
--- Definition current  Sat Mar 12 03:04:25 2016
+-- Definition current  Mon Mar 21 01:12:03 2016
 
   (
     A                                INT DEFAULT NULL /*altered_col*/
@@ -988,7 +988,7 @@ A            B   C                 Z
 >>invoke t027t7;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T7
--- Definition current  Sat Mar 12 03:04:44 2016
+-- Definition current  Mon Mar 21 01:12:26 2016
 
   (
     A                                SMALLINT DEFAULT 0 NOT NULL NOT DROPPABLE
@@ -1025,7 +1025,7 @@ A       B   C       Z
 >>invoke t027t7;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T7
--- Definition current  Sat Mar 12 03:05:07 2016
+-- Definition current  Mon Mar 21 01:12:50 2016
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -1057,7 +1057,7 @@ A            B   C                 Z
 >>invoke t027t7;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T7
--- Definition current  Sat Mar 12 03:05:32 2016
+-- Definition current  Mon Mar 21 01:13:16 2016
 
   (
     A                                LARGEINT DEFAULT NULL /*altered_col*/
@@ -1086,7 +1086,7 @@ A                     B   C                 Z
 >>invoke t027t7;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T7
--- Definition current  Sat Mar 12 03:05:57 2016
+-- Definition current  Mon Mar 21 01:13:44 2016
 
   (
     A                                LARGEINT DEFAULT NULL /*altered_col*/
@@ -1113,7 +1113,7 @@ A                     C                 Z
 >>invoke t027t7;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T7
--- Definition current  Sat Mar 12 03:06:00 2016
+-- Definition current  Mon Mar 21 01:13:51 2016
 
   (
     A                                LARGEINT DEFAULT NULL /*altered_col*/
@@ -1142,7 +1142,7 @@ A                     C                 Z            B
 >>invoke t027t7;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T7
--- Definition current  Sat Mar 12 03:06:25 2016
+-- Definition current  Mon Mar 21 01:14:16 2016
 
   (
     A                                LARGEINT DEFAULT NULL /*altered_col*/
@@ -1177,7 +1177,7 @@ SCH027.T027V1
 >>invoke t027v1;
 
 -- Definition of Trafodion view TRAFODION.SCH027.T027V1
--- Definition current  Sat Mar 12 03:06:33 2016
+-- Definition current  Mon Mar 21 01:14:24 2016
 
   (
     A                                LARGEINT DEFAULT NULL
@@ -1193,7 +1193,7 @@ SCH027.T027V1
 >>invoke t027v1;
 
 -- Definition of Trafodion view TRAFODION.SCH027.T027V1
--- Definition current  Sat Mar 12 03:07:06 2016
+-- Definition current  Mon Mar 21 01:14:58 2016
 
   (
     A                                SMALLINT DEFAULT NULL
@@ -1266,7 +1266,7 @@ SCH027.T027V1
 >>invoke t027t7;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T7
--- Definition current  Sat Mar 12 03:09:01 2016
+-- Definition current  Mon Mar 21 01:17:02 2016
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -1295,7 +1295,7 @@ A            B   C                 Z
 >>invoke t027t7;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T7
--- Definition current  Sat Mar 12 03:09:12 2016
+-- Definition current  Mon Mar 21 01:17:13 2016
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -1324,7 +1324,7 @@ A            BB  C                 Z
 >>invoke t027t7;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T7
--- Definition current  Sat Mar 12 03:09:24 2016
+-- Definition current  Mon Mar 21 01:17:28 2016
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -1534,16 +1534,93 @@ SCH027.T027V122
 >>invoke t027t7;
 
 -- Definition of Trafodion table TRAFODION.SCH027.T027T7
--- Definition current  Thu Mar 17 14:48:27 2016
+-- Definition current  Mon Mar 21 01:21:43 2016
 
   (
-    SYSKEY                           INT NO DEFAULT NOT NULL NOT DROPPABLE 
+    SYSKEY                           INT NO DEFAULT NOT NULL NOT DROPPABLE
   , "_SALT_"                         INT DEFAULT NULL /*altered_col*/
   , "_DIVISION_1"                    INT DEFAULT NULL /*added_col*/
   )
   PRIMARY KEY (SYSKEY ASC)
 
 --- SQL operation complete.
+>>
+>>-- not null and default clause can appear in any order
+>>drop table if exists t027t1 cascade;
+
+--- SQL operation complete.
+>>create table t027t1 (a int, b int not null, c int default 10,
++>   d int default 10 not null, e int not null default 10, 
++>   f int not null default 10 check (f > 0),
++>   g int not null not droppable default 10);
+
+--- SQL operation complete.
+>>invoke t027t1;
+
+-- Definition of Trafodion table TRAFODION.SCH027.T027T1
+-- Definition current  Mon Mar 21 01:21:53 2016
+
+  (
+    SYSKEY                           LARGEINT NO DEFAULT NOT NULL NOT DROPPABLE
+  , A                                INT DEFAULT NULL
+  , B                                INT NO DEFAULT NOT NULL NOT DROPPABLE
+  , C                                INT DEFAULT 10
+  , D                                INT DEFAULT 10 NOT NULL NOT DROPPABLE
+  , E                                INT DEFAULT 10 NOT NULL NOT DROPPABLE
+  , F                                INT DEFAULT 10 NOT NULL NOT DROPPABLE
+  , G                                INT DEFAULT 10 NOT NULL NOT DROPPABLE
+  )
+
+--- SQL operation complete.
+>>insert into t027t1 (b) values (10);
+
+--- 1 row(s) inserted.
+>>select * from t027t1;
+
+A            B            C            D            E            F            G
+-----------  -----------  -----------  -----------  -----------  -----------  -----------
+
+          ?           10           10           10           10           10           10
+
+--- 1 row(s) selected.
+>>alter table t027t1 add column h int not null default 10;
+
+--- SQL operation complete.
+>>invoke t027t1;
+
+-- Definition of Trafodion table TRAFODION.SCH027.T027T1
+-- Definition current  Mon Mar 21 01:22:00 2016
+
+  (
+    SYSKEY                           LARGEINT NO DEFAULT NOT NULL NOT DROPPABLE
+  , A                                INT DEFAULT NULL
+  , B                                INT NO DEFAULT NOT NULL NOT DROPPABLE
+  , C                                INT DEFAULT 10
+  , D                                INT DEFAULT 10 NOT NULL NOT DROPPABLE
+  , E                                INT DEFAULT 10 NOT NULL NOT DROPPABLE
+  , F                                INT DEFAULT 10 NOT NULL NOT DROPPABLE
+  , G                                INT DEFAULT 10 NOT NULL NOT DROPPABLE
+  , H                                INT DEFAULT 10 NOT NULL NOT DROPPABLE
+      /*added_col*/
+  )
+
+--- SQL operation complete.
+>>select * from t027t1;
+
+A            B            C            D            E            F            G            H
+-----------  -----------  -----------  -----------  -----------  -----------  -----------  -----------
+
+          ?           10           10           10           10           10           10           10
+
+--- 1 row(s) selected.
+>>
+>>--should give error
+>>create table t027t2 (a int default 10 not null default 20);
+
+*** ERROR[3052] Duplicate DEFAULT clauses were specified in column definition A.
+
+*** ERROR[8822] The statement was not prepared.
+
 >>
 >>-- cleanup
 >>?section clean_up

--- a/core/sql/regress/seabase/TEST010
+++ b/core/sql/regress/seabase/TEST010
@@ -281,7 +281,7 @@ select "_SALT_", * from table(table t010t3, partition number from 1 to 3);
 
 ?section otherMdam
 drop table if exists minotaur.events_load75;
-create schema minotaur;
+create schema if not exists minotaur;
 CREATE TABLE if not exists TRAFODION.MINOTAUR.EVENTS_LOAD75
   (
     SRCIP                            CHAR(45) CHARACTER SET ISO88591 COLLATE

--- a/core/sql/regress/seabase/TEST027
+++ b/core/sql/regress/seabase/TEST027
@@ -308,6 +308,22 @@ alter table t027t7 add column "_DIVISION_1" int;
 alter table t027t7 alter column b rename to "_SALT_";
 invoke t027t7;
 
+-- not null and default clause can appear in any order
+drop table if exists t027t1 cascade;
+create table t027t1 (a int, b int not null, c int default 10,
+   d int default 10 not null, e int not null default 10, 
+   f int not null default 10 check (f > 0),
+   g int not null not droppable default 10);
+invoke t027t1;
+insert into t027t1 (b) values (10);
+select * from t027t1;
+alter table t027t1 add column h int not null default 10;
+invoke t027t1;
+select * from t027t1;
+
+--should give error
+create table t027t2 (a int default 10 not null default 20);
+
 -- cleanup
 ?section clean_up
 drop table if exists t027t7 cascade;

--- a/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
@@ -5727,7 +5727,7 @@ short CmpSeabaseDDL::buildColInfoArray(
       ElemDDLParamDef *paramNode = (*paramArray)[index];
       ElemDDLColDef colNode(NULL, &paramNode->getParamName(), 
                             paramNode->getParamDataType(),
-                            NULL, NULL, STMTHEAP);
+                            NULL, STMTHEAP);
 
       NAString colFamily;
       NAString colName;

--- a/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
@@ -1548,7 +1548,7 @@ short CmpSeabaseDDL::createSeabaseTable2(
 
   NAString syskeyColName("SYSKEY");
   SQLLargeInt * syskeyType = new(STMTHEAP) SQLLargeInt(TRUE, FALSE, STMTHEAP);
-  ElemDDLColDef syskeyColDef(NULL, &syskeyColName, syskeyType, NULL, NULL,
+  ElemDDLColDef syskeyColDef(NULL, &syskeyColName, syskeyType, NULL,
                              STMTHEAP);
   ElemDDLColRef edcr("SYSKEY", COM_ASCENDING_ORDER);
   CollIndex numSysCols = 0;
@@ -1688,7 +1688,7 @@ short CmpSeabaseDDL::createSeabaseTable2(
              ElemDDLColDefault::COL_COMPUTED_DEFAULT);
       saltDef->setComputedDefaultExpr(saltExprText);
       ElemDDLColDef * saltColDef =
-        new(STMTHEAP) ElemDDLColDef(NULL, &saltColName, saltType, saltDef, NULL,
+        new(STMTHEAP) ElemDDLColDef(NULL, &saltColName, saltType, saltDef,
                                     STMTHEAP);
 
       ElemDDLColRef * edcrs = 
@@ -1866,7 +1866,7 @@ short CmpSeabaseDDL::createSeabaseTable2(
               boundDivExpr->unparse(divExprText, PARSER_PHASE, COMPUTED_COLUMN_FORMAT);
               divColDefault->setComputedDefaultExpr(divExprText);
               ElemDDLColDef * divColDef =
-                new(STMTHEAP) ElemDDLColDef(NULL, &divColName, divColType, divColDefault, NULL,
+                new(STMTHEAP) ElemDDLColDef(NULL, &divColName, divColType, divColDefault,
                                             STMTHEAP);
 
               ElemDDLColRef * edcrs = 

--- a/core/sql/sqlcomp/CmpSeabaseDDLview.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLview.cpp
@@ -234,7 +234,6 @@ short CmpSeabaseDDL::buildViewColInfo(StmtDDLCreateView * createViewParseNode,
       colDefArray->insert(new (STMTHEAP) ElemDDLColDef
 			  ( NULL, &viewColDefArray[i]->getColumnName()
 			    , (NAType *)&valIdList[i].getType()
-			    , NULL    // default value (n/a for view def)
 			    , NULL    // col attr list (not needed)
 
 			    , STMTHEAP));


### PR DESCRIPTION
Default clause can now appear in any order during column definition of
a create table or alter table statement.
One can specify any mix of "not null", "default", "constraint..." and other
column attributes.
