### PR TITLE
[TRAFODION-1916] dcscheck fails with cdh5.4.4 and hbase 1.0.0

### DIFF
--- a/dcs/src/assembly/all.xml
+++ b/dcs/src/assembly/all.xml
@@ -84,6 +84,7 @@
          <include>org.slf4j:slf4j-log4j12</include>
          <include>org.slf4j:slf4j-api</include>
          <include>org.mortbay.jetty</include>
+         <include>org.apache.zookeeper:zookeeper</include>
       </includes>
       <fileMode>0644</fileMode>
       <directoryMode>0644</directoryMode>


### PR DESCRIPTION
Zookeeper jar file will now get installed in $DCS_INSTALL_DIR/lib
as was done before TRAFODION-1828. This is similar to how it's
currently been done for REST subsystem.