### PR TITLE
[TRAFODION-1974] Limit HBase cache size for ustat direct sampling

### DIFF
--- a/core/sql/ustat/hs_globals.h
+++ b/core/sql/ustat/hs_globals.h
@@ -1339,6 +1339,10 @@ public:
     // parser errors
     enum { ERROR_NONE = 0, ERROR_SYNTAX, ERROR_SEMANTICS};
 
+    // Set CQDs controlling min/max HBase cache size to minimize risk of
+    // scanner timeout.
+    static NABoolean setHBaseCacheSize(double sampleRatio);
+
     // Static fns for determining minimum table sizes for sampling, and for
     // using lowest sampling rate, under default sampling protocol.
     static Int64 getMinRowCountForSample();


### PR DESCRIPTION
This is not a definitive fix for the issue of timeouts during Update
Statistics processing for very large tables, but should decrease the
frequency of such occurrences. It extends the fix for TRAFODION-1740
(SHA-1 99a143f29910c7d3c8e02fb1bf101214568bf80a, Dave Birdsall), which
modified the CQDs controlling HBase cache size based on the sampling
rate when the ustat sample table is populated. This commit does the
same thing when the sample can be read directly into memory from the
table being sampled.