### PR TITLE
[TRAFODION-1955] JNI optimization at the time of compilation

### DIFF
--- a/core/sql/executor/ExExeUtil.h
+++ b/core/sql/executor/ExExeUtil.h
@@ -54,7 +54,6 @@ class ExSqlComp;
 class ExProcessStats;
 
 class ExpHbaseInterface;
-class ByteArrayList;
 
 //class FILE_STREAM;
 #include "ComAnsiNamePart.h"
@@ -64,7 +63,7 @@ class ByteArrayList;
 #include "ExExeUtilCli.h"
 #include "ExpLOBstats.h"
 #include "hiveHook.h"
-
+#include "ExpHbaseDefs.h"
 
 #include "SequenceFileReader.h"
 
@@ -2552,7 +2551,7 @@ public:
 
  private:
   ExpHbaseInterface * ehi_;
-  ByteArrayList * bal_;
+  NAArray<HbaseStr> *hbaseTables_;
   Int32 currIndex_;
 
   NAString extTableName_;
@@ -3744,7 +3743,7 @@ protected:
   ComTdbRegionStatsVirtTableColumnStruct* stats_;  
 
   ExpHbaseInterface * ehi_;
-  ByteArrayList * regionInfoList_;
+  NAArray<HbaseStr> *regionInfoList_;
 
   Int32 currIndex_;
 

--- a/core/sql/executor/ExExeUtilGet.cpp
+++ b/core/sql/executor/ExExeUtilGet.cpp
@@ -3080,13 +3080,11 @@ short ExExeUtilGetHbaseObjectsTcb::work()
                 break;
               }
 
-            Int32 len = hbaseTables_->at(currIndex_).len;
-            char *tmp  = hbaseTables_->at(currIndex_).val;
-            len = hbaseTables_->at(currIndex_).len;
-            if (len > ComMAX_3_PART_EXTERNAL_UTF8_NAME_LEN_IN_BYTES+6)
-                len = ComMAX_3_PART_EXTERNAL_UTF8_NAME_LEN_IN_BYTES+6; 
-            strncpy(hbaseNameBuf_, tmp, len);
-            hbaseNameBuf_[len] = 0;
+            HbaseStr *hbaseName = &hbaseTables_->at(currIndex_);
+            if (hbaseName->len > ComMAX_3_PART_EXTERNAL_UTF8_NAME_LEN_IN_BYTES+6)
+                hbaseName->len = ComMAX_3_PART_EXTERNAL_UTF8_NAME_LEN_IN_BYTES+6; 
+            strncpy(hbaseNameBuf_, hbaseName->val, hbaseName->len);
+            hbaseNameBuf_[hbaseName->len] = 0;
             hbaseName_ = hbaseNameBuf_;
 
             Lng32 numParts = 0;

--- a/core/sql/executor/HBaseClient_JNI.cpp
+++ b/core/sql/executor/HBaseClient_JNI.cpp
@@ -27,6 +27,225 @@
 #include "QRLogger.h"
 #include <signal.h>
 #include "pthread.h"
+// ===========================================================================
+// ===== Class ByteArrayList
+// ===========================================================================
+
+JavaMethodInit* ByteArrayList::JavaMethods_ = NULL;
+jclass ByteArrayList::javaClass_ = 0;
+bool ByteArrayList::javaMethodsInitialized_ = false;
+pthread_mutex_t ByteArrayList::javaMethodsInitMutex_ = PTHREAD_MUTEX_INITIALIZER;
+
+
+static const char* const balErrorEnumStr[] =
+{
+  "JNI NewStringUTF() in add() for writing."  // BAL_ERROR_ADD_PARAM
+ ,"Java exception in add() for writing."      // BAL_ERROR_ADD_EXCEPTION
+ ,"Java exception in get() for reading."      // BAL_ERROR_GET_EXCEPTION
+};
+
+//////////////////////////////////////////////////////////////////////////////
+// 
+//////////////////////////////////////////////////////////////////////////////
+char* ByteArrayList::getErrorText(BAL_RetCode errEnum)
+{
+  if (errEnum < (BAL_RetCode)JOI_LAST)
+    return JavaObjectInterface::getErrorText((JOI_RetCode)errEnum);
+  else
+    return (char*)balErrorEnumStr[errEnum-BAL_FIRST-1];
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// 
+//////////////////////////////////////////////////////////////////////////////
+ByteArrayList::~ByteArrayList()
+{
+//  QRLogger::log(CAT_JNI_TOP, LL_DEBUG, "ByteArrayList destructor called.");
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// 
+//////////////////////////////////////////////////////////////////////////////
+BAL_RetCode ByteArrayList::init()
+{
+  static char className[]="org/trafodion/sql/ByteArrayList";
+  BAL_RetCode rc;
+
+  if (isInitialized())
+    return BAL_OK;
+
+  if (javaMethodsInitialized_)
+    return (BAL_RetCode)JavaObjectInterface::init(className, javaClass_, JavaMethods_, (Int32)JM_LAST, javaMethodsInitialized_);
+  else
+  {
+    pthread_mutex_lock(&javaMethodsInitMutex_);
+    if (javaMethodsInitialized_)
+    {
+      pthread_mutex_unlock(&javaMethodsInitMutex_);
+      return (BAL_RetCode)JavaObjectInterface::init(className, javaClass_, JavaMethods_, (Int32)JM_LAST, javaMethodsInitialized_);
+    }
+    JavaMethods_ = new JavaMethodInit[JM_LAST];
+
+    JavaMethods_[JM_CTOR      ].jm_name      = "<init>";
+    JavaMethods_[JM_CTOR      ].jm_signature = "()V";
+    JavaMethods_[JM_ADD       ].jm_name      = "addElement";
+    JavaMethods_[JM_ADD       ].jm_signature = "([B)V";
+    JavaMethods_[JM_GET       ].jm_name      = "getElement";
+    JavaMethods_[JM_GET       ].jm_signature = "(I)[B";
+    JavaMethods_[JM_GETSIZE   ].jm_name      = "getSize";
+    JavaMethods_[JM_GETSIZE   ].jm_signature = "()I";
+    JavaMethods_[JM_GETENTRYSIZE].jm_name      = "getEntrySize";
+    JavaMethods_[JM_GETENTRYSIZE].jm_signature = "(I)I";
+    JavaMethods_[JM_GETENTRY  ].jm_name      = "getEntry";
+    JavaMethods_[JM_GETENTRY].jm_signature = "(I)[B";
+
+    rc = (BAL_RetCode)JavaObjectInterface::init(className, javaClass_, JavaMethods_, (Int32)JM_LAST, javaMethodsInitialized_);
+    javaMethodsInitialized_ = TRUE;
+    pthread_mutex_unlock(&javaMethodsInitMutex_);
+  }
+  return rc;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// 
+//////////////////////////////////////////////////////////////////////////////
+BAL_RetCode ByteArrayList::add(const Text& t)
+{
+//  QRLogger::log(CAT_SQL_HBASE, LL_DEBUG, "ByteArrayList::add(%s) called.", t.data());
+
+  int len = t.size();
+  jbyteArray jba_t = jenv_->NewByteArray(len);
+  if (jba_t == NULL)
+  {
+    GetCliGlobals()->setJniErrorStr(getErrorText(BAL_ERROR_ADD_PARAM));
+    return BAL_ERROR_ADD_PARAM;
+  }
+  jenv_->SetByteArrayRegion(jba_t, 0, len, (const jbyte*)t.data());
+
+  // void add(byte[]);
+  jenv_->CallVoidMethod(javaObj_, JavaMethods_[JM_ADD].methodID, jba_t);
+  jenv_->DeleteLocalRef(jba_t);
+  if (jenv_->ExceptionCheck())
+  {
+    getExceptionDetails();
+    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
+    return BAL_ERROR_ADD_EXCEPTION;
+  }
+  return BAL_OK;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// 
+//////////////////////////////////////////////////////////////////////////////
+BAL_RetCode ByteArrayList::add(const TextVec& vec)
+{
+  for (std::vector<Text>::const_iterator it = vec.begin() ; it != vec.end(); ++it)
+  {
+    Text str(*it);
+    add(str);
+  }
+
+  return BAL_OK;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// 
+//////////////////////////////////////////////////////////////////////////////
+BAL_RetCode ByteArrayList::addElement(const char* data, int keyLength)
+{
+  Text str(data, keyLength);
+  add(str);
+  return BAL_OK;
+}
+
+//////////////////////////////////////////////////////////////////////////////
+// 
+//////////////////////////////////////////////////////////////////////////////
+Text* ByteArrayList::get(Int32 i)
+{
+  // byte[] get(i);
+  jbyteArray jba_val = static_cast<jbyteArray>(jenv_->CallObjectMethod(javaObj_, JavaMethods_[JM_GET].methodID, i));
+  if (jenv_->ExceptionCheck())
+  {
+    getExceptionDetails();
+    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
+    return NULL;
+  }
+
+  if (jba_val == NULL)
+    return NULL;
+
+  jbyte* p_val = jenv_->GetByteArrayElements(jba_val, 0);
+  int len = jenv_->GetArrayLength(jba_val);
+  Text* val = new (heap_) Text((char*)p_val, len);
+  jenv_->ReleaseByteArrayElements(jba_val, p_val, JNI_ABORT);
+  jenv_->DeleteLocalRef(jba_val);
+
+  return val;
+}
+
+Int32 ByteArrayList::getSize()
+{
+  Int32 len = jenv_->CallIntMethod(javaObj_, JavaMethods_[JM_GETSIZE].methodID);
+  if (jenv_->ExceptionCheck())
+  {
+    getExceptionDetails();
+    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
+    return 0;
+  }
+  return len;
+}
+
+Int32 ByteArrayList::getEntrySize(Int32 i)
+{
+  jint jidx = i;
+
+  Int32 len =
+    jenv_->CallIntMethod(javaObj_, JavaMethods_[JM_GETENTRYSIZE].methodID, jidx);
+
+  if (jenv_->ExceptionCheck())
+  {
+    getExceptionDetails();
+    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
+    return 0;
+  }
+  return len;
+}
+
+
+char* ByteArrayList::getEntry(Int32 i, char* buf, Int32 bufLen, Int32& datalen)
+{
+  datalen = 0;
+
+  jint jidx = i;
+
+  jbyteArray jBuffer = static_cast<jbyteArray>
+      (jenv_->CallObjectMethod(javaObj_, JavaMethods_[JM_GETENTRY].methodID, jidx));
+
+  if (jenv_->ExceptionCheck())
+  {
+    getExceptionDetails();
+    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
+    return NULL;
+  }
+
+  if (jBuffer != NULL) {
+
+    datalen = jenv_->GetArrayLength(jBuffer);
+
+    if (datalen > bufLen)
+      // call setJniErrorStr?
+      return NULL;
+
+    jenv_->GetByteArrayRegion(jBuffer, 0, datalen, (jbyte*)buf);
+
+    jenv_->DeleteLocalRef(jBuffer);
+  }
+
+  return buf;
+}
+
+                                   
 //
 // ===========================================================================
 // ===== Class HBaseClient_JNI
@@ -282,9 +501,9 @@ HBC_RetCode HBaseClient_JNI::init()
     JavaMethods_[JM_HBC_CHECKANDDELETE_ROW ].jm_name      = "checkAndDeleteRow";
     JavaMethods_[JM_HBC_CHECKANDDELETE_ROW ].jm_signature = "(JLjava/lang/String;ZJ[B[B[BJZ)Z";
     JavaMethods_[JM_HBC_GETSTARTKEYS ].jm_name      = "getStartKeys";
-    JavaMethods_[JM_HBC_GETSTARTKEYS ].jm_signature = "(Ljava/lang/String;)[[B";
+    JavaMethods_[JM_HBC_GETSTARTKEYS ].jm_signature = "(Ljava/lang/String;Z)[[B";
     JavaMethods_[JM_HBC_GETENDKEYS ].jm_name      = "getEndKeys";
-    JavaMethods_[JM_HBC_GETENDKEYS ].jm_signature = "(Ljava/lang/String;)[[B";
+    JavaMethods_[JM_HBC_GETENDKEYS ].jm_signature = "(Ljava/lang/String;Z)[[B";
     rc = (HBC_RetCode)JavaObjectInterface::init(className, javaClass_, JavaMethods_, (Int32)JM_LAST, javaMethodsInitialized_);
     javaMethodsInitialized_ = TRUE;
     pthread_mutex_unlock(&javaMethodsInitMutex_);
@@ -3253,17 +3472,17 @@ HBC_RetCode HBaseClient_JNI::checkAndDeleteRow(NAHeap *heap, const char *tableNa
   return HBC_OK;
 }
 
-NAArray<HbaseStr>* HBaseClient_JNI::getStartKeys(NAHeap *heap, const char *tableName)
+NAArray<HbaseStr>* HBaseClient_JNI::getStartKeys(NAHeap *heap, const char *tableName, bool useTRex)
 {
-   return HBaseClient_JNI::getKeys(JM_HBC_GETSTARTKEYS, heap, tableName);
+   return HBaseClient_JNI::getKeys(JM_HBC_GETSTARTKEYS, heap, tableName, useTRex);
 }
 
-NAArray<HbaseStr>* HBaseClient_JNI::getEndKeys(NAHeap *heap, const char * tableName)
+NAArray<HbaseStr>* HBaseClient_JNI::getEndKeys(NAHeap *heap, const char * tableName, bool useTRex)
 {
-   return HBaseClient_JNI::getKeys(JM_HBC_GETENDKEYS, heap, tableName);
+   return HBaseClient_JNI::getKeys(JM_HBC_GETENDKEYS, heap, tableName, useTRex);
 }
 
-NAArray<HbaseStr>* HBaseClient_JNI::getKeys(Int32 funcIndex, NAHeap *heap, const char *tableName)
+NAArray<HbaseStr>* HBaseClient_JNI::getKeys(Int32 funcIndex, NAHeap *heap, const char *tableName, bool useTRex)
 {
 
   if (jenv_->PushLocalFrame(jniHandleCapacity_) != 0) {
@@ -3276,9 +3495,9 @@ NAArray<HbaseStr>* HBaseClient_JNI::getKeys(Int32 funcIndex, NAHeap *heap, const
     jenv_->PopLocalFrame(NULL);
     return NULL;
   }
-
+  jboolean j_useTRex = useTRex;
   jarray j_keyArray=
-     (jarray)jenv_->CallObjectMethod(javaObj_, JavaMethods_[funcIndex].methodID, js_tblName);
+     (jarray)jenv_->CallObjectMethod(javaObj_, JavaMethods_[funcIndex].methodID, js_tblName, j_useTRex);
 
   if (jenv_->ExceptionCheck())
   {
@@ -5397,8 +5616,10 @@ int convertStringObjectArrayToList(NAHeap *heap, jarray j_objArray,
 
 jint convertByteArrayObjectArrayToNAArray(NAHeap *heap, jarray j_objArray, NAArray<HbaseStr> **retArray)
 {
-    if (j_objArray == NULL)
+    if (j_objArray == NULL) {
+       *retArray = NULL;
        return 0;
+    }
     int arrayLen = jenv_->GetArrayLength(j_objArray);
     jbyteArray j_ba;
     jint j_baLen;
@@ -5406,8 +5627,7 @@ jint convertByteArrayObjectArrayToNAArray(NAHeap *heap, jarray j_objArray, NAArr
     jboolean isCopy;
     HbaseStr element; 
     NAArray<HbaseStr> *tmpArray = new (heap) NAArray<HbaseStr> (heap, arrayLen); 
-    for (int i = 0; i < arrayLen; i++)
-    {
+    for (int i = 0; i < arrayLen; i++) {
         j_ba = (jbyteArray)jenv_->GetObjectArrayElement((jobjectArray)j_objArray, i);
         j_baLen = jenv_->GetArrayLength(j_ba);
         ba = new (heap) BYTE[j_baLen];

--- a/core/sql/executor/HBaseClient_JNI.cpp
+++ b/core/sql/executor/HBaseClient_JNI.cpp
@@ -27,225 +27,7 @@
 #include "QRLogger.h"
 #include <signal.h>
 #include "pthread.h"
-
-// ===========================================================================
-// ===== Class ByteArrayList
-// ===========================================================================
-
-JavaMethodInit* ByteArrayList::JavaMethods_ = NULL;
-jclass ByteArrayList::javaClass_ = 0;
-bool ByteArrayList::javaMethodsInitialized_ = false;
-pthread_mutex_t ByteArrayList::javaMethodsInitMutex_ = PTHREAD_MUTEX_INITIALIZER;
-
-
-static const char* const balErrorEnumStr[] = 
-{
-  "JNI NewStringUTF() in add() for writing."  // BAL_ERROR_ADD_PARAM
- ,"Java exception in add() for writing."      // BAL_ERROR_ADD_EXCEPTION
- ,"Java exception in get() for reading."      // BAL_ERROR_GET_EXCEPTION
-};
-
-//////////////////////////////////////////////////////////////////////////////
-// 
-//////////////////////////////////////////////////////////////////////////////
-char* ByteArrayList::getErrorText(BAL_RetCode errEnum)
-{
-  if (errEnum < (BAL_RetCode)JOI_LAST)
-    return JavaObjectInterface::getErrorText((JOI_RetCode)errEnum);
-  else    
-    return (char*)balErrorEnumStr[errEnum-BAL_FIRST-1];
-}
-
-//////////////////////////////////////////////////////////////////////////////
-// 
-//////////////////////////////////////////////////////////////////////////////
-ByteArrayList::~ByteArrayList()
-{
-//  QRLogger::log(CAT_JNI_TOP, LL_DEBUG, "ByteArrayList destructor called.");
-}
- 
-//////////////////////////////////////////////////////////////////////////////
-// 
-//////////////////////////////////////////////////////////////////////////////
-BAL_RetCode ByteArrayList::init()
-{
-  static char className[]="org/trafodion/sql/ByteArrayList";
-  BAL_RetCode rc;
-  
-  if (isInitialized())
-    return BAL_OK;
-    
-  if (javaMethodsInitialized_)
-    return (BAL_RetCode)JavaObjectInterface::init(className, javaClass_, JavaMethods_, (Int32)JM_LAST, javaMethodsInitialized_);
-  else
-  {
-    pthread_mutex_lock(&javaMethodsInitMutex_);
-    if (javaMethodsInitialized_)
-    {
-      pthread_mutex_unlock(&javaMethodsInitMutex_);
-      return (BAL_RetCode)JavaObjectInterface::init(className, javaClass_, JavaMethods_, (Int32)JM_LAST, javaMethodsInitialized_);
-    }
-    JavaMethods_ = new JavaMethodInit[JM_LAST];
-    
-    JavaMethods_[JM_CTOR      ].jm_name      = "<init>";
-    JavaMethods_[JM_CTOR      ].jm_signature = "()V";
-    JavaMethods_[JM_ADD       ].jm_name      = "addElement";
-    JavaMethods_[JM_ADD       ].jm_signature = "([B)V";
-    JavaMethods_[JM_GET       ].jm_name      = "getElement";
-    JavaMethods_[JM_GET       ].jm_signature = "(I)[B";
-    JavaMethods_[JM_GETSIZE   ].jm_name      = "getSize";
-    JavaMethods_[JM_GETSIZE   ].jm_signature = "()I";
-    JavaMethods_[JM_GETENTRYSIZE].jm_name      = "getEntrySize";
-    JavaMethods_[JM_GETENTRYSIZE].jm_signature = "(I)I";
-    JavaMethods_[JM_GETENTRY  ].jm_name      = "getEntry";
-    JavaMethods_[JM_GETENTRY].jm_signature = "(I)[B";
-    
-    rc = (BAL_RetCode)JavaObjectInterface::init(className, javaClass_, JavaMethods_, (Int32)JM_LAST, javaMethodsInitialized_);
-    javaMethodsInitialized_ = TRUE;
-    pthread_mutex_unlock(&javaMethodsInitMutex_);
-  }
-  return rc;
-}
-
-//////////////////////////////////////////////////////////////////////////////
-// 
-//////////////////////////////////////////////////////////////////////////////
-BAL_RetCode ByteArrayList::add(const Text& t)
-{
-//  QRLogger::log(CAT_SQL_HBASE, LL_DEBUG, "ByteArrayList::add(%s) called.", t.data());
-
-  int len = t.size();
-  jbyteArray jba_t = jenv_->NewByteArray(len);
-  if (jba_t == NULL) 
-  {
-    GetCliGlobals()->setJniErrorStr(getErrorText(BAL_ERROR_ADD_PARAM));
-    return BAL_ERROR_ADD_PARAM;
-  }
-  jenv_->SetByteArrayRegion(jba_t, 0, len, (const jbyte*)t.data());
-
-  // void add(byte[]);
-  jenv_->CallVoidMethod(javaObj_, JavaMethods_[JM_ADD].methodID, jba_t);
-  jenv_->DeleteLocalRef(jba_t);  
-  if (jenv_->ExceptionCheck())
-  {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    return BAL_ERROR_ADD_EXCEPTION;
-  }
-
-  return BAL_OK;
-}
-
-//////////////////////////////////////////////////////////////////////////////
-// 
-//////////////////////////////////////////////////////////////////////////////
-BAL_RetCode ByteArrayList::add(const TextVec& vec)
-{
-  for (std::vector<Text>::const_iterator it = vec.begin() ; it != vec.end(); ++it)
-  {
-    Text str(*it);
-    add(str);
-  }
-
-  return BAL_OK;
-}
-
-//////////////////////////////////////////////////////////////////////////////
-// 
-//////////////////////////////////////////////////////////////////////////////
-BAL_RetCode ByteArrayList::addElement(const char* data, int keyLength)
-{
-  Text str(data, keyLength);
-  add(str);
-  return BAL_OK;
-}
-
-//////////////////////////////////////////////////////////////////////////////
-// 
-//////////////////////////////////////////////////////////////////////////////
-Text* ByteArrayList::get(Int32 i)
-{
-  // byte[] get(i);
-  jbyteArray jba_val = static_cast<jbyteArray>(jenv_->CallObjectMethod(javaObj_, JavaMethods_[JM_GET].methodID, i));
-  if (jenv_->ExceptionCheck())
-  {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    return NULL;
-  }
-
-  if (jba_val == NULL)
-    return NULL;
-
-  jbyte* p_val = jenv_->GetByteArrayElements(jba_val, 0);
-  int len = jenv_->GetArrayLength(jba_val);
-  Text* val = new (heap_) Text((char*)p_val, len); 
-  jenv_->ReleaseByteArrayElements(jba_val, p_val, JNI_ABORT);
-  jenv_->DeleteLocalRef(jba_val);  
-
-  return val;
-}
-
-Int32 ByteArrayList::getSize()
-{
-  Int32 len = jenv_->CallIntMethod(javaObj_, JavaMethods_[JM_GETSIZE].methodID);
-  if (jenv_->ExceptionCheck())
-  {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    return 0;
-  }
-  return len;
-}
-
-Int32 ByteArrayList::getEntrySize(Int32 i)
-{
-  jint jidx = i;  
-
-  Int32 len = 
-    jenv_->CallIntMethod(javaObj_, JavaMethods_[JM_GETENTRYSIZE].methodID, jidx);
-
-  if (jenv_->ExceptionCheck())
-  {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    return 0;
-  }
-  return len;
-}
-
-
-char* ByteArrayList::getEntry(Int32 i, char* buf, Int32 bufLen, Int32& datalen)
-{
-  datalen = 0;
-
-  jint jidx = i;  
-
-  jbyteArray jBuffer = static_cast<jbyteArray>
-      (jenv_->CallObjectMethod(javaObj_, JavaMethods_[JM_GETENTRY].methodID, jidx));
-
-  if (jenv_->ExceptionCheck())
-  {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    return NULL;
-  }
-
-  if (jBuffer != NULL) {
-
-    datalen = jenv_->GetArrayLength(jBuffer);
-
-    if (datalen > bufLen)
-      // call setJniErrorStr?
-      return NULL;
-
-    jenv_->GetByteArrayRegion(jBuffer, 0, datalen, (jbyte*)buf);
-
-    jenv_->DeleteLocalRef(jBuffer);
-  }
-
-  return buf;
-}
+//
 // ===========================================================================
 // ===== Class HBaseClient_JNI
 // ===========================================================================
@@ -315,6 +97,8 @@ static const char* const hbcErrorEnumStr[] =
  ,"Preparing parameters for checkAndDeleteRow()."
  ,"Java exception in checkAndDeleteRow()."
  ,"Row not found in checkAndDeleteRow()."
+ ,"Preparing parameters for getKeys()."
+ ,"Preparing parameters for getRegionStats()."
 };
 
 //////////////////////////////////////////////////////////////////////////////
@@ -446,9 +230,9 @@ HBC_RetCode HBaseClient_JNI::init()
     JavaMethods_[JM_DROP_ALL       ].jm_name      = "dropAll";
     JavaMethods_[JM_DROP_ALL       ].jm_signature = "(Ljava/lang/String;J)Z";
     JavaMethods_[JM_LIST_ALL       ].jm_name      = "listAll";
-    JavaMethods_[JM_LIST_ALL       ].jm_signature = "(Ljava/lang/String;)Lorg/trafodion/sql/ByteArrayList;";
+    JavaMethods_[JM_LIST_ALL       ].jm_signature = "(Ljava/lang/String;)[[B";
     JavaMethods_[JM_GET_REGION_STATS       ].jm_name      = "getRegionStats";
-    JavaMethods_[JM_GET_REGION_STATS       ].jm_signature = "(Ljava/lang/String;)Lorg/trafodion/sql/ByteArrayList;";
+    JavaMethods_[JM_GET_REGION_STATS       ].jm_signature = "(Ljava/lang/String;)[[B";
     JavaMethods_[JM_COPY       ].jm_name      = "copy";
     JavaMethods_[JM_COPY       ].jm_signature = "(Ljava/lang/String;Ljava/lang/String;Z)Z";
     JavaMethods_[JM_EXISTS     ].jm_name      = "exists";
@@ -497,6 +281,10 @@ HBC_RetCode HBaseClient_JNI::init()
     JavaMethods_[JM_HBC_DIRECT_DELETE_ROWS ].jm_signature = "(JLjava/lang/String;ZJSLjava/lang/Object;JZ)Z";
     JavaMethods_[JM_HBC_CHECKANDDELETE_ROW ].jm_name      = "checkAndDeleteRow";
     JavaMethods_[JM_HBC_CHECKANDDELETE_ROW ].jm_signature = "(JLjava/lang/String;ZJ[B[B[BJZ)Z";
+    JavaMethods_[JM_HBC_GETSTARTKEYS ].jm_name      = "getStartKeys";
+    JavaMethods_[JM_HBC_GETSTARTKEYS ].jm_signature = "(Ljava/lang/String;)[[B";
+    JavaMethods_[JM_HBC_GETENDKEYS ].jm_name      = "getEndKeys";
+    JavaMethods_[JM_HBC_GETENDKEYS ].jm_signature = "(Ljava/lang/String;)[[B";
     rc = (HBC_RetCode)JavaObjectInterface::init(className, javaClass_, JavaMethods_, (Int32)JM_LAST, javaMethodsInitialized_);
     javaMethodsInitialized_ = TRUE;
     pthread_mutex_unlock(&javaMethodsInitMutex_);
@@ -1368,7 +1156,7 @@ HBC_RetCode HBaseClient_JNI::dropAll(const char* pattern, bool async, Int64 tran
 //////////////////////////////////////////////////////////////////////////////
 // 
 //////////////////////////////////////////////////////////////////////////////
-ByteArrayList* HBaseClient_JNI::listAll(const char* pattern)
+NAArray<HbaseStr>* HBaseClient_JNI::listAll(NAHeap *heap, const char* pattern)
 {
   QRLogger::log(CAT_SQL_HBASE, LL_DEBUG, "HBaseClient_JNI::listAll(%s) called.", pattern);
 
@@ -1389,8 +1177,8 @@ ByteArrayList* HBaseClient_JNI::listAll(const char* pattern)
   }
 
   tsRecentJMFromJNI = JavaMethods_[JM_LIST_ALL].jm_full_name;
-  jobject jByteArrayList = 
-    jenv_->CallObjectMethod(javaObj_, JavaMethods_[JM_LIST_ALL].methodID, js_pattern);
+  jarray j_hbaseTables = 
+    (jarray)jenv_->CallObjectMethod(javaObj_, JavaMethods_[JM_LIST_ALL].methodID, js_pattern);
 
   jenv_->DeleteLocalRef(js_pattern);  
 
@@ -1403,28 +1191,24 @@ ByteArrayList* HBaseClient_JNI::listAll(const char* pattern)
     return NULL;
   }
 
-  if (jByteArrayList == NULL) {
+  if (j_hbaseTables  == NULL) {
     jenv_->PopLocalFrame(NULL);
     return NULL;
   }
 
-  ByteArrayList* hbaseTables = new (heap_) ByteArrayList(heap_, jByteArrayList);
-  jenv_->DeleteLocalRef(jByteArrayList);
-  if (hbaseTables->init() != BAL_OK)
-    {
-      NADELETE(hbaseTables, ByteArrayList, heap_);
-      jenv_->PopLocalFrame(NULL);
-      return NULL;
-    }
-  
+  NAArray<HbaseStr> *hbaseTables;
+  jint retcode = convertByteArrayObjectArrayToNAArray(heap, j_hbaseTables, &hbaseTables);
   jenv_->PopLocalFrame(NULL);
-  return hbaseTables;
+  if (retcode == 0)
+     return NULL;
+  else
+     return hbaseTables;
 }
 
 //////////////////////////////////////////////////////////////////////////////
 // 
 //////////////////////////////////////////////////////////////////////////////
-ByteArrayList* HBaseClient_JNI::getRegionStats(const char* tblName)
+NAArray<HbaseStr>* HBaseClient_JNI::getRegionStats(NAHeap *heap, const char* tblName)
 {
   QRLogger::log(CAT_SQL_HBASE, LL_DEBUG, "HBaseClient_JNI::getRegionStats(%s) called.", tblName);
 
@@ -1439,14 +1223,14 @@ ByteArrayList* HBaseClient_JNI::getRegionStats(const char* tblName)
   jstring js_tblName = jenv_->NewStringUTF(tblName);
   if (js_tblName == NULL) 
   {
-    GetCliGlobals()->setJniErrorStr(getErrorText(HBC_ERROR_DROP_PARAM));
+    GetCliGlobals()->setJniErrorStr(getErrorText(HBC_ERROR_REGION_STATS));
     jenv_->PopLocalFrame(NULL);
     return NULL;
   }
 
   tsRecentJMFromJNI = JavaMethods_[JM_GET_REGION_STATS].jm_full_name;
-  jobject jByteArrayList = 
-    jenv_->CallObjectMethod(javaObj_, JavaMethods_[JM_GET_REGION_STATS].methodID, js_tblName);
+  jarray j_regionInfo = 
+    (jarray)jenv_->CallObjectMethod(javaObj_, JavaMethods_[JM_GET_REGION_STATS].methodID, js_tblName);
 
   jenv_->DeleteLocalRef(js_tblName);  
 
@@ -1459,22 +1243,19 @@ ByteArrayList* HBaseClient_JNI::getRegionStats(const char* tblName)
     return NULL;
   }
 
-  if (jByteArrayList == NULL) {
+  if (j_regionInfo == NULL) {
     jenv_->PopLocalFrame(NULL);
     return NULL;
   }
 
-  ByteArrayList* regionInfo = new (heap_) ByteArrayList(heap_, jByteArrayList);
-  jenv_->DeleteLocalRef(jByteArrayList);
-  if (regionInfo->init() != BAL_OK)
-    {
-      NADELETE(regionInfo, ByteArrayList, heap_);
-      jenv_->PopLocalFrame(NULL);
-      return NULL;
-    }
-  
+  NAArray<HbaseStr> *regionInfo;
+  jint retcode = convertByteArrayObjectArrayToNAArray(heap, j_regionInfo, &regionInfo);
+
   jenv_->PopLocalFrame(NULL);
-  return regionInfo;
+  if (retcode == 0)
+     return NULL;
+  else
+     return regionInfo;
 }
 
 //////////////////////////////////////////////////////////////////////////////
@@ -3472,6 +3253,50 @@ HBC_RetCode HBaseClient_JNI::checkAndDeleteRow(NAHeap *heap, const char *tableNa
   return HBC_OK;
 }
 
+NAArray<HbaseStr>* HBaseClient_JNI::getStartKeys(NAHeap *heap, const char *tableName)
+{
+   return HBaseClient_JNI::getKeys(JM_HBC_GETSTARTKEYS, heap, tableName);
+}
+
+NAArray<HbaseStr>* HBaseClient_JNI::getEndKeys(NAHeap *heap, const char * tableName)
+{
+   return HBaseClient_JNI::getKeys(JM_HBC_GETENDKEYS, heap, tableName);
+}
+
+NAArray<HbaseStr>* HBaseClient_JNI::getKeys(Int32 funcIndex, NAHeap *heap, const char *tableName)
+{
+
+  if (jenv_->PushLocalFrame(jniHandleCapacity_) != 0) {
+    getExceptionDetails();
+    return NULL;
+  }
+   jstring js_tblName = jenv_->NewStringUTF(tableName);
+  if (js_tblName == NULL) {
+    GetCliGlobals()->setJniErrorStr(getErrorText(HBC_ERROR_GETKEYS));
+    jenv_->PopLocalFrame(NULL);
+    return NULL;
+  }
+
+  jarray j_keyArray=
+     (jarray)jenv_->CallObjectMethod(javaObj_, JavaMethods_[funcIndex].methodID, js_tblName);
+
+  if (jenv_->ExceptionCheck())
+  {
+    getExceptionDetails();
+    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
+    jenv_->PopLocalFrame(NULL);
+    return NULL;
+  }
+  NAArray<HbaseStr> *retArray;
+  jint retcode = convertByteArrayObjectArrayToNAArray(heap, j_keyArray, &retArray);
+  jenv_->PopLocalFrame(NULL);
+  if (retcode == 0)
+     return NULL;
+  else
+     return retArray;  
+}
+
+
 
 // ===========================================================================
 // ===== Class HTableClient
@@ -3594,8 +3419,6 @@ HTC_RetCode HTableClient_JNI::init()
     JavaMethods_[JM_GET_NAME   ].jm_signature = "()Ljava/lang/String;";
     JavaMethods_[JM_GET_HTNAME ].jm_name      = "getTableName";
     JavaMethods_[JM_GET_HTNAME ].jm_signature = "()Ljava/lang/String;";
-    JavaMethods_[JM_GETENDKEYS ].jm_name      = "getEndKeys";
-    JavaMethods_[JM_GETENDKEYS ].jm_signature = "()Lorg/trafodion/sql/ByteArrayList;";
     JavaMethods_[JM_SET_WB_SIZE ].jm_name      = "setWriteBufferSize";
     JavaMethods_[JM_SET_WB_SIZE ].jm_signature = "(J)Z";
     JavaMethods_[JM_SET_WRITE_TO_WAL ].jm_name      = "setWriteToWAL";
@@ -3604,8 +3427,6 @@ HTC_RetCode HTableClient_JNI::init()
     JavaMethods_[JM_FETCH_ROWS ].jm_signature = "()I";
     JavaMethods_[JM_COMPLETE_PUT ].jm_name      = "completeAsyncOperation";
     JavaMethods_[JM_COMPLETE_PUT ].jm_signature = "(I[Z)Z";
-    JavaMethods_[JM_GETBEGINKEYS ].jm_name      = "getStartKeys";
-    JavaMethods_[JM_GETBEGINKEYS ].jm_signature = "()Lorg/trafodion/sql/ByteArrayList;";
    
     rc = (HTC_RetCode)JavaObjectInterface::init(className, javaClass_, JavaMethods_, (Int32)JM_LAST, javaMethodsInitialized_);
     javaMethodsInitialized_ = TRUE;
@@ -4133,52 +3954,6 @@ HTC_RetCode HTableClient_JNI::coProcAggr(Int64 transID,
 
   jenv_->PopLocalFrame(NULL);
   return HTC_OK;
-}
-
-ByteArrayList* HTableClient_JNI::getBeginKeys()
-{
-   return HTableClient_JNI::getKeys(JM_GETBEGINKEYS);
-}
-
-ByteArrayList* HTableClient_JNI::getEndKeys()
-{
-   return HTableClient_JNI::getKeys(JM_GETENDKEYS);
-}
-
-ByteArrayList* HTableClient_JNI::getKeys(Int32 funcIndex)
-{
-
-  if (jenv_->PushLocalFrame(jniHandleCapacity_) != 0) {
-    getExceptionDetails();
-    return NULL;
-  }
-  jobject jByteArrayList = 
-     jenv_->CallObjectMethod(javaObj_, JavaMethods_[funcIndex].methodID);
-
-  if (jenv_->ExceptionCheck())
-  {
-    getExceptionDetails();
-    logError(CAT_SQL_HBASE, __FILE__, __LINE__);
-    jenv_->PopLocalFrame(NULL);
-    return NULL;
-  }
-
-  if (jByteArrayList == NULL) {
-    jenv_->PopLocalFrame(NULL);
-    return NULL;
-  }
-
-  ByteArrayList* keys = new (heap_) ByteArrayList(heap_, jByteArrayList);
-  jenv_->DeleteLocalRef(jByteArrayList);
-  if (keys->init() != BAL_OK)
-  {
-     NADELETE(keys, ByteArrayList, heap_);
-     jenv_->PopLocalFrame(NULL);
-     return NULL;
-  }
-  jenv_->PopLocalFrame(NULL);
-  return keys;
-
 }
 
 // ===========================================================================
@@ -5619,3 +5394,41 @@ int convertStringObjectArrayToList(NAHeap *heap, jarray j_objArray,
     return arrayLen;
 }
 
+
+jint convertByteArrayObjectArrayToNAArray(NAHeap *heap, jarray j_objArray, NAArray<HbaseStr> **retArray)
+{
+    if (j_objArray == NULL)
+       return 0;
+    int arrayLen = jenv_->GetArrayLength(j_objArray);
+    jbyteArray j_ba;
+    jint j_baLen;
+    BYTE *ba;
+    jboolean isCopy;
+    HbaseStr element; 
+    NAArray<HbaseStr> *tmpArray = new (heap) NAArray<HbaseStr> (heap, arrayLen); 
+    for (int i = 0; i < arrayLen; i++)
+    {
+        j_ba = (jbyteArray)jenv_->GetObjectArrayElement((jobjectArray)j_objArray, i);
+        j_baLen = jenv_->GetArrayLength(j_ba);
+        ba = new (heap) BYTE[j_baLen];
+        jenv_->GetByteArrayRegion(j_ba, 0, j_baLen, (jbyte *)ba); 
+        element.len = j_baLen;
+        element.val = (char *)ba;
+        tmpArray->insert(i,element);
+    }
+    *retArray = tmpArray;
+    return arrayLen;
+}
+
+void deleteNAArray(CollHeap *heap, NAArray<HbaseStr> *array)
+{
+  
+  if (array == NULL)
+     return;
+  CollIndex entryCount = array->entries();
+  for (CollIndex i = 0 ; i < entryCount; i++) {
+      NADELETEBASIC(array->at(i).val, heap);
+  }
+  NADELETE(array, NAArray, heap);
+}
+                      

--- a/core/sql/executor/HBaseClient_JNI.h
+++ b/core/sql/executor/HBaseClient_JNI.h
@@ -71,6 +71,70 @@ public :
   NAHeap *heap_;
 };
 
+// ===========================================================================
+// ===== The ByteArrayList class implements access to the Java 
+// ===== ByteArrayList class.
+// ===========================================================================
+
+typedef enum {
+  BAL_OK     = JOI_OK
+ ,BAL_FIRST  = JOI_LAST
+ ,BAL_ERROR_ADD_PARAM = BAL_FIRST
+ ,BAL_ERROR_ADD_EXCEPTION
+ ,BAL_ERROR_GET_EXCEPTION
+ ,BAL_LAST
+} BAL_RetCode;
+
+class ByteArrayList : public JavaObjectInterface
+{
+public:
+  ByteArrayList(NAHeap *heap, jobject jObj = NULL)
+    :  JavaObjectInterface(heap, jObj)
+  {}
+
+  // Destructor
+  virtual ~ByteArrayList();
+
+  // Initialize JVM and all the JNI configuration.
+  // Must be called.
+  BAL_RetCode    init();
+
+  BAL_RetCode add(const Text& str);
+
+  // Add a Text vector.
+  BAL_RetCode add(const TextVec& vec);
+
+  BAL_RetCode addElement(const char * data, int keyLength);
+
+  // Get a Text element
+  Text* get(Int32 i);
+
+  // Get the error description.
+  virtual char* getErrorText(BAL_RetCode errEnum);
+
+  Int32 getSize();
+  Int32 getEntrySize(Int32 i);
+  char* getEntry(Int32 i, char* buf, Int32 bufLen, Int32& dataLen);
+
+
+private:
+  enum JAVA_METHODS {
+    JM_CTOR = 0,
+    JM_ADD,
+    JM_GET,
+    JM_GETSIZE,
+    JM_GETENTRY,
+    JM_GETENTRYSIZE,
+    JM_LAST
+  };
+
+  static jclass          javaClass_;
+  static JavaMethodInit* JavaMethods_;
+  static bool javaMethodsInitialized_;
+  // this mutex protects both JaveMethods_ and javaClass_ initialization
+  static pthread_mutex_t javaMethodsInitMutex_;
+};
+
 
 // ===========================================================================
 // ===== The HTableClient class implements access to the Java 
@@ -79,7 +143,7 @@ public :
 
 typedef enum {
   HTC_OK     = JOI_OK
- ,HTC_FIRST  = JOI_LAST
+ ,HTC_FIRST  = BAL_LAST
  ,HTC_DONE   = HTC_FIRST
  ,HTC_DONE_RESULT = 1000
  ,HTC_DONE_DATA
@@ -502,13 +566,13 @@ public:
       ExHbaseAccessStats *hbs, bool useTRex, Int64 transID, HbaseStr rowID, 
       HbaseStr columnToCheck, HbaseStr columnValToCheck,
       Int64 timestamp, bool asyncOperation, HTableClient_JNI **outHtc);
-  NAArray<HbaseStr>* getStartKeys(NAHeap *heap, const char *tableName);
-  NAArray<HbaseStr>* getEndKeys(NAHeap *heap, const char * tableName);
+  NAArray<HbaseStr>* getStartKeys(NAHeap *heap, const char *tableName, bool useTRex);
+  NAArray<HbaseStr>* getEndKeys(NAHeap *heap, const char * tableName, bool useTRex);
 
 private:   
   // private default constructor
   HBaseClient_JNI(NAHeap *heap, int debugPort, int debugTimeout);
-  NAArray<HbaseStr>* getKeys(Int32 funcIndex, NAHeap *heap, const char *tableName);
+  NAArray<HbaseStr>* getKeys(Int32 funcIndex, NAHeap *heap, const char *tableName, bool useTRex);
 
 private:
   NAString  getLastJavaError();

--- a/core/sql/executor/HBaseClient_JNI.h
+++ b/core/sql/executor/HBaseClient_JNI.h
@@ -57,70 +57,6 @@ typedef enum {
  ,HBC_Req_Drop
 } HBaseClientReqType;
 
-// ===========================================================================
-// ===== The ByteArrayList class implements access to the Java 
-// ===== ByteArrayList class.
-// ===========================================================================
-
-typedef enum {
-  BAL_OK     = JOI_OK
- ,BAL_FIRST  = JOI_LAST
- ,BAL_ERROR_ADD_PARAM = BAL_FIRST
- ,BAL_ERROR_ADD_EXCEPTION
- ,BAL_ERROR_GET_EXCEPTION
- ,BAL_LAST
-} BAL_RetCode;
-
-class ByteArrayList : public JavaObjectInterface
-{
-public:
-  ByteArrayList(NAHeap *heap, jobject jObj = NULL)
-    :  JavaObjectInterface(heap, jObj)
-  {}
-
-  // Destructor
-  virtual ~ByteArrayList();
-  
-  // Initialize JVM and all the JNI configuration.
-  // Must be called.
-  BAL_RetCode    init();
-  
-  BAL_RetCode add(const Text& str);
-    
-  // Add a Text vector.
-  BAL_RetCode add(const TextVec& vec);
-
-  BAL_RetCode addElement(const char * data, int keyLength);
-    
-  // Get a Text element
-  Text* get(Int32 i);
-
-  // Get the error description.
-  virtual char* getErrorText(BAL_RetCode errEnum);
-
-  Int32 getSize();
-  Int32 getEntrySize(Int32 i);
-  char* getEntry(Int32 i, char* buf, Int32 bufLen, Int32& dataLen);
-
-
-private:  
-  enum JAVA_METHODS {
-    JM_CTOR = 0, 
-    JM_ADD,
-    JM_GET,
-    JM_GETSIZE,
-    JM_GETENTRY,
-    JM_GETENTRYSIZE,
-    JM_LAST
-  };
-  
-  static jclass          javaClass_;  
-  static JavaMethodInit* JavaMethods_;
-  static bool javaMethodsInitialized_;
-  // this mutex protects both JaveMethods_ and javaClass_ initialization
-  static pthread_mutex_t javaMethodsInitMutex_;
-};
-
 class HBaseClientRequest
 {
 public :
@@ -143,7 +79,7 @@ public :
 
 typedef enum {
   HTC_OK     = JOI_OK
- ,HTC_FIRST  = BAL_LAST
+ ,HTC_FIRST  = JOI_LAST
  ,HTC_DONE   = HTC_FIRST
  ,HTC_DONE_RESULT = 1000
  ,HTC_DONE_DATA
@@ -173,7 +109,6 @@ typedef enum {
  ,HTC_ERROR_GRANT_EXCEPTION
  ,HTC_ERROR_REVOKE_PARAM
  ,HTC_ERROR_REVOKE_EXCEPTION
- ,HTC_GETENDKEYS
  ,HTC_ERROR_GETHTABLENAME_EXCEPTION
  ,HTC_GET_COLNAME_EXCEPTION
  ,HTC_GET_COLVAL_EXCEPTION
@@ -309,9 +244,6 @@ public:
   // Get the error description.
   virtual char* getErrorText(HTC_RetCode errEnum);
 
-  ByteArrayList* getBeginKeys();
-  ByteArrayList* getEndKeys();
-
   void setTableName(const char *tableName)
   {
     Int32 len = strlen(tableName);
@@ -342,7 +274,6 @@ public:
 
 private:
   NAString getLastJavaError();
-  ByteArrayList* getKeys(Int32 funcIndex);
 
   enum JAVA_METHODS {
     JM_CTOR = 0
@@ -352,12 +283,10 @@ private:
    ,JM_COPROC_AGGR
    ,JM_GET_NAME
    ,JM_GET_HTNAME
-   ,JM_GETENDKEYS
    ,JM_SET_WB_SIZE
    ,JM_SET_WRITE_TO_WAL
    ,JM_FETCH_ROWS
    ,JM_COMPLETE_PUT
-   ,JM_GETBEGINKEYS
    ,JM_LAST
   };
   char *tableName_; 
@@ -471,6 +400,8 @@ typedef enum {
  ,HBC_ERROR_CHECKANDDELETEROW_PARAM
  ,HBC_ERROR_CHECKANDDELETEROW_EXCEPTION
  ,HBC_ERROR_CHECKANDDELETEROW_NOTFOUND
+ ,HBC_ERROR_GETKEYS
+ ,HBC_ERROR_REGION_STATS
  ,HBC_LAST
 } HBC_RetCode;
 
@@ -509,8 +440,9 @@ public:
   HBC_RetCode dropAll(const char* pattern, bool async, Int64 transID);
   HBC_RetCode copy(const char* srcTblName, const char* tgtTblName,
                    NABoolean force);
-  ByteArrayList* listAll(const char* pattern);
-  ByteArrayList* getRegionStats(const char* tblName);
+  NAArray<HbaseStr>* listAll(NAHeap *heap, const char* pattern);
+  NAArray<HbaseStr>* getRegionStats(NAHeap *heap, const char* tblName);
+
   HBC_RetCode exists(const char* fileName, Int64 transID);
   HBC_RetCode grant(const Text& user, const Text& tableName, const TextVec& actionCodes); 
   HBC_RetCode revoke(const Text& user, const Text& tableName, const TextVec& actionCodes);
@@ -570,10 +502,13 @@ public:
       ExHbaseAccessStats *hbs, bool useTRex, Int64 transID, HbaseStr rowID, 
       HbaseStr columnToCheck, HbaseStr columnValToCheck,
       Int64 timestamp, bool asyncOperation, HTableClient_JNI **outHtc);
+  NAArray<HbaseStr>* getStartKeys(NAHeap *heap, const char *tableName);
+  NAArray<HbaseStr>* getEndKeys(NAHeap *heap, const char * tableName);
 
 private:   
   // private default constructor
   HBaseClient_JNI(NAHeap *heap, int debugPort, int debugTimeout);
+  NAArray<HbaseStr>* getKeys(Int32 funcIndex, NAHeap *heap, const char *tableName);
 
 private:
   NAString  getLastJavaError();
@@ -618,6 +553,8 @@ private:
    ,JM_HBC_DELETE_ROW
    ,JM_HBC_DIRECT_DELETE_ROWS
    ,JM_HBC_CHECKANDDELETE_ROW
+   ,JM_HBC_GETSTARTKEYS
+   ,JM_HBC_GETENDKEYS
    ,JM_LAST
   };
   static jclass          javaClass_; 
@@ -826,6 +763,9 @@ jobjectArray convertToStringObjectArray(const HBASE_NAMELIST& nameList);
 jobjectArray convertToStringObjectArray(const NAText *text, int arrayLen);
 int convertStringObjectArrayToList(NAHeap *heap, jarray j_objArray, 
                                          LIST(Text *)&list);
+int convertByteArrayObjectArrayToNAArray(NAHeap *heap, jarray j_objArray, 
+             NAArray<HbaseStr> **retArray);
+void deleteNAArray(CollHeap *heap, NAArray<HbaseStr> *array);
 #endif
 
 

--- a/core/sql/exp/ExpHbaseInterface.cpp
+++ b/core/sql/exp/ExpHbaseInterface.cpp
@@ -1305,13 +1305,13 @@ Lng32 ExpHbaseInterface_JNI::revoke(
 
 NAArray<HbaseStr> *ExpHbaseInterface_JNI::getRegionBeginKeys(const char* tblName)
 { 
-  NAArray<HbaseStr> *retValue = client_->getStartKeys((NAHeap *)heap_, tblName);
+  NAArray<HbaseStr> *retValue = client_->getStartKeys((NAHeap *)heap_, tblName, useTRex_);
   return retValue;
 }
 
 NAArray<HbaseStr> *ExpHbaseInterface_JNI::getRegionEndKeys(const char* tblName)
 { 
-  NAArray<HbaseStr> *retValue = client_->getEndKeys((NAHeap *)heap_, tblName);
+  NAArray<HbaseStr> *retValue = client_->getEndKeys((NAHeap *)heap_, tblName, useTRex_);
   return retValue;
 }
 

--- a/core/sql/exp/ExpHbaseInterface.cpp
+++ b/core/sql/exp/ExpHbaseInterface.cpp
@@ -552,7 +552,7 @@ Lng32 ExpHbaseInterface_JNI::dropAll(const char * pattern, NABoolean async,
 }
 
 //----------------------------------------------------------------------------
-ByteArrayList* ExpHbaseInterface_JNI::listAll(const char * pattern)
+NAArray<HbaseStr>* ExpHbaseInterface_JNI::listAll(const char * pattern)
 {
   if (client_ == NULL)
   {
@@ -560,11 +560,8 @@ ByteArrayList* ExpHbaseInterface_JNI::listAll(const char * pattern)
       return NULL;
   }
     
-  ByteArrayList* bal = client_->listAll(pattern);
-  if (bal == NULL)
-    return NULL;
-
-  return bal;
+  NAArray<HbaseStr> *listArray = client_->listAll((NAHeap *)heap_, pattern);
+  return listArray;
 }
 
 //----------------------------------------------------------------------------
@@ -1306,30 +1303,16 @@ Lng32 ExpHbaseInterface_JNI::revoke(
     return HBASE_ACCESS_SUCCESS;
 }
 
-ByteArrayList* ExpHbaseInterface_JNI::getRegionBeginKeys(const char* tblName)
+NAArray<HbaseStr> *ExpHbaseInterface_JNI::getRegionBeginKeys(const char* tblName)
 { 
-  htc_ = client_->getHTableClient((NAHeap *)heap_, tblName, useTRex_, hbs_);
-  if (htc_ == NULL)
-  {
-    retCode_ = HBC_ERROR_GET_HTC_EXCEPTION;
-    return NULL;
-  }
-
-   ByteArrayList* bal = htc_->getBeginKeys();
-   return bal;
+  NAArray<HbaseStr> *retValue = client_->getStartKeys((NAHeap *)heap_, tblName);
+  return retValue;
 }
 
-ByteArrayList* ExpHbaseInterface_JNI::getRegionEndKeys(const char* tblName)
+NAArray<HbaseStr> *ExpHbaseInterface_JNI::getRegionEndKeys(const char* tblName)
 { 
-  htc_ = client_->getHTableClient((NAHeap *)heap_, tblName, useTRex_, hbs_);
-  if (htc_ == NULL)
-  {
-    retCode_ = HBC_ERROR_GET_HTC_EXCEPTION;
-    return NULL;
-  }
-
-   ByteArrayList* bal = htc_->getEndKeys();
-   return bal;
+  NAArray<HbaseStr> *retValue = client_->getEndKeys((NAHeap *)heap_, tblName);
+  return retValue;
 }
 
 Lng32 ExpHbaseInterface_JNI::getColVal(int colNo, BYTE *colVal,
@@ -1565,7 +1548,7 @@ Lng32 ExpHbaseInterface_JNI::getBlockCacheFraction(float& frac)
   return retCode_;
 }
 
-ByteArrayList * ExpHbaseInterface_JNI::getRegionStats(const HbaseStr& tblName)
+NAArray<HbaseStr> * ExpHbaseInterface_JNI::getRegionStats(const HbaseStr& tblName)
 {
   if (client_ == NULL)
     {
@@ -1573,7 +1556,7 @@ ByteArrayList * ExpHbaseInterface_JNI::getRegionStats(const HbaseStr& tblName)
         return NULL;
     }
   
-  ByteArrayList* regionStats = client_->getRegionStats(tblName.val);
+  NAArray<HbaseStr>* regionStats = client_->getRegionStats((NAHeap *)heap_, tblName.val);
   if (regionStats == NULL)
     return NULL;
   

--- a/core/sql/exp/ExpHbaseInterface.h
+++ b/core/sql/exp/ExpHbaseInterface.h
@@ -83,6 +83,7 @@ namespace {
 class ExpHbaseInterface : public NABasicObject
 {
  public:
+  NAHeap *getHeap() { return (NAHeap*)heap_; }
 
   static ExpHbaseInterface* newInstance(CollHeap* heap, 
                                         const char* server = NULL, 
@@ -132,7 +133,7 @@ class ExpHbaseInterface : public NABasicObject
   virtual Lng32 dropAll(const char * pattern, NABoolean async, NABoolean noXn) = 0;
 
   // retrieve all objects from hbase that match the pattern
-  virtual ByteArrayList* listAll(const char * pattern) = 0;
+  virtual NAArray<HbaseStr> *listAll(const char * pattern) = 0;
 
   // make a copy of srcTblName as tgtTblName
   // if force is true, remove target before copying.
@@ -359,8 +360,8 @@ class ExpHbaseInterface : public NABasicObject
 		      const Text& tblName,
 		      const std::vector<Text> & actionCodes) = 0;
 
-  virtual ByteArrayList* getRegionBeginKeys(const char*) = 0;
-  virtual ByteArrayList* getRegionEndKeys(const char*) = 0;
+  virtual NAArray<HbaseStr>* getRegionBeginKeys(const char*) = 0;
+  virtual NAArray<HbaseStr>* getRegionEndKeys(const char*) = 0;
 
   virtual Lng32 estimateRowCount(HbaseStr& tblName,
                                  Int32 partialRowSize,
@@ -380,7 +381,7 @@ class ExpHbaseInterface : public NABasicObject
                                    ARRAY(const char *)& nodeNames) = 0;
 
   // get regions and size
-  virtual ByteArrayList* getRegionStats(const HbaseStr& tblName) = 0;
+  virtual NAArray<HbaseStr> *getRegionStats(const HbaseStr& tblName) = 0;
 
 protected:
   enum 
@@ -444,7 +445,7 @@ class ExpHbaseInterface_JNI : public ExpHbaseInterface
   virtual Lng32 drop(HbaseStr &tblName, NABoolean async, NABoolean noXn);
   virtual Lng32 dropAll(const char * pattern, NABoolean async, NABoolean noXn);
 
-  virtual ByteArrayList* listAll(const char * pattern);
+  virtual NAArray<HbaseStr>* listAll(const char * pattern);
 
   // make a copy of srcTblName as tgtTblName
   // if force is true, remove target before copying.
@@ -661,9 +662,8 @@ virtual Lng32 initHFileParams(HbaseStr &tblName,
 		      const Text& tblName,
   		      const std::vector<Text> & actionCodes);
 
-
-  virtual ByteArrayList* getRegionBeginKeys(const char*);
-  virtual ByteArrayList* getRegionEndKeys(const char*);
+  virtual NAArray<HbaseStr>* getRegionBeginKeys(const char*);
+  virtual NAArray<HbaseStr>* getRegionEndKeys(const char*);
 
   virtual Lng32 estimateRowCount(HbaseStr& tblName,
                                  Int32 partialRowSize,
@@ -682,7 +682,7 @@ virtual Lng32 initHFileParams(HbaseStr &tblName,
                                    Int32 partns,
                                    ARRAY(const char *)& nodeNames) ;
 
-  virtual ByteArrayList* getRegionStats(const HbaseStr& tblName);
+  virtual NAArray<HbaseStr>* getRegionStats(const HbaseStr& tblName);
 
 private:
   bool  useTRex_;

--- a/core/sql/generator/GenRelScan.cpp
+++ b/core/sql/generator/GenRelScan.cpp
@@ -1313,7 +1313,7 @@ void populateRangeDescForBeginKey(char* buf, Int32 len, struct desc_struct* targ
 void populateRegionDescAsRANGE(char* buf, Int32 len, struct desc_struct* target, NAMemory*);
 
 desc_struct *HbaseAccess::createVirtualTableDesc(const char * name,
-						 NABoolean isRW, NABoolean isCW, ByteArrayList* beginKeys)
+						 NABoolean isRW, NABoolean isCW, NAArray<HbaseStr>* beginKeys)
 {
   desc_struct * table_desc = NULL;
 

--- a/core/sql/lib_mgmt/Makefile
+++ b/core/sql/lib_mgmt/Makefile
@@ -25,7 +25,7 @@ CP :=/bin/cp -f
 all:
 	@$(MAVEN) package
 	mkdir -p ${INSTALL_LIBDIR}
-	${CP} target/lib_mgmt-*.jar ${INSTALL_LIBDIR}/lib_mgmt.jar
+	${CP} target/lib_mgmt-${TRAFODION_VER}.jar ${INSTALL_LIBDIR}/lib_mgmt.jar
 	${CP} src/main/resources/init_libmgmt.sh ${INSTALL_SCRIPTSDIR}/
 	@chmod +x ${INSTALL_SCRIPTSDIR}/init_libmgmt.sh
 clean:

--- a/core/sql/optimizer/NATable.cpp
+++ b/core/sql/optimizer/NATable.cpp
@@ -7712,20 +7712,20 @@ ExpHbaseInterface* NATable::getHBaseInterfaceRaw()
   return ehi;
 }
 
-ByteArrayList* NATable::getRegionsBeginKey(const char* hbaseName) 
+NAArray<HbaseStr> *NATable::getRegionsBeginKey(const char* hbaseName) 
 {
   ExpHbaseInterface* ehi = getHBaseInterfaceRaw();
-  ByteArrayList* bal = NULL;
+  NAArray<HbaseStr> *keyArray = NULL;
 
   if (!ehi)
     return NULL;
   else
   {
-    bal = ehi->getRegionBeginKeys(hbaseName);
+    keyArray = ehi->getRegionBeginKeys(hbaseName);
 
     delete ehi;
   }
-  return bal;
+  return keyArray;
 }
 
 
@@ -8002,14 +8002,13 @@ NATable * NATableDB::get(CorrName& corrName, BindWA * bindWA,
 	      return NULL;
 	    }
 
-          ByteArrayList* bal = NATable::getRegionsBeginKey(extHBaseName);
+          NAArray<HbaseStr> *keyArray = NATable::getRegionsBeginKey(extHBaseName);
 
 	  tableDesc = 
 	    HbaseAccess::createVirtualTableDesc
 	    (corrName.getExposedNameAsAnsiString(FALSE, TRUE).data(),
-	     isHbaseRow, isHbaseCell, bal);
-
-          delete bal;
+	     isHbaseRow, isHbaseCell, keyArray);
+          deleteNAArray(STMTHEAP, keyArray);
 
 	  isSeabase = FALSE;
 

--- a/core/sql/optimizer/NATable.h
+++ b/core/sql/optimizer/NATable.h
@@ -44,6 +44,7 @@
 #include "hiveHook.h"
 #include "ExpLOBexternal.h"
 #include "ComSecurityKey.h"
+#include "ExpHbaseDefs.h"
 
 //forward declaration(s)
 // -----------------------------------------------------------------------
@@ -63,7 +64,6 @@ struct desc_struct;
 class HbaseCreateOption;
 class PrivMgrUserPrivs;
 class ExpHbaseInterface;
-class ByteArrayList;
 
 typedef QualifiedName* QualifiedNamePtr;
 typedef ULng32 (*HashFunctionPtr)(const QualifiedName&);
@@ -863,7 +863,7 @@ public:
   NABoolean getHbaseTableInfo(Int32& hbtIndexLevels, Int32& hbtBlockSize) const;
   NABoolean getRegionsNodeName(Int32 partns, ARRAY(const char *)& nodeNames) const;
 
-  static ByteArrayList* getRegionsBeginKey(const char* extHBaseName);
+  static NAArray<HbaseStr>* getRegionsBeginKey(const char* extHBaseName);
 
   NAString &defaultColFam() { return defaultColFam_; }
   NAList<NAString> &allColFams() { return allColFams_; }

--- a/core/sql/optimizer/RelScan.h
+++ b/core/sql/optimizer/RelScan.h
@@ -50,6 +50,7 @@
 #include "SchemaDB.h"
 #include "HbaseSearchSpec.h"
 #include "OptHints.h"
+#include "ExpHbaseDefs.h"
 #include <vector>
 
 // -----------------------------------------------------------------------
@@ -86,7 +87,6 @@ class QRDescGenerator;
 class RangeSpecRef;
 
 class MVMatch;
-class ByteArrayList;
 
 
 /*************************
@@ -1278,7 +1278,7 @@ public:
   static desc_struct *createVirtualTableDesc(const char * name,
 					     NABoolean isRW = FALSE,
 					     NABoolean isCW = FALSE, 
-                                             ByteArrayList* hbaseKeys = NULL);
+                                             NAArray<HbaseStr> * hbaseKeys = NULL);
 
   static desc_struct *createVirtualTableDesc(const char * name,
 					     NAList<char*> &colNameList,

--- a/core/sql/sqlcomp/CmpSeabaseDDL.h
+++ b/core/sql/sqlcomp/CmpSeabaseDDL.h
@@ -114,8 +114,6 @@ class NAType;
 struct desc_struct;
 class OutputInfo;
 
-class ByteArrayList;
-
 class HbaseCreateOption;
 
 class Parser;
@@ -1415,7 +1413,7 @@ private:
   NABoolean cmpSwitched_;
 };
 
-desc_struct* assembleDescs(ByteArrayList* bal, populateFuncT func, NAMemory* heap);
+desc_struct* assembleDescs(NAArray<HbaseStr>*keyArray, populateFuncT func, NAMemory* heap);
 
 
 #endif // _CMP_SEABASE_DDL_H_

--- a/core/sql/sqlcomp/CmpSeabaseDDLcleanup.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLcleanup.cpp
@@ -1186,12 +1186,11 @@ short CmpSeabaseMDcleanup::cleanupOrphanHbaseEntries(ExeCliInterface *cliInterfa
     {
       char cBuf[1000];
       
-      Int32 len = listArray->at(i).len;
-      char *val = listArray->at(i).val;
-      if (len >= sizeof(cBuf))
-         len = sizeof(cBuf)-1;
-      strncpy(cBuf, val, len);
-      cBuf[len] = '\0';
+      HbaseStr *hbaseStr = &listArray->at(i);
+      if (hbaseStr->len >= sizeof(cBuf))
+         hbaseStr->len = sizeof(cBuf)-1;
+      strncpy(cBuf, hbaseStr->val, hbaseStr->len);
+      cBuf[hbaseStr->len] = '\0';
       char *c = cBuf;
       Lng32 numParts = 0;
       char *parts[4];

--- a/core/sql/sqlcomp/CmpSeabaseDDLcleanup.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLcleanup.cpp
@@ -1174,22 +1174,25 @@ short CmpSeabaseMDcleanup::cleanupOrphanHbaseEntries(ExeCliInterface *cliInterfa
   NABoolean errorSeen = FALSE;
 
   // list all hbase objects that start with TRAFODION.* 
-  ByteArrayList* bal = ehi->listAll("TRAFODION\\..*");
-  if (! bal)
+  NAArray<HbaseStr>* listArray = ehi->listAll("TRAFODION\\..*");
+  if (! listArray)
     return -1;
 
   returnDetailsList_ = NULL;
   addReturnDetailsEntry(cliInterface, returnDetailsList_, NULL, TRUE);
 
   numOrphanHbaseEntries_ = 0;
-  for (Int32 i = 0; i < bal->getSize(); i++)
+  for (Int32 i = 0; i < listArray->entries(); i++)
     {
       char cBuf[1000];
       
-      Int32 len = 0;
-      char * c = bal->getEntry(i, cBuf, 1000, len);
-      c[len] = 0;
-      
+      Int32 len = listArray->at(i).len;
+      char *val = listArray->at(i).val;
+      if (len >= sizeof(cBuf))
+         len = sizeof(cBuf)-1;
+      strncpy(cBuf, val, len);
+      cBuf[len] = '\0';
+      char *c = cBuf;
       Lng32 numParts = 0;
       char *parts[4];
       LateNameInfo::extractParts(c, cBuf, numParts, parts, FALSE);
@@ -1247,7 +1250,7 @@ short CmpSeabaseMDcleanup::cleanupOrphanHbaseEntries(ExeCliInterface *cliInterfa
         }      
       
     } // for
-
+  deleteNAArray(ehi->getHeap(),listArray);
   return 0;
 }
 

--- a/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
@@ -10811,12 +10811,12 @@ desc_struct * CmpSeabaseDDL::getSeabaseUserTableDesc(const NAString &catName,
 
        // request the default
       ExpHbaseInterface* ehi =CmpSeabaseDDL::allocEHI();
-      ByteArrayList* bal = ehi->getRegionEndKeys(extNameForHbase);
+      NAArray<HbaseStr>* endKeyArray  = ehi->getRegionEndKeys(extNameForHbase);
 
       // create a list of region descriptors
       ((table_desc_struct*)tableDesc)->hbase_regionkey_desc = 
-        assembleDescs(bal, populateRegionDescAsRANGE, STMTHEAP);
-      delete bal;
+        assembleDescs(endKeyArray , populateRegionDescAsRANGE, STMTHEAP);
+      deleteNAArray(heap_, endKeyArray);
 
       // if this is base table or index and hbase object doesn't exist, then this object
       // is corrupted.
@@ -10966,32 +10966,20 @@ desc_struct * CmpSeabaseDDL::getSeabaseTableDesc(const NAString &catName,
 // Generator::createVirtualTableDesc() call make before this one that
 // uses STMTPHEAP througout.
 //
-desc_struct* assembleDescs(ByteArrayList* bal, populateFuncT func, NAMemory* heap)
+desc_struct* assembleDescs(NAArray<HbaseStr >* keyArray, populateFuncT func, NAMemory* heap)
 {
-   if ( !bal )
-     return NULL;
+   if (keyArray == NULL)
+      return NULL;
 
    desc_struct *result = NULL;
-
-   Int32 entries = bal->getSize();
-
+   Int32 entries = keyArray->entries();
    Int32 len = 0;
    char* buf = NULL;
 
    for (Int32 i=entries-1; i>=0; i-- ) {
-
-      // call JNI interface
-      len = bal->getEntrySize(i);
-   
-   
-      if ( len > 0 ) {
-   
-         buf = new (heap) char[len];
-         Int32 datalen;
-  
-         if ( !bal->getEntry(i, buf, len, datalen) || datalen != len ) {
-            return NULL;
-         }
+      len = keyArray->at(i).len;
+      if ( len > 0 ) { 
+         buf = keyArray->at(i).val; 
       } else
          buf = NULL;
 

--- a/core/sql/src/main/java/org/trafodion/sql/HBaseClient.java
+++ b/core/sql/src/main/java/org/trafodion/sql/HBaseClient.java
@@ -1748,19 +1748,19 @@ public class HBaseClient {
     return count;
   }
  
-  public byte[][] getStartKeys(String tblName) throws IOException 
+  public byte[][] getStartKeys(String tblName, boolean useTRex) throws IOException 
   {
     byte[][] startKeys;
-    HTableClient htc = getHTableClient(0, tblName, false);
+    HTableClient htc = getHTableClient(0, tblName, useTRex);
     startKeys = htc.getStartKeys();
     releaseHTableClient(htc);
     return startKeys;
   }
 
-  public byte[][] getEndKeys(String tblName) throws IOException 
+  public byte[][] getEndKeys(String tblName, boolean useTRex) throws IOException 
   {
     byte[][] endKeys;
-    HTableClient htc = getHTableClient(0, tblName, false);
+    HTableClient htc = getHTableClient(0, tblName, useTRex);
     endKeys = htc.getEndKeys();
     releaseHTableClient(htc);
     return endKeys;

--- a/core/sql/src/main/java/org/trafodion/sql/HTableClient.java
+++ b/core/sql/src/main/java/org/trafodion/sql/HTableClient.java
@@ -110,7 +110,6 @@ public class HTableClient {
 	Result[] getResultSet = null;
 	String lastError;
         RMInterface table = null;
-        ByteArrayList coprocAggrResult = null;
         private boolean writeToWAL = false;
 	int numRowsCached = 1;
 	int numColsInScan = 0;
@@ -1704,8 +1703,6 @@ public class HTableClient {
                         scan);
                     }
 
-		    coprocAggrResult = new ByteArrayList();
-
 		    byte[] rcBytes = 
                       ByteBuffer.allocate(8).order(ByteOrder.LITTLE_ENDIAN).putLong(rowCount).array();
                     return rcBytes; 
@@ -1768,46 +1765,14 @@ public class HTableClient {
            return true;
 	}
 
-	public ByteArrayList getEndKeys() throws IOException {
-	    if (logger.isTraceEnabled()) logger.trace("Enter getEndKeys() " + tableName);
-            ByteArrayList result = new ByteArrayList();
-            if (table == null) {
-                return null;
-            }
-            byte[][] htableResult = table.getEndKeys();
+    public byte[][] getStartKeys() throws IOException
+    {
+       return table.getStartKeys();
+    }
 
-            // transfer the HTable result to ByteArrayList
-            for (int i=0; i<htableResult.length; i++ ) {
-                if (logger.isTraceEnabled()) logger.trace("Inside getEndKeys(), result[i]: " + 
-                             htableResult[i]);
-                if (logger.isTraceEnabled()) logger.trace("Inside getEndKeys(), result[i]: " + 
-                             new String(htableResult[i]));
-                result.add(htableResult[i]);
-            }
-
-            if (logger.isTraceEnabled()) logger.trace("Exit getEndKeys(), result size: " + result.getSize());
-            return result;
-	}
-
-    public ByteArrayList getStartKeys() throws IOException {
-        if (logger.isTraceEnabled()) logger.trace("Enter getStartKeys() " + tableName);
-        ByteArrayList result = new ByteArrayList();
-        if (table == null) {
-            return null;
-        }
-        byte[][] htableResult = table.getStartKeys();
-
-        // transfer the HTable result to ByteArrayList
-        for (int i=0; i<htableResult.length; i++ ) {
-            if (logger.isTraceEnabled()) logger.trace("Inside getStartKeys(), result[i]: " + 
-                         htableResult[i]);
-            if (logger.isTraceEnabled()) logger.trace("Inside getStartKeys(), result[i]: " + 
-                         new String(htableResult[i]));
-            result.add(htableResult[i]);
-        }
-
-        if (logger.isTraceEnabled()) logger.trace("Exit getStartKeys(), result size: " + result.getSize());
-        return result;
+    public byte[][] getEndKeys() throws IOException
+    {
+       return table.getEndKeys();
     }
 
     private void cleanScan()


### PR DESCRIPTION
Removed ByteArrayList class and used array of byte array instead.
Only one JNI to java transistion is done to getRegionStartKeys
and getRegionEndKeys at the time of query compilation

Also fixed an issue with lib_mgmt Makefile.