### PR TITLE
[TRAFODION-1853] Fix overflow of long type bit wise shifting in T4 LogicalByteArray

### DIFF
--- a/core/conn/jdbcT4/src/main/java/org/trafodion/jdbc/t4/Bytes.java
+++ b/core/conn/jdbcT4/src/main/java/org/trafodion/jdbc/t4/Bytes.java
@@ -21,6 +21,8 @@
 
 package org.trafodion.jdbc.t4;
 
+import java.nio.ByteBuffer;
+
 /**
  * <code>Bytes</code> contains a set of static methods used for byte
  * manipulation. There are three basic types of methods:
@@ -101,19 +103,16 @@ class Bytes {
 		long value = 0;
 		int i=offset;
 		
-		if(swap) {
-			for (int shift = 0; shift < 64; shift += 8) {
-				value |= ( (long)( array[i] & 0xff ) ) << shift;
-				i++;
-			}
-			
-		}else {
-			for (int shift = 56; shift >= 0; shift -= 8) {
-				value |= ( (long)( array[i] & 0xff ) ) << shift;
-				i++;
-			}
-		}
-		
+        ByteBuffer buffer = ByteBuffer.allocate(8);
+        
+        buffer.put(array, offset, 8);
+        buffer.flip();
+
+        value = buffer.getLong();
+
+        if (swap)
+            value = Long.reverseBytes(value);
+            
 		return value;
 	}
 

--- a/core/conn/jdbcT4/src/main/java/org/trafodion/jdbc/t4/LogicalByteArray.java
+++ b/core/conn/jdbcT4/src/main/java/org/trafodion/jdbc/t4/LogicalByteArray.java
@@ -261,21 +261,18 @@ class LogicalByteArray {
 	
 	long extractLong() {
 		long value;
+        
+        ByteBuffer buffer = ByteBuffer.allocate(8);
+        
+        buffer.put(array, loc, 8);
+        buffer.flip();
 
-		if (swap) {
-			value = ((array[loc]) & 0x00000000000000ffL) | ((array[loc + 1] << 8) & 0x000000000000ff00L)
-					| ((array[loc + 2] << 16) & 0x0000000000ff0000L) | ((array[loc + 3] << 24) & 0x00000000ff000000L)
-					| ((array[loc + 4] << 32) & 0x000000ff00000000L) | ((array[loc + 5] << 40) & 0x0000ff0000000000L)
-					| ((array[loc + 6] << 48) & 0x00ff000000000000L) | ((array[loc + 7] << 56) & 0xff00000000000000L);
-		} else {
-			value = ((array[loc + 7]) & 0x00000000000000ffL) | ((array[loc + 6] << 8) & 0x000000000000ff00L)
-					| ((array[loc + 5] << 16) & 0x0000000000ff0000L) | ((array[loc + 4] << 24) & 0x00000000ff000000L)
-					| ((array[loc + 3] << 32) & 0x000000ff00000000L) | ((array[loc + 2] << 40) & 0x0000ff0000000000L)
-					| ((array[loc + 1] << 48) & 0x00ff000000000000L) | ((array[loc] << 56) & 0xff00000000000000L);
-		}
+        value = buffer.getLong();
+        loc += 8;
 
-		loc += 8;
-
+        if (swap)
+            value = Long.reverseBytes(value);
+            
 		return value;
 	}
 


### PR DESCRIPTION
Both extractLong() methods of LogicalByteArray and Bytes classes are using bit wise shifting to extract the long value from byte array, but larger then 32 bit wise shifting will overflow. Change to use java.nio.ByteBuffer to construct and convert the long value from the source byte array.