### PR TITLE
[TRAFODION-2044] Support SALT clause on CREATE TABLE LIKE

### DIFF
--- a/core/sql/bin/SqlciErrors.txt
+++ b/core/sql/bin/SqlciErrors.txt
@@ -905,7 +905,7 @@ $1~String1 --------------------------------
 3151 42000 99999 BEGINNER MAJOR DBADMIN Duplicate WITH HORIZONTAL PARTITIONS phrases were specified in LIKE clause in CREATE TABLE statement.
 3152 42000 99999 BEGINNER MAJOR DBADMIN Duplicate WITHOUT $0~string0 phrases were specified in LIKE clause in CREATE TABLE statement.
 3153 42000 99999 BEGINNER MAJOR DBADMIN The FIRST KEY clause is not allowed with hash or hash2 partitioning.
-3154 ZZZZZ 99999 BEGINNER MAJOR DBADMIN --- unused as of 03/25/04 ---
+3154 42000 99999 BEGINNER MAJOR DBADMIN The $0~String0 clause is not allowed with the $1~String1 clause.
 3155 42000 99999 BEGINNER MAJOR DBADMIN The POPULATE and NO POPULATE clauses cannot coexist in the same CREATE INDEX statement.
 3156 42000 99999 BEGINNER MAJOR DBADMIN The STORE BY clause is not allowed on a vertically partitioned table.
 3157 42000 99999 BEGINNER MAJOR DBADMIN A catalog name is required.

--- a/core/sql/common/OperTypeEnum.h
+++ b/core/sql/common/OperTypeEnum.h
@@ -1045,6 +1045,7 @@ enum OperatorTypeEnum {
                         ELM_LIKE_OPT_WITH_HEADINGS_ELEM,
                         ELM_LIKE_OPT_WITH_HORIZONTAL_PARTITIONS_ELEM,
                         ELM_LIKE_OPT_WITHOUT_SALT_ELEM,
+                        ELM_LIKE_OPT_SALT_CLAUSE_ELEM,
                         ELM_LIKE_OPT_WITHOUT_DIVISION_ELEM,
                         ELM_LOCATION_ELEM,
                         ELM_OPTION_LIST,

--- a/core/sql/parser/ElemDDLLikeOptions.cpp
+++ b/core/sql/parser/ElemDDLLikeOptions.cpp
@@ -173,6 +173,31 @@ const NAString ElemDDLLikeOptWithoutSalt::getText() const
   return "ElemDDLLikeOptWithoutSalt";
 }
 
+// -----------------------------------------------------------------------
+// methods for class ElemDDLLikeSaltClause
+// -----------------------------------------------------------------------
+
+// virtual destructor
+ElemDDLLikeSaltClause::~ElemDDLLikeSaltClause()
+{
+  delete saltClause_;
+}
+
+// casting
+ElemDDLLikeSaltClause * ElemDDLLikeSaltClause::castToElemDDLLikeSaltClause()
+{
+  return this;
+}
+
+//
+// methods for tracing
+//
+
+const NAString ElemDDLLikeSaltClause::getText() const
+{
+  return "ElemDDLLikeSaltClause";
+}
+
 
 // -----------------------------------------------------------------------
 // methods for class ElemDDLLikeOptWithoutDivision

--- a/core/sql/parser/ElemDDLLikeOptions.h
+++ b/core/sql/parser/ElemDDLLikeOptions.h
@@ -197,6 +197,40 @@ private:
 
 
 // -----------------------------------------------------------------------
+// definition of class ElemDDLLikeSaltClause
+// -----------------------------------------------------------------------
+class ElemDDLLikeSaltClause : public ElemDDLLikeOpt
+{
+
+public:
+
+  // constructor
+  ElemDDLLikeSaltClause(ElemDDLSaltOptionsClause * saltClause)
+    : ElemDDLLikeOpt(ELM_LIKE_OPT_SALT_CLAUSE_ELEM),
+      saltClause_(saltClause)
+  { }
+
+  // virtual destructor
+  virtual ~ElemDDLLikeSaltClause();
+
+  // cast
+  virtual ElemDDLLikeSaltClause *
+    castToElemDDLLikeSaltClause();
+
+  // method for tracing
+  virtual const NAString getText() const;
+
+  ElemDDLSaltOptionsClause * getSaltClause()
+  { return saltClause_; };
+
+
+private:
+
+  ElemDDLSaltOptionsClause * saltClause_;
+
+}; // class ElemDDLLikeOptWithoutSalt
+
+// -----------------------------------------------------------------------
 // definition of class ElemDDLLikeOptWithoutDivision
 // -----------------------------------------------------------------------
 class ElemDDLLikeOptWithoutDivision : public ElemDDLLikeOpt

--- a/core/sql/parser/ElemDDLNode.cpp
+++ b/core/sql/parser/ElemDDLNode.cpp
@@ -558,6 +558,11 @@ ElemDDLLikeOptWithoutSalt * ElemDDLNode::castToElemDDLLikeOptWithoutSalt()
   return NULL;
 }
 
+ElemDDLLikeSaltClause * ElemDDLNode::castToElemDDLLikeSaltClause()
+{
+  return NULL;
+}
+
 ElemDDLLikeOptWithoutDivision * ElemDDLNode::castToElemDDLLikeOptWithoutDivision()
 {
   return NULL;
@@ -3306,6 +3311,33 @@ NABoolean
 ElemDDLSaltOptionsClause::getLikeTable() const
 {
   return likeTable_;
+}
+
+void
+ElemDDLSaltOptionsClause::unparseIt(NAString & result) const
+{
+  if (likeTable_)
+    result = "SALT LIKE TABLE";
+  else
+    {  
+      char buf[40];
+      sprintf(buf," SALT USING %d PARTITIONS",numPartitions_);
+      result = buf;
+
+      if (saltColumnArray_.entries() > 0)
+        {
+          result += " ON (";
+          const ElemDDLColRef * colRef = saltColumnArray_[0];
+          result += colRef->getColumnName();
+          for (CollIndex i = 1; i < saltColumnArray_.entries(); i++)
+            {
+              result += ",";
+              colRef = saltColumnArray_[i];
+              result += colRef->getColumnName();
+            }
+          result += ")";
+        }
+    }
 }
 
 //

--- a/core/sql/parser/ElemDDLNode.h
+++ b/core/sql/parser/ElemDDLNode.h
@@ -135,6 +135,7 @@ class ElemDDLLikeOptWithoutConstraints;
 class ElemDDLLikeOptWithHeadings;
 class ElemDDLLikeOptWithHorizontalPartitions;
 class ElemDDLLikeOptWithoutSalt;
+class ElemDDLLikeSaltClause;
 class ElemDDLLikeOptWithoutDivision;
 class ElemDDLList;
 class ElemDDLLocation;
@@ -455,6 +456,7 @@ public:
   virtual ElemDDLLikeOptWithHeadings    * castToElemDDLLikeOptWithHeadings();
   virtual ElemDDLLikeOptWithHorizontalPartitions    * castToElemDDLLikeOptWithHorizontalPartitions();
   virtual ElemDDLLikeOptWithoutSalt     * castToElemDDLLikeOptWithoutSalt();
+  virtual ElemDDLLikeSaltClause         * castToElemDDLLikeSaltClause();
   virtual ElemDDLLikeOptWithoutDivision * castToElemDDLLikeOptWithoutDivision();
   virtual ElemDDLList                   * castToElemDDLList();
   virtual ElemDDLLocation               * castToElemDDLLocation();

--- a/core/sql/parser/ElemDDLSaltOptions.h
+++ b/core/sql/parser/ElemDDLSaltOptions.h
@@ -107,6 +107,8 @@ public:
 
   NABoolean getLikeTable() const;
 
+  void unparseIt(NAString & result) const;
+
 private:
 
   //

--- a/core/sql/parser/ParDDLLikeOptsCreateTable.h
+++ b/core/sql/parser/ParDDLLikeOptsCreateTable.h
@@ -119,6 +119,12 @@ public:
     return isLikeOptWithoutSalt_;
   }
 
+  const NAString *
+  getSaltClause() const
+  {
+    return isLikeOptSaltClause_;
+  }
+
   const NABoolean
   getIsWithoutDivision() const
   {
@@ -195,6 +201,7 @@ private:
   NABoolean isLikeOptWithHelpTextSpec_;
   NABoolean isLikeOptWithHorizontalPartitionsSpec_;
   NABoolean isLikeOptWithoutSaltSpec_;
+  NABoolean isLikeOptSaltClauseSpec_;
   NABoolean isLikeOptWithoutDivisionSpec_;
 
   // legal Like options in DDL Create Table statements
@@ -205,6 +212,7 @@ private:
   NABoolean isLikeOptWithHelpText_;
   NABoolean isLikeOptWithHorizontalPartitions_;
   NABoolean isLikeOptWithoutSalt_;
+  NAString * isLikeOptSaltClause_;
   NABoolean isLikeOptWithoutDivision_;
 
 }; // class ParDDLLikeOptsCreateTable

--- a/core/sql/regress/compGeneral/EXPECTED015.SB
+++ b/core/sql/regress/compGeneral/EXPECTED015.SB
@@ -89,7 +89,7 @@ z
 >>-- Ambiguous col ref A
 >>select a from t015ta x join t015ta y on 1=1;
 
-*** ERROR[4004] Column name A is ambiguous.  Tables in scope: X, Y.  Default schema: SEABASE.SCH.
+*** ERROR[4004] Column name A is ambiguous.  Tables in scope: X, Y.  Default schema: TRAFODION.SCH.
 
 *** ERROR[8822] The statement was not prepared.
 
@@ -198,7 +198,7 @@ z     y             25  z     y             25
 +>  (t015ta cc natural join t015ta dd)
 +>  on 1=1;
 
-*** ERROR[4004] Column name A is ambiguous.  Tables in scope: AA, BB, CC, DD.  Default schema: SEABASE.SCH.
+*** ERROR[4004] Column name A is ambiguous.  Tables in scope: AA, BB, CC, DD.  Default schema: TRAFODION.SCH.
 
 *** ERROR[8822] The statement was not prepared.
 
@@ -313,7 +313,7 @@ z     y             25
 >>-- ambig col ref A
 >>select * from t015ta where exists(select * from (select a,a from t015ta) x group by a);
 
-*** ERROR[4004] Column name A is ambiguous.  Tables in scope: X.  Default schema: SEABASE.SCH.
+*** ERROR[4004] Column name A is ambiguous.  Tables in scope: X.  Default schema: TRAFODION.SCH.
 
 *** ERROR[8822] The statement was not prepared.
 
@@ -321,7 +321,7 @@ z     y             25
 >>-- col X not found
 >>select * from t015ta where exists(select * from (select a,a from t015ta) x group by x);
 
-*** ERROR[4001] Column X is not found.  Tables in scope: SEABASE.SCH.T015TA, X.  Default schema: SEABASE.SCH.
+*** ERROR[4001] Column X is not found.  Tables in scope: TRAFODION.SCH.T015TA, X.  Default schema: TRAFODION.SCH.
 
 *** ERROR[8822] The statement was not prepared.
 
@@ -329,7 +329,7 @@ z     y             25
 >>-- col B not found
 >>select * from (select a,a from t015ta) x group by b;
 
-*** ERROR[4001] Column B is not found.  Tables in scope: X.  Default schema: SEABASE.SCH.
+*** ERROR[4001] Column B is not found.  Tables in scope: X.  Default schema: TRAFODION.SCH.
 
 *** ERROR[8822] The statement was not prepared.
 
@@ -337,7 +337,7 @@ z     y             25
 >>-- ambig col ref A
 >>select * from (select a,a from t015ta) x group by a;
 
-*** ERROR[4004] Column name A is ambiguous.  Tables in scope: X.  Default schema: SEABASE.SCH.
+*** ERROR[4004] Column name A is ambiguous.  Tables in scope: X.  Default schema: TRAFODION.SCH.
 
 *** ERROR[8822] The statement was not prepared.
 
@@ -353,7 +353,7 @@ z     y             25
 >>-- ambig col ref A
 >>select * from t015ta where exists(select a from (select a,a from t015ta) x group by b);
 
-*** ERROR[4004] Column name A is ambiguous.  Tables in scope: X.  Default schema: SEABASE.SCH.
+*** ERROR[4004] Column name A is ambiguous.  Tables in scope: X.  Default schema: TRAFODION.SCH.
 
 *** ERROR[8822] The statement was not prepared.
 
@@ -465,8 +465,8 @@ z     y             25
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          1.000E+001   10 fragment_   
-TRAFODION_SCAN         T0          1.000E+001   10 fragment_   
+ROOT                          1.000E+002   100 fragment   
+TRAFODION_SCAN    T0          1.000E+002   100 fragment   
 
 --- 2 row(s) selected.
 >>
@@ -480,7 +480,7 @@ OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
 ROOT                          1.000E+002   100 fragment   
-TRAFODION_SCAN         T6          1.000E+002   100 fragment   
+TRAFODION_SCAN    T6          1.000E+002   100 fragment   
 
 --- 2 row(s) selected.
 >>
@@ -493,8 +493,8 @@ TRAFODION_SCAN         T6          1.000E+002   100 fragment
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          1.000E+003   1000 fragmen   
-TRAFODION_SCAN         T8          1.000E+003   1000 fragmen   
+ROOT                          1.000E+002   100 fragment   
+TRAFODION_SCAN    T8          1.000E+002   100 fragment   
 
 --- 2 row(s) selected.
 >>
@@ -507,8 +507,8 @@ TRAFODION_SCAN         T8          1.000E+003   1000 fragmen
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          1.000E+004   10000 fragme   
-TRAFODION_SCAN         T9          1.000E+004   10000 fragme   
+ROOT                          1.000E+002   100 fragment   
+TRAFODION_SCAN    T9          1.000E+002   100 fragment   
 
 --- 2 row(s) selected.
 >>
@@ -521,8 +521,8 @@ TRAFODION_SCAN         T9          1.000E+004   10000 fragme
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          1.000E+005   100000 fragm   
-TRAFODION_SCAN         T10         1.000E+005   100000 fragm   
+ROOT                          1.000E+002   100 fragment   
+TRAFODION_SCAN    T10         1.000E+002   100 fragment   
 
 --- 2 row(s) selected.
 >>
@@ -535,8 +535,8 @@ TRAFODION_SCAN         T10         1.000E+005   100000 fragm
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          1.250E+004   100000 fragm   
-TRAFODION_SCAN         T10         1.250E+004   100000 fragm   
+ROOT                          1.300E+001   100 fragment   
+TRAFODION_SCAN    T10         1.300E+001   100 fragment   
 
 --- 2 row(s) selected.
 >>select count(*) from (SELECT * FROM t10 WHERE d like 'one%') as t;
@@ -557,8 +557,8 @@ TRAFODION_SCAN         T10         1.250E+004   100000 fragm
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          8.750E+004   100000 fragm   
-TRAFODION_SCAN         T10         8.750E+004   100000 fragm   
+ROOT                          8.900E+001   100 fragment   
+TRAFODION_SCAN    T10         8.900E+001   100 fragment   
 
 --- 2 row(s) selected.
 >>select count(*) from (SELECT * FROM t10 WHERE d not like 'one%') as t;
@@ -581,7 +581,7 @@ OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
 ROOT                          1.000E+000   1 fragment_i   
-TRAFODION_SCAN_UNIQUE  T10         1.000E+000   1 fragment_i   
+TRAFODION_SCAN    T10         1.000E+000   1 fragment_i   
 
 --- 2 row(s) selected.
 >>select count(*) from (SELECT * FROM t10 WHERE a = 1) as t;
@@ -604,7 +604,7 @@ OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
 ROOT                          1.000E+000   1 fragment_i   
-TRAFODION_SCAN_UNIQUE  T10         1.000E+000   1 fragment_i   
+TRAFODION_SCAN    T10         1.000E+000   1 fragment_i   
 
 --- 2 row(s) selected.
 >>
@@ -618,8 +618,8 @@ TRAFODION_SCAN_UNIQUE  T10         1.000E+000   1 fragment_i
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          1.000E+004   10000 fragme   
-TRAFODION_SCAN         T10         1.000E+004   10000 fragme   
+ROOT                          1.000E+001   99 fragment_   
+TRAFODION_SCAN    T10         1.000E+001   99 fragment_   
 
 --- 2 row(s) selected.
 >>select count(*) from (SELECT * FROM t10 WHERE d = 'one') as t;
@@ -641,8 +641,8 @@ TRAFODION_SCAN         T10         1.000E+004   10000 fragme
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          1.000E+004   10000 fragme   
-TRAFODION_SCAN         T10         1.000E+004   10000 fragme   
+ROOT                          5.000E+001   50 fragment_   
+TRAFODION_SCAN    T10         5.000E+001   50 fragment_   
 
 --- 2 row(s) selected.
 >>
@@ -656,8 +656,8 @@ TRAFODION_SCAN         T10         1.000E+004   10000 fragme
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          9.999E+004   99999 fragme   
-TRAFODION_SCAN         T10         9.999E+004   99999 fragme   
+ROOT                          3.300E+001   50 fragment_   
+TRAFODION_SCAN    T10         3.300E+001   50 fragment_   
 
 --- 2 row(s) selected.
 >>
@@ -670,8 +670,8 @@ TRAFODION_SCAN         T10         9.999E+004   99999 fragme
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          9.999E+004   99999 fragme   
-TRAFODION_SCAN         T10         9.999E+004   99999 fragme   
+ROOT                          3.400E+001   50 fragment_   
+TRAFODION_SCAN    T10         3.300E+001   50 fragment_   
 
 --- 2 row(s) selected.
 >>
@@ -684,8 +684,8 @@ TRAFODION_SCAN         T10         9.999E+004   99999 fragme
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          1.000E+000   1 fragment_i   
-TRAFODION_SCAN         T10         1.000E+000   1 fragment_i   
+ROOT                          3.300E+001   50 fragment_   
+TRAFODION_SCAN    T10         3.300E+001   50 fragment_   
 
 --- 2 row(s) selected.
 >>
@@ -698,8 +698,8 @@ TRAFODION_SCAN         T10         1.000E+000   1 fragment_i
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          2.000E+000   2 fragment_i   
-TRAFODION_SCAN         T10         2.000E+000   2 fragment_i   
+ROOT                          3.300E+001   51 fragment_   
+TRAFODION_SCAN    T10         3.300E+001   51 fragment_   
 
 --- 2 row(s) selected.
 >>
@@ -712,8 +712,8 @@ TRAFODION_SCAN         T10         2.000E+000   2 fragment_i
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          1.000E+005   100000 fragm   
-TRAFODION_SCAN         T10         1.000E+005   100000 fragm   
+ROOT                          6.700E+001   100 fragment   
+TRAFODION_SCAN    T10         6.700E+001   100 fragment   
 
 --- 2 row(s) selected.
 >>
@@ -727,8 +727,8 @@ TRAFODION_SCAN         T10         1.000E+005   100000 fragm
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          5.000E+004   50000 fragme   
-TRAFODION_SCAN         T10         5.000E+004   50000 fragme   
+ROOT                          3.300E+001   56 fragment_   
+TRAFODION_SCAN    T10         3.300E+001   56 fragment_   
 
 --- 2 row(s) selected.
 >>
@@ -741,8 +741,8 @@ TRAFODION_SCAN         T10         5.000E+004   50000 fragme
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          6.000E+004   60000 fragme   
-TRAFODION_SCAN         T10         6.000E+004   60000 fragme   
+ROOT                          3.300E+001   78 fragment_   
+TRAFODION_SCAN    T10         3.300E+001   78 fragment_   
 
 --- 2 row(s) selected.
 >>
@@ -755,8 +755,8 @@ TRAFODION_SCAN         T10         6.000E+004   60000 fragme
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          4.000E+004   40000 fragme   
-TRAFODION_SCAN         T10         4.000E+004   40000 fragme   
+ROOT                          3.300E+001   44 fragment_   
+TRAFODION_SCAN    T10         3.300E+001   44 fragment_   
 
 --- 2 row(s) selected.
 >>
@@ -769,8 +769,8 @@ TRAFODION_SCAN         T10         4.000E+004   40000 fragme
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          5.000E+004   50000 fragme   
-TRAFODION_SCAN         T10         5.000E+004   50000 fragme   
+ROOT                          3.300E+001   72 fragment_   
+TRAFODION_SCAN    T10         3.300E+001   72 fragment_   
 
 --- 2 row(s) selected.
 >>
@@ -783,8 +783,8 @@ TRAFODION_SCAN         T10         5.000E+004   50000 fragme
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          9.000E+004   90000 fragme   
-TRAFODION_SCAN         T10         9.000E+004   90000 fragme   
+ROOT                          6.700E+001   100 fragment   
+TRAFODION_SCAN    T10         6.700E+001   100 fragment   
 
 --- 2 row(s) selected.
 >>
@@ -797,8 +797,8 @@ TRAFODION_SCAN         T10         9.000E+004   90000 fragme
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          3.333E+004   100000 fragm   
-TRAFODION_SCAN         T10         3.333E+004   100000 fragm   
+ROOT                          3.300E+001   100 fragment   
+TRAFODION_SCAN    T10         3.300E+001   100 fragment   
 
 --- 2 row(s) selected.
 >>
@@ -811,8 +811,8 @@ TRAFODION_SCAN         T10         3.333E+004   100000 fragm
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          3.333E+004   100000 fragm   
-TRAFODION_SCAN         T10         3.333E+004   100000 fragm   
+ROOT                          3.300E+001   100 fragment   
+TRAFODION_SCAN    T10         3.300E+001   100 fragment   
 
 --- 2 row(s) selected.
 >>
@@ -825,8 +825,8 @@ TRAFODION_SCAN         T10         3.333E+004   100000 fragm
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          3.333E+004   100000 fragm   
-TRAFODION_SCAN         T10         3.333E+004   100000 fragm   
+ROOT                          3.300E+001   100 fragment   
+TRAFODION_SCAN    T10         3.300E+001   100 fragment   
 
 --- 2 row(s) selected.
 >>
@@ -839,8 +839,8 @@ TRAFODION_SCAN         T10         3.333E+004   100000 fragm
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          3.333E+004   100000 fragm   
-TRAFODION_SCAN         T10         3.333E+004   100000 fragm   
+ROOT                          3.300E+001   100 fragment   
+TRAFODION_SCAN    T10         3.300E+001   100 fragment   
 
 --- 2 row(s) selected.
 >>
@@ -853,8 +853,8 @@ TRAFODION_SCAN         T10         3.333E+004   100000 fragm
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          9.999E+004   100000 fragm   
-TRAFODION_SCAN         T10         9.999E+004   100000 fragm   
+ROOT                          5.000E+001   100 fragment   
+TRAFODION_SCAN    T10         5.000E+001   100 fragment   
 
 --- 2 row(s) selected.
 >>
@@ -867,8 +867,8 @@ TRAFODION_SCAN         T10         9.999E+004   100000 fragm
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          3.333E+004   100000 fragm   
-TRAFODION_SCAN         T10         3.333E+004   100000 fragm   
+ROOT                          3.300E+001   100 fragment   
+TRAFODION_SCAN    T10         3.300E+001   100 fragment   
 
 --- 2 row(s) selected.
 >>
@@ -881,8 +881,8 @@ TRAFODION_SCAN         T10         3.333E+004   100000 fragm
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          3.333E+004   100000 fragm   
-TRAFODION_SCAN         T10         3.333E+004   100000 fragm   
+ROOT                          3.300E+001   100 fragment   
+TRAFODION_SCAN    T10         3.300E+001   100 fragment   
 
 --- 2 row(s) selected.
 >>
@@ -895,8 +895,8 @@ TRAFODION_SCAN         T10         3.333E+004   100000 fragm
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          3.333E+004   100000 fragm   
-TRAFODION_SCAN         T10         3.333E+004   100000 fragm   
+ROOT                          3.300E+001   100 fragment   
+TRAFODION_SCAN    T10         3.300E+001   100 fragment   
 
 --- 2 row(s) selected.
 >>
@@ -909,8 +909,8 @@ TRAFODION_SCAN         T10         3.333E+004   100000 fragm
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          3.333E+004   100000 fragm   
-TRAFODION_SCAN         T10         3.333E+004   100000 fragm   
+ROOT                          3.300E+001   100 fragment   
+TRAFODION_SCAN    T10         3.300E+001   100 fragment   
 
 --- 2 row(s) selected.
 >>
@@ -923,8 +923,8 @@ TRAFODION_SCAN         T10         3.333E+004   100000 fragm
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          9.000E+004   100000 fragm   
-TRAFODION_SCAN         T10         9.000E+004   100000 fragm   
+ROOT                          5.000E+001   100 fragment   
+TRAFODION_SCAN    T10         5.000E+001   100 fragment   
 
 --- 2 row(s) selected.
 >>
@@ -938,7 +938,7 @@ OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
 ROOT                          1.000E+000   1 fragment_i   
-TRAFODION_SCAN         T10         1.000E+000   1 fragment_i   
+TRAFODION_SCAN    T10         1.000E+000   1 fragment_i   
 
 --- 2 row(s) selected.
 >>
@@ -951,8 +951,8 @@ TRAFODION_SCAN         T10         1.000E+000   1 fragment_i
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          1.000E+005   100000 fragm   
-TRAFODION_SCAN         T10         1.000E+005   100000 fragm   
+ROOT                          1.000E+002   100 fragment   
+TRAFODION_SCAN    T10         1.000E+002   100 fragment   
 
 --- 2 row(s) selected.
 >>
@@ -966,7 +966,7 @@ OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
 ROOT                          1.000E+000   1 fragment_i   
-TRAFODION_SCAN         T10         1.000E+000   1 fragment_i   
+TRAFODION_SCAN    T10         1.000E+000   1 fragment_i   
 
 --- 2 row(s) selected.
 >>
@@ -979,8 +979,8 @@ TRAFODION_SCAN         T10         1.000E+000   1 fragment_i
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          1.000E+005   100000 fragm   
-TRAFODION_SCAN         T10         1.000E+005   100000 fragm   
+ROOT                          9.900E+001   100 fragment   
+TRAFODION_SCAN    T10         9.900E+001   100 fragment   
 
 --- 2 row(s) selected.
 >>
@@ -993,8 +993,8 @@ TRAFODION_SCAN         T10         1.000E+005   100000 fragm
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          5.000E+004   100000 fragm   
-TRAFODION_SCAN         T10         5.000E+004   100000 fragm   
+ROOT                          5.000E+001   100 fragment   
+TRAFODION_SCAN    T10         5.000E+001   100 fragment   
 
 --- 2 row(s) selected.
 >>
@@ -1007,8 +1007,8 @@ TRAFODION_SCAN         T10         5.000E+004   100000 fragm
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          3.333E+004   100000 fragm   
-TRAFODION_SCAN         T10         3.333E+004   100000 fragm   
+ROOT                          3.300E+001   100 fragment   
+TRAFODION_SCAN    T10         3.300E+001   100 fragment   
 
 --- 2 row(s) selected.
 >>
@@ -1021,8 +1021,8 @@ TRAFODION_SCAN         T10         3.333E+004   100000 fragm
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          3.333E+004   100000 fragm   
-TRAFODION_SCAN         T10         3.333E+004   100000 fragm   
+ROOT                          3.300E+001   100 fragment   
+TRAFODION_SCAN    T10         3.300E+001   100 fragment   
 
 --- 2 row(s) selected.
 >>
@@ -1035,8 +1035,8 @@ TRAFODION_SCAN         T10         3.333E+004   100000 fragm
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          3.333E+004   100000 fragm   
-TRAFODION_SCAN         T10         3.333E+004   100000 fragm   
+ROOT                          3.300E+001   100 fragment   
+TRAFODION_SCAN    T10         3.300E+001   100 fragment   
 
 --- 2 row(s) selected.
 >>
@@ -1049,8 +1049,8 @@ TRAFODION_SCAN         T10         3.333E+004   100000 fragm
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          3.333E+004   100000 fragm   
-TRAFODION_SCAN         T10         3.333E+004   100000 fragm   
+ROOT                          3.300E+001   100 fragment   
+TRAFODION_SCAN    T10         3.300E+001   100 fragment   
 
 --- 2 row(s) selected.
 >>
@@ -1063,8 +1063,8 @@ TRAFODION_SCAN         T10         3.333E+004   100000 fragm
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          5.000E+004   100000 fragm   
-TRAFODION_SCAN         T10         5.000E+004   100000 fragm   
+ROOT                          5.000E+001   100 fragment   
+TRAFODION_SCAN    T10         5.000E+001   100 fragment   
 
 --- 2 row(s) selected.
 >>
@@ -1077,8 +1077,8 @@ TRAFODION_SCAN         T10         5.000E+004   100000 fragm
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          3.000E+000   3 fragment_i   
-TRAFODION_SCAN         T10         3.000E+000   3 fragment_i   
+ROOT                          1.500E+001   15 fragment_   
+TRAFODION_SCAN    T10         1.100E+001   11 fragment_   
 
 --- 2 row(s) selected.
 >>
@@ -1091,8 +1091,8 @@ TRAFODION_SCAN         T10         3.000E+000   3 fragment_i
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          5.000E+004   50000 fragme   
-TRAFODION_SCAN         T10         5.000E+004   50000 fragme   
+ROOT                          1.100E+001   78 fragment_   
+TRAFODION_SCAN    T10         1.100E+001   78 fragment_   
 
 --- 2 row(s) selected.
 >>
@@ -1106,7 +1106,7 @@ OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
 ROOT                          1.000E+000   1 fragment_i   
-TRAFODION_SCAN_UNIQUE  T10         1.000E+000   1 fragment_i   
+TRAFODION_SCAN    T10         1.000E+000   1 fragment_i   
 
 --- 2 row(s) selected.
 >>
@@ -1120,7 +1120,7 @@ OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
 ROOT                          1.000E+000   1 fragment_i   
-TRAFODION_SCAN_UNIQUE  T10         1.000E+000   1 fragment_i   
+TRAFODION_SCAN    T10         1.000E+000   1 fragment_i   
 
 --- 2 row(s) selected.
 >>
@@ -1133,8 +1133,8 @@ TRAFODION_SCAN_UNIQUE  T10         1.000E+000   1 fragment_i
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          1.000E+004   10001 fragme   
-TRAFODION_SCAN         T10         1.000E+004   10001 fragme   
+ROOT                          1.100E+001   51 fragment_   
+TRAFODION_SCAN    T10         1.100E+001   51 fragment_   
 
 --- 2 row(s) selected.
 >>
@@ -1147,8 +1147,8 @@ TRAFODION_SCAN         T10         1.000E+004   10001 fragme
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          1.000E+004   10001 fragme   
-TRAFODION_SCAN         T10         1.000E+004   10001 fragme   
+ROOT                          7.500E+001   100 fragment   
+TRAFODION_SCAN    T10         7.500E+001   100 fragment   
 
 --- 2 row(s) selected.
 >>
@@ -1161,7 +1161,7 @@ OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
 ROOT                          1.000E+000   1 fragment_i   
-TRAFODION_SCAN_UNIQUE  T10         1.000E+000   1 fragment_i   
+TRAFODION_SCAN    T10         1.000E+000   1 fragment_i   
 
 --- 2 row(s) selected.
 >> -- min(1e5, 1) should = 1
@@ -1174,8 +1174,8 @@ TRAFODION_SCAN_UNIQUE  T10         1.000E+000   1 fragment_i
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          1.250E+004   12500 fragme   
-TRAFODION_SCAN         T10         1.250E+004   12500 fragme   
+ROOT                          1.300E+001   50 fragment_   
+TRAFODION_SCAN    T10         1.300E+001   50 fragment_   
 
 --- 2 row(s) selected.
 >> -- min(1e5, 1e4) should = 1e4
@@ -1189,7 +1189,7 @@ OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
 ROOT                          1.000E+000   1 fragment_i   
-TRAFODION_SCAN_UNIQUE  T10         1.000E+000   1 fragment_i   
+TRAFODION_SCAN    T10         1.000E+000   1 fragment_i   
 
 --- 2 row(s) selected.
 >> -- min(1e5, 1) should = 1
@@ -1202,8 +1202,8 @@ TRAFODION_SCAN_UNIQUE  T10         1.000E+000   1 fragment_i
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          1.000E+000   10000 fragme   
-TRAFODION_SCAN         T10         1.000E+000   10000 fragme   
+ROOT                          1.000E+001   99 fragment_   
+TRAFODION_SCAN    T10         1.000E+001   99 fragment_   
 
 --- 2 row(s) selected.
 >> -- min(1e4, 1e5) should = 1e4
@@ -1220,8 +1220,8 @@ TRAFODION_SCAN         T10         1.000E+000   10000 fragme
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          2.000E+002   200 fragment   
-TRAFODION_SCAN         T10         2.000E+002   200 fragment   
+ROOT                          2.000E+001   100 fragment   
+TRAFODION_SCAN    T10         2.000E+001   100 fragment   
 
 --- 2 row(s) selected.
 >>-- maxSel("b in (1,2)") is min(maxSel("b=1")+maxSel("b=2"),1.)
@@ -1234,8 +1234,8 @@ TRAFODION_SCAN         T10         2.000E+002   200 fragment
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          2.000E+000   3 fragment_i   
-TRAFODION_SCAN         T10         2.000E+000   3 fragment_i   
+ROOT                          3.000E+000   3 fragment_i   
+TRAFODION_SCAN    T10         2.000E+000   2 fragment_i   
 
 --- 2 row(s) selected.
 >> -- maxSel(p1 and p2) is min(maxSel(p1), maxSel(p2))
@@ -1248,8 +1248,8 @@ TRAFODION_SCAN         T10         2.000E+000   3 fragment_i
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          2.030E+002   203 fragment   
-TRAFODION_SCAN         T10         2.030E+002   203 fragment   
+ROOT                          2.700E+001   100 fragment   
+TRAFODION_SCAN    T10         2.700E+001   100 fragment   
 
 --- 2 row(s) selected.
 >> -- maxSel(p1 or p2) is min(maxSel(p1)+maxSel(p2),1)
@@ -1265,10 +1265,10 @@ TRAFODION_SCAN         T10         2.030E+002   203 fragment
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-NESTED_JOIN                   1.000E+001   10 fragment_   
-ROOT                          1.000E+001   10 fragment_   
-TRAFODION_SCAN         T1          1.000E+001   10 fragment_   
-TRAFODION_SCAN_UNIQUE  T10         1.000E+000   10 fragment_   
+HYBRID_HASH_JOIN              1.000E+002   100 fragment   
+ROOT                          1.000E+002   100 fragment   
+TRAFODION_SCAN    T1          1.000E+002   100 fragment   
+TRAFODION_SCAN    T10         1.000E+002   100 fragment   
 
 --- 4 row(s) selected.
 >>
@@ -1281,10 +1281,10 @@ TRAFODION_SCAN_UNIQUE  T10         1.000E+000   10 fragment_
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-HYBRID_HASH_JOIN              1.000E+003   1000 fragmen   
-ROOT                          1.000E+003   1000 fragmen   
-TRAFODION_SCAN         T1          1.000E+001   10 fragment_   
-TRAFODION_SCAN         T10         1.000E+005   100000 fragm   
+HYBRID_HASH_JOIN              1.000E+002   100 fragment   
+ROOT                          1.000E+002   100 fragment   
+TRAFODION_SCAN    T1          1.000E+002   100 fragment   
+TRAFODION_SCAN    T10         1.000E+002   100 fragment   
 
 --- 4 row(s) selected.
 >>
@@ -1297,13 +1297,12 @@ TRAFODION_SCAN         T10         1.000E+005   100000 fragm
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-TRAFODION_SCAN_UNIQUE  T10         1.000E+000   10 fragment_   
-NESTED_JOIN                   1.000E+001   10 fragment_   
-PROBE_CACHE                   1.000E+000   10 fragment_   
-ROOT                          1.000E+001   10 fragment_   
-TRAFODION_SCAN         T1          1.000E+001   10 fragment_   
+HYBRID_HASH_JOIN              1.000E+002   100 fragment   
+ROOT                          1.000E+002   100 fragment   
+TRAFODION_SCAN    T1          1.000E+002   100 fragment   
+TRAFODION_SCAN    T10         1.000E+002   100 fragment   
 
---- 5 row(s) selected.
+--- 4 row(s) selected.
 >>
 >>-- test max cardinality for equi-joins where one side is complex
 >>prepare xx from
@@ -1315,10 +1314,10 @@ TRAFODION_SCAN         T1          1.000E+001   10 fragment_
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-HYBRID_HASH_JOIN              1.000E+003   1000 fragmen   
-ROOT                          1.000E+003   1000 fragmen   
-TRAFODION_SCAN         T10         1.000E+005   100000 fragm   
-TRAFODION_SCAN         T8          1.000E+003   1000 fragmen   
+HYBRID_HASH_JOIN              1.000E+002   100 fragment   
+ROOT                          1.000E+002   100 fragment   
+TRAFODION_SCAN    T10         1.000E+002   100 fragment   
+TRAFODION_SCAN    T8          1.000E+002   100 fragment   
 
 --- 4 row(s) selected.
 >>
@@ -1331,10 +1330,10 @@ TRAFODION_SCAN         T8          1.000E+003   1000 fragmen
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-HYBRID_HASH_JOIN              1.000E+005   100000 fragm   
-ROOT                          1.000E+005   100000 fragm   
-TRAFODION_SCAN         T10         1.000E+005   100000 fragm   
-TRAFODION_SCAN         T9          1.000E+004   10000 fragme   
+HYBRID_HASH_JOIN              1.000E+002   100 fragment   
+ROOT                          1.000E+002   100 fragment   
+TRAFODION_SCAN    T10         1.000E+002   100 fragment   
+TRAFODION_SCAN    T9          1.000E+002   100 fragment   
 
 --- 4 row(s) selected.
 >>
@@ -1347,10 +1346,10 @@ TRAFODION_SCAN         T9          1.000E+004   10000 fragme
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-HYBRID_HASH_JOIN              1.000E+006   1e+006 fragm   
-ROOT                          1.000E+006   1e+006 fragm   
-TRAFODION_SCAN         T10         1.000E+005   100000 fragm   
-TRAFODION_SCAN         T9          1.000E+004   10000 fragme   
+HYBRID_HASH_JOIN              5.000E+003   5000 fragmen   
+ROOT                          5.000E+003   5000 fragmen   
+TRAFODION_SCAN    T10         1.000E+002   100 fragment   
+TRAFODION_SCAN    T9          1.000E+002   100 fragment   
 
 --- 4 row(s) selected.
 >>
@@ -1368,8 +1367,8 @@ TRAFODION_SCAN         T9          1.000E+004   10000 fragme
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-ROOT                          1.000E+005   100000 fragm   
-TRAFODION_SCAN         T10         1.000E+005   100000 fragm   
+ROOT                          1.000E+002   100 fragment   
+TRAFODION_SCAN    T10         1.000E+002   100 fragment   
 
 --- 2 row(s) selected.
 >>select count(*) from (SELECT a,b,c,d FROM t10 GROUP BY a,b,c,d) as t;
@@ -1390,9 +1389,9 @@ TRAFODION_SCAN         T10         1.000E+005   100000 fragm
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-HASH_GROUPBY                  1.000E+005   100000 fragm   
-ROOT                          1.000E+005   100000 fragm   
-TRAFODION_SCAN         T10         1.000E+005   100000 fragm   
+HASH_GROUPBY                  8.000E+000   8 fragment_i   
+ROOT                          8.000E+000   8 fragment_i   
+TRAFODION_SCAN    T10         1.000E+002   100 fragment   
 
 --- 3 row(s) selected.
 >>select count(*) from (SELECT b,c,d FROM t10 GROUP BY b,c,d) as t;
@@ -1413,9 +1412,9 @@ TRAFODION_SCAN         T10         1.000E+005   100000 fragm
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-HASH_PARTIAL_GRO              1.000E+002   100 fragment   
-ROOT                          1.000E+002   100 fragment   
-TRAFODION_SCAN         T10         1.000E+005   100000 fragm   
+HASH_GROUPBY                  4.000E+000   4 fragment_i   
+ROOT                          4.000E+000   4 fragment_i   
+TRAFODION_SCAN    T10         1.000E+002   100 fragment   
 
 --- 3 row(s) selected.
 >>select count(*) from (SELECT c,d FROM t10 GROUP BY c,d) as t;
@@ -1436,9 +1435,9 @@ TRAFODION_SCAN         T10         1.000E+005   100000 fragm
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-HASH_PARTIAL_GRO              1.000E+001   10 fragment_   
-ROOT                          1.000E+001   10 fragment_   
-TRAFODION_SCAN         T10         1.000E+005   100000 fragm   
+HASH_GROUPBY                  2.000E+000   2 fragment_i   
+ROOT                          2.000E+000   2 fragment_i   
+TRAFODION_SCAN    T10         1.000E+002   100 fragment   
 
 --- 3 row(s) selected.
 >>select count(*) from (SELECT d FROM t10 GROUP BY d) as t;
@@ -1463,7 +1462,7 @@ OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 
 ROOT                          1.000E+000   1 fragment_i   
 SORT_SCALAR_AGGR              1.000E+000   1 fragment_i   
-TRAFODION_SCAN         T10         1.000E+002   100 fragment   
+TRAFODION_SCAN    T10         1.000E+001   99 fragment_   
 
 --- 3 row(s) selected.
 >>prepare xx from SELECT count(*) FROM t10 where c = 1;
@@ -1476,7 +1475,7 @@ OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 
 ROOT                          1.000E+000   1 fragment_i   
 SORT_SCALAR_AGGR              1.000E+000   1 fragment_i   
-TRAFODION_SCAN         T10         1.000E+003   1000 fragmen   
+TRAFODION_SCAN    T10         1.000E+001   99 fragment_   
 
 --- 3 row(s) selected.
 >>prepare xx from SELECT count(*) FROM t10 where b = 1 and c = 1;
@@ -1489,7 +1488,7 @@ OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 
 ROOT                          1.000E+000   1 fragment_i   
 SORT_SCALAR_AGGR              1.000E+000   1 fragment_i   
-TRAFODION_SCAN         T10         1.000E+000   100 fragment   
+TRAFODION_SCAN    T10         1.000E+000   99 fragment_   
 
 --- 3 row(s) selected.
 >>
@@ -1505,7 +1504,7 @@ OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 
 ROOT                          1.000E+000   1 fragment_i   
 SORT_SCALAR_AGGR              1.000E+000   1 fragment_i   
-TRAFODION_SCAN         T10         1.000E+003   1000 fragmen   
+TRAFODION_SCAN    T10         3.300E+001   50 fragment_   
 
 --- 3 row(s) selected.
 >>execute xx;
@@ -1527,7 +1526,7 @@ OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 
 ROOT                          1.000E+000   1 fragment_i   
 SORT_SCALAR_AGGR              1.000E+000   1 fragment_i   
-TRAFODION_SCAN         T10         1.000E+003   1000 fragmen   
+TRAFODION_SCAN    T10         3.300E+001   50 fragment_   
 
 --- 3 row(s) selected.
 >>execute xx;
@@ -1583,11 +1582,11 @@ TRAFODION_SCAN         T10         1.000E+003   1000 fragmen
 OPERATOR          TAB_NAME    CARDINALITY  MAX_CARDINALITY
 ----------------  ----------  -----------  ---------------
 
-HYBRID_HASH_JOIN              1.000E+004   10000 fragme   
+HYBRID_HASH_JOIN              1.000E+002   100 fragment   
 ROOT                          1.000E+000   1 fragment_i   
-SORT_PARTIAL_AGG              1.000E+000   1 fragment_i   
-TRAFODION_SCAN         T10         1.000E+005   100000 fragm   
-TRAFODION_SCAN         T9          1.000E+004   10000 fragme   
+SORT_SCALAR_AGGR              1.000E+000   1 fragment_i   
+TRAFODION_SCAN    T10         1.000E+002   100 fragment   
+TRAFODION_SCAN    T9          1.000E+002   100 fragment   
 
 --- 5 row(s) selected.
 >>execute xx;
@@ -1775,7 +1774,7 @@ join_method: hash (cross product)
 (EXPR)                           
 ---------------------------------
 
-join_method: hash  parallel_join_
+join_method: hash hash_join_predi
 
 --- 1 row(s) selected.
 >>
@@ -1794,11 +1793,11 @@ SYSTEM
 
 --- SQL operation complete.
 >>showcontrol default risk_premium_nj, match full, no header;
-1.2
+1.0
 
 --- SQL operation complete.
 >>showcontrol default risk_premium_serial, match full, no header;
-1.2
+1.0
 
 --- SQL operation complete.
 >>showcontrol default partitioning_scheme_sharing, match full, no header;
@@ -2109,11 +2108,11 @@ SYSTEM
 
 --- SQL operation complete.
 >>showcontrol default risk_premium_nj, match full, no header;
-1.2
+1.0
 
 --- SQL operation complete.
 >>showcontrol default risk_premium_serial, match full, no header;
-1.2
+1.0
 
 --- SQL operation complete.
 >>showcontrol default partitioning_scheme_sharing, match full, no header;
@@ -2256,7 +2255,7 @@ OPERATOR
 ----------------
 
 ROOT            
-NESTED_JOIN     
+HYBRID_HASH_JOIN
 
 --- 2 row(s) selected.
 >>
@@ -2269,7 +2268,7 @@ OPERATOR
 ----------------
 
 ROOT            
-NESTED_JOIN     
+HYBRID_HASH_JOIN
 
 --- 2 row(s) selected.
 >>
@@ -2283,7 +2282,7 @@ OPERATOR
 ----------------
 
 ROOT            
-NESTED_JOIN     
+HYBRID_HASH_JOIN
 
 --- 2 row(s) selected.
 >>
@@ -2687,12 +2686,7 @@ A            B
 --- SQL command prepared.
 >>execute explainIt;
 
-OPERATOR        
-----------------
-
-TUPLELIST       
-
---- 1 row(s) selected.
+--- 0 row(s) selected.
 >>execute XX;
 
 A            B            C          
@@ -2730,12 +2724,7 @@ A            B            C
 --- SQL command prepared.
 >>execute explainIt;
 
-OPERATOR        
-----------------
-
-TUPLELIST       
-
---- 1 row(s) selected.
+--- 0 row(s) selected.
 >>execute XX;
 
 A            B            C          
@@ -2760,7 +2749,7 @@ A            B            C
 +>select cast(tname as char(30)) tname,
 +>substring(description from position('mdam_disjunct' in description) + 15 for 30) mdam_disjunct
 +>from table(explain(NULL, 'XX'))
-+>where operator in ('TRAFODION_SCAN') and position('mdam_disjunct' in description) > 0
++>where operator in ('FILE_SCAN') and position('mdam_disjunct' in description) > 0
 +>;
 
 --- SQL command prepared.
@@ -2791,12 +2780,7 @@ A            B            C
 >>
 >>execute mdam_reporter;
 
-TNAME                           MDAM_DISJUNCT                 
-------------------------------  ------------------------------
-
-C2 (CAT.MYHCUBE.CUBE2)          (B = count(1 )) and ((A = 1) o
-
---- 1 row(s) selected.
+--- 0 row(s) selected.
 >>execute plan_reporter;
 
 OPERATOR                      
@@ -2814,12 +2798,7 @@ NESTED_JOIN
 >>
 >>execute mdam_reporter;
 
-TNAME                           MDAM_DISJUNCT                 
-------------------------------  ------------------------------
-
-C2 (CAT.MYHCUBE.CUBE2)          (B = max(CAT.MYHCUBE.T0.A)) an
-
---- 1 row(s) selected.
+--- 0 row(s) selected.
 >>execute plan_reporter;
 
 OPERATOR                      
@@ -2837,12 +2816,7 @@ NESTED_JOIN
 >>
 >>execute mdam_reporter;
 
-TNAME                           MDAM_DISJUNCT                 
-------------------------------  ------------------------------
-
-C2 (CAT.MYHCUBE.CUBE2)          (B = sum(CAT.MYHCUBE.T0.B)) an
-
---- 1 row(s) selected.
+--- 0 row(s) selected.
 >>execute plan_reporter;
 
 OPERATOR                      
@@ -2860,12 +2834,7 @@ NESTED_JOIN
 >>
 >>execute mdam_reporter;
 
-TNAME                           MDAM_DISJUNCT                 
-------------------------------  ------------------------------
-
-C2 (CAT.MYHCUBE.CUBE2)          (B = 2) and ((A = 1) or (A = 3
-
---- 1 row(s) selected.
+--- 0 row(s) selected.
 >>execute plan_reporter;
 
 OPERATOR                      
@@ -2885,12 +2854,7 @@ NESTED_JOIN
 >>
 >>execute mdam_reporter;
 
-TNAME                           MDAM_DISJUNCT                 
-------------------------------  ------------------------------
-
-C2 (CAT.MYHCUBE.CUBE2)          ((A = 1) or (A = 3))          
-
---- 1 row(s) selected.
+--- 0 row(s) selected.
 >>execute plan_reporter;
 
 OPERATOR                      
@@ -2908,12 +2872,7 @@ HYBRID_HASH_JOIN
 >>
 >>execute mdam_reporter;
 
-TNAME                           MDAM_DISJUNCT                 
-------------------------------  ------------------------------
-
-C2 (CAT.MYHCUBE.CUBE2)          (B = 2) and ((A = 1) or (A = 3
-
---- 1 row(s) selected.
+--- 0 row(s) selected.
 >>execute plan_reporter;
 
 OPERATOR                      
@@ -2942,18 +2901,13 @@ HYBRID_HASH_JOIN
 >>
 >>execute mdam_reporter;
 
-TNAME                           MDAM_DISJUNCT                 
-------------------------------  ------------------------------
-
-C2 (CAT.MYHCUBE.CUBE2)          ((A = 1) or (A = 3))          
-
---- 1 row(s) selected.
+--- 0 row(s) selected.
 >>execute plan_reporter;
 
 OPERATOR                      
 ------------------------------
 
-HYBRID_HASH_JOIN              
+NESTED_JOIN                   
 
 --- 1 row(s) selected.
 >>
@@ -2965,18 +2919,13 @@ HYBRID_HASH_JOIN
 >>
 >>execute mdam_reporter;
 
-TNAME                           MDAM_DISJUNCT                 
-------------------------------  ------------------------------
-
-C2 (CAT.MYHCUBE.CUBE2)          ((A = 1) or (A = 3))          
-
---- 1 row(s) selected.
+--- 0 row(s) selected.
 >>execute plan_reporter;
 
 OPERATOR                      
 ------------------------------
 
-HYBRID_HASH_JOIN              
+NESTED_JOIN                   
 
 --- 1 row(s) selected.
 >>
@@ -2988,18 +2937,13 @@ HYBRID_HASH_JOIN
 >>
 >>execute mdam_reporter;
 
-TNAME                           MDAM_DISJUNCT                 
-------------------------------  ------------------------------
-
-C2 (CAT.MYHCUBE.CUBE2)          ((A = 1) or (A = 3))          
-
---- 1 row(s) selected.
+--- 0 row(s) selected.
 >>execute plan_reporter;
 
 OPERATOR                      
 ------------------------------
 
-HYBRID_HASH_JOIN              
+NESTED_JOIN                   
 
 --- 1 row(s) selected.
 >>
@@ -3011,18 +2955,13 @@ HYBRID_HASH_JOIN
 >>
 >>execute mdam_reporter;
 
-TNAME                           MDAM_DISJUNCT                 
-------------------------------  ------------------------------
-
-C2 (CAT.MYHCUBE.CUBE2)          (B = 2) and ((A = 1) or (A = 3
-
---- 1 row(s) selected.
+--- 0 row(s) selected.
 >>execute plan_reporter;
 
 OPERATOR                      
 ------------------------------
 
-HYBRID_HASH_JOIN              
+NESTED_JOIN                   
 
 --- 1 row(s) selected.
 >>
@@ -3036,12 +2975,7 @@ HYBRID_HASH_JOIN
 >>
 >>execute mdam_reporter;
 
-TNAME                           MDAM_DISJUNCT                 
-------------------------------  ------------------------------
-
-C2 (CAT.MYHCUBE.CUBE2)          ((A = 1) or (A = 3))          
-
---- 1 row(s) selected.
+--- 0 row(s) selected.
 >>execute plan_reporter;
 
 OPERATOR                      
@@ -3059,12 +2993,7 @@ HYBRID_HASH_JOIN
 >>
 >>execute mdam_reporter;
 
-TNAME                           MDAM_DISJUNCT                 
-------------------------------  ------------------------------
-
-C2 (CAT.MYHCUBE.CUBE2)          (B = 2) and ((A = 1) or (A = 3
-
---- 1 row(s) selected.
+--- 0 row(s) selected.
 >>execute plan_reporter;
 
 OPERATOR                      
@@ -3096,12 +3025,7 @@ HYBRID_HASH_JOIN
 >>
 >>execute mdam_reporter;
 
-TNAME                           MDAM_DISJUNCT                 
-------------------------------  ------------------------------
-
-C2 (CAT.MYHCUBE.CUBE2)          (B = count(1 )) and ((A = 1) o
-
---- 1 row(s) selected.
+--- 0 row(s) selected.
 >>execute plan_reporter;
 
 OPERATOR                      
@@ -3119,12 +3043,7 @@ NESTED_JOIN
 >>
 >>execute mdam_reporter;
 
-TNAME                           MDAM_DISJUNCT                 
-------------------------------  ------------------------------
-
-C2 (CAT.MYHCUBE.CUBE2)          (B = max(CAT.MYHCUBE.T0.A)) an
-
---- 1 row(s) selected.
+--- 0 row(s) selected.
 >>execute plan_reporter;
 
 OPERATOR                      
@@ -3142,12 +3061,7 @@ NESTED_JOIN
 >>
 >>execute mdam_reporter;
 
-TNAME                           MDAM_DISJUNCT                 
-------------------------------  ------------------------------
-
-C2 (CAT.MYHCUBE.CUBE2)          (B = sum(CAT.MYHCUBE.T0.B)) an
-
---- 1 row(s) selected.
+--- 0 row(s) selected.
 >>execute plan_reporter;
 
 OPERATOR                      
@@ -3165,12 +3079,7 @@ NESTED_JOIN
 >>
 >>execute mdam_reporter;
 
-TNAME                           MDAM_DISJUNCT                 
-------------------------------  ------------------------------
-
-C2 (CAT.MYHCUBE.CUBE2)          (B = 2) and ((A = 1) or (A = 3
-
---- 1 row(s) selected.
+--- 0 row(s) selected.
 >>execute plan_reporter;
 
 OPERATOR                      
@@ -3190,12 +3099,7 @@ NESTED_JOIN
 >>
 >>execute mdam_reporter;
 
-TNAME                           MDAM_DISJUNCT                 
-------------------------------  ------------------------------
-
-C2 (CAT.MYHCUBE.CUBE2)          ((A = 1) or (A = 3))          
-
---- 1 row(s) selected.
+--- 0 row(s) selected.
 >>execute plan_reporter;
 
 OPERATOR                      
@@ -3213,12 +3117,7 @@ HYBRID_HASH_JOIN
 >>
 >>execute mdam_reporter;
 
-TNAME                           MDAM_DISJUNCT                 
-------------------------------  ------------------------------
-
-C2 (CAT.MYHCUBE.CUBE2)          (B = 2) and ((A = 1) or (A = 3
-
---- 1 row(s) selected.
+--- 0 row(s) selected.
 >>execute plan_reporter;
 
 OPERATOR                      

--- a/core/sql/regress/seabase/EXPECTED040
+++ b/core/sql/regress/seabase/EXPECTED040
@@ -1,0 +1,338 @@
+>>
+>>-- set-up
+>>
+>>?section set_up
+>>
+>>create table t040salt(a int not null, b int not null, c int, primary key (a,b))
++> salt using 4 partitions;
+
+--- SQL operation complete.
+>>
+>>showddl t040salt;
+
+CREATE TABLE TRAFODION.SCH.T040SALT
+  (
+    A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
+  , B                                INT NO DEFAULT NOT NULL NOT DROPPABLE
+  , C                                INT DEFAULT NULL
+  , PRIMARY KEY (A ASC, B ASC)
+  )
+  SALT USING 4 PARTITIONS
+;
+
+--- SQL operation complete.
+>>
+>>create table t040nosalt(a int not null, b int not null, c int, primary key (a,b));
+
+--- SQL operation complete.
+>>
+>>showddl t040nosalt;
+
+CREATE TABLE TRAFODION.SCH.T040NOSALT
+  (
+    A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
+  , B                                INT NO DEFAULT NOT NULL NOT DROPPABLE
+  , C                                INT DEFAULT NULL
+  , PRIMARY KEY (A ASC, B ASC)
+  )
+;
+
+--- SQL operation complete.
+>>
+>>-- positive tests
+>>
+>>?section positive_tests
+>>
+>>create table t040salt1 like t040salt without salt;
+
+--- SQL operation complete.
+>>
+>>showddl t040salt1;
+
+CREATE TABLE TRAFODION.SCH.T040SALT1
+  (
+    A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
+  , B                                INT NO DEFAULT NOT NULL NOT DROPPABLE
+  , C                                INT DEFAULT NULL
+  , PRIMARY KEY (A ASC, B ASC)
+  )
+;
+
+--- SQL operation complete.
+>>
+>>create table t040salt5 like t040salt salt using 5 partitions;
+
+--- SQL operation complete.
+>>
+>>showddl t040salt5;
+
+CREATE TABLE TRAFODION.SCH.T040SALT5
+  (
+    A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
+  , B                                INT NO DEFAULT NOT NULL NOT DROPPABLE
+  , C                                INT DEFAULT NULL
+  , PRIMARY KEY (A ASC, B ASC)
+  )
+  SALT USING 5 PARTITIONS
+;
+
+--- SQL operation complete.
+>>
+>>create table t040salt6 like t040salt salt using 6 partitions on (a);
+
+--- SQL operation complete.
+>>
+>>showddl t040salt6;
+
+CREATE TABLE TRAFODION.SCH.T040SALT6
+  (
+    A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
+  , B                                INT NO DEFAULT NOT NULL NOT DROPPABLE
+  , C                                INT DEFAULT NULL
+  , PRIMARY KEY (A ASC, B ASC)
+  )
+  SALT USING 6 PARTITIONS
+       ON (A)
+;
+
+--- SQL operation complete.
+>>
+>>create table t040salt7 like t040salt salt using 7 partitions on (b);
+
+--- SQL operation complete.
+>>
+>>showddl t040salt7;
+
+CREATE TABLE TRAFODION.SCH.T040SALT7
+  (
+    A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
+  , B                                INT NO DEFAULT NOT NULL NOT DROPPABLE
+  , C                                INT DEFAULT NULL
+  , PRIMARY KEY (A ASC, B ASC)
+  )
+  SALT USING 7 PARTITIONS
+       ON (B)
+;
+
+--- SQL operation complete.
+>>
+>>create table t040salt8 like t040salt salt using 8 partitions on (a,b);
+
+--- SQL operation complete.
+>>
+>>showddl t040salt8;
+
+CREATE TABLE TRAFODION.SCH.T040SALT8
+  (
+    A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
+  , B                                INT NO DEFAULT NOT NULL NOT DROPPABLE
+  , C                                INT DEFAULT NULL
+  , PRIMARY KEY (A ASC, B ASC)
+  )
+  SALT USING 8 PARTITIONS
+;
+
+--- SQL operation complete.
+>>
+>>create table t040nosalt1 like t040nosalt without salt;
+
+--- SQL operation complete.
+>>
+>>showddl t040nosalt1;
+
+CREATE TABLE TRAFODION.SCH.T040NOSALT1
+  (
+    A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
+  , B                                INT NO DEFAULT NOT NULL NOT DROPPABLE
+  , C                                INT DEFAULT NULL
+  , PRIMARY KEY (A ASC, B ASC)
+  )
+;
+
+--- SQL operation complete.
+>>
+>>create table t040nosalt4 like t040nosalt salt using 4 partitions;
+
+--- SQL operation complete.
+>>
+>>showddl t040nosalt4;
+
+CREATE TABLE TRAFODION.SCH.T040NOSALT4
+  (
+    A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
+  , B                                INT NO DEFAULT NOT NULL NOT DROPPABLE
+  , C                                INT DEFAULT NULL
+  , PRIMARY KEY (A ASC, B ASC)
+  )
+  SALT USING 4 PARTITIONS
+;
+
+--- SQL operation complete.
+>>
+>>create table t040saltsame like t040salt;
+
+--- SQL operation complete.
+>>
+>>showddl t040saltsame;
+
+CREATE TABLE TRAFODION.SCH.T040SALTSAME
+  (
+    A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
+  , B                                INT NO DEFAULT NOT NULL NOT DROPPABLE
+  , C                                INT DEFAULT NULL
+  , PRIMARY KEY (A ASC, B ASC)
+  )
+  SALT USING 4 PARTITIONS
+;
+
+--- SQL operation complete.
+>>
+>>create table t040nosaltsame like t040nosalt;
+
+--- SQL operation complete.
+>>
+>>showddl t040nosaltsame;
+
+CREATE TABLE TRAFODION.SCH.T040NOSALTSAME
+  (
+    A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
+  , B                                INT NO DEFAULT NOT NULL NOT DROPPABLE
+  , C                                INT DEFAULT NULL
+  , PRIMARY KEY (A ASC, B ASC)
+  )
+;
+
+--- SQL operation complete.
+>>
+>>-- negative tests
+>>
+>>?section negative_tests
+>>
+>>-- non-key column, should fail
+>>create table t040saltbad1 like t040salt salt using 5 partitions on (c);
+
+*** ERROR[1195] Column C is not allowed as a salt column. Only primary key columns or STORE BY columns are allowed.
+
+--- SQL operation failed with errors.
+>>
+>>-- non-existent column, should fail
+>>create table t040saltbad2 like t040salt salt using 5 partitions on (d);
+
+*** ERROR[1195] Column D is not allowed as a salt column. Only primary key columns or STORE BY columns are allowed.
+
+--- SQL operation failed with errors.
+>>
+>>-- should fail with error 3154
+>>create table t040saltbad3 like t040salt without salt salt using 4 partitions;
+
+*** ERROR[3154] The WITHOUT SALT clause is not allowed with the SALT clause.
+
+*** ERROR[8822] The statement was not prepared.
+
+>>
+>>-- should fail, duplicate clauses
+>>create table t040saltbad4 like t040salt without salt without salt;
+
+*** ERROR[3152] Duplicate WITHOUT SALT phrases were specified in LIKE clause in CREATE TABLE statement.
+
+*** ERROR[8822] The statement was not prepared.
+
+>>
+>>-- and now an extravaganza of errors
+>>create table t040saltbad5 like t040salt salt using 4 partitions without salt salt using 7 partitions;
+
+*** ERROR[3154] The WITHOUT SALT clause is not allowed with the SALT clause.
+
+*** ERROR[3183] Duplicate SALT clauses were specified.
+
+*** ERROR[3154] The WITHOUT SALT clause is not allowed with the SALT clause.
+
+*** ERROR[8822] The statement was not prepared.
+
+>>
+>>-- syntax error; clause not supported with LIKE
+>>create table t040saltbad6 like t040salt store by (b);
+
+*** ERROR[15001] A syntax error occurred at or before: 
+create table t040saltbad6 like t040salt store by (b);
+                                            ^ (45 characters from start of SQL statement)
+
+*** ERROR[8822] The statement was not prepared.
+
+>>
+>>?section clean_up
+>>
+>>-- clean up
+>>
+>>drop table if exists t040salt;
+
+--- SQL operation complete.
+>>
+>>drop table if exists t040nosalt;
+
+--- SQL operation complete.
+>>
+>>drop table if exists t040salt1;
+
+--- SQL operation complete.
+>>
+>>drop table if exists t040salt5;
+
+--- SQL operation complete.
+>>
+>>drop table if exists t040salt6;
+
+--- SQL operation complete.
+>>
+>>drop table if exists t040salt7;
+
+--- SQL operation complete.
+>>
+>>drop table if exists t040salt8;
+
+--- SQL operation complete.
+>>
+>>drop table if exists t040nosalt1;
+
+--- SQL operation complete.
+>>
+>>drop table if exists t040nosalt4;
+
+--- SQL operation complete.
+>>
+>>drop table if exists t040saltsame;
+
+--- SQL operation complete.
+>>
+>>drop table if exists t040nosaltsame;
+
+--- SQL operation complete.
+>>
+>>drop table if exists t040saltbad1;
+
+--- SQL operation complete.
+>>
+>>drop table if exists t040saltbad2;
+
+--- SQL operation complete.
+>>
+>>drop table if exists t040saltbad3;
+
+--- SQL operation complete.
+>>
+>>drop table if exists t040saltbad4;
+
+--- SQL operation complete.
+>>
+>>drop table if exists t040saltbad5;
+
+--- SQL operation complete.
+>>
+>>drop table if exists t040saltbad6;
+
+--- SQL operation complete.
+>>
+>>exit;
+
+End of MXCI Session
+

--- a/core/sql/regress/seabase/EXPECTED040
+++ b/core/sql/regress/seabase/EXPECTED040
@@ -1,7 +1,19 @@
 >>
+>>?section set_up
+>>
 >>-- set-up
 >>
->>?section set_up
+>>drop schema if exists t040sch cascade;
+
+--- SQL operation complete.
+>>
+>>create schema t040sch;
+
+--- SQL operation complete.
+>>
+>>set schema t040sch;
+
+--- SQL operation complete.
 >>
 >>create table t040salt(a int not null, b int not null, c int, primary key (a,b))
 +> salt using 4 partitions;
@@ -10,7 +22,7 @@
 >>
 >>showddl t040salt;
 
-CREATE TABLE TRAFODION.SCH.T040SALT
+CREATE TABLE TRAFODION.T040SCH.T040SALT
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
   , B                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -28,7 +40,7 @@ CREATE TABLE TRAFODION.SCH.T040SALT
 >>
 >>showddl t040nosalt;
 
-CREATE TABLE TRAFODION.SCH.T040NOSALT
+CREATE TABLE TRAFODION.T040SCH.T040NOSALT
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
   , B                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -39,9 +51,9 @@ CREATE TABLE TRAFODION.SCH.T040NOSALT
 
 --- SQL operation complete.
 >>
->>-- positive tests
->>
 >>?section positive_tests
+>>
+>>-- positive tests
 >>
 >>create table t040salt1 like t040salt without salt;
 
@@ -49,7 +61,7 @@ CREATE TABLE TRAFODION.SCH.T040NOSALT
 >>
 >>showddl t040salt1;
 
-CREATE TABLE TRAFODION.SCH.T040SALT1
+CREATE TABLE TRAFODION.T040SCH.T040SALT1
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
   , B                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -66,7 +78,7 @@ CREATE TABLE TRAFODION.SCH.T040SALT1
 >>
 >>showddl t040salt5;
 
-CREATE TABLE TRAFODION.SCH.T040SALT5
+CREATE TABLE TRAFODION.T040SCH.T040SALT5
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
   , B                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -84,7 +96,7 @@ CREATE TABLE TRAFODION.SCH.T040SALT5
 >>
 >>showddl t040salt6;
 
-CREATE TABLE TRAFODION.SCH.T040SALT6
+CREATE TABLE TRAFODION.T040SCH.T040SALT6
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
   , B                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -103,7 +115,7 @@ CREATE TABLE TRAFODION.SCH.T040SALT6
 >>
 >>showddl t040salt7;
 
-CREATE TABLE TRAFODION.SCH.T040SALT7
+CREATE TABLE TRAFODION.T040SCH.T040SALT7
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
   , B                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -122,7 +134,7 @@ CREATE TABLE TRAFODION.SCH.T040SALT7
 >>
 >>showddl t040salt8;
 
-CREATE TABLE TRAFODION.SCH.T040SALT8
+CREATE TABLE TRAFODION.T040SCH.T040SALT8
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
   , B                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -140,7 +152,7 @@ CREATE TABLE TRAFODION.SCH.T040SALT8
 >>
 >>showddl t040nosalt1;
 
-CREATE TABLE TRAFODION.SCH.T040NOSALT1
+CREATE TABLE TRAFODION.T040SCH.T040NOSALT1
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
   , B                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -157,7 +169,7 @@ CREATE TABLE TRAFODION.SCH.T040NOSALT1
 >>
 >>showddl t040nosalt4;
 
-CREATE TABLE TRAFODION.SCH.T040NOSALT4
+CREATE TABLE TRAFODION.T040SCH.T040NOSALT4
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
   , B                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -175,7 +187,7 @@ CREATE TABLE TRAFODION.SCH.T040NOSALT4
 >>
 >>showddl t040saltsame;
 
-CREATE TABLE TRAFODION.SCH.T040SALTSAME
+CREATE TABLE TRAFODION.T040SCH.T040SALTSAME
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
   , B                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -193,7 +205,7 @@ CREATE TABLE TRAFODION.SCH.T040SALTSAME
 >>
 >>showddl t040nosaltsame;
 
-CREATE TABLE TRAFODION.SCH.T040NOSALTSAME
+CREATE TABLE TRAFODION.T040SCH.T040NOSALTSAME
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
   , B                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -204,9 +216,9 @@ CREATE TABLE TRAFODION.SCH.T040NOSALTSAME
 
 --- SQL operation complete.
 >>
->>-- negative tests
->>
 >>?section negative_tests
+>>
+>>-- negative tests
 >>
 >>-- non-key column, should fail
 >>create table t040saltbad1 like t040salt salt using 5 partitions on (c);
@@ -260,79 +272,4 @@ create table t040saltbad6 like t040salt store by (b);
 *** ERROR[8822] The statement was not prepared.
 
 >>
->>?section clean_up
->>
->>-- clean up
->>
->>drop table if exists t040salt;
-
---- SQL operation complete.
->>
->>drop table if exists t040nosalt;
-
---- SQL operation complete.
->>
->>drop table if exists t040salt1;
-
---- SQL operation complete.
->>
->>drop table if exists t040salt5;
-
---- SQL operation complete.
->>
->>drop table if exists t040salt6;
-
---- SQL operation complete.
->>
->>drop table if exists t040salt7;
-
---- SQL operation complete.
->>
->>drop table if exists t040salt8;
-
---- SQL operation complete.
->>
->>drop table if exists t040nosalt1;
-
---- SQL operation complete.
->>
->>drop table if exists t040nosalt4;
-
---- SQL operation complete.
->>
->>drop table if exists t040saltsame;
-
---- SQL operation complete.
->>
->>drop table if exists t040nosaltsame;
-
---- SQL operation complete.
->>
->>drop table if exists t040saltbad1;
-
---- SQL operation complete.
->>
->>drop table if exists t040saltbad2;
-
---- SQL operation complete.
->>
->>drop table if exists t040saltbad3;
-
---- SQL operation complete.
->>
->>drop table if exists t040saltbad4;
-
---- SQL operation complete.
->>
->>drop table if exists t040saltbad5;
-
---- SQL operation complete.
->>
->>drop table if exists t040saltbad6;
-
---- SQL operation complete.
->>
->>exit;
-
-End of MXCI Session
-
+>>log;

--- a/core/sql/regress/seabase/TEST040
+++ b/core/sql/regress/seabase/TEST040
@@ -1,0 +1,139 @@
+-- test for CREATE TABLE LIKE
+--
+-- @@@ START COPYRIGHT @@@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+-- @@@ END COPYRIGHT @@@
+
+set schema $$TEST_SCHEMA$$;
+log LOG040 clear;
+
+-- set-up
+
+?section set_up
+
+create table t040salt(a int not null, b int not null, c int, primary key (a,b))
+ salt using 4 partitions;
+
+showddl t040salt;
+
+create table t040nosalt(a int not null, b int not null, c int, primary key (a,b));
+
+showddl t040nosalt;
+
+-- positive tests
+
+?section positive_tests
+
+create table t040salt1 like t040salt without salt;
+
+showddl t040salt1;
+
+create table t040salt5 like t040salt salt using 5 partitions;
+
+showddl t040salt5;
+
+create table t040salt6 like t040salt salt using 6 partitions on (a);
+
+showddl t040salt6;
+
+create table t040salt7 like t040salt salt using 7 partitions on (b);
+
+showddl t040salt7;
+
+create table t040salt8 like t040salt salt using 8 partitions on (a,b);
+
+showddl t040salt8;
+
+create table t040nosalt1 like t040nosalt without salt;
+
+showddl t040nosalt1;
+
+create table t040nosalt4 like t040nosalt salt using 4 partitions;
+
+showddl t040nosalt4;
+
+create table t040saltsame like t040salt;
+
+showddl t040saltsame;
+
+create table t040nosaltsame like t040nosalt;
+
+showddl t040nosaltsame;
+
+-- negative tests
+
+?section negative_tests
+
+-- non-key column, should fail
+create table t040saltbad1 like t040salt salt using 5 partitions on (c);
+
+-- non-existent column, should fail
+create table t040saltbad2 like t040salt salt using 5 partitions on (d);
+
+-- should fail with error 3154
+create table t040saltbad3 like t040salt without salt salt using 4 partitions;
+
+-- should fail, duplicate clauses
+create table t040saltbad4 like t040salt without salt without salt;
+
+-- and now an extravaganza of errors
+create table t040saltbad5 like t040salt salt using 4 partitions without salt salt using 7 partitions;
+
+-- syntax error; clause not supported with LIKE
+create table t040saltbad6 like t040salt store by (b);
+
+?section clean_up
+
+-- clean up
+
+drop table if exists t040salt;
+
+drop table if exists t040nosalt;
+
+drop table if exists t040salt1;
+
+drop table if exists t040salt5;
+
+drop table if exists t040salt6;
+
+drop table if exists t040salt7;
+
+drop table if exists t040salt8;
+
+drop table if exists t040nosalt1;
+
+drop table if exists t040nosalt4;
+
+drop table if exists t040saltsame;
+
+drop table if exists t040nosaltsame;
+
+drop table if exists t040saltbad1;
+
+drop table if exists t040saltbad2;
+
+drop table if exists t040saltbad3;
+
+drop table if exists t040saltbad4;
+
+drop table if exists t040saltbad5;
+
+drop table if exists t040saltbad6;
+

--- a/core/sql/regress/seabase/TEST040
+++ b/core/sql/regress/seabase/TEST040
@@ -21,12 +21,17 @@
 --
 -- @@@ END COPYRIGHT @@@
 
-set schema $$TEST_SCHEMA$$;
 log LOG040 clear;
+
+?section set_up
 
 -- set-up
 
-?section set_up
+drop schema if exists t040sch cascade;
+
+create schema t040sch;
+
+set schema t040sch;
 
 create table t040salt(a int not null, b int not null, c int, primary key (a,b))
  salt using 4 partitions;
@@ -37,9 +42,9 @@ create table t040nosalt(a int not null, b int not null, c int, primary key (a,b)
 
 showddl t040nosalt;
 
--- positive tests
-
 ?section positive_tests
+
+-- positive tests
 
 create table t040salt1 like t040salt without salt;
 
@@ -77,9 +82,9 @@ create table t040nosaltsame like t040nosalt;
 
 showddl t040nosaltsame;
 
--- negative tests
-
 ?section negative_tests
+
+-- negative tests
 
 -- non-key column, should fail
 create table t040saltbad1 like t040salt salt using 5 partitions on (c);
@@ -99,41 +104,12 @@ create table t040saltbad5 like t040salt salt using 4 partitions without salt sal
 -- syntax error; clause not supported with LIKE
 create table t040saltbad6 like t040salt store by (b);
 
+log;
+
 ?section clean_up
 
 -- clean up
 
-drop table if exists t040salt;
+drop schema if exists t040sch cascade;
 
-drop table if exists t040nosalt;
-
-drop table if exists t040salt1;
-
-drop table if exists t040salt5;
-
-drop table if exists t040salt6;
-
-drop table if exists t040salt7;
-
-drop table if exists t040salt8;
-
-drop table if exists t040nosalt1;
-
-drop table if exists t040nosalt4;
-
-drop table if exists t040saltsame;
-
-drop table if exists t040nosaltsame;
-
-drop table if exists t040saltbad1;
-
-drop table if exists t040saltbad2;
-
-drop table if exists t040saltbad3;
-
-drop table if exists t040saltbad4;
-
-drop table if exists t040saltbad5;
-
-drop table if exists t040saltbad6;
 

--- a/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
@@ -374,11 +374,17 @@ void CmpSeabaseDDL::createSeabaseTableLike(
         done = TRUE;
     }
 
-    if (NOT keyClause.isNull())
-      {
-        // add the keyClause
-        query += keyClause;
-      }
+  if (NOT keyClause.isNull())
+    {
+      // add the keyClause
+      query += keyClause;
+    }
+
+  const NAString * saltClause = likeOptions.getSaltClause();
+  if (saltClause)
+    {
+      query += saltClause->data();
+    }
 
   // send any user CQDs down 
   Lng32 retCode = sendAllControls(FALSE, FALSE, TRUE);

--- a/docs/messages_guide/src/asciidoc/_chapters/parser_msgs.adoc
+++ b/docs/messages_guide/src/asciidoc/_chapters/parser_msgs.adoc
@@ -2116,6 +2116,19 @@ partitioning, which is not supported.
 
 *Recovery:* Correct the syntax and resubmit.
 
+[[SQL-3154]]
+== SQL 3154
+
+```
+The <clause-name-1> clause is not allowed with the <clause-name-2> clause.
+```
+
+*Cause:* You attempted to use two mutually exclusive clauses, which is not supported.
+
+*Effect:* The operation fails.
+
+*Recovery:* Correct the syntax and resubmit.
+
 <<<
 [[SQL-3155]]
 == SQL 3155

--- a/docs/messages_guide/src/asciidoc/_chapters/sqlstate.adoc
+++ b/docs/messages_guide/src/asciidoc/_chapters/sqlstate.adoc
@@ -1379,6 +1379,7 @@ Suggestion: a) Inspect the CQS in effect; or b) Raise the optimization level to 
 | 42000    | -3150   | Duplicate WITH HEADING phrases in LIKE clause in CREATE TABLE statement.
 | 42000    | -3151   | Duplicate WITH HORIZONTAL PARTITIONS phrases in LIKE clause in CREATE TABLE statement.
 | 42000    | -3153   | The FIRST KEY clause is not allowed with hash partitioning.
+| 42000    | -3154   | The <clause-name-1> clause is not allowed with the <clause-name-2> clause.
 | 42000    | -3155   | The POPULATE and NO POPULATE clauses cannot coexist in the same CREATE INDEX statement.
 | 42000    | -3157   | Catalog name is required.
 | 42000    | -3159   | If you intended <name> to be a character set specifier for a character string literal, you must remove the spaces in front of the single quote delimiter.

--- a/docs/sql_reference/src/asciidoc/_chapters/sql_statements.adoc
+++ b/docs/sql_reference/src/asciidoc/_chapters/sql_statements.adoc
@@ -2235,12 +2235,18 @@ session.
 
 ```
 CREATE [VOLATILE] TABLE IF NOT EXISTS table
-    { table-spec | like-spec }
+    table-spec
     [SALT USING num PARTITIONS [ON (column[, column]...)]]
     [STORE BY {PRIMARY KEY | (key-column-list)}]
-    [HBASEOPTIONS (hbase-options-list)]
+    [HBASE_OPTIONS (hbase-options-list)]
     [LOAD IF EXISTS | NO LOAD]
     [AS select-query]
+
+CREATE [VOLATILE] TABLE IF NOT EXISTS table
+    like-spec
+    [SALT USING num PARTITIONS [ON (column[, column]...)]]
+
+Note: Support for SALT on CREATE TABLE LIKE is added in Trafodion release 2.1.
 
 table-spec is:
     (table-element [,table-element]...)
@@ -2313,7 +2319,7 @@ key-column-list is:
     [,column-name [ASC[ENDING] | DESC[ENDING]]]...
 
 like-spec is:
-    LIKE source-table [include-option]
+    LIKE source-table [include-option]...
 
 hbase-options-list is:
     hbase-option = 'value'[, hbase-option = 'value']...
@@ -2341,6 +2347,10 @@ pre-splits the table into multiple regions when the table is created. Salting ad
 prefix, thus avoiding hot spots for sequential keys. The number of partitions that you specify can be a function of the
 number of region servers present in the HBase cluster. You can specify a number from 2 to 1024. If you do not specify
 columns, the default is to use all primary key columns.
++
+If SALT is specified with LIKE, then this specification overrides that of the _source-table_. Note:
+this is a new feature in Trafodion 2.1. In earlier releases, the SALT clause is ignored if specified
+with LIKE.
 
 <<<
 * `STORE BY { PRIMARY KEY | (_key-column-list_)}`
@@ -2455,8 +2465,7 @@ See <<null,Null>>.
 * `UNIQUE, or, UNIQUE (_column-list_)`
 +
 is a column or table constraint, respectively, that specifies that the column or set of columns cannot contain more than
-one occurrence of the same value or set of values. If you omit UNIQUE, duplicate values are allowed unless the column is
-part of the PRIMARY KEY.
+one occurrence of the same value or set of values. If you omit UNIQUE, duplicate values are allowed unless the column or set of columns is the PRIMARY KEY.
 
 ** _column-list_ cannot include more than one occurrence of the same column. In addition, the set of columns that you
 specify on a UNIQUE constraint cannot match the set of columns on any other UNIQUE constraint for the table or on the
@@ -2544,6 +2553,19 @@ as its original _source-table_ counterpart. The new table partitions do not inhe
 Instead, {project-name} SQL generates new names based on the physical file location.
 +
 If you specify the LIKE clause and the SALT USING _num_ PARTITIONS clause, you cannot specify WITH PARTITIONS.
+
+*** `WITHOUT DIVISION`
++
+directs {project-name} SQL to not use divisioning from _source-table_. If this clause is omitted, then 
+the _table_ will have the same divisioning as the _source-table_.
+
+*** `WITHOUT SALT`
++
+directs {project-name} SQL to not use salting for _table_. If this clause is omitted,
+and no SALT clause is specified,
+the _table_ will have the same divisioning as the _source-table_.
++
+This option cannot be specified if a SALT clause is also specified.
 
 <<<
 [[create_table_considerations]]

--- a/docs/sql_reference/src/asciidoc/_chapters/sql_statements.adoc
+++ b/docs/sql_reference/src/asciidoc/_chapters/sql_statements.adoc
@@ -323,8 +323,7 @@ ALTER TABLE name alter-action
 
 alter-action is:
 
-     ADD [COLUMN] column-definition
-   | ADD IF NOT EXISTS column-definition
+     ADD [IF NOT EXISTS][COLUMN] column-definition
    | ADD [CONSTRAINT constraint-name] table-constraint
    | DROP CONSTRAINT constraint-name [RESTRICT]
    | RENAME TO new-name [CASCADE]
@@ -2234,7 +2233,7 @@ this statement, AUTOCOMMIT must be turned ON (the default) for the
 session.
 
 ```
-CREATE [VOLATILE] TABLE IF NOT EXISTS table
+CREATE [VOLATILE] TABLE [IF NOT EXISTS] table
     table-spec
     [SALT USING num PARTITIONS [ON (column[, column]...)]]
     [STORE BY {PRIMARY KEY | (key-column-list)}]
@@ -2242,7 +2241,7 @@ CREATE [VOLATILE] TABLE IF NOT EXISTS table
     [LOAD IF EXISTS | NO LOAD]
     [AS select-query]
 
-CREATE [VOLATILE] TABLE IF NOT EXISTS table
+CREATE [VOLATILE] TABLE [IF NOT EXISTS] table
     like-spec
     [SALT USING num PARTITIONS [ON (column[, column]...)]]
 


### PR DESCRIPTION
Formerly, several clauses (examples: SALT and STORE BY) were allowed on CREATE TABLE LIKE, but were ignored. So, for example, one could say, "CREATE TABLE t2 LIKE t1 SALT USING 6 PARTITIONS", but t2 would end up getting the same salting as t1 instead.

With this change, the parser has been changed so that, except for SALT, specifying these clauses will now result in a syntax error.

For the SALT clause, it is now fully supported with CREATE TABLE LIKE. So, in our example above, t2 would get 6 partitions, and would be salted on the primary key.

A new regression test, seabase/TEST040, has been added to cover this support. The manuals have also been updated, and a few unrelated corrections in CREATE TABLE have been made also.

This pull request also updates the expected results for regression test compGeneral/TEST015, which has been failing for a little while. This change is unrelated to the rest of the changes.