### PR TITLE
[TRAFODION-2015] hive/TEST018 fails in daily build regressions

### DIFF
--- a/core/sql/executor/ExExeUtilLoad.cpp
+++ b/core/sql/executor/ExExeUtilLoad.cpp
@@ -1907,7 +1907,7 @@ void ExExeUtilHBaseBulkUnLoadTcb::freeResources()
 
   if (sequenceFileWriter_)
   {
-    NADELETEBASIC(sequenceFileWriter_, getMyHeap());
+    NADELETE(sequenceFileWriter_, SequenceFileWriter, getMyHeap());
     sequenceFileWriter_ = NULL;
   }
 

--- a/core/sql/executor/ExFastTransport.cpp
+++ b/core/sql/executor/ExFastTransport.cpp
@@ -516,7 +516,9 @@ ExHdfsFastExtractTcb::~ExHdfsFastExtractTcb()
     lobGlob_ = NULL;
   }
 
-  //release sequenceFileWriter_???
+  if (sequenceFileWriter_ != NULL) {
+     NADELETE(sequenceFileWriter_, SequenceFileWriter, getHeap());
+  }
 
 } // ExHdfsFastExtractTcb::~ExHdfsFastExtractTcb()
 
@@ -745,8 +747,8 @@ ExWorkProcRetcode ExHdfsFastExtractTcb::work()
           if ((isSequenceFile() || myTdb().getBypassLibhdfs()) &&
               !sequenceFileWriter_)
           {
-            sequenceFileWriter_ = new(getSpace())
-                                     SequenceFileWriter((NAHeap *)getSpace());
+            sequenceFileWriter_ = new(getHeap())
+                                     SequenceFileWriter((NAHeap *)getHeap());
             sfwRetCode = sequenceFileWriter_->init();
             if (sfwRetCode != SFW_OK)
             {


### PR DESCRIPTION
SequenceFileWriter java objects had global references on the JNI side.
These references were not deleted because the corresponding JNI objects
were not deallocated. This was causing the java objects leak.