### PR TITLE
TRAFODION-1910 mxosrvr crashes on Hive query after reconnect

### DIFF
--- a/core/sql/cli/CliExtern.cpp
+++ b/core/sql/cli/CliExtern.cpp
@@ -6316,7 +6316,8 @@ Lng32 SQL_EXEC_DeleteHbaseJNI()
       threadContext->incrNumOfCliCalls();
 
       HBaseClient_JNI::deleteInstance();
-      HiveClient_JNI::deleteInstance();
+      // The Hive client persists across connections
+      // HiveClient_JNI::deleteInstance();
    }
    catch(...)
    {


### PR DESCRIPTION
NATableDB is caching a pointer to a HiveClient_JNI object
(HiveMetaData::client_), but that object gets deallocated when a JDBC
client disconnects.  Fixing this by keeping the HiveClient_JNI around
across sessions.