### PR TITLE
[TRAFODION-2046]change DTM's memoryUsageChore default settings to ena…

### DIFF
--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/coprocessor/transactional/TrxRegionEndpoint.java.tmpl
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/coprocessor/transactional/TrxRegionEndpoint.java.tmpl
@@ -357,9 +357,9 @@ CoprocessorService, Coprocessor {
   private static final int MINIMUM_LEASE_TIME = 7200 * 1000;
   private static final int LEASE_CHECK_FREQUENCY = 1000;
   private static final int DEFAULT_SLEEP = 60 * 1000;
-  private static final int DEFAULT_MEMORY_THRESHOLD = 100; // 100% memory used
+  private static final int DEFAULT_MEMORY_THRESHOLD = 90; // 90% memory used
   private static final int DEFAULT_MEMORY_SLEEP = 15 * 1000;
-  private static final boolean DEFAULT_MEMORY_WARN_ONLY = true;        
+  private static final boolean DEFAULT_MEMORY_WARN_ONLY = false;        
   private static final boolean DEFAULT_MEMORY_PERFORM_GC = false;
   private static final int DEFAULT_ASYNC_WAL = 1;
   private static final boolean DEFAULT_SKIP_WAL = false;


### PR DESCRIPTION
…ble memory threthold

Change the default behavior of DTM to restrict the memory usage in Region Server to 90%, if above that threshold, stop all new transaction operations until memory released under the threshold.