### PR TITLE
[TRAFODION-2004][TRAFODION-1775] Two follow-on fixes

### DIFF
--- a/core/sql/sqlcomp/NADefaults.h
+++ b/core/sql/sqlcomp/NADefaults.h
@@ -398,14 +398,10 @@ private:
   float            **currentFloats_;
   DefaultToken	   **currentTokens_;
 
+  class HeldDefaults;  // forward reference for helper class used below
+
   // these default values were 'held' through a cqd HOLD stmt.
-  char             **heldDefaults_;
-
-  // and these default values were 'held' through a sequence of two HOLD stmts.
-  char             **heldHeldDefaults_;
-
-  // if there are three HOLD stmts in succession, the first set of values go
-  // into the bit bucket.
+  HeldDefaults     **heldDefaults_;
 
   Provenance       currentState_;
   LIST(NAString)   tablesRead_;

--- a/core/sql/sqlcomp/nadefaults.cpp
+++ b/core/sql/sqlcomp/nadefaults.cpp
@@ -3601,7 +3601,7 @@ XDDkwd__(SUBQUERY_UNNESTING,			"ON"),
   DDkwd__(USTAT_USE_SIDETREE_INSERT,            "ON"),
   DDkwd__(USTAT_USE_SLIDING_SAMPLE_RATIO,       "ON"), // Trend sampling rate down w/increasing table size, going
                                                        //   flat at 1%.
- XDDui1__(USTAT_YOULL_LIKELY_BE_SORRY,          "100000000"),  // guard against unintentional long-running UPDATE STATS
+ XDDflt1_(USTAT_YOULL_LIKELY_BE_SORRY,          "100000000"),  // guard against unintentional long-running UPDATE STATS
   DDkwd__(VALIDATE_RFORK_REDEF_TS,	        "OFF"),
 
   DDkwd__(VALIDATE_VIEWS_AT_OPEN_TIME,		"OFF"),
@@ -6018,6 +6018,7 @@ enum DefaultConstants NADefaults::holdOrRestore	(const char *attrName,
         {
           // Gasp! We've done three successive HOLDs... it's off to
           // the bit bucket for the deepest value
+          CMPASSERT(heldHeldDefaults_[attrEnum] == NULL);  // on second thought, let's assert instead
           NADELETEBASIC(heldHeldDefaults_[attrEnum], NADHEAP);
         }
       heldHeldDefaults_[attrEnum] = heldDefaults_[attrEnum];


### PR DESCRIPTION
[TRAFODION-2004] In the review for https://github.com/apache/incubator-trafodion/pull/499, @zellerh suggested adding an assert when CQD HOLDs overflow their stack. This has now been done.
[TRAFODION-1775] Pull request https://github.com/apache/incubator-trafodion/pull/292 (released in release 2.0) added a new CQD, USTAT_YOULL_LIKELY_BE_SORRY. Unfortunately it was added as a 32-bit integer, which meant that if one wanted to set it to 10 billion, then that would fail with a validation error. But 10 billion is a reasonable size for a table. This code change changes the validation rule to be a float greater than or equal to 1. So now 10 billion would be possible.