### PR TITLE
[TRAFODION-1978] Report a nice error when attempting UPD STATS on LOBs

### DIFF
--- a/core/sql/bin/SqlciErrors.txt
+++ b/core/sql/bin/SqlciErrors.txt
@@ -1875,6 +1875,8 @@ drop the default context
 9242 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Unable to create schema for Hive statistics.
 9243 ZZZZZ 99999 BEGINNER MAJOR DBADMIN This UPDATE STATISTICS command may take too long. It is recommended to use the SAMPLE clause instead. If you wish to do this without a SAMPLE clause, specify NO SAMPLE explicitly.
 9244 ZZZZZ 99999 BEGINNER MAJOR DBADMIN UPDATE STATISTICS is not allowed in a user transaction.
+9245 ZZZZZ 99999 UUUUUUUU UUUUU UUUUUUU ---- unused ----
+9246 ZZZZZ 99999 BEGINNER MAJOR DBADMIN UPDATE STATISTICS is not supported on LOB columns. Column $0~String0 is a LOB column.
 9250 ZZZZZ 99999 UUUUUUUU UUUUU UUUUUUU Last UPDATE STATISTICS error.
 10000 ZZZZZ 99999 UUUUUUUU UUUUU UUUUUUU Sort Error: First Sort error
 10001 ZZZZZ 99999 ADVANCED MAJOR DIALOUT Sort Error : No error text defined. Unexpected error. $0~String0

--- a/core/sql/regress/executor/EXPECTED130
+++ b/core/sql/regress/executor/EXPECTED130
@@ -1,4 +1,3 @@
->>obey TEST130(setup);
 >>log;
 >>create schema trafodion.lob130;
 
@@ -22,7 +21,7 @@
 --- SQL operation complete.
 >>
 >>
->>obey TEST130(dml_insert);
+>>?section dml_insert
 >>insert into t130lob1 values(NULL);
 
 --- 1 row(s) inserted.
@@ -54,9 +53,9 @@ C1
 C1           C2
 -----------  ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-          1  LOBH00000200010200982774330343097219200982774335666384818212328542081589586020"TRAFODION"."LOB130"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              
-          2  LOBH00000200010200982774330343097219200982774336230243318212328542087163180020"TRAFODION"."LOB130"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              
-          3  LOBH00000200010200982774330343097219200982774336733971718212328542092274951020"TRAFODION"."LOB130"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              
+          1  LOBH00000200010669695009493408479919669695009498814985418212329581527003582020"TRAFODION"."LOB130"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              
+          2  LOBH00000200010669695009493408479919669695009499452607918212329581533443121020"TRAFODION"."LOB130"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              
+          3  LOBH00000200010669695009493408479919669695009500088291418212329581539790325020"TRAFODION"."LOB130"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              
 
 --- 3 row(s) selected.
 >>
@@ -93,7 +92,7 @@ C1           (EXPR)
 --- 3 row(s) selected.
 >>
 >>
->>obey TEST130(dml_join);
+>>?section dml_join
 >>insert into t130lob3 values (1,stringtolob('inserted row21a'),stringtolob('inserted row21b'));
 
 --- 1 row(s) inserted.
@@ -127,7 +126,7 @@ inserted row13
 >>
 >>
 >>
->>obey TEST130(dml_update);
+>>?section dml_update
 >>
 >>update t130lob2 set c2=stringtolob('updated c2 in all rows');
 
@@ -165,7 +164,8 @@ C1           (EXPR)
 
 --- 1 row(s) selected.
 >>
->>obey TEST130(dml_update_append);
+>>
+>>?section dml_update_append
 >>
 >>update t130lob2 set c2=stringtolob('appended row21a',append) where c1=1;
 
@@ -204,7 +204,8 @@ C1           (EXPR)
 
 --- 3 row(s) selected.
 >>
->>obey TEST130(dml_delete);
+>>
+>>?section dml_delete
 >>
 >>delete from t130lob3 where c1=1;
 
@@ -226,6 +227,38 @@ C1           (EXPR)                          (EXPR)
 >>select * from t130lob2;
 
 --- 0 row(s) selected.
+>>
+>>?section update_stats
+>>
+>>-- positive tests; LOB columns should be silently skipped
+>>update statistics for table t130lob1 on every column;
+
+--- SQL operation complete.
+>>
+>>update statistics for table t130lob4 on c1 to c2;
+
+--- SQL operation complete.
+>>
+>>-- negative tests; attempts to explicitly create stats on LOB
+>>-- columns should fail with error 9246
+>>update statistics for table t130lob4 on c3;
+
+*** ERROR[9246] UPDATE STATISTICS is not supported on LOB columns. Column C3 is a LOB column.
+
+--- SQL operation failed with errors.
+>>
+>>update statistics for table t130lob2 on (c1,c2);
+
+*** ERROR[9246] UPDATE STATISTICS is not supported on LOB columns. Column C2 is a LOB column.
+
+--- SQL operation failed with errors.
+>>
+>>update statistics for table t130lob4 on c2 to c3;
+
+*** ERROR[9246] UPDATE STATISTICS is not supported on LOB columns. Column C3 is a LOB column.
+
+--- SQL operation failed with errors.
+>>
 >>log;
 >>--setup
 >>sh echo "Test for file input and extract";
@@ -353,7 +386,7 @@ And the dish ran away with the fork !
 >>sh grep "^LOBH" TMP130 | sed "s/^/extract lobtofile(LOB '/g" | sed "s/$/' , 'tlob130_txt1.txt');/g" >> t130_extract_command;
 >>
 >>obey t130_extract_command;
->>extract lobtofile(LOB 'LOBH00000200010200982774330346590219200982774370093833718212328542425748115020"TRAFODION"."LOB130"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              ' , 'tlob130_txt1.txt');
+>>extract lobtofile(LOB 'LOBH00000200010669695009493412345019669695009536909968118212329581908062051020"TRAFODION"."LOB130"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              ' , 'tlob130_txt1.txt');
 Success. Targetfile :tlob130_txt1.txt  Length : 19
 
 --- SQL operation complete.
@@ -369,7 +402,7 @@ Success. Targetfile :tlob130_txt1.txt  Length : 19
 >>sh rm t130_extract_command;
 >>sh grep "^LOBH" TMP130 | sed "s/^/extract lobtofile(LOB '/g" | sed "s/$/' , 'tlob130_deep.jpg');/g" >> t130_extract_command;
 >>obey t130_extract_command;
->>extract lobtofile(LOB 'LOBH00000200010200982774330346651219200982774376837892918212328542493209860020"TRAFODION"."LOB130"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              ' , 'tlob130_deep.jpg');
+>>extract lobtofile(LOB 'LOBH00000200010669695009493412404519669695009543226997218212329581971119639020"TRAFODION"."LOB130"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              ' , 'tlob130_deep.jpg');
 Success. Targetfile :tlob130_deep.jpg  Length : 159018
 
 --- SQL operation complete.
@@ -385,7 +418,7 @@ Success. Targetfile :tlob130_deep.jpg  Length : 159018
 >>sh grep "^LOBH" TMP130 | sed "s/^/extract lobtofile(LOB '/g" | sed "s/$/' , 'tlob130_anoush.jpg');/g" >> t130_extract_command;
 >>
 >>obey t130_extract_command;
->>extract lobtofile(LOB 'LOBH00000200010200982774330346651219200982774376837892918212328542493209860020"TRAFODION"."LOB130"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              ' , 'tlob130_anoush.jpg');
+>>extract lobtofile(LOB 'LOBH00000200010669695009493412404519669695009543226997218212329581971119639020"TRAFODION"."LOB130"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              ' , 'tlob130_anoush.jpg');
 Success. Targetfile :tlob130_anoush.jpg  Length : 230150
 
 --- SQL operation complete.
@@ -395,7 +428,8 @@ Success. Targetfile :tlob130_anoush.jpg  Length : 230150
 >>
 >>-- Test for hdfs input
 >>--cleanup -- comment the following lines out if you want to debug this test and save intermediate files.
->>obey TEST130(lob_hdfs_cleanup);
+>>
+>>?section lob_hdfs_cleanup
 >>log;
 >>create table tlob130txt2 (c1 int not null, c2 clob, primary key (c1));
 
@@ -504,7 +538,7 @@ And the dish ran away with the fork !
 >>sh grep "^LOBH" TMP130 | sed "s/^/extract lobtofile(LOB '/g" | sed "s/$/' , 'hdfs:\/\/\/lobs\/tlob130_txt2.txt');/g" >> t130_extract_command;
 >>
 >>obey t130_extract_command;
->>extract lobtofile(LOB 'LOBH00000200010200982774330347819519200982774383085167918212328542555756185020"TRAFODION"."LOB130"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              ' , 'hdfs:///lobs/tlob130_txt2.txt');
+>>extract lobtofile(LOB 'LOBH00000200010669695009493413536419669695009549202243618212329582030992428020"TRAFODION"."LOB130"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              ' , 'hdfs:///lobs/tlob130_txt2.txt');
 Success. Targetfile :hdfs:///lobs/tlob130_txt2.txt  Length : 19
 
 --- SQL operation complete.
@@ -520,7 +554,7 @@ Success. Targetfile :hdfs:///lobs/tlob130_txt2.txt  Length : 19
 >>sh rm t130_extract_command;
 >>sh grep "^LOBH" TMP130 | sed "s/^/extract lobtofile(LOB '/g" | sed "s/$/' , 'hdfs:\/\/\/lobs\/tlob130_deep.jpg');/g" >> t130_extract_command;
 >>obey t130_extract_command;
->>extract lobtofile(LOB 'LOBH00000200010200982774330347890419200982774389242411018212328542617280373020"TRAFODION"."LOB130"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              ' , 'hdfs:///lobs/tlob130_deep.jpg');
+>>extract lobtofile(LOB 'LOBH00000200010669695009493413599619669695009555279429118212329582091774912020"TRAFODION"."LOB130"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              ' , 'hdfs:///lobs/tlob130_deep.jpg');
 Success. Targetfile :hdfs:///lobs/tlob130_deep.jpg  Length : 159018
 
 --- SQL operation complete.
@@ -536,7 +570,7 @@ Success. Targetfile :hdfs:///lobs/tlob130_deep.jpg  Length : 159018
 >>sh grep "^LOBH" TMP130 | sed "s/^/extract lobtofile(LOB '/g" | sed "s/$/' , 'hdfs:\/\/\/lobs\/tlob130_anoush.jpg');/g" >> t130_extract_command;
 >>
 >>obey t130_extract_command;
->>extract lobtofile(LOB 'LOBH00000200010200982774330346651219200982774376837892918212328542493209860020"TRAFODION"."LOB130"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              ' , 'hdfs:///lobs/tlob130_anoush.jpg');
+>>extract lobtofile(LOB 'LOBH00000200010669695009493412404519669695009543226997218212329581971119639020"TRAFODION"."LOB130"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              ' , 'hdfs:///lobs/tlob130_anoush.jpg');
 Success. Targetfile :hdfs:///lobs/tlob130_anoush.jpg  Length : 230150
 
 --- SQL operation complete.
@@ -555,7 +589,7 @@ Column Name : c2
 Input a filename to extract to : 
 Output File Name : lobc2out.jpg
 Extracting  lob handle for column c2...
-LOB handle for c2: LOBH00000200010200982774330346651219200982774376837892918212328542493209860020"TRAFODION"."LOB130"
+LOB handle for c2: LOBH00000200010669695009493412404519669695009543226997218212329581971119639020"TRAFODION"."LOB130"
 Extracting LOB data length for the above handle...
 LOB data length :230150
 Extracting lob data into file in chunks of 1000 ...
@@ -792,7 +826,8 @@ Wrote 1000 bytes to file : lobc2out.jpg
 Wrote 150 bytes to file : lobc2out.jpg
 >>
 >>------------------------------------------------------------------------------
->>obey TEST130(lob_misc_cleanup);
+>>
+>>?section lob_misc_cleanup
 >>log;
 >>-- 2 clob columns
 >>create table tlob130txt3 (c1 int not null, c2 int, c3 clob, c4 clob, primary key (c1));
@@ -833,7 +868,7 @@ And the dish ran away with the spoon.
 >>sh rm t130_extract_command;
 >>sh grep "^LOBH" TMP130 | sed "s/^/extract lobtofile(LOB '/g" | sed "s/$/' , 'tlob130_deep2.jpg');/g" >> t130_extract_command;
 >>obey t130_extract_command;
->>extract lobtofile(LOB 'LOBH00000200020200982774330349738319200982774400272091018212328542727572065020"TRAFODION"."LOB130"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              ' , 'tlob130_deep2.jpg');
+>>extract lobtofile(LOB 'LOBH00000200020669695009493415412319669695009566298720718212329582202018367020"TRAFODION"."LOB130"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              ' , 'tlob130_deep2.jpg');
 Success. Targetfile :tlob130_deep2.jpg  Length : 159018
 
 --- SQL operation complete.
@@ -842,7 +877,7 @@ Success. Targetfile :tlob130_deep2.jpg  Length : 159018
 >>sh rm t130_extract_command;
 >>sh grep "^LOBH" TMP130 | sed "s/^/extract lobtofile(LOB '/g" | sed "s/$/' , 'hdfs:\/\/\/lobs\/tlob130_anoush2.jpg');/g" >> t130_extract_command;
 >>obey t130_extract_command;
->>extract lobtofile(LOB 'LOBH00000200030200982774330349738319200982774400783874418212328542732607600020"TRAFODION"."LOB130"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              ' , 'hdfs:///lobs/tlob130_anoush2.jpg');
+>>extract lobtofile(LOB 'LOBH00000200030669695009493415412319669695009566813234018212329582207185399020"TRAFODION"."LOB130"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              ' , 'hdfs:///lobs/tlob130_anoush2.jpg');
 Success. Targetfile :hdfs:///lobs/tlob130_anoush2.jpg  Length : 230150
 
 --- SQL operation complete.
@@ -869,12 +904,12 @@ Hey diddle diddle,
 >>sh rm t130_extract_command;
 >>sh grep "^LOBH" TMP130 | sed "s/^/extract lobtofile(LOB '/g" | sed "s/$/' , 'tlob130_anoush3.jpg',create,truncate);/g" >> t130_extract_command;
 >>obey t130_extract_command;
->>extract lobtofile(LOB 'LOBH00000200030200982774330350112719200982774404493754218212328542769759826020"TRAFODION"."LOB130"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              ' , 'tlob130_anoush3.jpg',create,truncate);
+>>extract lobtofile(LOB 'LOBH00000200030669695009493415804519669695009570711099518212329582246227037020"TRAFODION"."LOB130"                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              ' , 'tlob130_anoush3.jpg',create,truncate);
 Success. Targetfile :tlob130_anoush3.jpg  Length : 230150
 
 --- SQL operation complete.
 >>
->>obey TEST130(lob_gc_cleanup);
+>>?section lob_gc_cleanup
 >>log;
 >>create table tlob130gc (c1 int not null, c2 blob, c3 blob, primary key (c1));
 
@@ -954,7 +989,7 @@ C1           (EXPR)      (EXPR)
 
 --- SQL operation complete.
 >>
->>obey TEST130(lob_get_cleanup);
+>>?section lob_get_cleanup
 >>log;
 >>create table tlob130gt (c1 int not null, c2 blob, c3 clob, c4 blob, primary key (c1));
 
@@ -976,17 +1011,17 @@ Lob Information for table: "TRAFODION".LOB130.TLOB130GT
 
   ColumnName :  C2
   Lob Location :  /lobs
-  LOB Data File:  LOBP_02009827743303525717_0001
+  LOB Data File:  LOBP_06696950094934183379_0001
   LOB EOD :  15
   LOB Used Len :  15
   ColumnName :  C3
   Lob Location :  /lobs
-  LOB Data File:  LOBP_02009827743303525717_0002
+  LOB Data File:  LOBP_06696950094934183379_0002
   LOB EOD :  15
   LOB Used Len :  15
   ColumnName :  C4
   Lob Location :  /lobs
-  LOB Data File:  LOBP_02009827743303525717_0003
+  LOB Data File:  LOBP_06696950094934183379_0003
   LOB EOD :  45
   LOB Used Len :  45
 
@@ -996,9 +1031,9 @@ Lob Information for table: "TRAFODION".LOB130.TLOB130GT
 CATALOG_NAME                                                                                                                                                                                                                                                      SCHEMA_NAME                                                                                                                                                                                                                                                       OBJECT_NAME                                                                                                                                                                                                                                                       COLUMN_NAME                                                                                                                                                                                                                                                       LOB_LOCATION                                                                                                                                                                                                                                                      LOB_DATA_FILE                                                                                                                                                                                                                                                     LOB_DATA_FILE_SIZE_EOD  LOB_DATA_FILE_SIZE_USED
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  ----------------------  -----------------------
 
-TRAFODION                                                                                                                                                                                                                                                         LOB130                                                                                                                                                                                                                                                            TLOB130GT                                                                                                                                                                                                                                                         C2                                                                                                                                                                                                                                                                /lobs                                                                                                                                                                                                                                                             LOBP_02009827743303525717_0001                                                                                                                                                                                                                                                        15                       15
-TRAFODION                                                                                                                                                                                                                                                         LOB130                                                                                                                                                                                                                                                            TLOB130GT                                                                                                                                                                                                                                                         C3                                                                                                                                                                                                                                                                /lobs                                                                                                                                                                                                                                                             LOBP_02009827743303525717_0002                                                                                                                                                                                                                                                        15                       15
-TRAFODION                                                                                                                                                                                                                                                         LOB130                                                                                                                                                                                                                                                            TLOB130GT                                                                                                                                                                                                                                                         C4                                                                                                                                                                                                                                                                /lobs                                                                                                                                                                                                                                                             LOBP_02009827743303525717_0003                                                                                                                                                                                                                                                        45                       45
+TRAFODION                                                                                                                                                                                                                                                         LOB130                                                                                                                                                                                                                                                            TLOB130GT                                                                                                                                                                                                                                                         C2                                                                                                                                                                                                                                                                /lobs                                                                                                                                                                                                                                                             LOBP_06696950094934183379_0001                                                                                                                                                                                                                                                        15                       15
+TRAFODION                                                                                                                                                                                                                                                         LOB130                                                                                                                                                                                                                                                            TLOB130GT                                                                                                                                                                                                                                                         C3                                                                                                                                                                                                                                                                /lobs                                                                                                                                                                                                                                                             LOBP_06696950094934183379_0002                                                                                                                                                                                                                                                        15                       15
+TRAFODION                                                                                                                                                                                                                                                         LOB130                                                                                                                                                                                                                                                            TLOB130GT                                                                                                                                                                                                                                                         C4                                                                                                                                                                                                                                                                /lobs                                                                                                                                                                                                                                                             LOBP_06696950094934183379_0003                                                                                                                                                                                                                                                        45                       45
 
 --- 3 row(s) selected.
 >>delete from tlob130gt where c1=2;
@@ -1015,17 +1050,17 @@ Lob Information for table: "TRAFODION".LOB130.TLOB130GT
 
   ColumnName :  C2
   Lob Location :  /lobs
-  LOB Data File:  LOBP_02009827743303525717_0001
+  LOB Data File:  LOBP_06696950094934183379_0001
   LOB EOD :  30
   LOB Used Len :  25
   ColumnName :  C3
   Lob Location :  /lobs
-  LOB Data File:  LOBP_02009827743303525717_0002
+  LOB Data File:  LOBP_06696950094934183379_0002
   LOB EOD :  31
   LOB Used Len :  26
   ColumnName :  C4
   Lob Location :  /lobs
-  LOB Data File:  LOBP_02009827743303525717_0003
+  LOB Data File:  LOBP_06696950094934183379_0003
   LOB EOD :  71
   LOB Used Len :  56
 
@@ -1035,15 +1070,16 @@ Lob Information for table: "TRAFODION".LOB130.TLOB130GT
 CATALOG_NAME                                                                                                                                                                                                                                                      SCHEMA_NAME                                                                                                                                                                                                                                                       OBJECT_NAME                                                                                                                                                                                                                                                       COLUMN_NAME                                                                                                                                                                                                                                                       LOB_LOCATION                                                                                                                                                                                                                                                      LOB_DATA_FILE                                                                                                                                                                                                                                                     LOB_DATA_FILE_SIZE_EOD  LOB_DATA_FILE_SIZE_USED
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  ----------------------  -----------------------
 
-TRAFODION                                                                                                                                                                                                                                                         LOB130                                                                                                                                                                                                                                                            TLOB130GT                                                                                                                                                                                                                                                         C2                                                                                                                                                                                                                                                                /lobs                                                                                                                                                                                                                                                             LOBP_02009827743303525717_0001                                                                                                                                                                                                                                                        30                       25
-TRAFODION                                                                                                                                                                                                                                                         LOB130                                                                                                                                                                                                                                                            TLOB130GT                                                                                                                                                                                                                                                         C3                                                                                                                                                                                                                                                                /lobs                                                                                                                                                                                                                                                             LOBP_02009827743303525717_0002                                                                                                                                                                                                                                                        31                       26
-TRAFODION                                                                                                                                                                                                                                                         LOB130                                                                                                                                                                                                                                                            TLOB130GT                                                                                                                                                                                                                                                         C4                                                                                                                                                                                                                                                                /lobs                                                                                                                                                                                                                                                             LOBP_02009827743303525717_0003                                                                                                                                                                                                                                                        71                       56
+TRAFODION                                                                                                                                                                                                                                                         LOB130                                                                                                                                                                                                                                                            TLOB130GT                                                                                                                                                                                                                                                         C2                                                                                                                                                                                                                                                                /lobs                                                                                                                                                                                                                                                             LOBP_06696950094934183379_0001                                                                                                                                                                                                                                                        30                       25
+TRAFODION                                                                                                                                                                                                                                                         LOB130                                                                                                                                                                                                                                                            TLOB130GT                                                                                                                                                                                                                                                         C3                                                                                                                                                                                                                                                                /lobs                                                                                                                                                                                                                                                             LOBP_06696950094934183379_0002                                                                                                                                                                                                                                                        31                       26
+TRAFODION                                                                                                                                                                                                                                                         LOB130                                                                                                                                                                                                                                                            TLOB130GT                                                                                                                                                                                                                                                         C4                                                                                                                                                                                                                                                                /lobs                                                                                                                                                                                                                                                             LOBP_06696950094934183379_0003                                                                                                                                                                                                                                                        71                       56
 
 --- 3 row(s) selected.
 >>
 >>-- test to ensure all lob dependent tables and schemas containing lob tables
 >>-- get dropped cleanly.
->>obey TEST130(lob_drop_table_schema);
+>>
+>>?section lob_drop_table_schema
 >>log;
 >>create schema trafodion.lobsch;
 
@@ -1065,9 +1101,9 @@ TRAFODION                                                                       
 Tables in Schema TRAFODION.LOBSCH
 =================================
 
-LOBDescChunks__02009827743303536445_0001
-LOBDescHandle__02009827743303536445_0001
-LOBMD__02009827743303536445
+LOBDescChunks__06696950094934193691_0001
+LOBDescHandle__06696950094934193691_0001
+LOBMD__06696950094934193691
 SB_HISTOGRAMS
 SB_HISTOGRAM_INTERVALS
 TLOB130TS2
@@ -1085,5 +1121,6 @@ TLOB130TS2
 --- SQL operation complete.
 >>
 >>
->>obey TEST130(lob_general_cleanup);
+>>-- cleanup
+>>?section lob_general_cleanup
 >>log;

--- a/core/sql/regress/executor/TEST130
+++ b/core/sql/regress/executor/TEST130
@@ -35,14 +35,6 @@
 cqd TRAF_BLOB_AS_VARCHAR 'OFF'; 
 cqd TRAF_CLOB_AS_VARCHAR 'OFF'; 
 
-obey TEST130(clnup);
-
-log LOG130 clear;
-obey TEST130(setup);
---obey TEST130(dml);
---obey TEST130(clnup);
---exit;
-
 
 ?section clnup
 set schema trafodion.lob130;
@@ -53,6 +45,7 @@ drop table t130lob4 cascade;
 
 
 ?section setup
+log LOG130 clear;
 log;
 drop schema trafodion.lob130 cascade;
 log LOG130;
@@ -65,8 +58,6 @@ c2 blob, c3 blob, primary key (c1));
 create table t130lob4 (c1 int not null,
 c2 char(10), c3 clob, primary key (c1));
 
-
-obey TEST130(dml_insert);
 
 ?section dml_insert
 insert into t130lob1 values(NULL);
@@ -84,8 +75,6 @@ select lobtostring(c2,2) from t130lob2;
 select c1,lobtostring(c2,100) from t130lob2;
 
 
-obey TEST130(dml_join);
-
 ?section dml_join
 insert into t130lob3 values (1,stringtolob('inserted row21a'),stringtolob('inserted row21b'));
 insert into t130lob3 values (2,stringtolob('inserted row22a'),stringtolob('inserted row22b'));
@@ -101,8 +90,6 @@ select lobtostring(t130lob2.c2,30) from t130lob2, t130lob3 where t130lob2.c1 = t
 
 
 
-obey TEST130(dml_update);
-
 ?section dml_update
 
 update t130lob2 set c2=stringtolob('updated c2 in all rows');
@@ -112,7 +99,6 @@ update t130lob2 set c2=stringtolob('updated row21a') where c1=1;
 select c1, lobtostring(c2,30) from t130lob2;
 select c1, lobtostring(c2,30) from t130lob2 where c1=1;
 
-obey TEST130(dml_update_append);
 
 ?section dml_update_append
 
@@ -124,7 +110,6 @@ select c1, lobtostring(c2,100) from t130lob2 where c1=1;
 update t130lob2 set c2=stringtolob(' appended c2 to all rows',append);
 select c1, lobtostring(c2,60) from t130lob2;
 
-obey TEST130(dml_delete);
 
 ?section dml_delete
 
@@ -133,16 +118,31 @@ select c1, lobtostring(c2,30), lobtostring(c3,30)  from t130lob3;
 
 delete from t130lob2 ;
 select * from t130lob2;
+
+?section update_stats
+
+-- positive tests; LOB columns should be silently skipped
+update statistics for table t130lob1 on every column;
+
+update statistics for table t130lob4 on c1 to c2;
+
+-- negative tests; attempts to explicitly create stats on LOB
+-- columns should fail with error 9246
+update statistics for table t130lob4 on c3;
+
+update statistics for table t130lob2 on (c1,c2);
+
+update statistics for table t130lob4 on c2 to c3;
+
 log;
 obey TEST130(clnup);
-
 
 
 sh echo "Test for file input and extract";
 -- Test for local input
 
 --cleanup -- comment the following lines out if you want to debug this test and save intermediate files.
-obey TEST130(lob_local_cleanup);
+
 ?section lob_local_cleanup
 log;
 drop table tlob130txt1; 
@@ -155,7 +155,6 @@ sh rm tlob130_deep.jpg;
 sh rm tlob130_anoush.jpg;
 
 
-obey TEST130(lob_local_file);
 ?section lob_local_file
 log LOG130;
 --setup
@@ -252,7 +251,7 @@ obey t130_extract_command;
 
 -- Test for hdfs input
 --cleanup -- comment the following lines out if you want to debug this test and save intermediate files.
-obey TEST130(lob_hdfs_cleanup);
+
 ?section lob_hdfs_cleanup
 log;
 drop table tlob130txt2; 
@@ -265,7 +264,6 @@ sh regrhadoop.ksh fs -rm /lobs/tlob130_anoush.jpg;
 sh regrhadoop.ksh fs -rm /lobs/tlob130_txt2.txt;
 
 
-obey TEST130(lob_hdfs_file);
 ?section lob_hdfs_file
 log LOG130;
 create table tlob130txt2 (c1 int not null, c2 clob, primary key (c1));
@@ -354,7 +352,7 @@ obey t130_extract_command;
 sh clitestdriver 2 < TEST130_argfile 2>&1 | tee -a LOG130;
 
 ------------------------------------------------------------------------------
-obey TEST130(lob_misc_cleanup);
+
 ?section lob_misc_cleanup
 log;
 drop table tlob130txt3;
@@ -365,7 +363,6 @@ sh rm tlob130_txt1.txt;
 sh regrhadoop.ksh fs -rm /lobs/tlob130_anoush2.jpg;
 sh rm tlob130_anoush3.jpg;
 
-obey TEST130(lob_miscfile_test);
 
 ?section lob_miscfile_test
 log LOG130;
@@ -415,11 +412,9 @@ sh rm t130_extract_command;
 sh grep "^LOBH" TMP130 | sed "s/^/extract lobtofile(LOB '/g" | sed "s/$/' , 'tlob130_anoush3.jpg',create,truncate);/g" >> t130_extract_command;
 obey t130_extract_command;
 
-obey TEST130(lob_gc_cleanup);
 ?section lob_gc_cleanup
 log;
 drop table tlob130gc;
-obey TEST130(lob_gc_test);
 
 ?section lob_gc_test
 log LOG130;
@@ -446,11 +441,10 @@ insert into tlob130gc values(9,stringtolob('aaaa'), stringtolob('bbbbb'));
 select c1,lobtostring(c2,10),lobtostring(c3,10) from tlob130gc;
 cqd LOB_GC_LIMIT_SIZE reset;
 
-obey TEST130(lob_get_cleanup);
 ?section lob_get_cleanup
 log;
 drop table tlob130gt;
-obey TEST130(lob_get_test);
+
 ?section lob_get_test
 log LOG130;
 create table tlob130gt (c1 int not null, c2 blob, c3 clob, c4 blob, primary key (c1));
@@ -466,7 +460,7 @@ select * from table(lob stats(tlob130gt));
 
 -- test to ensure all lob dependent tables and schemas containing lob tables
 -- get dropped cleanly.
-obey TEST130(lob_drop_table_schema);
+
 ?section lob_drop_table_schema
 log;
 cleanup schema trafodion.lobsch;
@@ -483,7 +477,6 @@ select OBJECT_NAME,OBJECT_TYPE from TRAFODION."_MD_".OBJECTS where catalog_name=
 set schema trafodion.lob130;
 
 
-obey TEST130(lob_general_cleanup);
 -- cleanup
 ?section lob_general_cleanup
 log;

--- a/core/sql/ustat/hs_const.h
+++ b/core/sql/ustat/hs_const.h
@@ -168,6 +168,7 @@ enum USTAT_ERROR_CODES {UERR_SYNTAX_ERROR                    = 15001,
                         UERR_CANT_CREATE_HIVE_STATS_SCHEMA   = 9242,
                         UERR_YOU_WILL_LIKELY_BE_SORRY        = 9243,
                         UERR_USER_TRANSACTION                = 9244,
+                        UERR_LOB_STATS_NOT_SUPPORTED         = 9246,
                         UERR_NO_ERROR                        = 9250,
                         UERR_LAST_ERROR                      = 9250
                        };

--- a/core/sql/ustat/hs_la.cpp
+++ b/core/sql/ustat/hs_la.cpp
@@ -652,6 +652,19 @@ Lng32 HSTableDef::getColNum(const char *colName, NABoolean errIfNotFound) const
         if ((&colInfo_[i] != NULL) &&
             (ansiForm == *colInfo_[i].colname))
           {
+            // raise an error when a LOB column is explicitly specified
+            if (DFS2REC::isLOB(colInfo_[i].datatype))
+              {
+                if (LM->LogNeeded())
+                  {
+                    sprintf(LM->msg, "***[ERROR]:  Column (%s) is a LOB column.", colName);
+                    LM->Log(LM->msg);
+                  }
+                HSFuncMergeDiags(-UERR_LOB_STATS_NOT_SUPPORTED, colName);
+                HSHandleError(retcode);
+                return retcode;               
+              }
+
             return i;
           }
       }

--- a/core/sql/ustat/hs_parser.cpp
+++ b/core/sql/ustat/hs_parser.cpp
@@ -1108,10 +1108,13 @@ Lng32 AddEveryColumn(const char *startColumn, const char *endColumn)
                 LM->Log(LM->msg);
               }
           }
-        else                                 // add to single-column group list
+        else if (!DFS2REC::isLOB(hs_globals->objDef->getColInfo(colNumber).datatype))
           {
+            // add to single-column group list
             retcode = AddSingleColumn(colNumber);
           }
+        // else it's a LOB column; silently exclude it (the column was only
+        // implicitly referenced)
       }
 
     if (!startColumn &&  // ON EVERY COLUMN causes key groups to be added as well


### PR DESCRIPTION
Histogram statistics on LOB columns do not make sense at the moment; Trafodion does not support them. However, the UPDATE STATISTICS command would fail in odd and diverse ways when asked to create stats on LOB columns. This has been fixed. Now when LOB columns are explicitly referenced in an UPDATE STATISTICS command, an error 9246 will result. When LOB columns are implicitly referenced (e.g., in an ON EVERY COLUMN clause), they will be silently skipped.