### PR TITLE
[TRAFODION-1128]Remove current catalog& schema check

### DIFF
--- a/core/sql/sqlcomp/CmpSeabaseDDLindex.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLindex.cpp
@@ -1911,12 +1911,6 @@ void CmpSeabaseDDL::alterSeabaseTableDisableOrEnableAllIndexes(
   const NAString schemaNamePart = tableName.getSchemaNamePartAsAnsiString(TRUE);
   const NAString objectNamePart = tableName.getObjectNamePartAsAnsiString(TRUE);
 
-  // If you try to perform an alter table <table> disable/enable all constraints
-  // and the current schema does not match the schema where the table resides, the
-  // following CMPASSERT will fail.
-  CMPASSERT (catalogNamePart == currCatName);
-  CMPASSERT (schemaNamePart == currSchName);
-
   ExeCliInterface cliInterface(STMTHEAP, NULL, NULL, 
        CmpCommon::context()->sqlSession()->getParentQid());
 


### PR DESCRIPTION
Have check the code context that it's useless to check current catalog and schema. As the comments, it's used for alter table but it has nothing about current catalog and schema against my testing.