### PR TITLE
[TRAFODION-2031] At times T2 JDBC applications dump core at the time of lo…

### DIFF
--- a/core/conn/jdbc_type2/Makefile
+++ b/core/conn/jdbc_type2/Makefile
@@ -61,7 +61,7 @@ T2_OBJS  = $(OUTDIR)/CommonDiags.o \
 OBJS = $(COMMON_OBJS) $(T2_OBJS)
 MXODIR = $(SQ_HOME)/../conn/odbc/src/odbc
 
-INCLUDES     = -I. -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux -Inative -I$(MXODIR)/Krypton/generated_incs -I$(MXODIR)/dependencies/include -I$(MXODIR)/dependencies/linux -I$(SQ_HOME)/export/include/sql -I$(SQ_HOME)/inc/tmf_tipapi -I$(SQ_HOME)/inc -I$(SQ_HOME)/export/include -I$(SQ_HOME)/inc/rosetta -I$(SQ_HOME)/../sql/cli -I$(SQ_HOME)/../sql/common -I$(SQ_HOME)/../dbsecurity/cert/inc -I$(SQ_HOME)/../dbsecurity/auth/inc
+INCLUDES     = -I. -I$(JAVA_HOME)/include -I$(JAVA_HOME)/include/linux -Inative -I$(MXODIR)/Krypton/generated_incs -I$(MXODIR)/dependencies/include -I$(MXODIR)/dependencies/linux -I$(SQ_HOME)/export/include/sql -I$(SQ_HOME)/inc/tmf_tipapi -I$(SQ_HOME)/inc -I$(SQ_HOME)/export/include -I$(SQ_HOME)/inc/rosetta -I$(SQ_HOME)/../sql/cli -I$(SQ_HOME)/../sql/common -I$(SQ_HOME)/../dbsecurity/cert/inc -I$(SQ_HOME)/../dbsecurity/auth/inc -I$(SQ_HOME)/commonLogger
 COMMON_DEFINES = -DTRAFODION_JDBCT2_VER_MAJOR=$(TRAFODION_VER_MAJOR) -DTRAFODION_JDBCT2_VER_MINOR=$(TRAFODION_VER_MINOR) -D_LP64 -DNA_LINUX -DSIZEOF_LONG_INT=4 -DSQ_GUARDIAN_CALL -DDISABLE_NOWAIT -D_FASTPATH -DTODO -D_SQ64 -w
 
 DEFINES =  $(COMMON_DEFINES)

--- a/core/conn/jdbc_type2/native/SQLMXDriver.cpp
+++ b/core/conn/jdbc_type2/native/SQLMXDriver.cpp
@@ -48,9 +48,10 @@
 #include "org_trafodion_jdbc_t2_T2Driver.h"
 #include "Debug.h"
 #include "GlobalInformation.h"
+#include "CommonLogger.h"
+#include "sqlcli.h"
 
 static bool driverVersionChecked = false;
-
 #ifdef NSK_PLATFORM	// Linux port - ToDo txn related
 int client_initialization(void);
 #endif
@@ -86,28 +87,19 @@ JNIEXPORT void JNICALL Java_org_trafodion_jdbc_t2_T2Driver_SQLMXInitialize(JNIEn
 	//MFC
 	const char					*nModuleCaching;
 	const char					*nCompiledModuleLocation;
+        
+        sqInit();
 
-/*
-	// Seaquest related - Linux port
-	int argc = 0;
-	char *argv[] = {"AAA"};
-	//argv[0] = NULL;
-	// Initialize seabed
-	int	sbResult;
-	char buffer[FILENAME_MAX] = {0};
-	bzero(buffer, sizeof(buffer));
-	
-	sbResult = file_init_attach(&argc, &argv, true, buffer);
-	if(sbResult != XZFIL_ERR_OK){
-		abort();
-	}
-	sbResult = file_mon_process_startup(true);
-	if(sbResult != XZFIL_ERR_OK){
-		abort();
-	}
-	msg_mon_enable_mon_messages(true);
-	// End Seaquest related
-*/
+        int myNid;
+        pid_t myPid;
+        MS_Mon_Process_Info_Type  proc_info;
+        msg_mon_get_process_info_detail(NULL, &proc_info);
+        myNid = proc_info.nid;
+        myPid = proc_info.pid;
+
+        char logNameSuffix[32];
+        sprintf( logNameSuffix, "_%d_%d.log", myNid, myPid );
+        CommonLogger::instance().initLog4cxx("log4cxx.trafodion.masterexe.config", logNameSuffix);
 
 	if (!driverVersionChecked)
 	{

--- a/core/sql/cli/CliExtern.cpp
+++ b/core/sql/cli/CliExtern.cpp
@@ -852,7 +852,6 @@ short my_mpi_setup (Int32* argc, char** argv[] );
 };
 
 
-static 
 short sqInit()
 {
   static bool sbInitialized = false;

--- a/core/sql/cli/SessionDefaults.cpp
+++ b/core/sql/cli/SessionDefaults.cpp
@@ -275,7 +275,8 @@ void SessionDefaults::setIsoMappingName(const char * attrValue, Lng32 attrValueL
     }
   
   isoMappingName_ = new(heap_) char[attrValueLen + 1];
-  strcpy(isoMappingName_, attrValue);
+  strncpy(isoMappingName_, attrValue, attrValueLen);
+  isoMappingName_[attrValueLen] = '\0';
   
   // upcase isoMappingName_
   str_cpy_convert(isoMappingName_, isoMappingName_, attrValueLen, 1);

--- a/core/sql/cli/SessionDefaults.h
+++ b/core/sql/cli/SessionDefaults.h
@@ -98,6 +98,7 @@ public:
     CANCEL_QUERY_ALLOWED,
     CANCEL_UNIQUE_QUERY,
     CATALOG,
+    COMPILER_IDLE_TIMEOUT,
     DBTR_PROCESS,
     ESP_ASSIGN_DEPTH,
     ESP_ASSIGN_TIME_WINDOW,
@@ -132,7 +133,6 @@ public:
     SUSPEND_LOGGING,
     USER_EXPERIENCE_LEVEL,
     WMS_PROCESS,
-    COMPILER_IDLE_TIMEOUT,
     LAST_SESSION_DEFAULT_ATTRIBUTE  // This enum entry should be last always. Add new enums before this entry
   };
   
@@ -252,7 +252,8 @@ public:
       }
     
     catalog_ = new(heap_) char[attrValueLen + 1];
-    strcpy(catalog_, attrValue);
+    strncpy(catalog_, attrValue, attrValueLen);
+    catalog_[attrValueLen] = '\0';
 
     updateDefaultsValueString(CATALOG, catalog_);
   }
@@ -265,8 +266,8 @@ public:
       }
     
     schema_ = new(heap_) char[attrValueLen + 1];
-    strcpy(schema_, attrValue);
-
+    strncpy(schema_, attrValue, attrValueLen);
+    schema_[attrValueLen] = '\0';
     updateDefaultsValueString(SCHEMA, schema_);
   }
 
@@ -278,8 +279,8 @@ public:
       }
     
     uel_ = new(heap_) char[attrValueLen + 1];
-    strcpy(uel_, attrValue);
-
+    strncpy(uel_, attrValue, attrValueLen);
+    uel_[attrValueLen] = '\0';
     updateDefaultsValueString(USER_EXPERIENCE_LEVEL, uel_);
   }
   void setEspAssignDepth(Lng32 espAssignDepth) 

--- a/core/sql/cli/sqlcli.h
+++ b/core/sql/cli/sqlcli.h
@@ -2086,6 +2086,8 @@ SQLCLI_LIB_FUNC Int32 SQL_EXEC_SetDescEntryCount(
 		/*IN*/ SQLDESC_ID * sql_descriptor,
 		/*IN*/ Int32 num_entries);
 
+SQLCLI_LIB_FUNC short sqInit();
+
 #endif /*__cplusplus*/
 
 #endif /*SQLCLI_HDR*/


### PR DESCRIPTION
…gging error

Cores were dumped when SQL tries to log the error message via log4cxx. Log4cxx instance
was not initialized in case of T2 driver

[TRAFODION-1956] session defaults was getting corrupted in mxosrvr. COMPILER_IDLE_TIMEOUT wasn't added
in alphabetical order. Also fixed the possible buffer overrun issue with some of the set
commands in SessionDefaults