### PR TITLE
[TRAFODION-1924] Add license/notice files to jdbc driver jars

### DIFF
--- a/core/conn/jdbc_type2/build.xml
+++ b/core/conn/jdbc_type2/build.xml
@@ -30,6 +30,8 @@
     <property file="buildId"/>
     <property name="vproc.str" value="Traf_JDBC_Type2_Build_${bldId}"/>
     <property name="my_sqroot" value="../../sqf"/>
+    <property name="src.lic" value="${base.dir}/../../../licenses"/>
+    <property name="src.notice" value="${base.dir}/../../.."/>
 
     <property name="dest.src" value="${base.dir}/src/main/java"/>
     <property name="package.src" value="${dest.src}/org/trafodion/jdbc/t2"/>
@@ -43,6 +45,8 @@
        <mkdir dir="dist"/>
        <property file="${my_sqroot}/export/include/SCMBuildMan.mf"/>
        <jar destfile="dist/jdbcT2.jar" compress="true">
+           <include name="LICENSE" />
+           <include name="NOTICE" />
            <fileset dir="classes"/>
            <manifest id="mf">
               <attribute name="Main-Class" value="JdbcT2"/>
@@ -78,6 +82,8 @@
 
     <target name="compile" depends="init">
       <copy todir="${dest.classes}" overwrite="yes" file="${dest.src}/SQLMXT2Messages_en.properties"/>
+      <copy file="${src.lic}/Apache" tofile="${dest.classes}/LICENSE" />
+      <copy todir="${dest.classes}" file="${src.notice}/NOTICE" />
       <exec executable="/bin/sh">
          <arg line="../doDrvInfo ${package.src}/DriverInfo.java ${package.src}/DriverInfo.java-tmpl ${vproc.str}"/>
       </exec>   

--- a/core/conn/jdbc_type4/build.xml
+++ b/core/conn/jdbc_type4/build.xml
@@ -42,6 +42,8 @@
 	<property name="src.install" value="${src.root}/install" />
 	<property name="src.samples" value="${src.root}/samples"/>
 	<property name="src.lib" value="${src.root}/lib"/>
+	<property name="src.lic" value="${src.root}/../../../licenses"/>
+	<property name="src.notice" value="${src.root}/../../.."/>
 	<property name="client.dir" value="${src.root}/../clients"/>
 	<property name="temp.dir" value="${src.root}/temp"/>
 	<property name="deploy.dir" value="${temp.dir}/deploy" />
@@ -89,7 +91,11 @@
 			<fileset dir="${src.src}">
 				<include name="**/*.properties" />
 			</fileset>
+			<fileset dir="${src.notice}">
+				<include name="NOTICE" />
+			</fileset>
 		</copy>
+		<copy file="${src.lic}/Apache" tofile="${temp.classes}/LICENSE" />
 
 		<replace file="${temp.src}/${vproc.java}" token="@@@@" value="${vproc.str}" />
 		<javac destdir="${temp.classes}" srcdir="${temp.src}" debug="on" includes="**/*.java" classpath="${java.home}/lib/tools.jar;${temp.classes}" includeAntRuntime="false" />
@@ -99,6 +105,8 @@
 	<target name="lib" depends="compile">
 		<property file="${my_sqroot}/export/include/SCMBuildMan.mf"/>
 		<jar destfile="${jdbcT4.jar}" basedir="${temp.classes}">
+			<include name="LICENSE" />
+			<include name="NOTICE" />
 			<include name="**/*.class" />
 			<include name="**/*.properties" />
 

--- a/core/sqf/sqenvcom.sh
+++ b/core/sqf/sqenvcom.sh
@@ -488,9 +488,9 @@ EOF
 
   # Hadoop/HBase/Hive install directories, as determined by this script,
   # when using an Apache installation without one of the distros
-  APACHE_HADOOP_HOME=
-  APACHE_HBASE_HOME=
-  APACHE_HIVE_HOME=
+  APACHE_HADOOP_HOME=None
+  APACHE_HBASE_HOME=None
+  APACHE_HIVE_HOME=None
 
   if [ -f $HADOOP_PREFIX/etc/hadoop/core-site.xml ]; then
     APACHE_HADOOP_HOME=$HADOOP_PREFIX
@@ -532,14 +532,6 @@ EOF
   fi
   if [ ! -d $APACHE_HIVE_HOME/lib -a -d /usr/lib/hive ]; then
     APACHE_HIVE_HOME=/usr/lib/hive
-  fi
-
-  if [ ! -d $APACHE_HADOOP_HOME/lib ]; then
-    echo "**** ERROR: Unable to determine location of Hadoop lib directory"
-  fi
-
-  if [ ! -d $APACHE_HBASE_HOME/lib ]; then
-    echo "**** ERROR: Unable to determine location of HBase lib directory"
   fi
 
   if [ -n "$HBASE_CNF_DIR" -a -n "$HADOOP_CNF_DIR" -a \


### PR DESCRIPTION
This will allow distribution of jars directly via maven repos.

Also fix build-time sqenvcom.sh issue. The default empty variables
of APACHE_*_HOME caused existence check of /lib directory, which of
course always exists. Changed default location to "None", so we do
not falsely think we have hbase and query it for classpath.

Removed error checks, since it is fine in the build case to not have those
components.