### PR TITLE
[TRAFODION-2004] UPDATE STATS not supported on volatile tables

### DIFF
--- a/core/sql/bin/SqlciErrors.txt
+++ b/core/sql/bin/SqlciErrors.txt
@@ -1878,6 +1878,7 @@ drop the default context
 9244 ZZZZZ 99999 BEGINNER MAJOR DBADMIN UPDATE STATISTICS is not allowed in a user transaction.
 9245 ZZZZZ 99999 UUUUUUUU UUUUU UUUUUUU ---- unused ----
 9246 ZZZZZ 99999 BEGINNER MAJOR DBADMIN UPDATE STATISTICS is not supported on LOB columns. Column $0~String0 is a LOB column.
+9247 ZZZZZ 99999 BEGINNER MAJOR DBADMIN UPDATE STATISTICS is not supported on volatile tables presently.
 9250 ZZZZZ 99999 UUUUUUUU UUUUU UUUUUUU Last UPDATE STATISTICS error.
 10000 ZZZZZ 99999 UUUUUUUU UUUUU UUUUUUU Sort Error: First Sort error
 10001 ZZZZZ 99999 ADVANCED MAJOR DIALOUT Sort Error : No error text defined. Unexpected error. $0~String0

--- a/core/sql/regress/executor/EXPECTED013.SB
+++ b/core/sql/regress/executor/EXPECTED013.SB
@@ -21,7 +21,7 @@
 >>invoke t013t1;
 
 -- Definition of Trafodion table TRAFODION.T013_SCH.T013T1
--- Definition current  Sat Mar 12 07:39:38 2016
+-- Definition current  Tue May 24 21:30:23 2016
 
   (
     SYSKEY                           LARGEINT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -50,7 +50,7 @@ A
 >>invoke t013t1;
 
 -- Definition of Trafodion volatile table T013T1
--- Definition current  Sat Mar 12 07:39:53 2016
+-- Definition current  Tue May 24 21:30:37 2016
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -91,9 +91,11 @@ A            B
 
 --- SQL operation complete.
 >>
->>#ifndef SEABASE_REGRESS
 >>update statistics for table t013t1 on every column;
->>#endif
+
+*** ERROR[9247] UPDATE STATISTICS is not supported on volatile tables presently.
+
+--- SQL operation failed with errors.
 >>
 >>select * from t013_sch.t013t1;
 
@@ -113,7 +115,7 @@ A
 >>invoke t013t1;
 
 -- Definition of Trafodion table TRAFODION.T013_SCH.T013T1
--- Definition current  Sat Mar 12 07:40:59 2016
+-- Definition current  Tue May 24 21:31:43 2016
 
   (
     SYSKEY                           LARGEINT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -139,7 +141,7 @@ A
 >>invoke t013t1;
 
 -- Definition of Trafodion volatile table T013T1
--- Definition current  Sat Mar 12 07:41:18 2016
+-- Definition current  Tue May 24 21:32:04 2016
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -179,7 +181,7 @@ A            B            C
 >>invoke t013t1;
 
 -- Definition of Trafodion table TRAFODION.T013_SCH.T013T1
--- Definition current  Sat Mar 12 07:41:32 2016
+-- Definition current  Tue May 24 21:32:16 2016
 
   (
     SYSKEY                           LARGEINT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -202,7 +204,7 @@ A
 >>invoke t013t1;
 
 -- Definition of Trafodion volatile table T013T1
--- Definition current  Sat Mar 12 07:41:38 2016
+-- Definition current  Tue May 24 21:32:22 2016
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -291,10 +293,16 @@ A            B            C            D
 *** ERROR[8822] The statement was not prepared.
 
 >>
->>#ifndef SEABASE_REGRESS
 >>update statistics for table volatile_schema_a.t on every column;
+
+*** ERROR[4082] Object TRAFODION.VOLATILE_SCHEMA_A.T does not exist or is inaccessible.
+
+--- SQL operation failed with errors.
 >>update statistics for table $$TEST_CATALOG$$.volatile_schema_a.t on every column;
->>#endif
+
+*** ERROR[4082] Object TRAFODION.VOLATILE_SCHEMA_A.T does not exist or is inaccessible.
+
+--- SQL operation failed with errors.
 >>
 >>-- cannot create volatile index on regular tables and vica-versa
 >>create volatile index tempi on $$TEST_CATALOG$$.t013_sch.t013t1(a);
@@ -454,7 +462,7 @@ CONTROL QUERY DEFAULT
 >>invoke t013t1;
 
 -- Definition of Trafodion table TRAFODION.T013_SCH.T013T1
--- Definition current  Sat Mar 12 07:42:40 2016
+-- Definition current  Tue May 24 21:33:35 2016
 
   (
     SYSKEY                           LARGEINT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -475,7 +483,7 @@ CONTROL QUERY DEFAULT
 >>invoke t013t1;
 
 -- Definition of Trafodion table TRAFODION.T013_SCH.T013T1
--- Definition current  Sat Mar 12 07:42:49 2016
+-- Definition current  Tue May 24 21:33:43 2016
 
   (
     SYSKEY                           LARGEINT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -567,7 +575,7 @@ control query shape nested_join(anything,anything);
 >>invoke t013t3;
 
 -- Definition of Trafodion table TRAFODION.T013SCH1.T013T3
--- Definition current  Sat Mar 12 07:43:35 2016
+-- Definition current  Tue May 24 21:34:35 2016
 
   (
     SYSKEY                           LARGEINT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -585,7 +593,7 @@ control query shape nested_join(anything,anything);
 >>invoke t013t3;
 
 -- Definition of Trafodion volatile table T013T3
--- Definition current  Sat Mar 12 07:43:40 2016
+-- Definition current  Tue May 24 21:34:42 2016
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -601,7 +609,7 @@ control query shape nested_join(anything,anything);
 >>invoke t013t3;
 
 -- Definition of Trafodion table TRAFODION.T013SCH1.T013T3
--- Definition current  Sat Mar 12 07:43:52 2016
+-- Definition current  Tue May 24 21:34:55 2016
 
   (
     SYSKEY                           LARGEINT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -667,7 +675,7 @@ CREATE VOLATILE TABLE T013T3
 >>invoke t013t3;
 
 -- Definition of Trafodion table TRAFODION.T013SCH1.T013T3
--- Definition current  Sat Mar 12 07:44:35 2016
+-- Definition current  Tue May 24 21:35:47 2016
 
   (
     SYSKEY                           LARGEINT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -1289,7 +1297,7 @@ CREATE VOLATILE TABLE T013T1
 >>invoke t013t1;
 
 -- Definition of Trafodion table TRAFODION.T013_SCH.T013T1
--- Definition current  Sat Mar 12 07:51:06 2016
+-- Definition current  Tue May 24 21:42:50 2016
 
   (
     SYSKEY                           LARGEINT NO DEFAULT NOT NULL NOT DROPPABLE

--- a/core/sql/regress/executor/TEST013
+++ b/core/sql/regress/executor/TEST013
@@ -85,9 +85,7 @@ select * from t013t1;
 
 create volatile index t013t1i2 on t013t1 (b);
 
-#ifndef SEABASE_REGRESS
 update statistics for table t013t1 on every column;
-#endif
 
 select * from t013_sch.t013t1;
 
@@ -147,10 +145,8 @@ select * from $$TEST_CATALOG$$.volatile_schema_a.t;
 drop table volatile_schema_a.t;
 drop table $$TEST_CATALOG$$.volatile_schema_a.t;
 
-#ifndef SEABASE_REGRESS
 update statistics for table volatile_schema_a.t on every column;
 update statistics for table $$TEST_CATALOG$$.volatile_schema_a.t on every column;
-#endif
 
 -- cannot create volatile index on regular tables and vica-versa
 create volatile index tempi on $$TEST_CATALOG$$.t013_sch.t013t1(a);

--- a/core/sql/regress/hive/EXPECTED018
+++ b/core/sql/regress/hive/EXPECTED018
@@ -140,9 +140,9 @@ Task:  CLEANUP         Status: Started    Object: TRAFODION.HBASE.CUSTOMER_ADDRE
 Task:  CLEANUP         Status: Ended      Object: TRAFODION.HBASE.CUSTOMER_ADDRESS
 Task:  PREPARATION     Status: Started    Object: TRAFODION.HBASE.CUSTOMER_ADDRESS
        Rows Processed: 50000 
-Task:  PREPARATION     Status: Ended      ET: 00:00:09.186
+Task:  PREPARATION     Status: Ended      ET: 00:00:07.552
 Task:  COMPLETION      Status: Started    Object: TRAFODION.HBASE.CUSTOMER_ADDRESS
-Task:  COMPLETION      Status: Ended      ET: 00:00:00.247
+Task:  COMPLETION      Status: Ended      ET: 00:00:00.234
 
 --- 50000 row(s) loaded.
 >>--
@@ -171,9 +171,9 @@ Task:  CLEANUP         Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOG
 Task:  CLEANUP         Status: Ended      Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS
 Task:  PREPARATION     Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS
        Rows Processed: 20000 
-Task:  PREPARATION     Status: Ended      ET: 00:00:14.900
+Task:  PREPARATION     Status: Ended      ET: 00:00:09.332
 Task:  COMPLETION      Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS
-Task:  COMPLETION      Status: Ended      ET: 00:00:00.277
+Task:  COMPLETION      Status: Ended      ET: 00:00:00.204
 
 --- 20000 row(s) loaded.
 >>--
@@ -203,9 +203,9 @@ Task:  CLEANUP         Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOG
 Task:  CLEANUP         Status: Ended      Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS_SALT
 Task:  PREPARATION     Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS_SALT
        Rows Processed: 20000 
-Task:  PREPARATION     Status: Ended      ET: 00:00:07.686
+Task:  PREPARATION     Status: Ended      ET: 00:00:06.534
 Task:  COMPLETION      Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS_SALT
-Task:  COMPLETION      Status: Ended      ET: 00:00:00.271
+Task:  COMPLETION      Status: Ended      ET: 00:00:00.188
 
 --- 20000 row(s) loaded.
 >>--                                                                              
@@ -225,9 +225,9 @@ Task:  CLEANUP         Status: Started    Object: TRAFODION.HBASE.CUSTOMER_SALT
 Task:  CLEANUP         Status: Ended      Object: TRAFODION.HBASE.CUSTOMER_SALT
 Task:  PREPARATION     Status: Started    Object: TRAFODION.HBASE.CUSTOMER_SALT
        Rows Processed: 100000 
-Task:  PREPARATION     Status: Ended      ET: 00:00:11.309
+Task:  PREPARATION     Status: Ended      ET: 00:00:07.227
 Task:  COMPLETION      Status: Started    Object: TRAFODION.HBASE.CUSTOMER_SALT
-Task:  COMPLETION      Status: Ended      ET: 00:00:00.281
+Task:  COMPLETION      Status: Ended      ET: 00:00:00.159
 
 --- 100000 row(s) loaded.
 >>--
@@ -256,9 +256,9 @@ Task:  CLEANUP         Status: Started    Object: TRAFODION.HBASE.STORE_SALES_SA
 Task:  CLEANUP         Status: Ended      Object: TRAFODION.HBASE.STORE_SALES_SALT
 Task:  PREPARATION     Status: Started    Object: TRAFODION.HBASE.STORE_SALES_SALT
        Rows Processed: 160756 
-Task:  PREPARATION     Status: Ended      ET: 00:00:13.015
+Task:  PREPARATION     Status: Ended      ET: 00:00:08.924
 Task:  COMPLETION      Status: Started    Object: TRAFODION.HBASE.STORE_SALES_SALT
-Task:  COMPLETION      Status: Ended      ET: 00:00:00.289
+Task:  COMPLETION      Status: Ended      ET: 00:00:00.166
 
 --- 160756 row(s) loaded.
 >>--
@@ -304,10 +304,10 @@ aaa5                                                          ?
 +>   select * from nulls;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.008
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.010
 Task:  EXTRACT         Status: Started
        Rows Processed: 6 
-Task:  EXTRACT         Status: Ended      ET: 00:00:00.259
+Task:  EXTRACT         Status: Ended      ET: 00:00:00.223
 
 --- 6 row(s) unloaded.
 >>select * from hive.hive.nulls order by a,b;
@@ -349,12 +349,12 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 +>;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.006
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.004
 Task:  EXTRACT         Status: Started
        Rows Processed: 50000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:03.068
+Task:  EXTRACT         Status: Ended      ET: 00:00:02.445
 Task:  MERGE FILES     Status: Started
-Task:  MERGE FILES     Status: Ended      ET: 00:00:00.037
+Task:  MERGE FILES     Status: Ended      ET: 00:00:00.034
 
 --- 50000 row(s) unloaded.
 >>log;
@@ -387,12 +387,12 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 +><<+ cardinality 10e10 >>;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.011
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.006
 Task:  EXTRACT         Status: Started
        Rows Processed: 20000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:00.931
+Task:  EXTRACT         Status: Ended      ET: 00:00:00.773
 Task:  MERGE FILES     Status: Started
-Task:  MERGE FILES     Status: Ended      ET: 00:00:00.025
+Task:  MERGE FILES     Status: Ended      ET: 00:00:00.031
 
 --- 20000 row(s) unloaded.
 >>log;
@@ -411,12 +411,12 @@ cat /tmp/merged_customer_demogs | wc -l
 +><<+ cardinality 10e10 >>;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.006
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.008
 Task:  EXTRACT         Status: Started
        Rows Processed: 20000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:00.967
+Task:  EXTRACT         Status: Ended      ET: 00:00:00.769
 Task:  MERGE FILES     Status: Started
-Task:  MERGE FILES     Status: Ended      ET: 00:00:00.072
+Task:  MERGE FILES     Status: Ended      ET: 00:00:00.026
 
 --- 20000 row(s) unloaded.
 >>log;
@@ -448,12 +448,12 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 +><<+ cardinality 10e10 >>;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.008
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.007
 Task:  EXTRACT         Status: Started
        Rows Processed: 20000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:01.354
+Task:  EXTRACT         Status: Ended      ET: 00:00:00.736
 Task:  MERGE FILES     Status: Started
-Task:  MERGE FILES     Status: Ended      ET: 00:00:00.050
+Task:  MERGE FILES     Status: Ended      ET: 00:00:00.039
 
 --- 20000 row(s) unloaded.
 >>
@@ -471,12 +471,12 @@ regrhadoop.ksh fs -du -s /bulkload/customer_demographics_salt/merged_customer_de
 +><<+ cardinality 10e10 >>;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.007
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.005
 Task:  EXTRACT         Status: Started
        Rows Processed: 20000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:01.301
+Task:  EXTRACT         Status: Ended      ET: 00:00:00.552
 Task:  MERGE FILES     Status: Started
-Task:  MERGE FILES     Status: Ended      ET: 00:00:00.049
+Task:  MERGE FILES     Status: Ended      ET: 00:00:00.032
 
 --- 20000 row(s) unloaded.
 >>
@@ -509,10 +509,10 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 +><<+ cardinality 10e10 >>;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.009
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.005
 Task:  EXTRACT         Status: Started
        Rows Processed: 20000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:01.076
+Task:  EXTRACT         Status: Ended      ET: 00:00:00.480
 
 --- 20000 row(s) unloaded.
 >>
@@ -532,12 +532,12 @@ regrhadoop.ksh fs -ls /bulkload/customer_demographics_salt/file* |  grep file | 
 +><<+ cardinality 10e10 >>;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.011
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.008
 Task:  EXTRACT         Status: Started
        Rows Processed: 20000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:00.906
+Task:  EXTRACT         Status: Ended      ET: 00:00:00.560
 Task:  MERGE FILES     Status: Started
-Task:  MERGE FILES     Status: Ended      ET: 00:00:00.041
+Task:  MERGE FILES     Status: Ended      ET: 00:00:00.034
 
 --- 20000 row(s) unloaded.
 >>
@@ -673,9 +673,9 @@ Task:  EMPTY TARGET    Status: Started
 Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.006
 Task:  EXTRACT         Status: Started
        Rows Processed: 20000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:01.150
+Task:  EXTRACT         Status: Ended      ET: 00:00:00.541
 Task:  MERGE FILES     Status: Started
-Task:  MERGE FILES     Status: Ended      ET: 00:00:00.046
+Task:  MERGE FILES     Status: Ended      ET: 00:00:00.035
 
 --- 20000 row(s) unloaded.
 >>log;
@@ -710,12 +710,12 @@ regrhadoop.ksh fs -ls /bulkload/customer_demographics_salt/merged* | grep merge 
 +><<+ cardinality 10e10 >>;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.006
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.005
 Task:  EXTRACT         Status: Started
        Rows Processed: 20000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:01.176
+Task:  EXTRACT         Status: Ended      ET: 00:00:00.447
 Task:  MERGE FILES     Status: Started
-Task:  MERGE FILES     Status: Ended      ET: 00:00:00.054
+Task:  MERGE FILES     Status: Ended      ET: 00:00:00.035
 
 --- 20000 row(s) unloaded.
 >>
@@ -765,10 +765,10 @@ CD_DEMO_SK   CD_GENDER                                                          
 +><<+ cardinality 10e10 >>;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.007
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.005
 Task:  EXTRACT         Status: Started
        Rows Processed: 20000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:01.320
+Task:  EXTRACT         Status: Ended      ET: 00:00:00.434
 
 --- 20000 row(s) unloaded.
 >>
@@ -815,10 +815,10 @@ CD_DEMO_SK   CD_GENDER                                                          
 +>select * from trafodion.hbase.customer_address ;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.006
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.005
 Task:  EXTRACT         Status: Started
        Rows Processed: 50000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:02.420
+Task:  EXTRACT         Status: Ended      ET: 00:00:01.808
 
 --- 50000 row(s) unloaded.
 >>
@@ -868,10 +868,10 @@ CA_ADDRESS_SK  CA_ADDRESS_ID                                                    
 +>select * from trafodion.hbase.customer_address ;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.007
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.005
 Task:  EXTRACT         Status: Started
        Rows Processed: 50000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:02.294
+Task:  EXTRACT         Status: Ended      ET: 00:00:01.800
 
 --- 50000 row(s) unloaded.
 >>
@@ -933,7 +933,7 @@ Task:  EMPTY TARGET    Status: Started
 Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.005
 Task:  EXTRACT         Status: Started
        Rows Processed: 100000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:06.344
+Task:  EXTRACT         Status: Ended      ET: 00:00:05.750
 
 --- 100000 row(s) unloaded.
 >>select count(*) from hive.hive.unload_customer;
@@ -983,10 +983,10 @@ C_CUSTOMER_SK  C_CUSTOMER_ID                                                    
 +>select * from trafodion.hbase.customer_demographics_salt;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.011
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.008
 Task:  EXTRACT         Status: Started
        Rows Processed: 20000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:00.864
+Task:  EXTRACT         Status: Ended      ET: 00:00:00.834
 
 --- 20000 row(s) unloaded.
 >>
@@ -1036,12 +1036,12 @@ CD_DEMO_SK   CD_GENDER                                                          
 +>select * from trafodion.hbase.customer_address where ca_address_sk < 100;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.006
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.005
 Task:  EXTRACT         Status: Started
        Rows Processed: 99 
 Task:  EXTRACT         Status: Ended      ET: 00:00:00.211
 Task:  MERGE FILES     Status: Started
-Task:  MERGE FILES     Status: Ended      ET: 00:00:00.024
+Task:  MERGE FILES     Status: Ended      ET: 00:00:00.032
 
 --- 99 row(s) unloaded.
 >>
@@ -1077,10 +1077,10 @@ regrhadoop.ksh fs -rm /user/hive/exttables/unload_customer_demographics/*
 +>select ss_sold_date_sk,ss_store_sk, sum (ss_quantity) from store_sales_salt group by  ss_sold_date_sk ,ss_store_sk;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.006
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.005
 Task:  EXTRACT         Status: Started
        Rows Processed: 12349 
-Task:  EXTRACT         Status: Ended      ET: 00:00:06.234
+Task:  EXTRACT         Status: Ended      ET: 00:00:05.807
 
 --- 12349 row(s) unloaded.
 >>
@@ -1199,10 +1199,10 @@ SS_SOLD_DATE_SK  SS_STORE_SK  SS_QUANTITY
 +>select * from trafodion.hbase.customer_salt c join trafodion.hbase.customer_address ca on c.c_current_addr_sk = ca.ca_address_sk ;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.005
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.004
 Task:  EXTRACT         Status: Started
        Rows Processed: 100000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:07.489
+Task:  EXTRACT         Status: Ended      ET: 00:00:06.844
 
 --- 100000 row(s) unloaded.
 >>
@@ -1250,10 +1250,10 @@ C_CUSTOMER_SK  C_CUSTOMER_ID                                                    
 +>select * from customer_address where ca_address_sk < 1000 union select * from customer_address where ca_address_sk > 40000  and ca_address_sk < 41000;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.012
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.008
 Task:  EXTRACT         Status: Started
        Rows Processed: 1998 
-Task:  EXTRACT         Status: Ended      ET: 00:00:00.794
+Task:  EXTRACT         Status: Ended      ET: 00:00:00.450
 
 --- 1998 row(s) unloaded.
 >>
@@ -1364,7 +1364,7 @@ ESP_EXCHANGE ==============================  SEQ_NO 3        ONLY CHILD 2
   use_snapshot_scan ...... TRUE
   full_table_name ........ TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS_SALT
   snapshot_name .......... TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS_SALT_SNAP111
-  snapshot_temp_location   /bulkload/20151101132150/
+  snapshot_temp_location   /bulkload/20160524211033/
 grep -i -e 'explain reg' -e snapshot -e full_table_name  -e esp_exchange  LOG018_REGULAR_SCAN_PLAN.TXT | grep -v snapshot_scan_run_id
 >>--no snapshot
 >>explain reg;
@@ -1444,7 +1444,7 @@ grep -i -e 'explain snp' -e snapshot -e full_table_name -e esp_exchange LOG018_S
   use_snapshot_scan ...... TRUE
   full_table_name ........ TRAFODION.HBASE.CUSTOMER_ADDRESS
   snapshot_name .......... TRAFODION.HBASE.CUSTOMER_ADDRESS_SNAP111
-  snapshot_temp_location   /bulkload/20151101132159/
+  snapshot_temp_location   /bulkload/20160524211040/
 grep -i -e 'explain reg' -e snapshot -e full_table_name  -e esp_exchange  LOG018_REGULAR_SCAN_PLAN.TXT | grep -v snapshot_scan_run_id
 >>--no snapshot
 >>explain reg;
@@ -1526,11 +1526,11 @@ grep -i -e 'explain snp' -e snapshot -e full_table_name -e esp_exchange LOG018_S
   use_snapshot_scan ...... TRUE
   full_table_name ........ TRAFODION.HBASE.CUSTOMER_SALT
   snapshot_name .......... TRAFODION.HBASE.CUSTOMER_SALT_SNAP111
-  snapshot_temp_location   /bulkload/20151101132221/
+  snapshot_temp_location   /bulkload/20160524211101/
   use_snapshot_scan ...... TRUE
   full_table_name ........ TRAFODION.HBASE.CUSTOMER_ADDRESS
   snapshot_name .......... TRAFODION.HBASE.CUSTOMER_ADDRESS_SNAP111
-  snapshot_temp_location   /bulkload/20151101132221/
+  snapshot_temp_location   /bulkload/20160524211101/
 grep -i -e 'explain reg' -e snapshot -e full_table_name  -e esp_exchange  LOG018_REGULAR_SCAN_PLAN.TXT | grep -v snapshot_scan_run_id
 >>--no snapshot
 >>explain reg;
@@ -1615,6 +1615,10 @@ C_CUSTOMER_SK  C_CUSTOMER_ID     C_CURRENT_CDEMO_SK  C_CURRENT_HDEMO_SK  C_CURRE
 >>--*********************BULK UNLOAD with SNAPSHOT SCAN
 >>--unload 20
 >>
+>>cqd comp_bool_226 'on';
+
+--- SQL operation complete.
+>>  -- allow the extract syntax
 >>explain options 'f' 
 +>UNLOAD EXTRACT TO '/bulkload/customer_address'
 +>select * from trafodion.hbase.customer_address <<+ cardinality 10e10 >>;
@@ -1627,6 +1631,9 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 .    .    1    trafodion_scan                  CUSTOMER_ADDRESS      1.00E+011
 
 --- SQL operation complete.
+>>cqd comp_bool_226 reset;
+
+--- SQL operation complete.
 >>
 >>UNLOAD
 +>WITH PURGEDATA FROM TARGET
@@ -1636,13 +1643,13 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 +><<+ cardinality 10e10 >>;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.006
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.004
 Task:  VERIFY SNAPSHO  Status: Started
        Snapshots verified: 1 
-Task:  VERIFY SNAPSHO  Status: Ended      ET: 00:00:00.346
+Task:  VERIFY SNAPSHO  Status: Ended      ET: 00:00:00.281
 Task:  EXTRACT         Status: Started
        Rows Processed: 50000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:03.382
+Task:  EXTRACT         Status: Ended      ET: 00:00:01.844
 
 --- 50000 row(s) unloaded.
 >>
@@ -1686,6 +1693,10 @@ CA_ADDRESS_SK  CA_ADDRESS_ID                                                    
 >>
 >>--unload 21
 >>
+>>cqd comp_bool_226 'on';
+
+--- SQL operation complete.
+>>  -- allow the extract syntax
 >>explain options 'f' 
 +>UNLOAD EXTRACT TO '/user/hive/exttables/unload_customer_demographics'
 +>select * from trafodion.hbase.customer_demographics_salt <<+ cardinality 10e10 >>;
@@ -1699,6 +1710,9 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 .    .    1    trafodion_scan                  CUSTOMER_DEMOGRAPHIC  1.00E+011
 
 --- SQL operation complete.
+>>cqd comp_bool_226 reset;
+
+--- SQL operation complete.
 >>
 >>UNLOAD  
 +>WITH PURGEDATA FROM TARGET
@@ -1707,13 +1721,13 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 +>select * from trafodion.hbase.customer_demographics_salt <<+ cardinality 10e10 >>;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.003
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.002
 Task:  VERIFY SNAPSHO  Status: Started
        Snapshots verified: 1 
-Task:  VERIFY SNAPSHO  Status: Ended      ET: 00:00:00.316
+Task:  VERIFY SNAPSHO  Status: Ended      ET: 00:00:00.274
 Task:  EXTRACT         Status: Started
        Rows Processed: 20000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:02.630
+Task:  EXTRACT         Status: Ended      ET: 00:00:01.322
 
 --- 20000 row(s) unloaded.
 >>
@@ -1761,13 +1775,13 @@ CD_DEMO_SK   CD_GENDER                                                          
 +>select * from trafodion.hbase.customer_demographics_salt <<+ cardinality 10e10 >>;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.008
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.011
 Task:  CREATE SNAPSHO  Status: Started
        Snapshots created: 1 
-Task:  CREATE SNAPSHO  Status: Ended      ET: 00:00:00.919
+Task:  CREATE SNAPSHO  Status: Ended      ET: 00:00:02.441
 Task:  EXTRACT         Status: Started
        Rows Processed: 20000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:01.959
+Task:  EXTRACT         Status: Ended      ET: 00:00:01.258
 Task:  DELETE SNAPSHO  Status: Started
        Snapshots deleted: 1 
 Task:  DELETE SNAPSHO  Status: Ended      ET: 00:00:00.012
@@ -1818,16 +1832,16 @@ CD_DEMO_SK   CD_GENDER                                                          
 +>select * from trafodion.hbase.customer_demographics_salt <<+ cardinality 10e10 >>;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.008
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.007
 Task:  CREATE SNAPSHO  Status: Started
        Snapshots created: 1 
-Task:  CREATE SNAPSHO  Status: Ended      ET: 00:00:00.620
+Task:  CREATE SNAPSHO  Status: Ended      ET: 00:00:01.509
 Task:  EXTRACT         Status: Started
        Rows Processed: 20000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:01.852
+Task:  EXTRACT         Status: Ended      ET: 00:00:00.975
 Task:  DELETE SNAPSHO  Status: Started
        Snapshots deleted: 1 
-Task:  DELETE SNAPSHO  Status: Ended      ET: 00:00:00.005
+Task:  DELETE SNAPSHO  Status: Ended      ET: 00:00:00.003
 
 --- 20000 row(s) unloaded.
 >>
@@ -1876,16 +1890,16 @@ CD_DEMO_SK   CD_GENDER                                                          
 +>select * from customer_address where ca_address_sk < 1000 union select * from customer_address where ca_address_sk > 40000  and ca_address_sk < 41000;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.006
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.004
 Task:  CREATE SNAPSHO  Status: Started
        Snapshots created: 1 
-Task:  CREATE SNAPSHO  Status: Ended      ET: 00:00:01.010
+Task:  CREATE SNAPSHO  Status: Ended      ET: 00:00:01.481
 Task:  EXTRACT         Status: Started
        Rows Processed: 1998 
-Task:  EXTRACT         Status: Ended      ET: 00:00:00.742
+Task:  EXTRACT         Status: Ended      ET: 00:00:00.606
 Task:  DELETE SNAPSHO  Status: Started
        Snapshots deleted: 1 
-Task:  DELETE SNAPSHO  Status: Ended      ET: 00:00:00.005
+Task:  DELETE SNAPSHO  Status: Ended      ET: 00:00:00.003
 
 --- 1998 row(s) unloaded.
 >>
@@ -1960,16 +1974,16 @@ CA_ADDRESS_SK  CA_ADDRESS_ID                                                    
 +>select * from trafodion.hbase.customer_salt c join trafodion.hbase.customer_address ca on c.c_current_addr_sk = ca.ca_address_sk ;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.006
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.003
 Task:  CREATE SNAPSHO  Status: Started
        Snapshots created: 2 
-Task:  CREATE SNAPSHO  Status: Ended      ET: 00:00:02.525
+Task:  CREATE SNAPSHO  Status: Ended      ET: 00:00:04.114
 Task:  EXTRACT         Status: Started
        Rows Processed: 100000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:10.505
+Task:  EXTRACT         Status: Ended      ET: 00:00:08.014
 Task:  DELETE SNAPSHO  Status: Started
        Snapshots deleted: 2 
-Task:  DELETE SNAPSHO  Status: Ended      ET: 00:00:00.009
+Task:  DELETE SNAPSHO  Status: Ended      ET: 00:00:00.007
 
 --- 100000 row(s) unloaded.
 >>
@@ -2010,6 +2024,10 @@ C_CUSTOMER_SK  C_CUSTOMER_ID                                                    
 --- 20 row(s) selected.
 >>
 >>--unload 26 --test with index scan
+>>cqd comp_bool_226 'on';
+
+--- SQL operation complete.
+>>  -- allow the extract syntax
 >>explain options 'f' 
 +>UNLOAD EXTRACT TO '/bulkload/customer_name'
 +>select c_first_name,c_last_name from trafodion.hbase.customer_salt;
@@ -2022,6 +2040,9 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 .    .    1    trafodion_index_scan            CUSTOMER_IDX1         1.00E+002
 
 --- SQL operation complete.
+>>cqd comp_bool_226 reset;
+
+--- SQL operation complete.
 >>
 >>UNLOAD
 +>WITH PURGEDATA FROM TARGET
@@ -2030,16 +2051,16 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 +>select c_first_name,c_last_name from trafodion.hbase.customer_salt;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.010
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.006
 Task:  CREATE SNAPSHO  Status: Started
        Snapshots created: 1 
-Task:  CREATE SNAPSHO  Status: Ended      ET: 00:00:00.375
+Task:  CREATE SNAPSHO  Status: Ended      ET: 00:00:00.873
 Task:  EXTRACT         Status: Started
        Rows Processed: 100000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:03.885
+Task:  EXTRACT         Status: Ended      ET: 00:00:01.164
 Task:  DELETE SNAPSHO  Status: Started
        Snapshots deleted: 1 
-Task:  DELETE SNAPSHO  Status: Ended      ET: 00:00:00.005
+Task:  DELETE SNAPSHO  Status: Ended      ET: 00:00:00.004
 
 --- 100000 row(s) unloaded.
 >>
@@ -2112,7 +2133,7 @@ unload with delimiter 0 into '/bulkload/test' select * from CUSTOMER_ADDRESS;
 Task: UNLOAD           Status: Started
 Task:  EXTRACT         Status: Started
        Rows Processed: 50000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:02.002
+Task:  EXTRACT         Status: Ended      ET: 00:00:01.708
 
 --- 50000 row(s) unloaded.
 >>--unload  24 -- should give an error
@@ -2177,7 +2198,7 @@ regrhadoop.ksh fs -rm /user/hive/exttables/unload_customer_demographics/*
 Task: UNLOAD           Status: Started
 Task:  EXTRACT         Status: Started
        Rows Processed but NOT Written to Disk: 20000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:00.722
+Task:  EXTRACT         Status: Ended      ET: 00:00:00.606
 
 --- 20000 row(s) unloaded.
 >>select count(*) from hive.hive.unload_customer_demographics;

--- a/core/sql/regress/hive/TEST018
+++ b/core/sql/regress/hive/TEST018
@@ -597,9 +597,11 @@ cqd TRAF_TABLE_SNAPSHOT_SCAN_TABLE_SIZE_THRESHOLD '0';
 --*********************BULK UNLOAD with SNAPSHOT SCAN
 --unload 20
 
+cqd comp_bool_226 'on';  -- allow the extract syntax
 explain options 'f' 
 UNLOAD EXTRACT TO '/bulkload/customer_address'
 select * from trafodion.hbase.customer_address <<+ cardinality 10e10 >>;
+cqd comp_bool_226 reset;
 
 UNLOAD
 WITH PURGEDATA FROM TARGET
@@ -613,9 +615,11 @@ select [first 20] * from hive.hive.unload_customer_address  where ca_address_sk 
 
 --unload 21
 
+cqd comp_bool_226 'on';  -- allow the extract syntax
 explain options 'f' 
 UNLOAD EXTRACT TO '/user/hive/exttables/unload_customer_demographics'
 select * from trafodion.hbase.customer_demographics_salt <<+ cardinality 10e10 >>;
+cqd comp_bool_226 reset;
 
 UNLOAD  
 WITH PURGEDATA FROM TARGET
@@ -669,9 +673,11 @@ select count(*) from hive.hive.unload_customer_and_address;
 select [first 20] * from hive.hive.unload_customer_and_address order by ca_address_sk,c_customer_sk;
 
 --unload 26 --test with index scan
+cqd comp_bool_226 'on';  -- allow the extract syntax
 explain options 'f' 
 UNLOAD EXTRACT TO '/bulkload/customer_name'
 select c_first_name,c_last_name from trafodion.hbase.customer_salt;
+cqd comp_bool_226 reset;
 
 UNLOAD
 WITH PURGEDATA FROM TARGET

--- a/core/sql/sqlcomp/NADefaults.h
+++ b/core/sql/sqlcomp/NADefaults.h
@@ -401,6 +401,12 @@ private:
   // these default values were 'held' through a cqd HOLD stmt.
   char             **heldDefaults_;
 
+  // and these default values were 'held' through a sequence of two HOLD stmts.
+  char             **heldHeldDefaults_;
+
+  // if there are three HOLD stmts in succession, the first set of values go
+  // into the bit bucket.
+
   Provenance       currentState_;
   LIST(NAString)   tablesRead_;
   NABoolean        readFromSQDefaultsTable_;

--- a/core/sql/sqlcomp/nadefaults.cpp
+++ b/core/sql/sqlcomp/nadefaults.cpp
@@ -3775,6 +3775,7 @@ void NADefaults::initCurrentDefaultsWithDefaultDefaults()
   currentTokens_	= new NADHEAP DefaultToken * [numAttrs];
   currentState_		= INIT_DEFAULT_DEFAULTS;
   heldDefaults_	        = new NADHEAP char * [numAttrs];
+  heldHeldDefaults_	= new NADHEAP char * [numAttrs];
 
   // reset all entries
   size_t i = 0;
@@ -3790,6 +3791,7 @@ void NADefaults::initCurrentDefaultsWithDefaultDefaults()
   memset( currentFloats_, 0, sizeof(float *) * numAttrs );
   memset( currentTokens_, 0, sizeof(DefaultToken *) * numAttrs );
   memset( heldDefaults_, 0, sizeof(char *) * numAttrs );
+  memset( heldHeldDefaults_, 0, sizeof(char *) * numAttrs );
 
   #ifndef NDEBUG
     // This env-var turns on consistency checking of default-defaults and
@@ -4041,6 +4043,7 @@ NADefaults::NADefaults(NAMemory * h)
   , currentFloats_(NULL)
   , currentTokens_(NULL)
   , heldDefaults_(NULL)
+  , heldHeldDefaults_(NULL)
   , currentState_(UNINITIALIZED)
   , readFromSQDefaultsTable_(FALSE)
   , SqlParser_NADefaults_(NULL)
@@ -4113,6 +4116,12 @@ void NADefaults::deleteMe()
     for (size_t i = numDefaultAttributes(); i--; )
       NADELETEBASIC(heldDefaults_[i], NADHEAP);
     NADELETEBASIC(heldDefaults_, NADHEAP);
+  }
+
+  if (heldHeldDefaults_) {
+    for (size_t i = numDefaultAttributes(); i--; )
+      NADELETEBASIC(heldHeldDefaults_[i], NADHEAP);
+    NADELETEBASIC(heldHeldDefaults_, NADHEAP);
   }
 
   for (CollIndex i = tablesRead_.entries(); i--; )
@@ -6004,10 +6013,13 @@ enum DefaultConstants NADefaults::holdOrRestore	(const char *attrName,
   char * value = NULL;
   if (holdOrRestoreCQD == 1) // hold cqd
     {
-      if (heldDefaults_[attrEnum])
-	{
-	  NADELETEBASIC(heldDefaults_[attrEnum], NADHEAP);
-	}
+      if (heldHeldDefaults_[attrEnum])
+        {
+          // Gasp! We've done three successive HOLDs... it's off to
+          // the bit bucket for the deepest value
+          NADELETEBASIC(heldHeldDefaults_[attrEnum], NADHEAP);
+        }
+      heldHeldDefaults_[attrEnum] = heldDefaults_[attrEnum];
 
       if (currentDefaults_[attrEnum])
 	{
@@ -6027,15 +6039,24 @@ enum DefaultConstants NADefaults::holdOrRestore	(const char *attrName,
       if (! heldDefaults_[attrEnum])
 	return attrEnum;
 
+      // there is an odd semantic that if currentDefaults_[attrEnum]
+      // is null, we leave it as null, but pop a held value anyway;
+      // this semantic was preserved when the second level 
+      // (heldHeldDefaults_) was added.
+
       if (currentDefaults_[attrEnum])
-	{
-	  NADELETEBASIC(currentDefaults_[attrEnum], NADHEAP);
-	  value = new NADHEAP char[strlen(heldDefaults_[attrEnum]) + 1];
-	  strcpy(value, heldDefaults_[attrEnum]);
-	  currentDefaults_[attrEnum] = value;
-	}
+        {
+          // do a validateAndInsert so the caches (such as currentToken_)
+          // get updated and so appropriate semantic actions are taken
+          NAString value(heldDefaults_[attrEnum]);
+          validateAndInsert(lookupAttrName(attrEnum), // sad that we have to do a lookup again
+                            value,
+                            FALSE);
+        }
+      
       NADELETEBASIC(heldDefaults_[attrEnum], NADHEAP);
-      heldDefaults_[attrEnum] = NULL;
+      heldDefaults_[attrEnum] = heldHeldDefaults_[attrEnum];
+      heldHeldDefaults_[attrEnum] = NULL;
     }
 
   return attrEnum;

--- a/core/sql/ustat/hs_const.h
+++ b/core/sql/ustat/hs_const.h
@@ -169,6 +169,7 @@ enum USTAT_ERROR_CODES {UERR_SYNTAX_ERROR                    = 15001,
                         UERR_YOU_WILL_LIKELY_BE_SORRY        = 9243,
                         UERR_USER_TRANSACTION                = 9244,
                         UERR_LOB_STATS_NOT_SUPPORTED         = 9246,
+                        UERR_VOLATILE_TABLES_NOT_SUPPORTED   = 9247,
                         UERR_NO_ERROR                        = 9250,
                         UERR_LAST_ERROR                      = 9250
                        };

--- a/core/sql/ustat/hs_parser.cpp
+++ b/core/sql/ustat/hs_parser.cpp
@@ -308,6 +308,19 @@ Lng32 AddTableName( const hs_table_type type
           }
         else 
           {
+            // This is for UPDATE STATISTICS; the volatile schema name exists.
+            // For now, UPDATE STATISTICS is not supported. (See also JIRA Trafodion-2004.)
+
+            HSFuncMergeDiags(-UERR_VOLATILE_TABLES_NOT_SUPPORTED);
+            retcode = -1;
+            HSHandleError(retcode); // causes a return from this function
+
+            // The code below is old code that will be needed once we turn on
+            // support for UPDATE STATISTICS on volatile tables. We leave it here
+            // until the code changes described in JIRA Trafodion-2004 are complete.
+            // The code below is never reached because of the HSHandleError call
+            // above.
+
             // if schema name was specified, validate that it is the
             // current username.
             if (schema)

--- a/docs/sql_reference/src/asciidoc/_chapters/sql_statements.adoc
+++ b/docs/sql_reference/src/asciidoc/_chapters/sql_statements.adoc
@@ -2593,8 +2593,7 @@ any conflicts.
 * Volatile tables are partitioned by the system. The number of partitions is limited to four partitions by default.
 The partitions will be distributed across the cluster. The default value is four partitions regardless of the system
 configuration.
-* Statistics are not automatically updated for volatile tables. If you need statistics, you must explicitly run
-UPDATE STATISTICS.
+* UPDATE STATISTICS is not supported for volatile tables. If you need statistics, you must use a non-volatile table instead.
 * Volatile tables can be created and accessed using one-part, two-part, or three-part names. However, you must use the
 same name (one part, two part, or three part) for any further DDL or DML statements on the created volatile table.
 See <<create_table_examples,Examples of CREATE TABLE>>.


### PR DESCRIPTION
UPDATE STATISTICS currently does not work on volatile tables in Trafodion. Before this change, it gave confusing and varying error messages when invoked on a volatile table. This code change will cause UPDATE STATISTICS to put out error 9247 "UPDATE STATISTICS is not supported on volatile tables presently" instead.

Ironically, to get this error message to come out in all the right contexts, there were two bugs in CQD logic that needed to be addressed. It is ironic, because we'd have to fix these bugs to make UPDATE STATISTICS work for volatile tables. So, we've taken a small step toward that goal with these changes.

The bugs were in the CQD HOLD and CQD RESTORE mechanism. CQD HOLD essentially allows one to push the current value of a CQD in preparation for setting a different value temporarily. CQD RESTORE pops that value. The first bug was that the current logic implemented a stack of depth one, however there are code paths in Trafodion that do two CQD HOLDs, then two CQD RESTOREs. This caused a stack overflow; the original value going in the bit bucket. The fix was to essentially implement a stack of depth two. The second bug was that CQD RESTORE would only update the currentDefaults_ array in nadefaults.cpp. It failed to update other cached information such as currentTokens_, nor did it perform the semantic actions associated with particular CQDs. The result was that sometimes the CQD didn't really get restored. The fix was to do the normal semantic processing of a CQD at RESTORE time, instead of simply setting currentDefaults_.

These two bugs manifested in UPDATE STATISTICS by giving it an inaccurate impression of when a volatile schema was active. Sometimes UPDATE STATISTICS would think that no volatile schema was in use when in fact one was. Thus, an incorrect error message would be issued in that case if attempting UPDATE STATISTICS on a volatile table. 

