### PR TITLE
[TRAFODION-2039] Add support for ALTER LIBRARY FILE '<file-name>'

### DIFF
--- a/core/sql/optimizer/RelExeUtil.cpp
+++ b/core/sql/optimizer/RelExeUtil.cpp
@@ -80,6 +80,7 @@
 #include "StmtDDLCreateRoutine.h"
 #include "StmtDDLDropRoutine.h"
 #include "StmtDDLCleanupObjects.h"
+#include "StmtDDLAlterLibrary.h"
 
 #include <cextdecs/cextdecs.h>
 #include "wstr.h"
@@ -3914,6 +3915,7 @@ RelExpr * DDLExpr::bindNode(BindWA *bindWA)
   NABoolean alterIdentityCol = FALSE;
   NABoolean alterColDatatype = FALSE;
   NABoolean alterColRename = FALSE;
+  NABoolean alterLibrary = FALSE;
   NABoolean externalTable = FALSE;
   
   returnStatus_ = FALSE;
@@ -4308,6 +4310,14 @@ RelExpr * DDLExpr::bindNode(BindWA *bindWA)
       qualObjName_ = getExprNode()->castToStmtDDLNode()->
         castToStmtDDLDropLibrary()->getLibraryNameAsQualifiedName();
     }
+    else if (getExprNode()->castToStmtDDLNode()->castToStmtDDLAlterLibrary())
+    {
+      isAlter_ = TRUE;
+      isLibrary_ = TRUE;
+      alterLibrary = TRUE ;
+      qualObjName_ = getExprNode()->castToStmtDDLNode()->
+	castToStmtDDLAlterLibrary()->getLibraryNameAsQualifiedName();
+    }
     else if (getExprNode()->castToStmtDDLNode()->castToStmtDDLCreateRoutine())
     {
       isCreate_ = TRUE;
@@ -4342,7 +4352,7 @@ RelExpr * DDLExpr::bindNode(BindWA *bindWA)
           (isAlter_ && (alterAddCol || alterDropCol || alterDisableIndex || alterEnableIndex || 
 			alterAddConstr || alterDropConstr || alterRenameTable ||
                         alterIdentityCol || alterColDatatype || alterColRename ||
-                        alterHBaseOptions || otherAlters)))))
+                        alterHBaseOptions || alterLibrary || otherAlters)))))
       {
 	if (NOT isNative_)
 	  {

--- a/core/sql/parser/StmtDDLAlterLibrary.h
+++ b/core/sql/parser/StmtDDLAlterLibrary.h
@@ -70,6 +70,8 @@ public:
    inline const NAString getFilename() const;  
    inline const NAString &getClientName() const;  
    inline const NAString &getClientFilename() const;  
+   inline const QualifiedName & getLibraryNameAsQualifiedName() const;
+   inline       QualifiedName & getLibraryNameAsQualifiedName();
 
 // for tracing
 
@@ -113,4 +115,16 @@ inline const  NAString &StmtDDLAlterLibrary::getClientFilename() const
 {
    return clientFilename_;
 }
+
+inline QualifiedName &
+ StmtDDLAlterLibrary::getLibraryNameAsQualifiedName()
+ {
+   return libraryName_;
+ }
+ 
+ inline const QualifiedName &
+ StmtDDLAlterLibrary::getLibraryNameAsQualifiedName() const
+ {
+   return libraryName_;
+ }
 #endif  // STMTDDLALTERLIBRARY

--- a/core/sql/regress/udr/EXPECTED001
+++ b/core/sql/regress/udr/EXPECTED001
@@ -188,7 +188,7 @@
 *** ERROR[11246] An error occurred locating function or class 'SESSIONIZE_NON_EXISTENT' in library 'TEST001.dll'.
 
 *** ERROR[11248] A call to dlsym returned errors 0 and 0. Details: 
-/mnt/sandhyasun/incubator-trafodion/core/sqf/rundir/udr/TEST001.dll: undefined symbol: SESSIONIZE_NON_EXISTENT.
+/mnt/ssubbiah/incubator-trafodion/core/sqf/rundir/udr/TEST001.dll: undefined symbol: SESSIONIZE_NON_EXISTENT.
 
 --- SQL operation failed with errors.
 >>-- For now this will succeed, since we don't load the library during
@@ -305,10 +305,10 @@ CREATE TABLE_MAPPING FUNCTION TRAFODION.SCH.SESSIONIZE_JAVA
 SESSION_ID            SEQUENCE_NO           USERID                            TS                    IPADDR
 --------------------  --------------------  --------------------------------  --------------------  ---------------
 
-                   1                     1  super-user                          212329072799500000  12.345.567.345 
-                   2                     1  super-user                          212329079999500000  12.345.567.345 
-                   2                     2  super-services                      212329079999500000  12.345.567.345 
-                   2                     3  super-services                      212329079999550000  12.345.567.345 
+                   1                     1  super-user                          212332183199500000  12.345.567.345 
+                   2                     1  super-user                          212332190399500000  12.345.567.345 
+                   2                     2  super-services                      212332190399500000  12.345.567.345 
+                   2                     3  super-services                      212332190399550000  12.345.567.345 
 
 --- 4 row(s) selected.
 >>
@@ -366,7 +366,7 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 SESSION_ID            SEQUENCE_NO           USERID                            TS                    IPADDR
 --------------------  --------------------  --------------------------------  --------------------  ---------------
 
-                   1                     1  super-user                          212329072799500000  12.345.567.345 
+                   1                     1  super-user                          212332183199500000  12.345.567.345 
 
 --- 1 row(s) selected.
 >>
@@ -459,7 +459,7 @@ IPADDR           SESSION_ID            SEQUENCE_NO
 SESSION_ID            SEQUENCE_NO           USERID                            TS                    IPADDR
 --------------------  --------------------  --------------------------------  --------------------  ---------------
 
-                   1                     1  super-user                          212329072799500000  12.345.567.345 
+                   1                     1  super-user                          212332183199500000  12.345.567.345 
 
 --- 1 row(s) selected.
 >>
@@ -707,4 +707,12 @@ ER BY ts), cast('TS' as char(2)),                     'USERID',
 *** ERROR[8822] The statement was not prepared.
 
 >>-- PARTITION BY 3 has an invalid column number
+>>
+>> CREATE LIBRARY TRAFODION.SCH.ALTERTEST FILE $$QUOTE$$ $$REGRRUNDIR$$/TEST001.dll $$QUOTE$$;
+
+--- SQL operation complete.
+>> ALTER LIBRARY TRAFODION.SCH.ALTERTEST FILE $$QUOTE$$ $$REGRRUNDIR$$/TEST001.jar $$QUOTE$$;
+
+--- SQL operation complete.
+>>
 >>log;

--- a/core/sql/regress/udr/TEST001
+++ b/core/sql/regress/udr/TEST001
@@ -45,6 +45,7 @@ drop library TEST001;
 drop table_mapping function sessionize_java;
 drop table_mapping function fibonacci_java;
 drop library TEST001_Java;
+drop library ALTERTEST;
 
 ?section compile_libs
 --------------------------------------------------------------------------
@@ -409,3 +410,7 @@ FROM UDF(sessionize_dynamic(TABLE(SELECT userid, JULIANTIMESTAMP(ts) as TS
                             'TS',
                             60000000)) XOX;
 -- PARTITION BY 3 has an invalid column number
+
+ CREATE LIBRARY TRAFODION.SCH.ALTERTEST FILE $$QUOTE$$ $$REGRRUNDIR$$/TEST001.dll $$QUOTE$$;
+ ALTER LIBRARY TRAFODION.SCH.ALTERTEST FILE $$QUOTE$$ $$REGRRUNDIR$$/TEST001.jar $$QUOTE$$;
+

--- a/core/sql/sqlcomp/CmpSeabaseDDL.h
+++ b/core/sql/sqlcomp/CmpSeabaseDDL.h
@@ -1162,6 +1162,9 @@ class CmpSeabaseDDL
   void dropSeabaseLibrary(StmtDDLDropLibrary  * dropLibraryNode,
                           NAString &currCatName, NAString &currSchName);
 
+  void  alterSeabaseLibrary(StmtDDLAlterLibrary  *alterLibraryNode,
+			    NAString &currCatName, NAString &currSchName);
+
   void createSeabaseRoutine(StmtDDLCreateRoutine  * createRoutineNode,
                             NAString &currCatName, NAString &currSchName);
   

--- a/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
@@ -69,6 +69,8 @@
 #include "CmpSeabaseDDLmd.h"
 #include "CmpSeabaseDDLroutine.h"
 #include "hdfs.h"
+#include "StmtDDLAlterLibrary.h"
+
 void cleanupLOBDataDescFiles(const char*, int, const char *);
 
 class QualifiedSchema
@@ -8903,6 +8905,15 @@ short CmpSeabaseDDL::executeSeabaseDDL(DDLExpr * ddlExpr, ExprNode * ddlNode,
           
           dropSeabaseLibrary(dropLibraryParseNode, currCatName, currSchName);
         }
+       else if (ddlNode->getOperatorType() == DDL_ALTER_LIBRARY)
+         {
+           // create seabase library
+           StmtDDLAlterLibrary * alterLibraryParseNode =
+             ddlNode->castToStmtDDLNode()->castToStmtDDLAlterLibrary();
+           
+           alterSeabaseLibrary(alterLibraryParseNode, currCatName, 
+                               currSchName);
+         }
       else if (ddlNode->getOperatorType() == DDL_CREATE_ROUTINE)
         {
           // create seabase routine

--- a/core/sql/sqlcomp/CmpSeabaseDDLroutine.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLroutine.cpp
@@ -46,6 +46,7 @@
 #include "StmtDDLDropRoutine.h"
 #include "StmtDDLCreateLibrary.h"
 #include "StmtDDLDropLibrary.h"
+#include "StmtDDLAlterLibrary.h"
 
 #include "ElemDDLColDefArray.h"
 #include "ElemDDLColRefArray.h"
@@ -342,7 +343,6 @@ void CmpSeabaseDDL::createSeabaseLibrary(
   NAString libFileName = createLibraryNode->getFilename() ;
   // strip blank spaces
   libFileName = libFileName.strip(NAString::both, ' ');
-
   if (validateLibraryFileExists(libFileName, FALSE))
     {
       deallocEHI(ehi); 
@@ -562,6 +562,139 @@ void CmpSeabaseDDL::dropSeabaseLibrary(StmtDDLDropLibrary * dropLibraryNode,
 
   deallocEHI(ehi);      
   processReturn();
+  return;
+}
+
+void  CmpSeabaseDDL::alterSeabaseLibrary(StmtDDLAlterLibrary  *alterLibraryNode,
+					 NAString &currCatName, 
+					 NAString &currSchName)
+{
+  Lng32 cliRC;
+  Lng32 retcode;
+  
+  NAString libraryName = alterLibraryNode->getLibraryName();
+  NAString libFileName = alterLibraryNode->getFilename();
+  
+  ComObjectName libName(libraryName, COM_TABLE_NAME);
+  ComAnsiNamePart currCatAnsiName(currCatName);
+  ComAnsiNamePart currSchAnsiName(currSchName);
+  libName.applyDefaults(currCatAnsiName, currSchAnsiName);
+  
+  NAString catalogNamePart = libName.getCatalogNamePartAsAnsiString();
+  NAString schemaNamePart = libName.getSchemaNamePartAsAnsiString(TRUE);
+  NAString libNamePart = libName.getObjectNamePartAsAnsiString(TRUE);
+  const NAString extLibName = libName.getExternalName(TRUE);
+  
+  ExeCliInterface cliInterface(STMTHEAP, NULL, NULL,
+			       CmpCommon::context()->sqlSession()->getParentQid());
+  
+  retcode = existsInSeabaseMDTable(&cliInterface, 
+				   catalogNamePart, schemaNamePart, libNamePart,
+				   COM_LIBRARY_OBJECT, TRUE, FALSE);
+  if (retcode < 0)
+    {
+      processReturn();
+      return;
+    }
+  
+  if (retcode == 0) // does not exist
+    {
+      CmpCommon::diags()->clear();
+      *CmpCommon::diags() << DgSqlCode(-1389)
+			  << DgString0(extLibName);
+      processReturn();
+      return;
+    }
+  
+  // strip blank spaces
+  libFileName = libFileName.strip(NAString::both, ' ');
+  if (validateLibraryFileExists(libFileName, FALSE))
+    {
+      processReturn();
+      return;
+    }
+  
+  Int32 objectOwnerID = 0;
+  Int32 schemaOwnerID = 0;
+  Int64 objectFlags = 0;
+  Int64 libUID = getObjectInfo(&cliInterface,
+			       catalogNamePart.data(), schemaNamePart.data(),
+			       libNamePart.data(), COM_LIBRARY_OBJECT,
+			       objectOwnerID,schemaOwnerID,objectFlags);
+  
+  // Check for error getting metadata information
+  if (libUID == -1 || objectOwnerID == 0)
+    {
+      if (CmpCommon::diags()->getNumber(DgSqlCode::ERROR_) == 0)
+	SEABASEDDL_INTERNAL_ERROR("getting object UID and owner for alter library");
+      processReturn();
+      return;
+    }
+  
+  // Verify that the current user has authority to perform operation
+  if (!isDDLOperationAuthorized(SQLOperation::ALTER_LIBRARY,
+				objectOwnerID,schemaOwnerID))
+    {
+      *CmpCommon::diags() << DgSqlCode(-CAT_NOT_AUTHORIZED);
+      processReturn();
+      return;
+    }
+  
+  Int64 redefTime = NA_JulianTimestamp();
+  
+  char buf[2048]; // filename max length is 512. Additional bytes for long
+  // library names.
+  str_sprintf(buf, "update %s.\"%s\".%s set library_filename = '%s' where library_uid = %Ld",
+	      getSystemCatalog(), SEABASE_MD_SCHEMA, SEABASE_LIBRARIES,
+	      libFileName.data(),
+	      libUID);
+  
+  cliRC = cliInterface.executeImmediate(buf);
+  if (cliRC < 0)
+    {
+      cliInterface.retrieveSQLDiagnostics(CmpCommon::diags());
+      return;
+    }
+  
+  if (updateObjectRedefTime(&cliInterface,
+			    catalogNamePart, schemaNamePart, libNamePart,
+			    COM_LIBRARY_OBJECT_LIT,
+			    redefTime))
+    {
+      processReturn();
+      return;
+   }
+  
+  BindWA bindWA(ActiveSchemaDB(), CmpCommon::context(), FALSE/*inDDL*/);
+  NARoutineDB *pRoutineDBCache  = ActiveSchemaDB()->getNARoutineDB();
+  Queue * usingRoutinesQueue = NULL;
+  cliRC = getUsingRoutines(&cliInterface, libUID, usingRoutinesQueue);
+  if (cliRC < 0)
+    {
+      processReturn();
+      return;
+    }
+  usingRoutinesQueue->position();
+  for (size_t i = 0; i < usingRoutinesQueue->numEntries(); i)
+    { 
+      OutputInfo * rou = (OutputInfo*)usingRoutinesQueue->getNext();    
+      char * routineName = rou->get(0);
+      ComObjectType objectType = PrivMgr::ObjectLitToEnum(rou->get(1));
+      // Remove routine from DBRoutinCache
+      ComObjectName objectName(routineName);
+      QualifiedName qualRoutineName(objectName, STMTHEAP);
+      NARoutineDBKey key(qualRoutineName, STMTHEAP);
+      NARoutine *cachedNARoutine = pRoutineDBCache->get(&bindWA, &key);
+      if (cachedNARoutine)
+	{
+	  Int64 routineUID = *(Int64*)rou->get(2);
+	  pRoutineDBCache->removeNARoutine(qualRoutineName,
+					   ComQiScope::REMOVE_FROM_ALL_USERS,
+					   routineUID,
+					   alterLibraryNode->ddlXns(), FALSE);
+	}
+    }
+  
   return;
 }
 


### PR DESCRIPTION
Library file (.jar, .dll or .so) can now be altered for an existing library 
object. ALTER command will check for existence of new file. Old library
definition will be removed from compiler cache.