### PR TITLE
[TRAFODION-1936] Update copyright banners for 2016

### DIFF
--- a/NOTICE
+++ b/NOTICE
@@ -1,5 +1,5 @@
 Apache Trafodion
-Copyright 2016 The Apache Software Foundation
+Copyright 2015-2016 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/core/sqf/sqenvcom.sh
+++ b/core/sqf/sqenvcom.sh
@@ -38,7 +38,7 @@ export TRAFODION_VER_UPDATE=0
 export TRAFODION_VER="${TRAFODION_VER_MAJOR}.${TRAFODION_VER_MINOR}.${TRAFODION_VER_UPDATE}"
 
 # Product copyright header
-export PRODUCT_COPYRIGHT_HEADER="2015 Apache Software Foundation"
+export PRODUCT_COPYRIGHT_HEADER="2015-2016 Apache Software Foundation"
 ##############################################################
 # Trafodion authentication:
 #    Set TRAFODION_ENABLE_AUTHENTICATION to YES to enable

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/regionserver/transactional/IdTmId.java
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/regionserver/transactional/IdTmId.java
@@ -21,16 +21,6 @@
 * @@@ END COPYRIGHT @@@
 **/
 
-/**
- * Copyright 2015 The Apache Software Foundation Licensed to the Apache Software Foundation (ASF) under one or more
- * contributor license agreements. See the NOTICE file distributed with this work for additional information regarding
- * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the "License"); you may
- * not use this file except in compliance with the License. You may obtain a copy of the License at
- * http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND,
- * either express or implied. See the License for the specific language governing permissions and limitations under the
- * License.
- */
 package org.apache.hadoop.hbase.regionserver.transactional;
 
 /**

--- a/win-odbc64/odbcclient/DSNConverter/DSNConverter.def
+++ b/win-odbc64/odbcclient/DSNConverter/DSNConverter.def
@@ -23,7 +23,7 @@
 
 ; DSNConverter.def : Declares the module parameters for the DLL.
 
-DESCRIPTION "ODBC/MX DSN Converter DLL, (C) Copyright (c) 2015 Apache Software Foundation"
+DESCRIPTION "ODBC/MX DSN Converter DLL, (C) Copyright (c) 2015-2016 Apache Software Foundation"
 LIBRARY DSNConverter
 EXPORTS
 	IsDriverInstalled @1

--- a/win-odbc64/odbcclient/Drvr35Res/Drvr35Res.rc
+++ b/win-odbc64/odbcclient/Drvr35Res/Drvr35Res.rc
@@ -93,7 +93,7 @@ BEGIN
             VALUE "FileDescription", "TRAF ODBC Driver Resource DLL"
             VALUE "FileVersion", "1.3.0.0"
             VALUE "InternalName", "TRAF ODBC Driver Resource DLL"
-            VALUE "LegalCopyright", "?Copyright 2015-2016 Apache Trafodion"
+            VALUE "LegalCopyright", "?Copyright 2015-2016 Apache Software Foundation"
             VALUE "OriginalFilename", "traf_ores0100.dll"
             VALUE "ProductName", "TRAF ODBC"
             VALUE "ProductVersion", "1.3.0.0"

--- a/win-odbc64/odbcclient/Drvr35Res/Drvr35Res.rc
+++ b/win-odbc64/odbcclient/Drvr35Res/Drvr35Res.rc
@@ -93,7 +93,7 @@ BEGIN
             VALUE "FileDescription", "TRAF ODBC Driver Resource DLL"
             VALUE "FileVersion", "1.3.0.0"
             VALUE "InternalName", "TRAF ODBC Driver Resource DLL"
-            VALUE "LegalCopyright", "?Copyright 2015 Apache Trafodion"
+            VALUE "LegalCopyright", "?Copyright 2015-2016 Apache Trafodion"
             VALUE "OriginalFilename", "traf_ores0100.dll"
             VALUE "ProductName", "TRAF ODBC"
             VALUE "ProductVersion", "1.3.0.0"

--- a/win-odbc64/odbcclient/TranslationDll/TranslationDll.def
+++ b/win-odbc64/odbcclient/TranslationDll/TranslationDll.def
@@ -21,7 +21,7 @@
 
 ; TranslationDll.def : Declares the module parameters for the DLL.
 
-;DESCRIPTION "ODBC Translation DLL, Copyright (c) 2015 Apache Software Foundation"
+;DESCRIPTION "ODBC Translation DLL, Copyright (c) 2015-2016 Apache Software Foundation"
 LIBRARY hp_translation03
 EXPORTS
 	SQLDriverToDataSource @1

--- a/win-odbc64/odbcclient/TranslationDll/TranslationDll.rc
+++ b/win-odbc64/odbcclient/TranslationDll/TranslationDll.rc
@@ -45,7 +45,7 @@ BEGIN
             VALUE "FileDescription", "TRAF ODBC Translation DLL"
             VALUE "FileVersion", "1.3.0.0"
             VALUE "InternalName", "TRAF ODBC Translation DLL"
-            VALUE "LegalCopyright", "?Copyright 2015 Apache Trafodion"
+            VALUE "LegalCopyright", "?Copyright 2015-2016 Apache Trafodion"
             VALUE "OriginalFilename", "traf_translation01.dll"
             VALUE "ProductName", "TRAF ODBC"
             VALUE "ProductVersion", "1.3.0.0"

--- a/win-odbc64/odbcclient/TranslationDll/TranslationDll.rc
+++ b/win-odbc64/odbcclient/TranslationDll/TranslationDll.rc
@@ -45,7 +45,7 @@ BEGIN
             VALUE "FileDescription", "TRAF ODBC Translation DLL"
             VALUE "FileVersion", "1.3.0.0"
             VALUE "InternalName", "TRAF ODBC Translation DLL"
-            VALUE "LegalCopyright", "?Copyright 2015-2016 Apache Trafodion"
+            VALUE "LegalCopyright", "?Copyright 2015-2016 Apache Software Foundation"
             VALUE "OriginalFilename", "traf_translation01.dll"
             VALUE "ProductName", "TRAF ODBC"
             VALUE "ProductVersion", "1.3.0.0"

--- a/win-odbc64/odbcclient/drvr35/TCPIPV4/TCPIPV4.RC
+++ b/win-odbc64/odbcclient/drvr35/TCPIPV4/TCPIPV4.RC
@@ -45,7 +45,7 @@ BEGIN
             VALUE "FileDescription", "TRAF ODBC TCPIPV4 DLL"
             VALUE "FileVersion", "1.3.0.0"
             VALUE "InternalName", "TRAF ODBC TCPIPV4 DLL"
-            VALUE "LegalCopyright", "?Copyright 2015 Apache Trafodion"
+            VALUE "LegalCopyright", "?Copyright 2015-2016 Apache Trafodion"
             VALUE "OriginalFilename", "traf_tcpipv40100.dll"
             VALUE "ProductName", "TRAF ODBC"
             VALUE "ProductVersion", "1.3.0.0"

--- a/win-odbc64/odbcclient/drvr35/TCPIPV4/TCPIPV4.RC
+++ b/win-odbc64/odbcclient/drvr35/TCPIPV4/TCPIPV4.RC
@@ -45,7 +45,7 @@ BEGIN
             VALUE "FileDescription", "TRAF ODBC TCPIPV4 DLL"
             VALUE "FileVersion", "1.3.0.0"
             VALUE "InternalName", "TRAF ODBC TCPIPV4 DLL"
-            VALUE "LegalCopyright", "?Copyright 2015-2016 Apache Trafodion"
+            VALUE "LegalCopyright", "?Copyright 2015-2016 Apache Software Foundation"
             VALUE "OriginalFilename", "traf_tcpipv40100.dll"
             VALUE "ProductName", "TRAF ODBC"
             VALUE "ProductVersion", "1.3.0.0"

--- a/win-odbc64/odbcclient/drvr35/TCPIPV6/TCPIPV6.RC
+++ b/win-odbc64/odbcclient/drvr35/TCPIPV6/TCPIPV6.RC
@@ -45,7 +45,7 @@ BEGIN
             VALUE "FileDescription", "TRAF ODBC TCPIPV6 DLL"
             VALUE "FileVersion", "1.3.0.0"
             VALUE "InternalName", "TRAF ODBC TCPIPV6 DLL"
-            VALUE "LegalCopyright", "?Copyright 2015-2016 Apache Trafodion"
+            VALUE "LegalCopyright", "?Copyright 2015-2016 Apache Software Foundation"
             VALUE "OriginalFilename", "traf_tcpipv60100.dll"
             VALUE "ProductName", "TRAF ODBC"
             VALUE "ProductVersion", "1.3.0.0"

--- a/win-odbc64/odbcclient/drvr35/TCPIPV6/TCPIPV6.RC
+++ b/win-odbc64/odbcclient/drvr35/TCPIPV6/TCPIPV6.RC
@@ -45,7 +45,7 @@ BEGIN
             VALUE "FileDescription", "TRAF ODBC TCPIPV6 DLL"
             VALUE "FileVersion", "1.3.0.0"
             VALUE "InternalName", "TRAF ODBC TCPIPV6 DLL"
-            VALUE "LegalCopyright", "?Copyright 2015 Apache Trafodion"
+            VALUE "LegalCopyright", "?Copyright 2015-2016 Apache Trafodion"
             VALUE "OriginalFilename", "traf_tcpipv60100.dll"
             VALUE "ProductName", "TRAF ODBC"
             VALUE "ProductVersion", "1.3.0.0"

--- a/win-odbc64/odbcclient/drvr35/drvr35.rc
+++ b/win-odbc64/odbcclient/drvr35/drvr35.rc
@@ -45,7 +45,7 @@ BEGIN
             VALUE "FileDescription", "TRAF ODBC Driver DLL"
             VALUE "FileVersion", "1.3.0.0"
             VALUE "InternalName", "TRAF ODBC Driver DLL"
-            VALUE "LegalCopyright", "?Copyright 2015-2016 Apache Trafodion"
+            VALUE "LegalCopyright", "?Copyright 2015-2016 Apache Software Foundation"
             VALUE "OriginalFilename", "trfodbc1.dll"
             VALUE "ProductName", "TRAF ODBC"
             VALUE "ProductVersion", "1.3.0.0"

--- a/win-odbc64/odbcclient/drvr35/drvr35.rc
+++ b/win-odbc64/odbcclient/drvr35/drvr35.rc
@@ -45,7 +45,7 @@ BEGIN
             VALUE "FileDescription", "TRAF ODBC Driver DLL"
             VALUE "FileVersion", "1.3.0.0"
             VALUE "InternalName", "TRAF ODBC Driver DLL"
-            VALUE "LegalCopyright", "?Copyright 2015 Apache Trafodion"
+            VALUE "LegalCopyright", "?Copyright 2015-2016 Apache Trafodion"
             VALUE "OriginalFilename", "trfodbc1.dll"
             VALUE "ProductName", "TRAF ODBC"
             VALUE "ProductVersion", "1.3.0.0"

--- a/win-odbc64/odbcclient/drvr35adm/drvr35adm.rc
+++ b/win-odbc64/odbcclient/drvr35adm/drvr35adm.rc
@@ -82,7 +82,7 @@ BEGIN
             VALUE "FileDescription", "TRAF ODBC Client Adminstration DLL"
             VALUE "FileVersion", "1.3.0.0"
             VALUE "InternalName", "TRAF ODBC Client Adminstration DLL"
-            VALUE "LegalCopyright", "?Copyright 2015 Apache Trafodion"
+            VALUE "LegalCopyright", "?Copyright 2015-2016 Apache Trafodion"
             VALUE "OriginalFilename", "trfoadm1.dll"
             VALUE "ProductName", "TRAF ODBC"
             VALUE "ProductVersion", "1.3.0.0"

--- a/win-odbc64/odbcclient/drvr35adm/drvr35adm.rc
+++ b/win-odbc64/odbcclient/drvr35adm/drvr35adm.rc
@@ -82,7 +82,7 @@ BEGIN
             VALUE "FileDescription", "TRAF ODBC Client Adminstration DLL"
             VALUE "FileVersion", "1.3.0.0"
             VALUE "InternalName", "TRAF ODBC Client Adminstration DLL"
-            VALUE "LegalCopyright", "?Copyright 2015-2016 Apache Trafodion"
+            VALUE "LegalCopyright", "?Copyright 2015-2016 Apache Software Foundation"
             VALUE "OriginalFilename", "trfoadm1.dll"
             VALUE "ProductName", "TRAF ODBC"
             VALUE "ProductVersion", "1.3.0.0"

--- a/win-odbc64/odbcclient/drvr35msg/DrvMsg35.rc
+++ b/win-odbc64/odbcclient/drvr35msg/DrvMsg35.rc
@@ -71,7 +71,7 @@ BEGIN
             VALUE "FileDescription", "TRAF ODBC Client Msg DLL"
             VALUE "FileVersion", "1.3.0.0"
             VALUE "InternalName", "TRAF ODBC Client Msg DLL"
-            VALUE "LegalCopyright", "?Copyright 2015-2016 Apache Trafodion"
+            VALUE "LegalCopyright", "?Copyright 2015-2016 Apache Software Foundation"
             VALUE "OriginalFilename", "traf_odbcDrvMsg_intl0100.dll"
             VALUE "ProductName", "TRAF ODBC"
             VALUE "ProductVersion", "1.3.0.0"

--- a/win-odbc64/odbcclient/drvr35msg/DrvMsg35.rc
+++ b/win-odbc64/odbcclient/drvr35msg/DrvMsg35.rc
@@ -71,7 +71,7 @@ BEGIN
             VALUE "FileDescription", "TRAF ODBC Client Msg DLL"
             VALUE "FileVersion", "1.3.0.0"
             VALUE "InternalName", "TRAF ODBC Client Msg DLL"
-            VALUE "LegalCopyright", "?Copyright 2015 Apache Trafodion"
+            VALUE "LegalCopyright", "?Copyright 2015-2016 Apache Trafodion"
             VALUE "OriginalFilename", "traf_odbcDrvMsg_intl0100.dll"
             VALUE "ProductName", "TRAF ODBC"
             VALUE "ProductVersion", "1.3.0.0"


### PR DESCRIPTION
Also removed a redundant license header from one source file.