### PR TITLE
TRAFODION [1944] Check status of authentication and authorization via a CLI call

### DIFF
--- a/core/sql/cli/CliExtern.cpp
+++ b/core/sql/cli/CliExtern.cpp
@@ -4612,7 +4612,7 @@ Lng32 SQL_EXEC_GetDatabaseUserID_Internal (/*IN*/   char   *string_value,
 }
 
 SQLCLI_LIB_FUNC
-Int32 SQL_EXEC_GetAuthState_Internal(
+Int32 SQL_EXEC_GetAuthState(
    /*OUT*/  bool & authenticationEnabled,
    /*OUT*/  bool & authorizationEnabled,
    /*OUT*/  bool & authorizationReady,

--- a/core/sql/cli/SQLCLIdev.h
+++ b/core/sql/cli/SQLCLIdev.h
@@ -932,13 +932,6 @@ SQLCLI_LIB_FUNC Lng32 SQL_EXEC_SetSessionAttr_Internal (
     /*IN OPTIONAL*/            Lng32 numeric_value,
     /*IN OPTIONAL*/            char  *string_value);
 
-SQLCLI_LIB_FUNC Int32 SQL_EXEC_GetAuthState_Internal(
-   /*OUT*/  bool & authenticationEnabled,
-   /*OUT*/  bool & authorizationEnabled,
-   /*OUT*/  bool & authorizationReady,
-   /*OUT*/  bool & auditingEnabled);
-
-
 SQLCLI_LIB_FUNC Lng32 SQL_EXEC_SetErrorCodeInRTS(
                 /*IN*/ SQLSTMT_ID * statement_id,
 	        /*IN*/ Lng32     sqlErrorCode);  

--- a/core/sql/cli/sqlcli.h
+++ b/core/sql/cli/sqlcli.h
@@ -1956,6 +1956,12 @@ SQLCLI_LIB_FUNC Int32 SQL_EXEC_SETAUTHID(
 		/* OUT OPTIONAL  role len*/ short *primaryRoleLen,
                 /* OUT OPTIONAL userRedefTime*/ Int64 *redefTime); // NA_64BIT
 
+SQLCLI_LIB_FUNC Int32 SQL_EXEC_GetAuthState(
+   /*OUT*/  bool & authenticationEnabled,
+   /*OUT*/  bool & authorizationEnabled,
+   /*OUT*/  bool & authorizationReady,
+   /*OUT*/  bool & auditingEnabled);
+
 SQLCLI_LIB_FUNC Int32 SQL_EXEC_DecodeAndFormatKey(
                /*IN*/void    * RCB_Pointer_Addr,    
 	       /*IN*/void    * KeyAddr,             

--- a/core/sql/sqlci/SqlciEnv.cpp
+++ b/core/sql/sqlci/SqlciEnv.cpp
@@ -1371,10 +1371,10 @@ Int32 SqlciEnv::getAuthState(bool &authenticationEnabled,
   HandleCLIErrorInit();
 
   Int32 localUID = 0;
-  Int32 rc = SQL_EXEC_GetAuthState_Internal(authenticationEnabled,
-                                            authorizationEnabled,
-                                            authorizationReady,
-                                            auditingEnabled);
+  Int32 rc = SQL_EXEC_GetAuthState(authenticationEnabled,
+                                   authorizationEnabled,
+                                   authorizationReady,
+                                   auditingEnabled);
   HandleCLIError(rc, this);
 
   return rc;


### PR DESCRIPTION
The SQL_EXEC_GetAuthState_Internal CLI request has been changed to 
SQL_EXEC_GetAuthState and moved from SQLCLIdev.h to sqlcli.h so it is available
to external callers.