### PR TITLE
Removed carousel with contributing companies 

### DIFF
--- a/docs/provisioning_guide/src/asciidoc/_chapters/prepare.adoc
+++ b/docs/provisioning_guide/src/asciidoc/_chapters/prepare.adoc
@@ -67,6 +67,8 @@ cat $HOME/.ssh/id_rsa.pub >> $HOME/.ssh/authorized_keys
 echo localhost $(cat /etc/ssh/ssh_host_rsa_key.pub) >> $HOME/.ssh/known_hosts
 echo "NoHostAuthenticationForLocalhost=yes" >> $HOME/.ssh/config
 chmod 600 $HOME/.ssh/config
+chmod 600 $HOME/.ssh/authorized_keys
+chmod 700 $HOME/.ssh/
 ```
 
 After running these commands, do the following:

--- a/docs/src/site/markdown/index.md
+++ b/docs/src/site/markdown/index.md
@@ -57,25 +57,23 @@ Trafodion provides SQL access to structured, semi-structured, and unstructured d
 
 </td></tr></table>
 
-<center><h1>Contributing Companies</h1></center>
+<!-- 20160524 GTA Need more logos before using this part.
 
----
+Powered by Trafodion
 
-<!-- Carousel with logos -->
-
-#### Join Our Community
+#### Join the Trafodion Movement
 
 ![Slide 1](images/logo-carousel/slide-1.png)
 
-Code, test, present, document, web sites, and many other ways to contribute.
+Contribution opportunites: usage, code, tests, presentations, documentations, web sites, and things we didn't think of yet.
 
-#### Add Your Logo Here
+#### Powered By Trafodion
 
 ![Slide 2](images/logo-carousel/slide-2.png)
 
-Already a contributor? We need permission to add your company's logo here. 
+Are you using Trafodion? We need permission to add your company's logo here. 
 
----
+-->
 
 ## About
 

--- a/docs/src/site/site.xml
+++ b/docs/src/site/site.xml
@@ -91,8 +91,7 @@
           <sections>
             <carousel />
             <body />
-            <carousel />
-            <body />
+            <!--carousel /-->
             <columns>2</columns>
             <body />
           </sections>

--- a/pom.xml
+++ b/pom.xml
@@ -132,7 +132,7 @@
   </properties>
 
   <modules>
-    <module>docs/client_install</module>
+    <!--module>docs/client_install</module>
     <module>dcs</module>
     <module>core/rest</module>
     <module>docs/command_interface</module>
@@ -143,7 +143,7 @@
     <module>docs/odb_user</module>
     <module>docs/spj_guide</module>
     <module>docs/sql_reference</module>
-    <module>docs/jdbct4ref_guide</module>
+    <module>docs/jdbct4ref_guide</module-->
   </modules>
 
   <build>


### PR DESCRIPTION
Change made to comply with the Apache standard.

Also, fixed errors in the provisioning guide regarding passwordless ssh.

Please rebuild **2.0.0** documentation and publish website.