### PR TITLE
[TRAFODION-1874] fix build issues when PDSH installed in build system

### DIFF
--- a/core/sqf/sql/scripts/makemsg.ksh
+++ b/core/sqf/sql/scripts/makemsg.ksh
@@ -81,10 +81,5 @@ echo "generating sql message catalog: $error_cat ... "
 gencat $error_cat SqlciErrors.m
 fi
 
-# On a cluster, copy it to all the nodes
-if [ -e $SQ_PDCP ]; then
-   echo "Doing a $SQ_PDCP -p -w ${ExNodeList[@]} -x `uname -n` $error_cat `dirname $error_cat`"
-   $SQ_PDCP -p -w ${ExNodeList[@]} -x `uname -n` $error_cat `dirname $error_cat`
-fi
 #exit 0
 


### PR DESCRIPTION
There is no need to copy gencat file at build time. Installer will copy it to all nodes during installation.
This in fact will break the build if the dev system happen to installed with pdsh.