### PR TITLE
[TRAFODION-1473] T4 support for new sqltypecode BLOB(-602) and CLOB(-…

### DIFF
--- a/core/conn/jdbc_type4/src/org/trafodion/jdbc/t4/HPT4Desc.java
+++ b/core/conn/jdbc_type4/src/org/trafodion/jdbc/t4/HPT4Desc.java
@@ -343,6 +343,8 @@ class HPT4Desc {
 			break;
 		case Types.VARCHAR:
 		case Types.LONGVARCHAR:
+		case Types.BLOB:
+		case Types.CLOB:
                         boolean shortLength = maxLen < Math.pow(2, 15);
                         int dataOffset = ((shortLength) ? 2 : 4);
 			if (sqlDataType_ == SQLTYPECODE_VARCHAR) {
@@ -352,9 +354,6 @@ class HPT4Desc {
 			}
 			displaySize_ = maxLen;
 			precision_ = maxLen; // ODBC2.0
-			break;
-		case Types.BLOB:
-		case Types.CLOB:
 			break;
 		default:
 			if (sqlDataType_ == SQLTYPECODE_INTERVAL) {
@@ -375,6 +374,7 @@ class HPT4Desc {
 			break;
 		}
 		if (sqlDataType_ == SQLTYPECODE_CHAR || sqlDataType_ == SQLTYPECODE_VARCHAR
+				|| sqlDataType_ == SQLTYPECODE_BLOB || sqlDataType_ == SQLTYPECODE_CLOB
 				|| sqlDataType_ == SQLTYPECODE_VARCHAR_LONG || sqlDataType_ == SQLTYPECODE_VARCHAR_WITH_LENGTH) {
 			isCaseSensitive_ = true;
 		}
@@ -453,6 +453,8 @@ class HPT4Desc {
 	public static final int SQLTYPECODE_VARCHAR_LONG = -1;
 	public static final int SQLTYPECODE_INTERVAL = 10;
 	public static final int SQLTYPECODE_VARCHAR_WITH_LENGTH = -601;
+	public static final int SQLTYPECODE_BLOB = -602;
+	public static final int SQLTYPECODE_CLOB = -603;
 	public static final int SQLTYPECODE_SMALLINT = 5;
 	public static final int SQLTYPECODE_INTEGER = 4;
 

--- a/core/conn/jdbc_type4/src/org/trafodion/jdbc/t4/InterfaceResultSet.java
+++ b/core/conn/jdbc_type4/src/org/trafodion/jdbc/t4/InterfaceResultSet.java
@@ -90,6 +90,8 @@ class InterfaceResultSet {
 	/* SQL/MP stype VARCHAR with length prefix:
 	 * */
 	static final int SQLTYPECODE_VARCHAR_WITH_LENGTH = -601;
+	static final int SQLTYPECODE_BLOB = -602;
+	static final int SQLTYPECODE_CLOB = -603;
 
 	/* LONG VARCHAR/ODBC CHARACTER VARYING */
 	static final int SQLTYPECODE_VARCHAR_LONG = -1; /* ## NEGATIVE??? */
@@ -144,6 +146,8 @@ class InterfaceResultSet {
 		case SQLTYPECODE_VARCHAR_LONG:
 		case SQLTYPECODE_VARCHAR_DBLBYTE:
 		case SQLTYPECODE_BITVAR:
+                case SQLTYPECODE_BLOB:
+                case SQLTYPECODE_CLOB:
 			allocLength = bufferLen + 2;
 			break;
 		case SQLTYPECODE_CHAR:
@@ -226,6 +230,8 @@ class InterfaceResultSet {
 			break;
 		case SQLTYPECODE_VARCHAR_WITH_LENGTH:
 		case SQLTYPECODE_VARCHAR_LONG:
+		case SQLTYPECODE_BLOB:
+		case SQLTYPECODE_CLOB:
 			tbuffer = new byte[byteLen - 2];
 			System.arraycopy(ibuffer, byteIndex + 2, tbuffer, 0, byteLen - 2);
 
@@ -374,6 +380,8 @@ class InterfaceResultSet {
 		case SQLTYPECODE_VARCHAR:
 		case SQLTYPECODE_VARCHAR_WITH_LENGTH:
 		case SQLTYPECODE_VARCHAR_LONG:
+		case SQLTYPECODE_BLOB:
+		case SQLTYPECODE_CLOB:
 			boolean shortLength = desc.precision_ < Math.pow(2, 15);
 			int dataOffset = noNullValue + ((shortLength) ? 2 : 4);
 
@@ -646,6 +654,8 @@ class InterfaceResultSet {
 					case SQLTYPECODE_CHAR:
 					case SQLTYPECODE_CHAR_DBLBYTE:
 					case SQLTYPECODE_VARCHAR:
+					case SQLTYPECODE_BLOB:
+					case SQLTYPECODE_CLOB:
 						byteIndex++;
 						break;
 					}

--- a/core/conn/jdbc_type4/src/org/trafodion/jdbc/t4/InterfaceStatement.java
+++ b/core/conn/jdbc_type4/src/org/trafodion/jdbc/t4/InterfaceStatement.java
@@ -122,7 +122,9 @@ class InterfaceStatement {
                 boolean shortLength = precision < Math.pow(2, 15);
                 int dataOffset = ((shortLength) ? 2 : 4);
 
-		if (dataType == InterfaceResultSet.SQLTYPECODE_VARCHAR_WITH_LENGTH) {
+		if ((dataType == InterfaceResultSet.SQLTYPECODE_VARCHAR_WITH_LENGTH)
+		 || (dataType == InterfaceResultSet.SQLTYPECODE_BLOB)
+		 || (dataType == InterfaceResultSet.SQLTYPECODE_CLOB)) {
 			dataLength += dataOffset;
 
 			if (dataLength % 2 != 0)
@@ -424,6 +426,8 @@ class InterfaceStatement {
 			break;
 		case InterfaceResultSet.SQLTYPECODE_VARCHAR_WITH_LENGTH:
 		case InterfaceResultSet.SQLTYPECODE_VARCHAR_LONG:
+		case InterfaceResultSet.SQLTYPECODE_BLOB:
+		case InterfaceResultSet.SQLTYPECODE_CLOB:
 			if (paramValue instanceof byte[]) {
 				tmpBarray = (byte[]) paramValue;
 			} else if (paramValue instanceof String) {
@@ -759,6 +763,8 @@ class InterfaceStatement {
 					colLength = stmt.inputDesc_[i].maxLen_;
 					dataType = stmt.inputDesc_[i].dataType_;
 					if (dataType == InterfaceResultSet.SQLTYPECODE_VARCHAR_WITH_LENGTH
+							|| dataType == InterfaceResultSet.SQLTYPECODE_BLOB
+							|| dataType == InterfaceResultSet.SQLTYPECODE_CLOB
 							|| dataType == InterfaceResultSet.SQLTYPECODE_VARCHAR_LONG
 							|| dataType == InterfaceResultSet.SQLTYPECODE_VARCHAR) {
                                                 boolean shortLength = colLength < Math.pow(2, 15);

--- a/core/conn/jdbc_type4/src/org/trafodion/jdbc/t4/TrafT4PreparedStatement.java
+++ b/core/conn/jdbc_type4/src/org/trafodion/jdbc/t4/TrafT4PreparedStatement.java
@@ -1196,6 +1196,8 @@ public class TrafT4PreparedStatement extends TrafT4Statement implements java.sql
 			case Types.CHAR:
 			case Types.VARCHAR:
 			case Types.LONGVARCHAR:
+                        case Types.BLOB:
+                        case Types.CLOB:
 				setString(parameterIndex, x.toString());
 				break;
 			case Types.VARBINARY:
@@ -1293,36 +1295,6 @@ public class TrafT4PreparedStatement extends TrafT4Statement implements java.sql
 			case Types.REAL:
 				tmpbd = Utility.getBigDecimalValue(locale, x);
 				setFloat(parameterIndex, tmpbd.floatValue());
-				break;
-			case Types.CLOB:
-				if (x instanceof Clob) {
-					setClob(parameterIndex, (Clob) x);
-				}
-				/*
-				 * else if (dataObj instanceof DataWrapper) {
-				 * addParamValue(parameterIndex, (DataWrapper) dataObj); }
-				 */
-				else if (x instanceof Long) {
-					addParamValue(parameterIndex, (Long) x);
-				} else {
-					throw HPT4Messages.createSQLException(connection_.props_, connection_.getLocale(),
-							"conversion_not_allowed", null);
-				}
-				break;
-			case Types.BLOB:
-				if (x instanceof Blob) {
-					setBlob(parameterIndex, (Blob) x);
-				}
-				/*
-				 * else if (dataObj instanceof DataWrapper) {
-				 * addParamValue(parameterIndex, (DataWrapper) dataObj); }
-				 */
-				else if (x instanceof Long) {
-					addParamValue(parameterIndex, (Long) x);
-				} else {
-					throw HPT4Messages.createSQLException(connection_.props_, connection_.getLocale(),
-							"conversion_not_allowed", null);
-				}
 				break;
 			case Types.OTHER:
 				if (inputDesc_[parameterIndex].fsDataType_ == InterfaceResultSet.SQLTYPECODE_INTERVAL) {

--- a/core/conn/jdbc_type4/src/org/trafodion/jdbc/t4/TrafT4ResultSet.java
+++ b/core/conn/jdbc_type4/src/org/trafodion/jdbc/t4/TrafT4ResultSet.java
@@ -460,6 +460,8 @@ public class TrafT4ResultSet extends HPT4Handle implements java.sql.ResultSet {
 		case Types.BINARY:
 		case Types.VARBINARY:
 		case Types.LONGVARBINARY:
+		case Types.BLOB:
+		case Types.CLOB:
 			data = getLocalString(columnIndex);
 			if (data != null) {
 				try {
@@ -640,6 +642,8 @@ public class TrafT4ResultSet extends HPT4Handle implements java.sql.ResultSet {
 		case Types.BINARY:
 		case Types.VARBINARY:
 		case Types.LONGVARBINARY:
+		case Types.BLOB:
+		case Types.CLOB:
 			data = getBytes(columnIndex);
 			if (data != null) {
 				return new java.io.ByteArrayInputStream(data);
@@ -838,6 +842,8 @@ public class TrafT4ResultSet extends HPT4Handle implements java.sql.ResultSet {
 		case Types.CHAR:
 		case Types.VARCHAR: // Extension allows varchar and
 		case Types.LONGVARCHAR: // longvarchar data types
+		case Types.BLOB:
+		case Types.CLOB:
 
 			Object x = getCurrentRow().getColumnObject(columnIndex);
 			if (x == null) {
@@ -911,6 +917,8 @@ public class TrafT4ResultSet extends HPT4Handle implements java.sql.ResultSet {
 		case Types.BINARY:
 		case Types.VARBINARY:
 		case Types.LONGVARBINARY:
+		case Types.BLOB:
+		case Types.CLOB:
 			data = getString(columnIndex);
 			if (data != null) {
 				return new java.io.StringReader(data);
@@ -1598,6 +1606,8 @@ public class TrafT4ResultSet extends HPT4Handle implements java.sql.ResultSet {
 		case Types.CHAR:
 		case Types.VARCHAR:
 		case Types.LONGVARCHAR:
+		case Types.BLOB:
+		case Types.CLOB:
 			return getString(columnIndex);
 		case Types.BINARY:
 		case Types.VARBINARY:
@@ -1890,6 +1900,8 @@ public class TrafT4ResultSet extends HPT4Handle implements java.sql.ResultSet {
 		case Types.CHAR:
 		case Types.VARCHAR:
 		case Types.LONGVARCHAR:
+		case Types.BLOB:
+		case Types.CLOB:
 			data = getLocalString(columnIndex);
 			if (stmt_ != null && stmt_.maxFieldSize_ != 0) {
 				if (data.length() > stmt_.maxFieldSize_) {
@@ -2033,7 +2045,6 @@ public class TrafT4ResultSet extends HPT4Handle implements java.sql.ResultSet {
 		case Types.ARRAY:
 		case Types.BIT:
 		case Types.REF:
-		case Types.BLOB:
 		case Types.DATALINK:
 		case Types.DISTINCT:
 		case Types.JAVA_OBJECT:
@@ -2106,6 +2117,8 @@ public class TrafT4ResultSet extends HPT4Handle implements java.sql.ResultSet {
 			case Types.CHAR:
 			case Types.VARCHAR:
 			case Types.LONGVARCHAR:
+		        case Types.BLOB:
+		        case Types.CLOB:
 				data = data.trim(); // Fall Thru
 			case Types.TIME:
 				try {
@@ -2242,6 +2255,8 @@ public class TrafT4ResultSet extends HPT4Handle implements java.sql.ResultSet {
 			case Types.CHAR:
 			case Types.VARCHAR:
 			case Types.LONGVARCHAR:
+		        case Types.BLOB:
+		        case Types.CLOB:
 				data = data.trim();
 			case Types.TIMESTAMP:
 			case Types.TIME:
@@ -2494,7 +2509,7 @@ public class TrafT4ResultSet extends HPT4Handle implements java.sql.ResultSet {
 		} else {
                        boolean shortLength = desc.maxLen_ < Math.pow(2, 15);
                        int dataOffset = ((shortLength) ? 2 : 4);
-		       int maxLen = desc.sqlDataType_ != InterfaceResultSet.SQLTYPECODE_VARCHAR_WITH_LENGTH ? desc.maxLen_ : desc.maxLen_ + dataOffset;
+		       int maxLen = (desc.sqlDataType_ != InterfaceResultSet.SQLTYPECODE_VARCHAR_WITH_LENGTH && desc.sqlDataType_ != InterfaceResultSet.SQLTYPECODE_BLOB && desc.sqlDataType_ != InterfaceResultSet.SQLTYPECODE_CLOB) ? desc.maxLen_ : desc.maxLen_ + dataOffset;
 	               ret = new byte[maxLen];
 	               System.arraycopy(rawBuffer_, desc.noNullValue_ + rowOffset, ret, 0, maxLen);
 		}

--- a/core/conn/odbc/src/odbc/Common/DrvrSrvr.cpp
+++ b/core/conn/odbc/src/odbc/Common/DrvrSrvr.cpp
@@ -56,6 +56,8 @@ int SRVR::getAllocLength(int DataType, int Length)
 		case SQLTYPECODE_VARCHAR_WITH_LENGTH:
 		//case SQLTYPECODE_VARCHAR_UP: // sqlcli doesn't support anymore
 		case SQLTYPECODE_VARCHAR_LONG:
+		case SQLTYPECODE_BLOB:
+		case SQLTYPECODE_CLOB:
 			AllocLength = Length+3;
 			break;
 		default:

--- a/core/conn/odbc/src/odbc/Common/nskieee.cpp
+++ b/core/conn/odbc/src/odbc/Common/nskieee.cpp
@@ -381,6 +381,8 @@ short ODBC::Datatype_Dependent_Swap(BYTE *source, long dataType, SQLINTEGER char
 		case SQLTYPECODE_VARCHAR_WITH_LENGTH:
 		case SQLTYPECODE_VARCHAR:
 		case SQLTYPECODE_VARCHAR_LONG:
+                case SQLTYPECODE_BLOB:
+                case SQLTYPECODE_CLOB:
 			if ((charSet == SQLCHARSETCODE_UCS2) && (CDataType != SQL_C_BINARY))
 				*(short*)source = 2 * (*(short *)source);
 //SQL_C_BINARY is specified, swap the data
@@ -458,6 +460,8 @@ void ODBC::SQLDatatype_Dependent_Swap(BYTE *source, long dataType, SQLINTEGER ch
 		case SQLTYPECODE_VARCHAR_WITH_LENGTH:
 		case SQLTYPECODE_VARCHAR:
 		case SQLTYPECODE_VARCHAR_LONG:
+                case SQLTYPECODE_BLOB:
+                case SQLTYPECODE_CLOB:
 			byte_swap_2(source);
 			if (charSet == SQLCHARSETCODE_UCS2)
 				byte_swap_string(source+2,*(short *)source);
@@ -543,6 +547,8 @@ long ODBC::dataLength(SQLSMALLINT SQLDataType, SQLINTEGER SQLOctetLength, SQLINT
 	case SQLTYPECODE_VARCHAR_WITH_LENGTH:
 	case SQLTYPECODE_VARCHAR_LONG:
 	case SQLTYPECODE_BITVAR:
+        case SQLTYPECODE_BLOB:
+        case SQLTYPECODE_CLOB:
 		allocLength = *(USHORT *)buffer + 3;
 		break;
 	case SQLTYPECODE_SMALLINT:
@@ -579,6 +585,8 @@ long ODBC::dataLength(SQLSMALLINT SQLDataType, SQLINTEGER SQLOctetLength, SQLINT
 	case SQLTYPECODE_VARCHAR_WITH_LENGTH:
 	case SQLTYPECODE_VARCHAR_LONG:
 	case SQLTYPECODE_BITVAR:
+        case SQLTYPECODE_BLOB:
+        case SQLTYPECODE_CLOB:
 		if (out == FALSE)
 			allocLength = *(USHORT *)buffer + 3;
 		else
@@ -621,6 +629,8 @@ long ODBC::dataLengthFetchRowset(SQLSMALLINT SQLDataType, SQLINTEGER SQLOctetLen
 	case SQLTYPECODE_VARCHAR_WITH_LENGTH:
 	case SQLTYPECODE_VARCHAR_LONG:
 	case SQLTYPECODE_BITVAR:
+        case SQLTYPECODE_BLOB:
+        case SQLTYPECODE_CLOB:
 		allocLength = *(USHORT *)buffer + 2;
 		break;
 	case SQLTYPECODE_CHAR:
@@ -650,6 +660,8 @@ long ODBC::dataLengthFetchPerf(SQLSMALLINT SQLDataType, SQLINTEGER SQLOctetLengt
 	case SQLTYPECODE_VARCHAR_WITH_LENGTH:
 	case SQLTYPECODE_VARCHAR_LONG:
 	case SQLTYPECODE_BITVAR:
+        case SQLTYPECODE_BLOB:
+        case SQLTYPECODE_CLOB:
 		allocLength = *(USHORT *)buffer + 3;
 		break;
 	case SQLTYPECODE_CHAR:
@@ -673,6 +685,8 @@ long ODBC::adjustIndexForBulkFetch(SQLSMALLINT SQLDataType, long index)
 	{
 	case SQLTYPECODE_VARCHAR_WITH_LENGTH:
 	case SQLTYPECODE_VARCHAR_LONG:
+        case SQLTYPECODE_BLOB:
+        case SQLTYPECODE_CLOB:
 		totalLength = ((totalLength + 2 - 1) >> 1) << 1; 
 		break;
 	case SQLTYPECODE_SMALLINT:
@@ -741,6 +755,8 @@ short ODBC::convertFromUCS2(BYTE *source, long dataType, SQLINTEGER charSet, lon
 
 		case SQLTYPECODE_VARCHAR_WITH_LENGTH:
 		case SQLTYPECODE_VARCHAR_LONG:
+                case SQLTYPECODE_BLOB:
+                case SQLTYPECODE_CLOB:
 			srcSz = (*(short *)source) / 2;
 			rc = WideCharToMultiByte(CP_ACP,0,
 									(LPCWSTR)(source+2),srcSz, 
@@ -804,6 +820,8 @@ short ODBC::convertToUCS2(BYTE *source, long dataType, SQLINTEGER charSet, short
 
 		case SQLTYPECODE_VARCHAR_WITH_LENGTH:
 		case SQLTYPECODE_VARCHAR_LONG:
+		case SQLTYPECODE_BLOB:
+		case SQLTYPECODE_CLOB:
 			rc = MultiByteToWideChar(CP_ACP,0,
 								(const char*)source, srcLength, 
 								(LPWSTR)Dest, MAXCHARLEN);

--- a/core/conn/odbc/src/odbc/nsksrvrcore/srvrkds.cpp
+++ b/core/conn/odbc/src/odbc/nsksrvrcore/srvrkds.cpp
@@ -342,6 +342,8 @@ long SRVR::kdsCopyToSMDSQLValueSeq(SQLValueList_def *SQLValueList,
 				break;
 			case SQLTYPECODE_VARCHAR_WITH_LENGTH:
 			case SQLTYPECODE_INTERVAL:
+			case SQLTYPECODE_BLOB:
+			case SQLTYPECODE_CLOB:
 			// case SQLTYPECODE_VARCHAR_UP: //             = -1201 // need to comment it out since sqlci.h doesn't support anymore.
 				length = strlen(dataValue);
 				if (length > allocLength-(1+2)) // 2 Bytes for Length


### PR DESCRIPTION
…603)

Support in T2 and odbc drivers will be addressed in later checkin.
Automated tests for drivers will be checked in at that stage.

Please refer to LOB Interface document in the jira for ways to extract/update data from such columns. set/get lob interfaces will be supported in the next release.