### PR TITLE
[TRAFODION-1585] Allow MDAM on inner child of NJ sometimes

### DIFF
--- a/core/sql/optimizer/ScanOptimizer.cpp
+++ b/core/sql/optimizer/ScanOptimizer.cpp
@@ -3462,6 +3462,12 @@ ScanOptimizer::isMdamEnabled() const
       return TRUE;
     }
 
+    // If the input logical property indicates exactly one, then we
+    // allow MDAM in spite of NJ.
+    NABoolean isInputCardinalityOne = 
+      getContext().getInputLogProp()->isCardinalityEqOne();
+    if (isInputCardinalityOne)
+      return TRUE;
 
     /*
      Right side Scan of a Nested Join will use MDAM disjuncts if and only if


### PR DESCRIPTION
If it is known that there will be exactly one probe of the inner child of a nested join, this change enables consideration of MDAM for that inner child.

This is a replacement of https://github.com/apache/incubator-trafodion/pull/174. It takes the suggestion from @zellerh to use the input logical properties instead of adding constraint information to the input physical properties. The result is a much simpler code change. I will close the older pull request shortly.
