### PR TITLE
[TRAFODION-1929] Set correct working dir for phx dependency builds

### DIFF
--- a/tests/phx/phoenix_test.py
+++ b/tests/phx/phoenix_test.py
@@ -746,6 +746,8 @@ gvars.my_MVN_ERROR_FILE = None
 
 prog_parse_args()
 
+os.chdir(gvars.my_ROOT)
+
 # check to make sure executables mvn and javac are in the PATH
 if spawn.find_executable("mvn") is None:
     print "ERROR: Could not find the Maven executable \'mvn\' in the PATH! \n"


### PR DESCRIPTION
Per the Jira, the testing automation now invokes the test script in
the trafodion user environment, but that also has the side effect of
making the current directory as trafodion home directory.

The test script already calculates the path where it was invoked,
so changing directory there makes the dependent builds work.