### PR TITLE
2.0.0 Release Notes

### DIFF
--- a/docs/src/site/markdown/documentation.md
+++ b/docs/src/site/markdown/documentation.md
@@ -14,7 +14,7 @@
 -->
 This page provides links to the per-release Trafodion documentation.
 
-# Latest
+## Latest (In development)
 
 Document                                              | Formats
 ------------------------------------------------------|-----------------------------------
@@ -24,7 +24,7 @@ Trafodion Code Examples                               | [wiki](https://cwiki.apa
 Trafodion Command Interface Guide                     | [Web Book](docs/command_interface/index.html),  [PDF](docs/command_interface/Trafodion_Command_Interface_Guide.pdf)
 Trafodion Control Query Default (CQD) Reference Guide | [Web Book](docs/cqd_reference/index.html),      [PDF](docs/cqd_interface/Trafodion_CQD_Reference_Guide.pdf)
 Trafodion Database Connectivity Services Guide        | [Web Book](docs/dcs_reference/index.html),      [API](docs/dcs_reference/apidocs/index.html)
-Trafodion JDBC Type 4 Programmer's Reference Guide    | [Web Book](docs/jdbct4ref_guide/index.html),     [PDF](docs/jdbct4ref_guide/Trafodion_JDBCT4_Reference_Guide.pdf)
+Trafodion JDBC Type 4 Programmer Reference Guide      | [Web Book](docs/jdbct4ref_guide/index.html),     [PDF](docs/jdbct4ref_guide/Trafodion_JDBCT4_Reference_Guide.pdf)
 Trafodion Load and Transform Guide                    | [Web Book](docs/load_transform/index.html),     [PDF](docs/load_transform/Trafodion_Load_Transform_Guide.pdf)
 Trafodion Messages Guide                              | [Web Book](docs/messages_guide/index.html),     [PDF](docs/messages_guide/Trafodion_Messages_Guide.pdf)
 Trafodion Manageability                               | [wiki](https://cwiki.apache.org/confluence/display/TRAFODION/Trafodion+Manageability)
@@ -35,7 +35,7 @@ Trafodion SQL Reference Manual                        | [Web Book](docs/sql_refe
 Trafodion Stored Procedures in Java (SPJ) Guide       | [Web Book](docs/spj_guide/index.html),          [PDF](docs/spj_guide/Trafodion_SPJ_Guide.pdf)
 UDF Tutorial                                          | [wiki](https://cwiki.apache.org/confluence/display/TRAFODION/Tutorial%3A+The+object-oriented+UDF+interface)
 
-# 2.0.0 (In Development)
+## 2.0.x Releases
 
 Document                                              | Formats
 ------------------------------------------------------|-----------------------------------
@@ -43,7 +43,7 @@ Trafodion Client Installation Guide                   | [Web Book](docs/2.0.0/cl
 Trafodion Command Interface Guide                     | [Web Book](docs/2.0.0/command_interface/index.html),  [PDF](docs/2.0.0/command_interface/Trafodion_Command_Interface_Guide.pdf)
 Trafodion Control Query Default (CQD) Reference Guide | [Web Book](docs/2.0.0/cqd_reference/index.html),      [PDF](docs/2.0.0/cqd_interface/Trafodion_CQD_Reference_Guide.pdf)
 Trafodion Database Connectivity Services Guide        | [Web Book](docs/2.0.0/dcs_reference/index.html),      [API](docs/2.0.0/dcs_reference/apidocs/index.html)
-Trafodion JDBC Type 4 Programmer's Reference Guide    | [Web Book](docs/2.0.0/jdbct4ref_guide/index.html),    [PDF](docs/2.0.0/jdbct4ref_guide/Trafodion_JDBCT4_Reference_Guide.pdf)
+Trafodion JDBC Type 4 Programmer Reference Guide      | [Web Book](docs/2.0.0/jdbct4ref_guide/index.html),    [PDF](docs/2.0.0/jdbct4ref_guide/Trafodion_JDBCT4_Reference_Guide.pdf)
 Trafodion Load and Transform Guide                    | [Web Book](docs/2.0.0/load_transform/index.html),     [PDF](docs/2.0.0/load_transform/Trafodion_Load_Transform_Guide.pdf)
 Trafodion Messages Guide                              | [Web Book](docs/2.0.0/messages_guide/index.html),     [PDF](docs/2.0.0/messages_guide/Trafodion_Messages_Guide.pdf)
 Trafodion odb User Guide                              | [Web Book](docs/2.0.0/odb/index.html),                [PDF](docs/2.0.0/odb/Trafodion_odb_User_Guide.pdf)
@@ -52,7 +52,7 @@ Trafodion REST Server Reference Guide                 | [Web Book](docs/2.0.0/re
 Trafodion SQL Reference Manual                        | [Web Book](docs/2.0.0/sql_reference/index.html),      [PDF](docs/2.0.0/sql_reference/Trafodion_SQL_Reference_Manual.pdf)
 Trafodion Stored Procedures in Java (SPJ) Guide       | [Web Book](docs/2.0.0/spj_guide/index.html),          [PDF](docs/2.0.0/spj_guide/Trafodion_SPJ_Guide.pdf)
 
-# 1.3.0
+## 1.3.0 Release
 
 Document                                              | Formats
 ------------------------------------------------------|-----------------------------------

--- a/docs/src/site/markdown/download.md
+++ b/docs/src/site/markdown/download.md
@@ -38,6 +38,7 @@ To build Trafodion from source code, see the [Trafodion Contributor Guide](https
 * Convenience Binaries
     * [Installer][ins200]  -  [PGP][inpgp200] [MD5][inmd5200] [SHA1][insha200]
     * [Server][ser200]  -  [PGP][sepgp200] [MD5][semd5200] [SHA1][sesha200]
+    * Clients binary package not available, must be built from source code.
 * [Documentation](documentation.html#20x_Releases)
 
 [src200]: http://www.apache.org/dyn/closer.lua/incubator/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion-2.0.0-incubating-src.tar.gz

--- a/docs/src/site/markdown/download.md
+++ b/docs/src/site/markdown/download.md
@@ -12,144 +12,54 @@
   limitations under the 
   License.
 -->
-This page describes how you download and install a Trafodion evaluation environment. 
 
-Other information:
-
-* [Trafodion Provision Guide](http://trafodion.incubator.apache.org/docs/provisioning_guide/index.html): Complete provisioning documentation.
-* [Trafodion Contributor Guide](https://cwiki.apache.org/confluence/display/TRAFODION/Trafodion+Contributor+Guide): 
-How to set up a Trafodion build and development environment. (Use if you intend to help develop the Trafodion source code.)
-
-# Download
 The Trafodion end-user environment is installed using the Trafodion Installer, which operates on Trafodion binaries only.
 
-## 1.3.0 Binaries
+See release specific installation instructions in [Documentation](documentation.html).
 
+* Server installation is described in the Trafodion Provisioning Guide
+* Client installation is described in the Trafodion Client Installation Guide
+
+To build Trafodion from source code, see the [Trafodion Contributor Guide](https://cwiki.apache.org/confluence/display/TRAFODION/Trafodion+Contributor+Guide).
+
+# Download
+
+## 2.0.1
+
+* Coming Soon
+
+* [Release Notes](release-notes-2-0-1.html)
+* [Documentation](documentation.html#20x_Releases)
+
+## 2.0.0
+
+* [Release Notes](release-notes-2-0-0.html)
+* [Source Code Release][src200]  -  [PGP][pgp200] [MD5][md5200] [SHA1][sha200]
+* Convenience Binaries
+    * [Installer][ins200]  -  [PGP][inpgp200] [MD5][inmd5200] [SHA1][insha200]
+    * [Server][ser200]  -  [PGP][sepgp200] [MD5][semd5200] [SHA1][sesha200]
+* [Documentation](documentation.html#20x_Releases)
+
+[src200]: http://www.apache.org/dyn/closer.lua/incubator/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion-2.0.0-incubating-src.tar.gz
+[pgp200]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion-2.0.0-incubating-src.tar.gz.asc
+[md5200]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion-2.0.0-incubating-src.tar.gz.md5
+[sha200]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion-2.0.0-incubating-src.tar.gz.sha
+[ins200]: http://www.apache.org/dyn/closer.lua/incubator/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion_installer-2.0.0-incubating.tar.gz
+[inpgp200]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion_installer-2.0.0-incubating.tar.gz.asc
+[inmd5200]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion_installer-2.0.0-incubating.tar.gz.md5
+[insha200]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion_installer-2.0.0-incubating.tar.gz.sha
+[ser200]: http://www.apache.org/dyn/closer.lua/incubator/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion_server-2.0.0-incubating.tar.gz
+[sepgp200]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion_server-2.0.0-incubating.tar.gz.asc
+[semd5200]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion_server-2.0.0-incubating.tar.gz.md5
+[sesha200]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion_server-2.0.0-incubating.tar.gz.sha
+
+## 1.3.0
+
+* [Release Notes](release-notes-1-3-0.html)
+* [Source Code Release](http://www.apache.org/dyn/closer.lua/incubator/trafodion/apache-trafodion-1.3.0-incubating/apache-trafodion-1.3.0-incubating-src.tar.gz) -  [PGP](https://www.apache.org/dist/incubator/trafodion/trafodion-1.3.0-incubating/apache-trafodion-1.3.0-incubating-src.tar.gz.asc) [MD5](http://www.apache.org/dist/incubator/trafodion/apache-trafodion-1.3.0-incubating/apache-trafodion-1.3.0-incubating-src.tar.gz.md5) [SHA1](http://www.apache.org/dist/incubator/trafodion/apache-trafodion-1.3.0-incubating/apache-trafodion-1.3.0-incubating-src.tar.gz.sha)
 * [log4c++ RPM](http://traf-builds.esgyn.com/downloads/trafodion/publish/release/1.3.0/log4cxx-0.10.0-13.el6.x86_64.rpm)
-* [Trafodion Installer](http://traf-builds.esgyn.com/downloads/trafodion/publish/release/1.3.0/apache-trafodion-installer-1.3.0-incubating-bin.tar.gz)
-* [Trafodion Server](http://traf-builds.esgyn.com/downloads/trafodion/publish/release/1.3.0/apache-trafodion-1.3.0-incubating-bin.tar.gz)
-* [Trafodion Clients](http://traf-builds.esgyn.com/downloads/trafodion/publish/release/1.3.0/apache-trafodion-clients-1.3.0-incubating-bin.tar.gz) (JDBC, odb, ODBC, trafci)
+* [Documentation](documentation.html#130_Release)
 
-# Install
+* * * *
 
-The following steps installs a Trafodion evaluation on a 64-bit RHEL/CentOS Hadoop environment running on of the following
-Hadoop distributions:
-
-## Prerequisites
-Trafodion is installed as an add-on to an existing Hadoop environment. Currently, one of the following Hadoop distributions is **required**:
-
-* Cloudera CDH 5.2
-* Cloudera CDH 5.3
-* Hortonworks HDP 2.2
-
-The following Hadoop services **must be** in a STARTED state and fully functional.
-
-* HDFS
-* YARN with MRv2
-* ZooKeeper
-* HBase
-* Hive (optional)
-
-## Create Provisioning User
-
-Create a Linux user on the Hadoop system that you're installing Trafodion on with the following characteristics:
-
-* Privileges to run **`sudo`** with **`root`** access levels.
-* Passwordless ssh access from the Provisioning Node to all other nodes in the cluster.
-* Not named **`trafodion`**.
-
-Perform the remaining steps in this procedure using the Provisioning User.
-
-## Download Binaries
-
-Download all binaries listed above except the **Trafodion Clients** into a diretory of your choosing
-
-**Example**
-
-```
-mkdir $HOME/trafodion
-mkdir $HOME/trafodion/downloads
-cd $HOME/trafodion/downloads
-wget <log4c++ RPM>
-wget <Trafodion Installer>
-wget <Trafodion Server>
-```
-
-## Install log4c++
-
-Use **`yum install`** to install the `log4c++` RPM on all nodes on all nodes in your Hadoop cluster.
-
-## Unpack Trafodion Installer
-
-Use **`tar -zxf`** to unpack the Trafodion Installer.
-
-**Example**
-
-```
-cd $HOME/trafodion/downloads
-tar -zxf apache-trafodion-installer-1.3.0-incubating-bin.tar.gz -C $HOME/trafodion
-```
-
-## Create Configuration File
-
-The Trafodion Installer uses a configuration file that describes your Hadoop environment.
-
-**Copy Configuration Template File**
-
-```
-cd $HOME/trafodion/installer
-cp trafodion_config_default my_config
-```
-
-**Edit Configuration File**
-
-Use the embedded guidance in the configuration file to define each of these settings:
-
-|-------------------|----------------------------------------------|-------------------|--------------------------------|--------------------------------
-**`LOCAL_WORKDIR`** | **`TRAF_USER_PASSWORD`** (change if desired) | **`NODE_LIST`**   | **`node_count`**               | **`MY_NODES`**
-**`JAVA_HOME`**     | **`TRAF_PACKAGE`**                           | **`HADOOP_TYPE`** | **`URL`**                      | **`ADMIN`**
-**`PASSWORD`**      | **`CLUSTER_NAME`**                           | **`SQ_ROOT`**     | **`START`** (set to **`"Y"`**) | **`INIT_TRAFODION`** (set to **`"Y"`**)
-
-## Run `trafodion_install`
-
-You'll use the Trafodion Installer (**`trafodion_install`**) to create the Trafodion Runtime User (**`trafodion`**), 
-modify your system and Hadoop environment, restart ZooKeeper, HDFS, and HBAse to activate configuration changes, 
-and install/starts Trafodion.
-
-**Example**
-
-```
-cd $HOME/trafodion/installer
-./trafodion_install --accept_license --config_file my_config
-```
-
-The Trafodion Installer performs all the operations required to install and start Trafodion. Wait for it to complete before
-continuing to the next step.
-
-## Verify Installation
-
-Perform this step as the **`trafodion`** user.
-
-First, check the status of the Trafodion environment.
-
-**Example**
-
-```
-sudo su trafodion
-swstatus
-```
-
-Second, run a simple smoke test using **`sqlci`**. Use the following commands:
-
-```
-sqlci
->> get schemas;
->> create table table1 (a int);
->> invoke table1;
->> insert into table1 values (1), (2), (3), (4);
->> select * from table1;
->> drop table table1;
->> exit;
-```
-
-The Trafodion installation is complete. Next, follow the steps in [Quick Start](quickstart.html) to get started with Trafodion.
+Note: when downloading from a mirror please check the [md5sum](http://www.apache.org/dev/release-signing#md5) and verify the [OpenPGP](http://www.apache.org/dev/release-signing#openpgp) compatible signature from the main [Apache](http://www.apache.org/) site. Links are provided above (next to the release download link). This [KEYS](http://www.apache.org/dist/incubator/trafodion/KEYS) file contains the public keys used for signing release. It is recommended that (when possible) a [web of trust](http://www.apache.org/dev/release-signing#web-of-trust) is used to confirm the identity of these keys. For more information, please see the [Apache Release FAQ](http://www.apache.org/dev/release.html).

--- a/docs/src/site/markdown/release-notes-2-0-0.md
+++ b/docs/src/site/markdown/release-notes-2-0-0.md
@@ -1,0 +1,152 @@
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# 2.0.0-incubating Release Notes
+
+This is the second release of the Apache Trafodion (incubating) project. It builds on the initial R1.3 release, with many new features and improvements, and will offer a binary package for the first time.
+
+Build instructions are available [here](build.html).
+
+## New Features
+
+<span>
+  <table>
+    <tr>
+      <th>Feature</th>
+      <th>Jira ID</th>
+    </tr>
+    <tr>
+      <td>Support for Hadoop distributions CDH 5.4, HDP 2.3, as well as Apache HBase 1.0</td>
+      <td>(TRAFODION-1706)</td>
+    </tr>
+    <tr>
+      <td>Ability to online add / remove nodes from a Trafodion instance</td>
+      <td>(TRAFODION-1885)</td>
+    </tr>
+    <tr>
+      <td>Transaction protection for DDL operations </td>
+      <td>(TRAFODION-1798)</td>
+    </tr>
+    <tr>
+      <td>Native support for Large OBjects (BLOB and CLOB data types) (PREVIEW MODE)</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Support to ALTER all attributes of a column</td>
+      <td>(TRAFODION-1844)</td>
+    </tr>
+    <tr>
+      <td>Support for GBK charset in SQL TRANSLATE function</td>
+      <td>(TRAFODION-1720)</td>
+    </tr>
+  </table>
+</span>
+
+## Improvements
+
+<span>
+  <table>
+    <tr>
+      <th>Feature</th>
+      <th>Jira ID</th>
+    </tr>
+    <tr>
+      <td>Advanced predicate pushdown</td>
+      <td>TRAFODION-1662</td>
+    </tr>
+    <tr>
+      <td>Improved co-ordination between transactions and HBase region splits / rebalance</td>
+      <td>TRAFODION-1648</td>
+    </tr>
+    <tr>
+      <td>Optimize MDAM scans with small scanner</td>
+      <td>TRAFODION-1900</td>
+    </tr>
+    <tr>
+      <td>Integrate library management into Trafodion metadata</td>
+      <td>TRAFODION-1879</td>
+    </tr>
+    <tr>
+      <td>Improved support for UPDATE STATISTICS for large tables (up to 1B rows)</td>
+      <td></td>
+    </tr>
+    <tr>
+      <td>Numerous build improvements</td>
+      <td></td>
+    </tr>
+  </table>
+</span>
+
+## Fixes
+
+This release contains 250+ fixes.
+
+## Migration Considerations
+
+1. This release does not include convenience binaries for the client package due to a licensing issue. Convenience binaries will be included in a follow-on patch release (R2.0.1) that should be available shortly. During this time, existing documentation (Trafodion Client Installation Guide and Trafodion Provisioning Guide), which refer to binaries, will be briefly out of sync. 
+
+2. New SQL procedures have been added to manage user libraries. If you have an existing Trafodion installation, execute the following as user trafodion.
+
+        $ sqlci
+        sql> initialize trafodion, create library management;
+        sql> exit;
+
+    This statement creates a new schema called \_LIBMGR\_ and creates the library management procedures in this schema. If security is enabled, a new system role called DM\_\_LIBMGRROLE is added. 
+
+
+## Notes
+
+### ESP Idle timeout [TRAFODION-1823]
+
+A new CQD ESP_IDLE_TIMEOUT has been introduced in this release. This setting governs the life of an idle ESP (defined as an ESP that is not executing any work). On expiry of the timer, the ESP will kill itself.
+
+    sql> CQD ESP_IDLE_TIMEOUT ‘<seconds>’;
+
+The default timer value is 1800 seconds. 
+
+### HBase Lease Timeout Patch [Same as Release 1.3]
+
+HBase uses a lease mechanism to protect against memory leaks in Region Servers caused by potential client instabilities that would open scanners, but die before having the opportunity to close cleanly and release resources. This mechanism relies on a server side timer, configured by the 'hbase.client.scanner.timeout.period' parameter in 'hbase-site.xml'. If a client fails to call 'next()' within the timeout period, the server will assume the client died, and will force close the server side scanner and release resources. However, in Trafodion, there are legitimate use cases where client is busy doing heavy processing, and needs more time than specified in the default scanner timeout value.  Increasing the 'hbase.client.scanner.timeout.period' value has the side effect of weakening the safety mechanism previously described. 
+
+The HBase community agrees that the correct behavior of this safety feature should be to have the client *reset* the scanner and resume where it left off instead of giving up and throwing an exception. The change will be implemented in a future release of HBase. In the meantime, this release includes a mechanism to invoke the correct behavior via a custom setting. You can enable the behavior by adding this parameter in 'hbase-site.xml'.
+
+    <property> 
+      <name>hbase.trafodion.patchclientscanner.enabled</name>
+      <value>true</value> 
+      <description>
+        Enable a Trafodion feature to allow a client to reset the HBase scanner and resume where it left off instead of throwing an exception upon expiration of the HBase hbase.client.scanner.timeout.period timer.
+      </description>
+    </property>
+
+The default value of the parameter is **false**.
+
+## Supported Platforms
+
+<span>
+  <table>
+    <tr>
+      <td>**Operating Systems**</td>
+      <td>RedHat / CentOS 6.5 -- 6.7</td>
+    </tr>
+    <tr>
+      <td>**Hadoop Distributions**</td>
+      <td>Cloudera distributions CDH 5.4<br />Hortonworks distribution HDP 2.3<br />Apache Hadoop with Apache HBase 1.0</td>
+     </tr>
+    <tr>
+      <td>**Java Version**</td>
+      <td>JDK 1.7.0_67 or newer</td>
+    </tr>
+  </table>
+</span>
+

--- a/docs/src/site/markdown/release-notes-2-0-1.md
+++ b/docs/src/site/markdown/release-notes-2-0-1.md
@@ -1,0 +1,40 @@
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# 2.0.1-incubating Release Notes
+
+Patch release. Also see the [2.0.0 Release Notes](release-notes-2-0-0.html).
+
+Clients package is now included with convenience bainaries.
+
+## Fixes
+
+<span>
+  <table>
+    <tr>
+      <th>Feature</th>
+      <th>Jira ID</th>
+    </tr>
+    <tr>
+      <td>Clarify LICENSE text</td>
+      <td>TRAFODION-2023</td>
+    </tr>
+    <tr>
+      <td>OpenSSL libraries are linked dynamically</td>
+      <td>TRAFODION-2024</td>
+    </tr>
+  </table>
+</span>
+
+

--- a/docs/src/site/markdown/release-notes.md
+++ b/docs/src/site/markdown/release-notes.md
@@ -16,7 +16,9 @@ The following releases have been created for Trafodion.
 
 Release                               | Description                                                           | Date
 --------------------------------------|-----------------------------------------------------------------------|--------------
-**[1.3.0](release-notes-1-3-0.html)** | First Apache release.                                                 | Pending
+**[2.0.1](release-notes-2-0-1.html)** | Patch release. Client package added to convenience binaries.          | June 2016
+**[2.0.0](release-notes-2-0-0.html)** | Major feature enhancements.                                           | June 2016
+**[1.3.0](release-notes-1-3-0.html)** | First Apache (incubating) release.                                    | January 2016
 **[1.1.0](release-notes-1-1-0.html)** | Major feature enhancements. Non-Apache release.                       | April 2015
 **[1.0.1](release-notes-1-0-1.html)** | Defect repair. Non-Apache release.                                    | February 2015
 **[1.0.0](release-notes-1-0-0.html)** | Performance, stability, and new features. Non-Apache release.         | January 2015


### PR DESCRIPTION
Update website with release notes for 2.0.0 and 2.0.1 (up coming).

Re-worked the download page to point to the provisioning guides, rather than try to summarize installation in a release independent way. 

Use apache download guidelines to point to mirror sites for tar-file downloads, but the main apache site for signatures and checksums.

Place-holder for 2.0.1 release download since it is not official yet.