### PR TITLE
[TRAFODION-2020] Safer APIs to manipulate Sql_ParserFlags

### DIFF
--- a/core/sql/parser/SqlParserGlobalsCmn.h
+++ b/core/sql/parser/SqlParserGlobalsCmn.h
@@ -136,6 +136,12 @@ enum SqlParser_Flags_Enum {
   inline static ULng32 Get_SqlParser_Flags(ULng32 flagbits)
   { return SqlParser_Flags & flagbits; }
 
+  // Deprecated; use Or_SqlParser_Flags or the PushAndSetSqlParserFlags
+  // class instead.
+  // This method tends to be error-prone because callers often are
+  // not aware of the different semantics when flagbits are zero.
+  // Oftentimes this method is coded when the caller really wanted
+  // to do a simple assign instead.
   inline static void Set_SqlParser_Flags(ULng32 flagbits)
   {
     if (flagbits)
@@ -144,18 +150,62 @@ enum SqlParser_Flags_Enum {
       SqlParser_Flags = 0;
   }
 
+  inline static void Or_SqlParser_Flags(ULng32 flagbits)
+  {
+    SqlParser_Flags |= flagbits;
+  }
+
   inline static void Assign_SqlParser_Flags(ULng32 flagbits)
   {
     SqlParser_Flags = flagbits;
   }
 
- inline static void Reset_SqlParser_Flags(ULng32 flagbits)
+  // Deprecated; use UnOr_SqlParser_Flags or the PushAndSetSqlParserFlags
+  // class instead.
+  // This method tends to be error-prone because callers often are
+  // not aware of the different semantics when flagbits are zero. 
+  inline static void Reset_SqlParser_Flags(ULng32 flagbits)
   {
     if (flagbits)
       SqlParser_Flags &= ~flagbits;
     else
       SqlParser_Flags = 0;
   }
+
+  // Turns off the bits given in flagbits. If you want to return
+  // bits to a previous state (whether on or off), use
+  // Assign_SqlParser_Flags or the PushAndSetSqlParserFlags class.
+  inline static void UnOr_SqlParser_Flags(ULng32 flagbits)
+  {
+    SqlParser_Flags &= ~flagbits;
+  }
+
+  // If you simply want to turn on one or more parser flags in the
+  // scope of one method, and then reset those flags to their original
+  // state on exit, use this class. Code a call to the constructor
+  // at the point where you want the flags set. The destructor will
+  // return them to the original state when it is called. When used
+  // as a stack variable this is very convenient; the flags get reset
+  // when the scope is exited. And it is exception-safe.
+  class PushAndSetSqlParserFlags
+  {
+  public:
+
+    PushAndSetSqlParserFlags(ULng32 flagbits) : savedBits_(SqlParser_Flags)
+    {
+      Or_SqlParser_Flags(flagbits); 
+    };
+    
+    ~PushAndSetSqlParserFlags(void)
+    {
+      Assign_SqlParser_Flags(savedBits_);
+    };
+
+  private:
+
+    ULng32 savedBits_;  // the value of SqlParser_Flags at ctor time
+  };
+ 
 #endif
 
 #if defined(SQLPARSERGLOBALS_NADEFAULTS) || defined(SQLPARSERGLOBALSCMN__INITIALIZE)

--- a/core/sql/ustat/hs_globals.cpp
+++ b/core/sql/ustat/hs_globals.cpp
@@ -4979,9 +4979,10 @@ Int64 HSGlobalsClass::getInternalSortMemoryRequirements(NABoolean performISForMC
 Lng32 HSGlobalsClass::validateIUSWhereClause()
 {
   Lng32 retcode = 0;
-  ULng32 savedParserFlags = Get_SqlParser_Flags(0xFFFFFFFF);
 
-  Set_SqlParser_Flags(PARSING_IUS_WHERE_CLAUSE);
+  // set PARSING_IUS_WHERE_CLAUSE bit in Sql_ParserFlags; return it to
+  // its entry value on exit
+  PushAndSetSqlParserFlags savedParserFlags(PARSING_IUS_WHERE_CLAUSE);
 
   NAString query = "select count(*) from ";
   query.append(getTableName(strrchr(user_table->data(), '.')+1, nameSpace));
@@ -5018,9 +5019,6 @@ Lng32 HSGlobalsClass::validateIUSWhereClause()
       else
         retcode = diagsArea.mainSQLCODE();
     }
-
-  // Restore parser flags to prior settings.
-  Set_SqlParser_Flags (savedParserFlags);
 
   return retcode;
 }

--- a/core/sql/ustat/hs_la.cpp
+++ b/core/sql/ustat/hs_la.cpp
@@ -129,9 +129,14 @@ void HSTableDef::setNATable()
     if (isVolatile())
       corrName.setIsVolatile(TRUE);
     Scan scan(corrName, NULL, REL_SCAN, STMTHEAP);
-    ULng32 savedParserFlags = Get_SqlParser_Flags(0xFFFFFFFF);
+    ULng32 flagToSet = 0;  // don't turn on flag unless next 'if' is true
     if (CmpCommon::context()->sqlSession()->volatileSchemaInUse())
-      Set_SqlParser_Flags(ALLOW_VOLATILE_SCHEMA_IN_TABLE_NAME);
+      flagToSet = ALLOW_VOLATILE_SCHEMA_IN_TABLE_NAME;
+
+    // set ALLOW_VOLATILE_SCHEMA_IN_TABLE_NAME bit in Sql_ParserFlags
+    // if needed, and return it to its entry value on exit
+    PushAndSetSqlParserFlags savedParserFlags(flagToSet);
+
     scan.bindNode(&bindWA);
     if (!bindWA.errStatus())
       {
@@ -139,8 +144,6 @@ void HSTableDef::setNATable()
         HS_ASSERT(naTbl_);
         objectType_ = naTbl_->getObjectType();
       }
-    // Restore parser flags to prior settings.
-    Set_SqlParser_Flags (savedParserFlags);
   }
 
 void HSSqTableDef::GetLabelInfo(labelDetail detail)


### PR DESCRIPTION
This code change provides new, safer APIs to manipulate the Sql_ParserFlags global.

Or_SqlParser_Flags is intended to replace Set_SqlParser_Flags. It simply turns on whatever bits are requested. If the input parameter is zero, it does nothing, in contrast to Set_SqlParser_Flags, which turns all the bits off in that case.

UnOr_SqlParser_Flags is intended to replace Reset_SqlParser_Flags. It simply turns off whatever bits are requested. If the input parameter is zero, it does nothing, in contrast to Reset_SqlParser_Flags, which turns off all the bits in that case.

For the common use case of a method that simply wants to turn on a few flags then return them to their entry-time state, the new class PushAndSetSqlParserFlags is provided. By coding a single line, one can turn on some flags, and be guaranteed that the flags will return to their original value at method exit (provided exit is via normal flow or via C++ exceptions). Thanks to @nonstop-qfchen and @selvaganesang for suggesting this idea.

This code change also changes the Update Statistics code to use this new class, replacing calls to the older APIs. Over time all calls to the older APIs can be replaced.