### PR TITLE
JIRA TRAFODION-2084 Handling of invalid data inserts into hive tables

### DIFF
--- a/core/sql/bin/SqlciErrors.txt
+++ b/core/sql/bin/SqlciErrors.txt
@@ -593,7 +593,7 @@
 2076 21000 99999 BEGINNER MAJOR DBADMIN HIST_NO_STATS_UEC should always be less than or equal to CQD HIST_NO_STATS_ROWCOUNT. Present Value of HIST_NO_STATS_ROWCOUNT is $0~string0.
 2077 ZZZZZ 99999 BEGINNER MINOR DBADMIN The max size $0~int0 must be greater than the initial size $1~int1.
 2078 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Assertion failure during semantic query optimization ($0~string0) in file $1~string1 at line $2~int0. Attempting to recover and produce a plan.
-2079 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Error occurred during initialization of NADefaults structure. Make sure that default constants specified in enum DefaultConstants are set up correctly in defaultDefaults[] array.
+2079 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Error occurred during initialization of NADefaults structure. Make sure that default constants specified in enum DefaultConstants are specified in defaultDefaults[] array, are in alphabetical order and the default values are valid.
 2080 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Error $3~int2 while reading file: $2~int1 bytes were read from $0~string0 when $1~int0 were expected in module $4~string1.
 2081 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Error $1~int0 while opening file $0~string0 for read.
 2082 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Error $1~int0 while opening file $0~string0 for write.

--- a/core/sql/comexe/ComTdbFastTransport.h
+++ b/core/sql/comexe/ComTdbFastTransport.h
@@ -72,7 +72,8 @@ public:
     PRINT_DIAGS                 = 0x0100,
     HDFS_COMPRESSED             = 0x0200,
     SKIP_WRITING_TO_FILES       = 0x0400,
-    BYPASS_LIBHDFS              = 0x0800
+    BYPASS_LIBHDFS              = 0x0800,
+    CONTINUE_ON_ERROR           = 0x1000
   };
 
   ComTdbFastExtract ()
@@ -365,6 +366,11 @@ public:
     return ((flags_ & BYPASS_LIBHDFS) != 0);
   }
 
+  void setContinueOnError(NABoolean value)
+  { value ? flags_ |= CONTINUE_ON_ERROR : flags_ &= ~CONTINUE_ON_ERROR; }
+  NABoolean getContinueOnError() const
+  { return ((flags_ & CONTINUE_ON_ERROR) != 0); }
+  
   NA_EIDPROC inline const char *getTargetName() const { return targetName_; }
   NA_EIDPROC inline const char *getHdfsHostName() const { return hdfsHostName_; }
   NA_EIDPROC inline const Int32 getHdfsPortNum() const {return (Int32)hdfsPortNum_;}

--- a/core/sql/executor/ExFastTransport.cpp
+++ b/core/sql/executor/ExFastTransport.cpp
@@ -986,9 +986,19 @@ ExWorkProcRetcode ExHdfsFastExtractTcb::work()
 
           if (expStatus == ex_expr::EXPR_ERROR)
           {
-            updateWorkATPDiagsArea(centry);
-            pstate.step_ = EXTRACT_ERROR;
-            break;
+            if (myTdb().getContinueOnError())
+              {
+                // ignore this row and continue to the next row
+                if (workAtp_->getDiagsArea())
+                  workAtp_->getDiagsArea()->clear();
+                break;
+              }
+            else
+              {
+                updateWorkATPDiagsArea(centry);
+                pstate.step_ = EXTRACT_ERROR;
+                break;
+              }
           }
         } // if (myTdb().getChildDataExpr())
         ///////////////////////

--- a/core/sql/regress/hive/EXPECTED005
+++ b/core/sql/regress/hive/EXPECTED005
@@ -2,6 +2,7 @@
 >>set schema hive.hive;
 
 --- SQL operation complete.
+>>
 >>set terminal_charset utf8;
 >>
 >>cqd AUTO_QUERY_RETRY_WARNINGS 'ON';
@@ -16,6 +17,7 @@
 >>cqd HIST_ROWCOUNT_REQUIRING_STATS '50000';
 
 --- SQL operation complete.
+>>
 >>------------------------------------------------------------
 >>-- Testing query plan invalidation in the compiler, but
 >>-- not the executor. Perform DML/DDL operations on a
@@ -548,16 +550,16 @@ C1           C2
 >>select * from tbl_bad;
 
 C1           C2                    C3                         C4               C5      C6                          C7                         C8
------------  --------------------  -------------------------  ---------------  ------  --------------------------  -------------------------  ------
+-----------  --------------------  -------------------------  ---------------  ------  --------------------------  -------------------------  ----
 
-          ?                     ?  c                                        ?       ?  ?                                                   ?       ?
-          ?                     ?  c                                        ?       ?  2017-01-01 10:10:10.000000   1.01000000000000000E+000       1
-          ?                     ?                                           ?       ?  ?                                                   ?       ?
-          1                     1  averylongstring            -1.0000000E+000       0  2017-01-01 10:10:10.000000   1.00010000000000000E+002       1
-          2                     2  good                        1.1000000E+000       2  2017-01-01 10:10:10.000000   2.00000000000000000E+002     100
-          3                     3  good                        1.0000000E+000       2  2017-01-01 10:10:10.000000   2.10000000000000000E+002      10
-          ?            4294967295  good                        3.3999999E+038       ?  2017-01-01 10:10:10.000000   1.69999999999999968E+308      10
-          0            9999999999  bad                                      ?       ?  ?                                                   ?       ?
+          ?                     ?  c                                        ?       ?  ?                                                   ?     ?
+          ?                     ?  c                                        ?       ?  2017-01-01 10:10:10.000000   1.01000000000000000E+000     1
+          ?                     ?                                           ?       ?  ?                                                   ?     ?
+          1                     1  averylongstring            -1.0000000E+000       0  2017-01-01 10:10:10.000000   1.00010000000000000E+002     1
+          2                     2  good                        1.1000000E+000       2  2017-01-01 10:10:10.000000   2.00000000000000000E+002   100
+          3                     3  good                        1.0000000E+000       2  2017-01-01 10:10:10.000000   2.10000000000000000E+002    10
+          ?            4294967295  good                        3.3999999E+038       ?  2017-01-01 10:10:10.000000   1.69999999999999968E+308    10
+          0            9999999999  bad                                      ?       ?  ?                                                   ?     ?
 
 --- 8 row(s) selected.
 >>cqd HIVE_SCAN_SPECIAL_MODE reset;
@@ -809,7 +811,7 @@ t005part.a	t005part.b	t005part.c
 
 *** ERROR[8442] Unable to access HDFS interface. Call to ExpLOBInterfaceEmptyDirectory returned error LOB_DIR_NAME_ERROR(535). Error detail 0.
 
-*** ERROR[8034] Truncation of hive table failed. Reason: specified partition does not exist
+*** ERROR[8035] Truncation of hive table failed. Reason: specified partition does not exist
 
 --- SQL operation failed with errors.
 >>
@@ -821,5 +823,160 @@ t005part.a	t005part.b	t005part.c
 
 *** ERROR[8822] The statement was not prepared.
 
+>>
+>>-- tests for hive insert error modes
+>>invoke hive.hive.thive_insert_smallint;
+
+-- Definition of hive table THIVE_INSERT_SMALLINT
+-- Definition current  Wed Jun 22 18:14:29 2016
+
+  (
+    A                                SMALLINT
+  )
+  /* stored as textfile */
+
+--- SQL operation complete.
+>>showddl hive.hive.thive_insert_smallint;
+
+/* Hive DDL */
+CREATE TABLE THIVE_INSERT_SMALLINT
+  (
+    A                                smallint
+  )
+  stored as textfile
+;
+
+--- SQL operation complete.
+>>
+>>truncate hive.hive.thive_insert_smallint;
+
+--- SQL operation complete.
+>>cqd hive_insert_error_mode '0';
+
+--- SQL operation complete.
+>>insert into hive.hive.thive_insert_smallint values (10), (11111111), (21), 
++>  (22222222);
+
+--- 4 row(s) inserted.
+>>select * from hive.hive.thive_insert_smallint;
+
+A     
+------
+
+    10
+
+*** ERROR[8411] A numeric overflow occurred during an arithmetic computation or data conversion. Conversion of Source Type:VARCHAR(REC_BYTE_V_ASCII,8 BYTES,ISO88591) Source Value:11111111 to Target Type:SMALLINT SIGNED(REC_BIN16_SIGNED).
+
+--- 1 row(s) selected.
+>>
+>>truncate hive.hive.thive_insert_smallint;
+
+--- SQL operation complete.
+>>cqd hive_insert_error_mode '1';
+
+--- SQL operation complete.
+>>insert into hive.hive.thive_insert_smallint values (10), (11111111), (21), 
++>  (22222222);
+
+*** ERROR[8411] A numeric overflow occurred during an arithmetic computation or data conversion. Source Type:INTEGER SIGNED(MBIN32S) Source Value:11111111 Target Type:LARGEINT(IBIN64S) Max Target Value:32767. Instruction:RANGE_HIGH_S32S64 Operation:RANGE_HIGH.
+
+--- 0 row(s) inserted.
+>>select * from hive.hive.thive_insert_smallint;
+
+--- 0 row(s) selected.
+>>
+>>truncate hive.hive.thive_insert_smallint;
+
+--- SQL operation complete.
+>>cqd hive_insert_error_mode '2';
+
+--- SQL operation complete.
+>>insert into hive.hive.thive_insert_smallint values (10), (11111111), (21), 
++>  (22222222);
+
+--- 2 row(s) inserted.
+>>select * from hive.hive.thive_insert_smallint;
+
+A     
+------
+
+    10
+    21
+
+--- 2 row(s) selected.
+>>
+>>truncate hive.hive.thive_insert_smallint;
+
+--- SQL operation complete.
+>>cqd hive_insert_error_mode '3';
+
+--- SQL operation complete.
+>>insert into hive.hive.thive_insert_smallint values (10), (11111111), (21), 
++>  (22222222);
+
+--- 4 row(s) inserted.
+>>select * from hive.hive.thive_insert_smallint;
+
+A     
+------
+
+    10
+     ?
+    21
+     ?
+
+--- 4 row(s) selected.
+>>
+>>cqd hive_max_string_length_in_bytes '2';
+
+--- SQL operation complete.
+>>invoke hive.hive.thive_insert_varchar;
+
+-- Definition of hive table THIVE_INSERT_VARCHAR
+-- Definition current  Wed Jun 22 18:14:36 2016
+
+  (
+    A                                VARCHAR(1 CHAR) CHARACTER SET UTF8 COLLATE
+      DEFAULT
+  , B                                VARCHAR(2 BYTES) CHARACTER SET UTF8
+      COLLATE DEFAULT
+  )
+  /* stored as textfile */
+
+--- SQL operation complete.
+>>showddl hive.hive.thive_insert_varchar;
+
+/* Hive DDL */
+CREATE TABLE THIVE_INSERT_VARCHAR
+  (
+    A                                varchar(1)
+  , B                                string
+  )
+  stored as textfile
+;
+
+--- SQL operation complete.
+>>cqd hive_insert_error_mode '1';
+
+--- SQL operation complete.
+>>truncate hive.hive.thive_insert_varchar;
+
+--- SQL operation complete.
+>>insert into hive.hive.thive_insert_varchar values ('abcddcba','efghijkl');
+
+--- 1 row(s) inserted.
+>>
+>>cqd hive_max_string_length_in_bytes '20';
+
+--- SQL operation complete.
+>>select * from hive.hive.thive_insert_varchar;
+
+A     B                   
+----  --------------------
+
+abcd  efghijkl            
+
+--- 1 row(s) selected.
+>>
 >>
 >>log;

--- a/core/sql/regress/hive/TEST005
+++ b/core/sql/regress/hive/TEST005
@@ -46,6 +46,7 @@ sh regrhadoop.ksh fs -rm   /user/hive/exttables/tbl_bad/*;
 
 --- setup Hive tables
 sh regrhive.ksh -v -f $REGRTSTDIR/TEST005_a.hive.sql;
+
 sh regrhadoop.ksh fs -put $REGRTSTDIR/tbl_utf8.data /user/hive/exttables/tbl_utf8;
 sh regrhadoop.ksh fs -put $REGRTSTDIR/tbl_type.data /user/hive/exttables/tbl_type;
 sh regrhadoop.ksh fs -put $REGRTSTDIR/tbl_gbk.data /user/hive/exttables/tbl_gbk;
@@ -56,12 +57,14 @@ sh regrhadoop.ksh fs -put $REGRTSTDIR/tbl_bad.data /user/hive/exttables/tbl_bad;
 log LOG005 clear;
 
 set schema hive.hive;
+
 set terminal_charset utf8;
 
 cqd AUTO_QUERY_RETRY_WARNINGS 'ON';
 cqd HIVE_MAX_STRING_LENGTH '25' ;
 cqd mode_seahive 'ON';
 cqd HIST_ROWCOUNT_REQUIRING_STATS '50000';
+
 ------------------------------------------------------------
 -- Testing query plan invalidation in the compiler, but
 -- not the executor. Perform DML/DDL operations on a
@@ -369,5 +372,44 @@ truncate hive.hive.t005part partition ('b=12');
 
 -- should return error
 purgedata hive.hive.thive;
+
+-- tests for hive insert error modes
+invoke hive.hive.thive_insert_smallint;
+showddl hive.hive.thive_insert_smallint;
+
+truncate hive.hive.thive_insert_smallint;
+cqd hive_insert_error_mode '0';
+insert into hive.hive.thive_insert_smallint values (10), (11111111), (21), 
+  (22222222);
+select * from hive.hive.thive_insert_smallint;
+
+truncate hive.hive.thive_insert_smallint;
+cqd hive_insert_error_mode '1';
+insert into hive.hive.thive_insert_smallint values (10), (11111111), (21), 
+  (22222222);
+select * from hive.hive.thive_insert_smallint;
+
+truncate hive.hive.thive_insert_smallint;
+cqd hive_insert_error_mode '2';
+insert into hive.hive.thive_insert_smallint values (10), (11111111), (21), 
+  (22222222);
+select * from hive.hive.thive_insert_smallint;
+
+truncate hive.hive.thive_insert_smallint;
+cqd hive_insert_error_mode '3';
+insert into hive.hive.thive_insert_smallint values (10), (11111111), (21), 
+  (22222222);
+select * from hive.hive.thive_insert_smallint;
+
+cqd hive_max_string_length_in_bytes '2';
+invoke hive.hive.thive_insert_varchar;
+showddl hive.hive.thive_insert_varchar;
+cqd hive_insert_error_mode '1';
+truncate hive.hive.thive_insert_varchar;
+insert into hive.hive.thive_insert_varchar values ('abcddcba','efghijkl');
+
+cqd hive_max_string_length_in_bytes '20';
+select * from hive.hive.thive_insert_varchar;
+
 
 log;

--- a/core/sql/regress/hive/TEST005_a.hive.sql
+++ b/core/sql/regress/hive/TEST005_a.hive.sql
@@ -201,3 +201,10 @@ ROW FORMAT DELIMITED
   FIELDS TERMINATED BY '|'
 LOCATION
 '/user/hive/exttables/tbl_bad';
+
+drop table thive_insert_smallint;
+create table thive_insert_smallint (a smallint);
+drop table thive_insert_varchar;
+create table thive_insert_varchar (a varchar(1), b string);
+
+

--- a/core/sql/regress/seabase/EXPECTED011
+++ b/core/sql/regress/seabase/EXPECTED011
@@ -1249,7 +1249,7 @@ a                     bbbbbbbbbb  c                                         dddd
 >>-- negative test
 >>create table t011t5 (a char(200000), b varchar(200000), c char(200000 bytes) character set utf8, d varchar(1000001 bytes) character set utf8);
 
-*** ERROR[4247] Specified size in bytes (1000001) exceeds the maximum size allowed (1000000) for column D.
+*** ERROR[4247] Specified size in bytes (1000001) exceeds the maximum size allowed (200000) for column D.
 
 --- SQL operation failed with errors.
 >>

--- a/core/sql/sqlcomp/DefaultConstants.h
+++ b/core/sql/sqlcomp/DefaultConstants.h
@@ -3833,6 +3833,15 @@ enum DefaultConstants
   // use info from external table created on this hive table
   HIVE_USE_EXT_TABLE_ATTRS,
 
+  // if 0, datatype error check is not done during inserts into hive tables.
+  //       Invalid values may get inserted.
+  // if 1, error check done, row is not inserted if conversion error,
+  //       and further processing stops.
+  // if 2, error check done, row is not inserted if conversion error,
+  //       and further processing continues.
+  // if 3, null inserted if conversion error, and processing continues.
+  HIVE_INSERT_ERROR_MODE,
+  
   // This enum constant must be the LAST one in the list; it's a count,
   // not an Attribute (it's not IN DefaultDefaults; it's the SIZE of it)!
   __NUM_DEFAULT_ATTRIBUTES

--- a/core/sql/sqlcomp/DefaultValidator.cpp
+++ b/core/sql/sqlcomp/DefaultValidator.cpp
@@ -706,6 +706,21 @@ Int32 ValidateNumericRange::validate( const char *value,
 	sprintf(minbuf, "%g", min_);
 	sprintf(maxbuf, "%g", max_);
       }
+
+      switch (attrEnum)
+        {
+        case HIVE_INSERT_ERROR_MODE:
+          {
+            sprintf(minbuf, "%u", 0);
+            sprintf(maxbuf, "%u", 3);
+          }
+          break;
+        default:
+          {
+            // do nothing
+          }
+        }
+      
       NAString range = NAString("[") + minbuf + "," + maxbuf + "]";
       *CmpCommon::diags() << DgSqlCode(ERRWARN(2056)) << DgString0(range);
     }

--- a/core/sql/sqlcomp/nadefaults.cpp
+++ b/core/sql/sqlcomp/nadefaults.cpp
@@ -1961,6 +1961,7 @@ SDDkwd__(EXE_DIAGNOSTIC_EVENTS,		"OFF"),
   DD_____(HIVE_FILE_CHARSET,                    ""),
   DD_____(HIVE_FILE_NAME,     "/hive/tpcds/customer/customer.dat" ),
   DD_____(HIVE_HDFS_STATS_LOG_FILE,             ""),
+  DDui___(HIVE_INSERT_ERROR_MODE,               "1"),
   DDint__(HIVE_LIB_HDFS_PORT_OVERRIDE,          "-1"),
   DDint__(HIVE_LOCALITY_BALANCE_LEVEL,          "0"),
   DDui___(HIVE_MAX_ESPS,                        "9999"),
@@ -4825,7 +4826,21 @@ Int32 NADefaults::validateFloat(const char *value, float &result,
 {
   Int32 n = -1;	// NT's scanf("%n") is not quite correct; hence this code-around
   sscanf(value, "%g%n", &result, &n);
-  if (n > 0 && value[n] == '\0') return TRUE;	// a valid float
+  if (n > 0 && value[n] == '\0') 
+    {
+      switch (attrEnum)
+        {
+        case HIVE_INSERT_ERROR_MODE:
+          {
+            Lng32 v = str_atoi(value, str_len(value));
+            if (v >= 0 && v <= 3)
+              return TRUE;
+          }
+          break;
+        default:
+          return TRUE;	// a valid float
+        }
+    }
 
   NAString v(value);
   NABoolean silentIf = (errOrWarn == SilentIfSYSTEM);
@@ -6578,12 +6593,13 @@ DefaultToken NADefaults::token(Int32 attrEnum,
 	  case '3':	return DF_MAXIMUM;
 	}
       // HBASE_FILTER_PREDS
-        if ((attrEnum == HBASE_FILTER_PREDS) && value.length()==1)
+      if ((attrEnum == HBASE_FILTER_PREDS) && value.length()==1)
       switch (*value.data()){
         case '0': return DF_OFF;
         case '1': return DF_MINIMUM;
         case '2': return DF_MEDIUM;
-        // in the future add DF_HIGH and DF_MAXIMUM when we implement more pushdown capabilities
+        // in the future add DF_HIGH and DF_MAXIMUM when we implement more 
+        // pushdown capabilities
       }
     if ( attrEnum == TEMPORARY_TABLE_HASH_PARTITIONS ||
          attrEnum == MVQR_REWRITE_CANDIDATES ||


### PR DESCRIPTION
cqd hive_insert_error_mode '<val>' has been added to control
insert behavior.
  if 0, datatype error check is not done during inserts into hive tables.
         Invalid values may get inserted.
         This is the behavior prior to this JIRA fix.
  if 1, error check done, row is not inserted if conversion error.
         Insertion stops. This is new default behavior.
  if 2, error check done, row is not inserted if conversion error.
         Insertion continues with next row
  if 3, null inserted if conversion error.
         Insertion processing continues. This is hive behavior.