### PR TITLE
[TRAFODION-1684]ODBC:preliminary support SQLStatistics

### DIFF
--- a/core/conn/odbc/src/odbc/nsksrvrcore/srvrothers.cpp
+++ b/core/conn/odbc/src/odbc/nsksrvrcore/srvrothers.cpp
@@ -4811,6 +4811,64 @@ odbc_SQLSvc_GetSQLCatalogs_sme_(
 
 			break;
 
+        case SQL_API_SQLSTATISTICS:
+            if (!checkIfWildCard(catalogNm, catalogNmNoEsc) && !metadataId)
+            {
+                exception_->exception_nr = odbc_SQLSvc_GetSQLCatalogs_ParamError_exn_;
+                exception_->u.ParamError.ParamDesc = SQLSVC_EXCEPTION_WILDCARD_NOT_SUPPORTED;
+            }
+            if (tableNm[0] != '$' && tableNm[0] != '\\')
+            {
+                if (strcmp(catalogNm, "") == 0)
+                    strcpy(tableName1, SEABASE_MD_CATALOG);
+                else
+                    strcpy(tableName1, catalogNm);
+            }
+
+            tableParam[0] = tableName1;
+            convertWildcard(metadataId, TRUE, schemaNm, expSchemaNm);
+            convertWildcardNoEsc(metadataId, TRUE, schemaNm, schemaNmNoEsc);
+            convertWildcard(metadataId, TRUE, tableNm, expTableNm);
+            convertWildcardNoEsc(metadataId, TRUE, tableNmNoEsc, tableNmNoEsc);
+            inputParam[0] = schemaNmNoEsc;
+            inputParam[1] = expSchemaNm;
+            inputParam[2] = tableNmNoEsc;
+            inputParam[3] = expTableNm;
+
+            snprintf(CatalogQuery, sizeof(CatalogQuery),
+                    "select "
+                    "cast('%s' as varchar(128)) TABLE_CAT, "
+                    "cast(trim(ob.SCHEMA_NAME) as varchar(128)) TABLE_SCHEM, "
+                    "cast(trim(ob.OBJECT_NAME) as varchar(128)) TABLE_NAME, "
+                    "cast(0 as smallint) NON_UNIQUE, " // not support
+                    "cast('' as varchar(128)) INDEX_QUALIFIER, " // not support
+                    "cast('' as varchar(128)) INDEX_NAME, "
+                    "cast(0 as smallint) TYPE, " // not support
+                    "cast((case when (trim(co.COLUMN_CLASS) <> 'S') then co.column_number+1 else "
+                        "co.column_number end) as smallint) ORDINAL_POSITION, "
+                    "cast(trim(co.COLUMN_NAME) as varchar(128)) COLUMN_NAME, "
+                    "cast('' as char(1)) ASC_OR_DES, "
+                    "cast(sb.rowcount as integer) CARDINALITY, "
+                    "cast(0 as integer) PAGES, " // not support
+                    "cast('' as varchar(128)) FILTER_CONDITION " // not support
+                    "from "
+                    "TRAFODION.\"_MD_\".OBJECTS ob, "
+                    "TRAFODION.\"_MD_\".COLUMNS co, "
+                    "TRAFODION.%s.sb_histograms sb "
+                    "where "
+                    "ob.OBJECT_UID = co.OBJECT_UID "
+                    "and co.COLUMN_NUMBER = sb.COLUMN_NUMBER "
+                    "and (ob.SCHEMA_NAME = '%s' or trim(ob.SCHEMA_NAME) LIKE '%s' ESCAPE '\\')  "
+                    "and (ob.OBJECT_NAME = '%s' or trim(ob.OBJECT_NAME) LIKE '%s' ESCAPE '\\') "
+                    "and (ob.OBJECT_TYPE in ('BT', 'VI')) "
+                    "and (trim(co.COLUMN_CLASS) not in('S', 'M'));",
+                    tableParam[0],
+                    inputParam[0],
+                    inputParam[0], inputParam[1],
+                    inputParam[2], inputParam[3]
+                    );
+
+            break;
                default :
                        exception_->exception_nr = odbc_SQLSvc_GetSQLCatalogs_ParamError_exn_;
                        exception_->u.ParamError.ParamDesc = SQLSVC_EXCEPTION_UNSUPPORTED_SMD_API_TYPE;

--- a/core/conn/odbc/src/odbc/nsksrvrcore/srvrothers.cpp
+++ b/core/conn/odbc/src/odbc/nsksrvrcore/srvrothers.cpp
@@ -4844,8 +4844,7 @@ odbc_SQLSvc_GetSQLCatalogs_sme_(
                     "cast('' as varchar(128)) INDEX_QUALIFIER, " // not support
                     "cast('' as varchar(128)) INDEX_NAME, "
                     "cast(0 as smallint) TYPE, " // not support
-                    "cast((case when (trim(co.COLUMN_CLASS) <> 'S') then co.column_number+1 else "
-                        "co.column_number end) as smallint) ORDINAL_POSITION, "
+                    "cast(co.column_number as smallint) ORDINAL_POSITION, "
                     "cast(trim(co.COLUMN_NAME) as varchar(128)) COLUMN_NAME, "
                     "cast('' as char(1)) ASC_OR_DES, "
                     "cast(sb.rowcount as integer) CARDINALITY, "
@@ -4857,7 +4856,9 @@ odbc_SQLSvc_GetSQLCatalogs_sme_(
                     "TRAFODION.%s.sb_histograms sb "
                     "where "
                     "ob.OBJECT_UID = co.OBJECT_UID "
+                    "and co.OBJECT_UID = sb.TABLE_UID "
                     "and co.COLUMN_NUMBER = sb.COLUMN_NUMBER "
+                    "and sb.colcount = 1 "
                     "and (ob.SCHEMA_NAME = '%s' or trim(ob.SCHEMA_NAME) LIKE '%s' ESCAPE '\\')  "
                     "and (ob.OBJECT_NAME = '%s' or trim(ob.OBJECT_NAME) LIKE '%s' ESCAPE '\\') "
                     "and (ob.OBJECT_TYPE in ('BT', 'VI')) "


### PR DESCRIPTION
[TRAFODION-1684]ODBC: trafodion doesn't support API SQLStatistics.
It's preliminary implementation for ODBC API SQLStatistics. Now, it
will ignore the parameter "Unique".
SQLStatistics returns information as a standard result set.
 TABLE_CAT        # support
 TABLE_SCHEM      # support
 TABLE_NAME       # support
 NON_UNIQUE       # support
 INDEX_QUALIFIER  # not support
 INDEX_NAME       # not support
 TYPE             # not support
 ORDINAL_POSITION # support
 ASC_OR_DESC      # not support
 CARDINALITY      # support
 PAGES            # not support
 FILTER_CONDITION # not support