### PR TITLE
[TRAFODION-1930] Phoenix T2 tests failing with HDP during build phase

### DIFF
--- a/tests/phx/phoenix_test.py
+++ b/tests/phx/phoenix_test.py
@@ -293,7 +293,7 @@ def generate_pom_xml(targettype, jdbc_groupid, jdbc_artid, jdbc_path, hadoop_dis
         hadoop_dict = {
             'HDP': {'MY_HADOOP_DISTRO': 'HDPReleases',
                     'MY_HADOOP_VERSION': get_hadoop_component_ver(hadoop_distro, "hadoop"),
-                    'MY_MVN_URL': 'http://repo.hortonworks.com/content/repositories/releases/',
+                    'MY_MVN_URL': 'http://repo.hortonworks.com/content/groups/public/',
                     'MY_HBASE_VERSION': get_hadoop_component_ver(hadoop_distro, "hbase"),
                     'MY_HIVE_VERSION': get_hadoop_component_ver(hadoop_distro, "hive"),
                     'MY_ZOOKEEPER_VERSION': get_hadoop_component_ver(hadoop_distro, "zookeeper"),


### PR DESCRIPTION
Change the repository URL to
http://repo.hortonworks.com/content/groups/public/

Note TRAFODION-1929 and TRAFODION-1930 will need a change in
testware to pass in the CLASSPATH till the root cause of Error 706
is known.