### PR TITLE
[TRAFODION-1971] Avoid redundant reinitialization during bulk load

### DIFF
--- a/core/sql/executor/ExHbaseIUD.cpp
+++ b/core/sql/executor/ExHbaseIUD.cpp
@@ -1064,7 +1064,7 @@ ExHbaseAccessBulkLoadPrepSQTcb::ExHbaseAccessBulkLoadPrepSQTcb(
     hdfsSampleFile_(NULL),
     lastErrorCnd_(NULL)
 {
-   hFileParamsInitialized_ = false;  ////temporary-- need better mechanism later
+   hFileParamsInitialized_ = false;
    //sortedListOfColNames_ = NULL;
    posVec_.clear();
 

--- a/core/sql/executor/ExHbaseIUD.cpp
+++ b/core/sql/executor/ExHbaseIUD.cpp
@@ -1285,7 +1285,6 @@ ExWorkProcRetcode ExHbaseAccessBulkLoadPrepSQTcb::work()
       matches_ = 0;
       currRowNum_ = 0;
       numRetries_ = 0;
-      hFileParamsInitialized_ = FALSE;
       prevTailIndex_ = 0;
       lastHandledStep_ = NOT_STARTED;
 


### PR DESCRIPTION
After each flush during the preparation phase of bulk load, HFile
initialization was taking place redundantly. This imposed significant
overhead and slowed down loads.