### PR TITLE
TRAFODION-1910 mxosrvr crashes on Hive query after reconnect (take 2)

### DIFF
--- a/core/sql/arkcmp/CmpStatement.cpp
+++ b/core/sql/arkcmp/CmpStatement.cpp
@@ -1311,8 +1311,6 @@ CmpStatement::process (const CmpMessageEndSession& es)
       CURRENTQCACHE->makeEmpty();
     }
 
-  SQL_EXEC_DeleteHbaseJNI();
-
   return CmpStatement_SUCCESS;
 }
 

--- a/core/sql/cli/CliExtern.cpp
+++ b/core/sql/cli/CliExtern.cpp
@@ -89,7 +89,6 @@ CLISemaphore globalSemaphore ;
 #include "SqlStats.h"
 #include "ComExeTrace.h"
 #include "Context.h"
-#include "HBaseClient_JNI.h"
 
 
 #ifndef CLI_PRIV_SRL
@@ -6298,41 +6297,6 @@ Lng32 SQL_EXEC_ResetParserFlagsForExSqlComp_Internal2(ULng32 flagbits)
 
    threadContext->decrNumOfCliCalls();
    tmpSemaphore->release();
-   return retcode;
-}
-
-Lng32 SQL_EXEC_DeleteHbaseJNI()
-{
-   Lng32 retcode;
-   CLISemaphore *tmpSemaphore;
-   ContextCli   *threadContext;
-
-   CLI_NONPRIV_PROLOGUE(retcode);
-
-   try
-   {
-      tmpSemaphore = getCliSemaphore(threadContext);
-      tmpSemaphore->get();
-      threadContext->incrNumOfCliCalls();
-
-      HBaseClient_JNI::deleteInstance();
-      HiveClient_JNI::deleteInstance();
-   }
-   catch(...)
-   {
-     retcode = -CLI_INTERNAL_ERROR;
-#if defined(_THROW_EXCEPTIONS)
-     if (cliWillThrow())
-     {
-         threadContext->decrNumOfCliCalls();
-         tmpSemaphore->release();
-         throw;
-     }
-#endif
-   }
-   threadContext->decrNumOfCliCalls();
-   tmpSemaphore->release();
-
    return retcode;
 }
 

--- a/core/sql/cli/SQLCLIdev.h
+++ b/core/sql/cli/SQLCLIdev.h
@@ -83,8 +83,6 @@ Lng32 SQL_EXEC_AssignParserFlagsForExSqlComp_Internal(
 Lng32 SQL_EXEC_GetParserFlagsForExSqlComp_Internal(
 						      /*IN*/ ULng32 &flagbits);
 
-Lng32 SQL_EXEC_DeleteHbaseJNI();
-
 // For internal use only -- do not document!
 SQLCLI_LIB_FUNC short SQL_EXEC_GetDefaultVolume_Internal(
                 /*OUT*/ char  outBuf[],

--- a/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
@@ -7625,8 +7625,6 @@ void CmpSeabaseDDL::dropSeabaseMD(NABoolean ddlXns)
   // drop all objects that match the pattern "TRAFODION.*"
   dropSeabaseObjectsFromHbase("TRAFODION\\..*", ddlXns);
 
-  SQL_EXEC_DeleteHbaseJNI();
-  
   //drop all lob data and descriptor files
   dropLOBHdfsFiles();
 


### PR DESCRIPTION
NATableDB is caching a pointer to a HiveClient_JNI object
(HiveMetaData::client_), but that object gets deallocated when a JDBC
client disconnects. Fixing this by keeping the HiveClient_JNI around
across sessions.

Selva and Suresh commented on the first fix and suggested to treat both
HBaseClient_JNI and HiveClient_JNI the same and to remove the CLI
interface that's used to delete these objects.

Therefore, the new fix is to remove this CLI call. It gets called from
two places, one is when an ODBC/JDBC connection closes and the other
is from "initialize trafodion, drop". We believe that neither of them
is needed. Note that we have only one object of each type per CLI
context, and that we delete both objects when we delete the context
(ContextCli::deleteMe()), so there are no leaks.