### PR TITLE
[TRAFODION-1720] rework, fix a bug in it

### DIFF
--- a/core/sql/generator/GenRelScan.cpp
+++ b/core/sql/generator/GenRelScan.cpp
@@ -232,7 +232,7 @@ int HbaseAccess::createAsciiColAndCastExpr(Generator * generator,
   // HIVE_FILE_CHARSET can only be empty or GBK
   else if (  needTranslate == TRUE )
   {
-      asciiType =  new (h) SQLVarChar(sizeof(Int64)/2, newGivenType->supportsSQLnull(),
+      asciiType =  new (h) SQLVarChar(sizeof(Int64), newGivenType->supportsSQLnull(),
                                       FALSE, FALSE, CharInfo::GBK);
   }
   else


### PR DESCRIPTION
It was found previous fix will cause abort if the src contains 'full-width' chars. The guess is the pointer length is not enough. So here, I simulate the same behavior as UTF8 before.
 asciiType =  new (h) SQLVarChar(sizeof(Int64) ... 
that means the max length is 8, not 4. This is a pointer to real data not the data itself.

With this change I test with:
ＲＥＡＬ
and it works well.