### PR TITLE
Fixes for TRAFODION-2068 and TRAFODION-2082

### DIFF
--- a/core/conn/Makefile
+++ b/core/conn/Makefile
@@ -34,7 +34,7 @@ endif
 .PHONY: all
 all: pkg-clients
 
-pkg-clients: clients/LICENSE clients/NOTICE
+pkg-clients: clients/LICENSE clients/NOTICE clients/DISCLAIMER
 	mkdir -p $$(dirname $(CLIENT_TAR))
 	tar -zcvf $(CLIENT_TAR) clients
 
@@ -45,6 +45,9 @@ clients/LICENSE: ../../licenses/LICENSE-clients
 	cd $(@D) && $(MAKE) $(@F)
 
 clients/NOTICE: ../../NOTICE
+	cp -f $? $@
+
+clients/DISCLAIMER: ../../DISCLAIMER
 	cp -f $? $@
 
 clean:	

--- a/core/sql/common/swscanf.cpp
+++ b/core/sql/common/swscanf.cpp
@@ -1,4 +1,6 @@
-/* -*-C++-*- 
+/* -*-C++-*-
+ * $OpenBSD: vfscanf.c,v 1.21 2006/01/13 21:33:28 millert Exp $ 
+ *-
  * Copyright (c) 1990, 1993
  *	The Regents of the University of California.  All rights reserved.
  *
@@ -13,11 +15,7 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 3. All advertising materials mentioning features or use of this software
- *    must display the following acknowledgement:
- *	This product includes software developed by the University of
- *	California, Berkeley and its contributors.
- * 4. Neither the name of the University nor the names of its contributors
+ * 3. Neither the name of the University nor the names of its contributors
  *    may be used to endorse or promote products derived from this software
  *    without specific prior written permission.
  *
@@ -39,7 +37,7 @@
   * File:         swscanf.h
   * Description:  SQL/MX wide-char swscanf() function, modified based on 
   *               NetBSD __svfscanf.c found at 
-  *               http://www.ajk.tele.fi/libc/stdio/vfscanf.c.html#__svfscanf
+  *               http://ftp.stu.edu.tw/BSD/OpenBSD/src/lib/libc/stdio/vfscanf.c
   * Created:      2/13/2002
   * Language:     C++
   * Limitation:   
@@ -49,8 +47,6 @@
   *
   *****************************************************************************
  */
-
-//LCOV_EXCL_START  // Used only by .../sqlutils/metamigr/MIGRATE.cpp which is not used in SQ
 
 /* commented out the useless static data structure.*/
 //#if defined(LIBC_SCCS) && !defined(lint)
@@ -864,5 +860,4 @@ Int32 na_swscanf(const NAWchar *str, NAWchar const *fmt, ...)
 	va_end(ap);
 	return (ret);
 }
-//LCOV_EXCL_STOP // Used only by .../sqlutils/metamigr/MIGRATE.cpp which is not used in SQ
 

--- a/core/sql/common/swsprintf.cpp
+++ b/core/sql/common/swsprintf.cpp
@@ -1,7 +1,8 @@
 /* -*-C++-*-
+ * $OpenBSD: sprintf.c,v 1.13 2005/10/10 12:00:52 espie Exp $ 
  *-
- * Copyright (c) 1990 The Regents of the University of California.
- * All rights reserved.
+ * Copyright (c) 1990, 1993
+ *	The Regents of the University of California.  All rights reserved.
  *
  * This code is derived from software contributed to Berkeley by
  * Chris Torek.
@@ -14,11 +15,7 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 3. All advertising materials mentioning features or use of this software
- *    must display the following acknowledgement:
- *	This product includes software developed by the University of
- *	California, Berkeley and its contributors.
- * 4. Neither the name of the University nor the names of its contributors
+ * 3. Neither the name of the University nor the names of its contributors
  *    may be used to endorse or promote products derived from this software
  *    without specific prior written permission.
  *
@@ -34,14 +31,11 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
-
-/*	$NetBSD: vfprintf.c,v 1.18 1997/04/02 12:50:25 kleink Exp $	*/
-
 /*****************************************************************************
  *
  * File:         swsprintf.h
  * Description:  SQL/MX wide-char swsprintf() function, adapted from NetBSD vfprintf.c
- *               found at http://www.ajk.tele.fi/libc/stdio/vfprintf.c.html#vfprintf.
+ *               found at http://ftp.stu.edu.tw/BSD/OpenBSD/src/lib/libc/stdio/sprintf.c 
  * Created:      2/13/2002
  * Language:     C++
  * Limitation:   Floating point numbers are not supported. 

--- a/install/Makefile
+++ b/install/Makefile
@@ -26,7 +26,7 @@ RELEASE_VER ?= 1.0.0_v002
 
 all: pkg-installer 
 
-pkg-installer: installer/LICENSE installer/NOTICE
+pkg-installer: installer/LICENSE installer/NOTICE installer/DISCLAIMER
 	tar czf installer-$(RELEASE_VER).tar.gz installer --exclude=tools
 
 installer/LICENSE: ../licenses/LICENSE-install
@@ -36,6 +36,9 @@ installer/LICENSE: ../licenses/LICENSE-install
 	cd $(@D) && $(MAKE) $(@F)
 
 installer/NOTICE: ../NOTICE
+	cp -f $? $@
+
+installer/DISCLAIMER: ../DISCLAIMER
 	cp -f $? $@
 
 version:

--- a/licenses/lic-server-src
+++ b/licenses/lic-server-src
@@ -3,30 +3,25 @@ The core component of Apache Trafodion uses several BSD-like and MIT-like licens
 
 +++++++++++++++++++++++++++++
 
-BSD-4 clause for files:
+BSD-3 clause for files:
    incubator-trafodion/core/sql/common/swsprintf.cpp
    incubator-trafodion/core/sql/common/swscanf.cpp
 
-The third clause of this license has since been rescinded. See the
-Historical Background section at https://opensource.org/licenses/BSD-3-Clause.
+Copyright (c) 1990, 1993
+   The Regents of the University of California.  All rights reserved.
 
- Copyright (c) 1990 The Regents of the University of California.
- Copyright (c) 1990, 1993 The Regents of the University of California.
- This code is derived from software contributed to Berkeley by Chris Torek.
+ This code is derived from software contributed to Berkeley by
+ Chris Torek.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
  are met:
  1. Redistributions of source code must retain the above copyright
     notice, this list of conditions and the following disclaimer.
- 2. Redistributions in binary form must reproduce the above copyright
+. Redistributions in binary form must reproduce the above copyright
     notice, this list of conditions and the following disclaimer in the
     documentation and/or other materials provided with the distribution.
- 3. All advertising materials mentioning features or use of this software
-    must display the following acknowledgement:
-      This product includes software developed by the University of
-      California, Berkeley and its contributors.
- 4. Neither the name of the University nor the names of its contributors
+ 3. Neither the name of the University nor the names of its contributors
     may be used to endorse or promote products derived from this software
     without specific prior written permission.
 


### PR DESCRIPTION
TRAFODION-2068: Missing DISCLAIMER files for release package
TRAFODION-2082: BSD-4 license for swsprintf and swscanf unclear

Added DISCLAIMER file to clients and installer packages
Updated BSD license text in swsprintf.cpp and swscanf.cpp