### PR TITLE
[TRAFODION-1992] Re-packaging server tar file broke install_traf_components

### DIFF
--- a/core/sqf/sql/scripts/install_traf_components
+++ b/core/sqf/sql/scripts/install_traf_components
@@ -39,12 +39,12 @@ REST_SRC=$MY_SQROOT/../rest
 PHX_SRC=$MY_SQROOT/../../tests/phx
 TRAF_TARS=$MY_SQROOT/../../distribution
 
-if [ -z "$DCS_TAR" ]; then
-  DCS_TAR=$(ls $TRAF_TARS/dcs*tar.gz 2>/dev/null)
+if [ -z "$DCS_BLD" ]; then
+  DCS_BLD=$(ls -d $DCS_SRC/target/dcs-*/dcs-* 2>/dev/null)
 fi
 
-if [ -z "$REST_TAR" ]; then
-  REST_TAR=$(ls $TRAF_TARS/rest*tar.gz 2>/dev/null)
+if [ -z "$REST_BLD" ]; then
+  REST_BLD=$(ls -d $REST_SRC/target/rest-*/rest-* 2>/dev/null)
 fi
 
 if [ -z "$PHX_TAR" ]; then
@@ -56,7 +56,7 @@ if [ -z "$DCSTEST_TAR" ]; then
 fi
 
 if [ -z "$CLIENT_TAR" ]; then
-    CLIENT_TAR=$(ls $TRAF_TARS/*clients*.tgz 2>/dev/null)
+    CLIENT_TAR=$(ls $TRAF_TARS/*clients* 2>/dev/null)
 fi
 
 if [[ -f $CLIENT_TAR ]]; then
@@ -84,8 +84,8 @@ else
 fi
 
 echo "   For local hadoop... $MY_SW_ROOT" | tee -a ${MY_LOG_FILE}
-echo "   For DCS_TAR... $DCS_TAR" | tee -a ${MY_LOG_FILE}
-echo "   For REST_TAR... $REST_TAR" | tee -a ${MY_LOG_FILE}
+echo "   For DCS_BLD... $DCS_BLD" | tee -a ${MY_LOG_FILE}
+echo "   For REST_BLD... $REST_BLD" | tee -a ${MY_LOG_FILE}
 
 if [[ -f $PHX_TAR ]]; then
   echo "   For PHX_TAR... $PHX_TAR" | tee -a ${MY_LOG_FILE}
@@ -105,31 +105,31 @@ echo | tee -a ${MY_LOG_FILE}
 if [ -d dcs-* ]; then
   echo "DCS files already exist, skipping DCS setup" | tee -a ${MY_LOG_FILE}
 else
-  if [[ -f $DCS_TAR ]]; then
-      echo "Using DCS Tar: $DCS_TAR" | tee -a ${MY_LOG_FILE}
+  if [[ -d $DCS_BLD ]]; then
+      echo "Using DCS Build: $DCS_BLD" | tee -a ${MY_LOG_FILE}
   elif [[ -d $DCS_SRC ]]; then
-      echo "DCS tar file was not found in $TRAF_TARS" | tee -a ${MY_LOG_FILE}
-      echo "Building DCS tar file" | tee -a ${MY_LOG_FILE}
+      echo "DCS built target was not found in $DCS_SRC" | tee -a ${MY_LOG_FILE}
+      echo "Building DCS" | tee -a ${MY_LOG_FILE}
       if [[ -f $MY_SQROOT/export/lib/jdbcT4.jar ]]; then
          echo "JDBCT4 jar file exist. Proceeding to build DCS from $DCS_SRC" | tee -a ${MY_LOG_FILE}
          cd $DCS_SRC
          ${MAVEN:-mvn} clean site package >>${MY_LOG_FILE} 2>&1
-         mv $DCS_SRC/target/dcs*.gz $TRAF_TARS
          cd $MY_SW_ROOT
       else
          echo "JDBCT4 jar file does not exist $MY_SQROOT/export/lib folder. " | tee -a ${MY_LOG_FILE}
          echo "Please build the core Trafodion component"  | tee -a ${MY_LOG_FILE}
          exit 2
       fi
+      DCS_BLD=$(ls -d $DCS_SRC/target/dcs-*/dcs-* 2>/dev/null)
   fi
 
-  if [[ ! -f $DCS_TAR ]]; then
-    echo "**** ERROR: DCS tar file not found. "  | tee -a ${MY_LOG_FILE}
+  if [[ ! -d $DCS_BLD ]]; then
+    echo "**** ERROR: DCS built target not found. "  | tee -a ${MY_LOG_FILE}
     exit 2
   fi
 # Install DCS
-  echo "Installing DCS from: $DCS_TAR"  | tee -a ${MY_LOG_FILE}
-  tar xzf $DCS_TAR | tee -a ${MY_LOG_FILE}
+  echo "Installing DCS from: $DCS_BLD"  | tee -a ${MY_LOG_FILE}
+  cp -r $DCS_BLD $MY_SW_ROOT/$(basename $DCS_BLD)
   DCS_HOME=$(/bin/ls -d $MY_SW_ROOT/dcs-*)
 
 # Configure DCS
@@ -188,31 +188,31 @@ echo | tee -a ${MY_LOG_FILE}
 if [ -d rest-* ]; then
   echo "REST files already exist, skipping REST setup"
 else
-  if [[ -f $REST_TAR ]]; then
-        echo "Using REST Tar: $REST_TAR" | tee -a ${MY_LOG_FILE}
+  if [[ -d $REST_BLD ]]; then
+        echo "Using REST Build: $REST_BLD" | tee -a ${MY_LOG_FILE}
   elif [[ -d $REST_SRC ]]; then
-      echo "REST tar file was not found in $TRAF_TARS" | tee -a ${MY_LOG_FILE}
-      echo "Building REST tar file" | tee -a ${MY_LOG_FILE}
+      echo "REST built target was not found in $REST_SRC" | tee -a ${MY_LOG_FILE}
+      echo "Building REST" | tee -a ${MY_LOG_FILE}
       if [[ -f $MY_SQROOT/export/lib/jdbcT4.jar ]]; then
          echo "JDBCT4 jar file exist. Proceeding to build REST from $REST_SRC" | tee -a ${MY_LOG_FILE}
          cd $REST_SRC
          ${MAVEN:-mvn} clean site package >>${MY_LOG_FILE} 2>&1
-         mv $REST_SRC/target/rest*.gz $TRAF_TARS
          cd $MY_SW_ROOT
        else
          echo "JDBCT4 jar file does not exist $MY_SQROOT/export/lib folder. Please build the core Trafodion components" | tee -a ${MY_LOG_FILE}
        exit 2
       fi
+      REST_BLD=$(ls -d $REST_SRC/target/rest-*/rest-* 2>/dev/null)
   fi
 
-  if [[ ! -f $REST_TAR ]]; then
-    echo "**** ERROR: REST tar file not found"  | tee -a ${MY_LOG_FILE}
+  if [[ ! -d $REST_BLD ]]; then
+    echo "**** ERROR: REST build target not found"  | tee -a ${MY_LOG_FILE}
     exit 2
   fi
 
 # Install REST
-  echo "Installing REST from: $REST_TAR"  | tee -a ${MY_LOG_FILE}
-  tar xzf $REST_TAR | tee -a ${MY_LOG_FILE}
+  echo "Installing REST from: $REST_BLD"  | tee -a ${MY_LOG_FILE}
+  cp -r $REST_BLD $MY_SW_ROOT/$(basename $REST_BLD)
   REST_HOME=$(/bin/ls -d $MY_SW_ROOT/rest-*)
 
 # Configure REST


### PR DESCRIPTION
Change install_traf_components to use built target directory
instead of tar file, now that tar file is not produced for DCS and REST.

Submitting to release2.0 branch. Since this is a developer script, end-user is not affected. Not critical for 2.0.0, but can be picked up in next patch release if it does not make this one.