### PR TITLE
TRAFODION-1983 error in preCodeGen plus more items

### DIFF
--- a/core/sql/common/Ipc.cpp
+++ b/core/sql/common/Ipc.cpp
@@ -1310,6 +1310,18 @@ void IpcAllConnections::fillInListOfPendingPhandles(GuaProcessHandle *phandles,
 }
 
 // Methods for connection tracing
+void IpcAllConnections::print()
+{
+  char buf[10000];
+  Int32 lineno = 0;
+
+  while (printConnTrace(lineno, buf))
+    {
+      printf("%s", buf);
+      lineno++;
+    }
+}
+
 const char *ConnTraceDesc = "All IpcConnections and their states";
 
 void IpcAllConnections::registTraceInfo(IpcEnvironment *env, ExeTraceInfo *ti)

--- a/core/sql/common/Ipc.h
+++ b/core/sql/common/Ipc.h
@@ -3162,6 +3162,7 @@ public:
 #endif
 
   // methods used for Ipc Connection tracing
+  void print(); // can be called from the debugger
   void registTraceInfo(IpcEnvironment *env, ExeTraceInfo *ti);
   Int32 printConnTrace(Int32 lineno, char *buf);
   static Int32 getAnEntry(void * mine, Int32 lineno, char * buf)

--- a/core/sql/generator/GenPreCode.cpp
+++ b/core/sql/generator/GenPreCode.cpp
@@ -11343,19 +11343,6 @@ short HbaseAccess::extractHbaseFilterPreds(Generator * generator,
        preds.advance(vid))
     {
       ItemExpr * ie = vid.getItemExpr();
-
-      // if it is AND operation, recurse through left and right children
-      if (ie->getOperatorType() == ITM_AND)
-        {
-          ValueIdSet leftPreds;
-          ValueIdSet rightPreds;
-          leftPreds += ie->child(0)->castToItemExpr()->getValueId();
-          rightPreds += ie->child(1)->castToItemExpr()->getValueId();
-          extractHbaseFilterPreds(generator, leftPreds, newExePreds);
-          extractHbaseFilterPreds(generator, rightPreds, newExePreds);
-          continue; 
-        }
-      
       ValueId colVID;
       ValueId valueVID;
       NABoolean removeFromOrigList = FALSE;

--- a/core/sql/nskgmake/udr_predef/Makefile
+++ b/core/sql/nskgmake/udr_predef/Makefile
@@ -27,8 +27,6 @@ CPPSRC := SqlUdrPredefLogReader.cpp \
 	  SqlUdrPredefTimeSeries.cpp \
 	  vers_libudr_predef.cpp
 
-DEFS += -DTRAF_SOFTWARE_VERS_MAJOR=$(TRAFODION_VER_MAJOR)  -DTRAF_SOFTWARE_VERS_MINOR=$(TRAFODION_VER_MINOR) -DTRAF_SOFTWARE_VERS_UPDATE=$(TRAFODION_VER_UPDATE)
-
 # Define the correct compilation and linking flags depending on whether
 # this is a debug or release build.
 

--- a/core/sql/optimizer/ValueDesc.cpp
+++ b/core/sql/optimizer/ValueDesc.cpp
@@ -6530,6 +6530,11 @@ ValueIdList::computeEncodedKey(const TableDesc* tDesc, NABoolean isMaxKey,
           
           ConstValue* value = NULL;
           if ( ie->doesExprEvaluateToConstant(TRUE, TRUE) ) {
+             ValueIdSet availableValues;
+             // do a simple VEG replacement with no available values
+             // and no inputs, all VEGies should have constants in
+             // them and should be replaced with those
+             ie = ie->replaceVEGExpressions(availableValues, availableValues);
              value = ie->evaluate(STMTHEAP);
              if ( !value )
                 return NULL;

--- a/core/sql/sqludr/sqludr.cpp
+++ b/core/sql/sqludr/sqludr.cpp
@@ -696,6 +696,10 @@ TypeInfo::TypeInfo(SQLTypeCode sqlType,
       // length is the length in characters, but d_.length_ is
       // the byte length, multiply by min bytes per char
       d_.length_ = length * minBytesPerChar();
+      if (d_.length_ < 0)
+        throw UDRException(38900,
+                           "Length of a character type must not be negative, got %d",
+                           d_.length_);
       if (d_.collation_ == UNDEFINED_COLLATION)
         throw UDRException(38900,"Collation must be specified for CHAR type in TypeInfo::TypeInfo");
       break;
@@ -711,6 +715,10 @@ TypeInfo::TypeInfo(SQLTypeCode sqlType,
       if (d_.length_ > 32767)
         // see also CharType::CharType in ../common/CharType.cpp
         d_.flags_ |= TYPE_FLAG_4_BYTE_VC_LEN;
+      if (d_.length_ < 0)
+        throw UDRException(38900,
+                           "Length of a varchar type must not be negative, got %d",
+                           d_.length_);
       break;
 
     case CLOB:
@@ -2012,13 +2020,16 @@ void TypeInfo::setString(const char *val, int stringLen, char *row) const
     case DECIMAL_UNSIGNED:
       {
         char buf[200];
-        long lval;
-        double dval;
+        long lval = 0;
+        double dval = 0.0;
         int numCharsConsumed = 0;
         int rc = 0;
+        int vScale = 0;
+        bool sawMinusDot = false;
 
         // ignore trailing blanks
-        while (val[stringLen-1] == ' ')
+        while (val[stringLen-1] == ' ' ||
+               val[stringLen-1] == '\t')
           stringLen--;
 
         if (stringLen+1 > sizeof(buf))
@@ -2032,15 +2043,89 @@ void TypeInfo::setString(const char *val, int stringLen, char *row) const
         buf[stringLen] = 0;
 
         if (isApproxNumeric)
-          rc = sscanf(buf,"%lf%n", &dval, &numCharsConsumed) < 0;
+          rc = sscanf(buf,"%lf%n", &dval, &numCharsConsumed);
         else
-          rc = sscanf(buf,"%ld%n", &lval, &numCharsConsumed) < 0;
+          rc = sscanf(buf,"%ld%n", &lval, &numCharsConsumed);
 
-        if (rc < 0)
-          throw UDRException(
-               38900,
-               "Error in setString(), \"%s\" is not a numeric value",
-               buf);
+        if (rc <= 0)
+          {
+            bool isOK = false;
+
+            // could not read a long or float value, this could be an error
+            // or a number that starts with '.' or '-.' with optional
+            // leading white space. Check for this special case before
+            // raising an exception.
+            if (!isApproxNumeric && d_.scale_ > 0 && numCharsConsumed == 0)
+              {
+                while (buf[numCharsConsumed] == ' ' ||
+                       buf[numCharsConsumed] == '\t')
+                  numCharsConsumed++;
+                if (buf[numCharsConsumed] == '-' &&
+                    buf[numCharsConsumed+1] == '.')
+                  {
+                    // the number starts with "-.", remember
+                    // to negate it at the end and go on
+                    sawMinusDot = true;
+                    numCharsConsumed++; // skip over the '-'
+                    isOK = true;
+                  }
+                else if (buf[numCharsConsumed] == '.')
+                  {
+                    // the number starts with '.', that's
+                    // ok, continue on
+                    isOK = true;
+                  }
+              }
+
+            if (!isOK)
+              throw UDRException(
+                   38900,
+                   "Error in setString(), \"%s\" is not a numeric value",
+                   buf);
+          }
+
+        if (d_.scale_ > 0 && !isApproxNumeric)
+          {
+            if (buf[numCharsConsumed] == '.')
+              {
+                int sign = (lval < 0 ? -1 : 1);
+
+                // skip over the decimal dot
+                numCharsConsumed++;
+
+                // process digits following the dot
+                while (numCharsConsumed < stringLen &&
+                       buf[numCharsConsumed] >= '0' &&
+                       buf[numCharsConsumed] <= '9' &&
+                       lval <= LONG_MAX/10)
+                  {
+                    lval = 10*lval +
+                      ((int)(buf[numCharsConsumed++] - '0')) * sign;
+                    vScale++;
+                  }
+              }
+
+            if (sawMinusDot)
+              lval = -lval;
+
+            while (vScale < d_.scale_)
+              if (lval <= LONG_MAX/10)
+                {
+                  lval *= 10;
+                  vScale++;
+                }
+              else
+                throw UDRException(
+                     38900,
+                     "Error in setString(): Value %s exceeds range for a long",
+                     buf);
+
+            if (vScale > d_.scale_)
+              throw UDRException(
+                     38900,
+                     "Error in setString(): Value %s exceeds scale %d",
+                     buf, d_.scale_);
+          }
 
         // check for any non-white space left after conversion
         while (numCharsConsumed < stringLen)
@@ -2048,7 +2133,7 @@ void TypeInfo::setString(const char *val, int stringLen, char *row) const
               buf[numCharsConsumed] != '\t')
             throw UDRException(
                  38900,
-                 "Found non-numeric character in setString for a numeric column: %s",
+                 "Error in setString(): \"%s\" is not a valid, in-range numeric value",
                  buf);
           else
             numCharsConsumed++;

--- a/core/sql/src/main/java/org/trafodion/sql/udr/TypeInfo.java
+++ b/core/sql/src/main/java/org/trafodion/sql/udr/TypeInfo.java
@@ -334,6 +334,9 @@ public class TypeInfo extends TMUDRSerializableObject {
             // length is the length in characters, but length_ is
             // the byte length, multiply by min bytes per char
             length_ = length * minBytesPerChar();
+            if (length_ < 0)
+                throw new UDRException(38900,"Length of a character type must not be negative, got %d",
+                                       length_);
             if (collation_ == SQLCollationCode.UNDEFINED_COLLATION.ordinal())
                 throw new UDRException(38900,"Collation must be specified for CHAR type in TypeInfo::TypeInfo");
             break;
@@ -349,6 +352,9 @@ public class TypeInfo extends TMUDRSerializableObject {
             if (length_ > 32767)
                 // see also CharType::CharType in ../common/CharType.cpp
                 flags_ |= TYPE_FLAG_4_BYTE_VC_LEN;
+            if (length_ < 0)
+                throw new UDRException(38900,"Length of a varchar type must not be negative, got %d",
+                                       length_);
             break;
 
         case CLOB:


### PR DESCRIPTION
This also constains a fix for TRAFODION-1710 (setString in UDFs does not accept numeric values with scale) as well as misc small fixes. It may make more sense to review the three commits in this PR separately, as they are on different topics.