### PR TITLE
TRAFODION [2056] Update installation documentation for Kerberos

### DIFF
--- a/docs/provisioning_guide/src/asciidoc/_chapters/about.adoc
+++ b/docs/provisioning_guide/src/asciidoc/_chapters/about.adoc
@@ -25,10 +25,10 @@
 
 = About This Document
 This guide describes how to provision the end-user {project-name} binaries on top of an existing Hadoop environment. This install allows you to store and query data using {project-name}, either via {project-name} clients
-(see {docs-url}/client_install/index.html[{project-name} Client Installation Guide] or via application code you write.
+(see {docs-url}/client_install/index.html[{project-name} Client Installation Guide]) or via application code you write.
 
 If you want to install a Trafodion developer-build environment, then please refer to the 
-http://trafodion.incubator.apache.org/contributing_redirect.html[Trafodion Contributor Guide] for instructions.
+http://trafodion.incubator.apache.org/contributing-redirect.html[Trafodion Contributor Guide] for instructions.
 
 == Intended Audience
 This guide assumes that you are well-versed in Linux and Hadoop administration. If you don't have such experience, then
@@ -53,7 +53,7 @@ Unless specifically qualified (bare-metal node, virtual-machine node, or cloud-n
 regardless of platform type.
 
 == New and Changed Information
-This is a new guide.
+This guide has been updated to include provisioning for LDAP and Kerberos.
 
 <<<
 == Notation Conventions

--- a/docs/provisioning_guide/src/asciidoc/_chapters/activate.adoc
+++ b/docs/provisioning_guide/src/asciidoc/_chapters/activate.adoc
@@ -84,6 +84,7 @@ Schemas in Catalog TRAFODION
 
 SEABASE
 _MD_
+_LIBMGR_
 _REPOS_
 
 --- SQL operation complete.

--- a/docs/provisioning_guide/src/asciidoc/_chapters/enable_security.adoc
+++ b/docs/provisioning_guide/src/asciidoc/_chapters/enable_security.adoc
@@ -26,25 +26,100 @@
 [[enable-security]]
 = Enable Security
 
-If you do not enable security in {project-name}, then a client interface to {project-name} may request a user name and password,
-but {project-name} ignores the user name and password entered in the client interface, and the session runs as the database *root* user,
-`DB__ROOT`, without restrictions. If you want to restrict users, restrict access to certain users only, or restrict access to an
-object or operation, then you must enable security, which enforces authentication and authorization. You can enable security
-during installation by answering the {project-name} Installer's prompts or after installation by running the `traf_authentication_setup`
-script, which enables both authentication and authorization. For more information, see
-<<enable-security-authentication-setup-script,Authentication Setup Script>> below.
+{project-name} supports user authentication with LDAP, integrates in Hadoop's Kerberos environment and
+supports authorization through database grant and revoke requests (privileges).
 
-{project-name} does not manage user names and passwords internally but does support authentication via directory servers that support
+If this is an initial installation, both LDAP and Kerberos can be configured by running {project-name} installer.
+If {project-name} is already installed, then both LDAP and Kerberos can be configured by running {project-name} 
+security installer. 
+
+* If Hadoop has enabled Kerberos, then {project-name} must also enable Kerberos.
+* If Kerberos is enabled, then LDAP must be enabled.
+* If LDAP is enabled, then database authorization (privilege support) is automatically enabled.
+* If Kerberos is not enabled, then enabling LDAP is optional.
+
+[[enable-security-kerberos]]
+== Configuring {project-name} for Kerberos
+Kerberos is a protocol for authenticating a request for a service or operation.  It uses the notion of a ticket to verify accessibility.  
+The ticket is proof of identity encrypted with a secret key for the particular requested service.  Tickets exist for a short time and 
+then expire. Therefore, you can use the service as long as your ticket is valid (i.e. not expired).  Hadoop uses Kerberos to provide 
+security for its services, as such {project-name} needs to function properly with Hadoop that has Kerberos enabled.  
+
+=== Kerberos configuration file
+It is assumed that Kerberos has already been setup on all the nodes by the time Trafodion is installed. 
+This section briefly discusses the Kerberos configuration file for reference.
+
+The Kerberos configuration file defaults to /etc/krb5.conf and contains, among other attributes:
+
+```
+* log location: location where Kerberos errors and other information is logged
+* KDC location: host location where the KDC (Key Distribution Center) is located
+* admin server location: host location where the Kerberos admin server is located
+* realm: the set of nodes that share a Kerberos database 
+* ticket defaults: contains defaults for ticket lifetimes, encoding, and other attributes
+```
+
+You need to have access to a Kerberos administrator account to enable Kerberos for Trafodion.  The following is an example request that lists principals defined in the Kerberos database that can be used to test connectivity: 
+
+```
+kadmin -p 'kdcadmin/admin' -w 'kdcadmin123' -s 'kdc.server' -q 'listprincs'
+* -p (principal): please replace 'kdcadmin/admin' with your admin principal
+* -w (password): please replace 'kdadmin123' with the password for the admin principal
+* -s (server location): please replace 'kdc.server' with your KDC admin server location
+* -q (command): defines the command to run, in this case principals are returned
+```
+=== Ticket Management
+When Kerberos is enabled in {project-name}, the security installation process:
+
+* Adds a Trafodion principal in Kerberos, one per node with the name trafodion/hostname@realm.
+* Creates a keytab for each principal and distributes the keytab to each node. The keytab name is the same for all nodes 
+and defaults to a value based on the distribution, for example: etc/trafodion/keytabs/trafodion.service.keytab.
+* Performs a "kinit" on all nodes in the cluster for the `trafodion` user.
+* Add commands to perform "kinit" and to start the ticket renewal procedure to the `trafodion` .bashrc scripts on each node. 
+
+The ticket renewal service renews tickets up until the maximum number of renewals allowed.  So if your ticket lifetime is 
+one day and the number of renewals is seven days, the ticket renewal service automatically renews tickets six times.  Once 
+the ticket expires, it must be initialized again to continue running Trafodion.  Connecting to each node as the `trafodion` 
+user initializes the ticket if one does not exist.
+
+TBD - add details on how tickets can be managed at the cluster level.
+
+=== Kerberos installation
+The {project-name} installation scripts automatically determine if Kerberos is enabled on the node.  If it is enabled,
+then the environment variable SECURE_HADOOP is set to "Y".  
+
+The following are questions that will be asked related to Kerberos:
+
+* Enter KDC server address, default is []: – no default
+* Enter admin principal (include realm), default is []:  - no default
+* Enter fully qualified name for HBase keytab, default is []: - Installer searches for a valid keytab based on the distribution
+* Enter fully qualified name for HBase keytab, default is []: - Installer searches for a valid keytab based on the distribution
+* Enter max lifetime for Trafodion principal (valid format required), default is [24hours]:
+* Enter renew lifetime for Trafodion principal (valid format required), default is [7days]:
+* Enter Trafodion keytab name, default is []:  - Installer determines default name based on the distribution
+* Enter keytab location, default is []:  - Installer determins default name based on the distribution
+
+NOTE: The {project-name} installer always asked for the KDC admin password when enabling Kerberos independent on whether running in Automated
+of Guided mode. It does not save this password.
+
+[[enable-security-ldap]]
+== Configuring LDAP
+{project-name} does not manage user names and passwords internally but supports authentication via directory servers using
 the OpenLDAP protocol, also known as LDAP servers. You can configure the LDAP servers during installation by answering the {project-name}
-Installer's prompts, or you can configure the LDAP servers manually after installation. For more information, please refer to
-<<enable-security-configuring-ldap-servers,Configuring LDAP Servers>> below.
+Installer's prompts. To configure LDAP after installation run security installer directly.  Installing LDAP also enables database
+authorization (privilege support). 
 
 Once authentication and authorization are enabled, {project-name} allows users to be registered in the database and allows privileges
 on objects to be granted to users and roles (which are granted to users). {project-name} also supports component-level (or system-level)
 privileges, such as MANAGE_USERS, which can be granted to users and roles. Refer to <<enable-security-manage-users,Manage Users>> below.
 
+NOTE: If you do not enable LDAP in {project-name}, then a client interface to {project-name} may request a user name and password,
+but {project-name} ignores the user name and password entered in the client interface, and the session runs as the database *root* user,
+`DB__ROOT`, without restrictions. If you want to restrict users, restrict access to certain users only, or restrict access to an
+object or operation, then you must enable security, which enforces authentication and authorization.
+
 [[enable-security-configuring-ldap-servers]]
-== Configuring LDAP Servers
+=== Configuring LDAP Servers
 To specify the LDAP server(s) to be used for authentication, you need to configure the text file `.traf_authentication_config`,
 located (by default) in `$MY_SQROOT/sql/scripts`. This file is a flat file, organized as a series of attribute/value pairs.
 Details on all the attributes and values accepted in the authentication configuration file and how to configure alternate locations
@@ -146,9 +221,9 @@ Authentication successful
 
 <<<
 [[enable-security-generate-trafodion-certificate]]
-== Generate {project-name} Certificate
+=== Generate {project-name} Certificate
 {project-name} clients such as `trafci` encrypt the password before sending it to {project-name}. A self-signed certificate is used to encrypt the password.
-The certificate and key should be generated when the `sqgen` script is invoked. By default, the files `server.key` and `server.crt` are located
+The certificate and key is generated when the `sqgen` script is invoked. By default, the files `server.key` and `server.crt` are located
 in `$HOME/sqcert`. If those files are not present and since {project-name} clients does not send unencrypted passwords, then you need to manually generate
 those files. To do so, run the script `sqcertgen` located in `$MY_SQROOT/sql/scripts`. The script runs `openssl` to generate the certificate and key.
 
@@ -187,94 +262,12 @@ then the default filename `server.key` or `server.crt` is appended to the value 
 * If the filename environment variable is not set and the directory environment variable is not set,
 then {project-name} uses the default location (`$HOME/sqcert`) and the default filename.
 
-[[enable-security-authentication-setup-script]]
-==  Authentication Setup Script
-The final step to enable security is to change the value of the environment variable `TRAFODION_ENABLE_AUTHENTICATION` from `NO` to `YES`
-and turn on authorization. This is achieved by invoking the `traf_authentication_setup` script, which is located in `$MY_SQROOT/sql/scripts`.
-
-*Usage*
-
-```
-Usage: traf_authentication_setup [options]
-
-Options:
-    --file <loc>  Optional location of OpenLDAP configuration file
-    --help        Prints this message
-    --off         Disables authentication and authorization                               
-    --on          Enables authentication and authorization
-    --setup       Enables authentication                             
-    --status      Returns status of authentication enablement
-```
-
-[cols="30%,90%",options="header"]
-|===
-| Option | Description
-| `--file` | If specified, then `filename` is copied to `$MY_SQROOT/`. Users working in their own private environment can refer to a
-site-specific configuration file from a central location.
-| `--on`   | `traf_authentication_setup` invokes <<enable-security-ldapconfigcheck,ldapconfigcheck>> to verify the configuration file is
-syntactically correct. It also invokes <<enable-security-ldapcheck,ldapcheck>> to verify that a connection can be made to an LDAP server. +
- +
-If both checks pass, the script sets the environment variable `TRAFODION_ENABLE_AUTHENTICATION` to `YES` in the file `$MY_SQROOT/sqenvcom.sh`,
-and propagates `sqenvcom.sh` and `.traf_authentication_config` to all nodes in the cluster. +
- +
-The last step is to enable authorization by creating privilege-related metadata tables and set up default permissions with a call to the database.
-The list of privilege-related metadata tables, users, roles, and component privileges are logged in `$MY_SQROOT/logs/authEnable.log`. +
- +
-Specifying `--on` requires that a valid `.traf_authentication_config` file exists and the {project-name} metadata initialized.
-| `--off` | If specified, then `traf_authentication_setup` sets the environment variable `TRAFODION_ENABLE_AUTHENTICATION` to `NO` in
-`$MY_SQROOT/sqenvcom.sh` and propagates the file to all the nodes in the cluster. +
- +
-The last step is to disable authorization by removing any privilege-related metadata and permissions with a call to the database.
-The results of this operation is logged in `$MY_SQROOT/logs/authEnable.log`.
-| `--setup` | Use this option if the {project-name} metadata has not been initialized. This option enables authentication but does not call the database
-to create privilege-related metadata tables. Later, when {project-name} metadata is initialized, privilege-related metadata tables and default permissions
-are automatically created.
-| `--status` | Reports the value of the environment variable `TRAFODION_ENABLE_AUTHENTICATION` in `$MY_SQROOT/sqenvcom.sh` on the current node and
-reports the status of security features in the database.
-|===
-
-*Example*
-
-```
-INFO: Start of security (authentication and authorization) script Wed Mar 25 15:12:50 PDT 2xxx.
-
-INFO:  *** Trafodion security (authentication and authorization) status *** 
-   Authentication is ENABLED
-   Authorization (grant/revoke) is ENABLED
-
-INFO: End of security (authorization and authentication) script Wed Mar 25 15:12:54 PDT 2xxx.
-```
-
-NOTE: Any time the environment file (`sqenvcom.sh`) is changed (and propagated to all nodes), Database Connectivity Services (DCS) must be restarted to
-pick up the new value. If the configuration file is changed, it re-reads in 30 minutes (by default), but you can have changes take effect
-immediately by restarting DCS.
-
-To restart DCS, run the scripts `stop-dcs.sh` and `start-dcs.sh`, located in `$MY_SQROOT/dcs-<x>.<y>.<z>/bin`.
-
-[[enable-security-manage-users]]
-== Manage Users
-Users are registered in the Trafodion database and are used to enforce authorization. If security is disabled, any user can register any user at any time.
-However, once security is enabled, user administration is considered a secure operation, and registration of users is restricted to `DB__ROOT` or any user
-granted the `MANAGE_USERS` component privilege. To initially register a user, connect to Trafodion with the external user mapped to `DB__ROOT`
-(also known as the Trafodion ID).
-
-When security is enabled, the `DB__ROOT` user is registered as the `TRAFODION` external user name. It is recommended that the `DB__ROOT` user be mapped
-to the external user name that is used to connect for root operations. To do this, start a `sqlci` session and perform the `ALTER USER` command, for example:
-
-```
-ALTER USER DB__ROOT SET EXTERNAL NAME trafodion_rootuser_in_ldap;
-```
-
-To learn more about how to register users, grant object and component privileges, and manage users and roles, please see the
-{docs-url}/sql_reference/index.html[Trafodion SQL Reference Manual].
-
-
 [[enable-security-traf-authentication-config]]
-== .traf_authentication_config
+=== Creating the LDAP configuration file
 The `.traf_authentication_config` file is user to enable the Trafodion security features.
 
-=== File Location
-By default, the Trafodion authentication configuration file is located in `$MY_SQROOT/sql/scripts/.traf_authentication_config`.
+==== File Location
+By default, the {project-name} authentication configuration file is located in `$MY_SQROOT/sql/scripts/.traf_authentication_config`.
 If you want to store the configuration file in a different location and/or use a different filename, then Trafodion supports environment
 variables to specify the alternate location/name.
 
@@ -288,13 +281,12 @@ If neither is set, Trafodion defaults to `$MY_SQROOT/sql/scripts/.traf_authentic
 
 <<<
 [[enable-security-template]]
-=== Template
+==== Template
 
 ```
 # To use authentication in Trafodion, this file must be configured
 # as described below and placed in $MY_SQROOT/sql/scripts and be named
-# .traf_authentication_config.  You must also enable authentication by
-# running the script traf_authentication_setup in $MY_SQROOT/sql/scripts.
+# .traf_authentication_config.  
 #
 # NOTE: the format of this configuration file is expected to change in the 
 # next release of Trafodion.  Backward compatibility is not guaranteed.
@@ -341,7 +333,7 @@ SECTION: local
 ```
 
 [[enable-security-configuration-attributes]]
-=== Configuration Attributes
+==== Configuration Attributes
 
 [cols="25%,20%,20%l,35%",options="header"]
 |===
@@ -405,9 +397,9 @@ Legal values are `LOCAL` and `ENTERPRISE`. This syntax is likely to change.
 
 
 [[enable-security-ldapcheck]]
-== ldapcheck
+=== Verifying configuration and users through ldapcheck
 
-=== Usage
+==== Usage
 
 ```
 ldapcheck  [<option>]...
@@ -424,7 +416,7 @@ ldapcheck  [<option>]...
                                   and LDAP errors
 ```
 
-=== Considerations
+==== Considerations
 
 * Aliases for primary include enterprise and local. Aliases for secondary include cluster and remote. If no configuration is specified, primary is assumed.
 * The equals sign is required when supplying a value to username or password.
@@ -434,11 +426,11 @@ ldapcheck  [<option>]...
 to the configured LDAP server(s) without knowing a valid username or password.
 
 [[enable-security-ldapconfigcheck]]
-== ldapconfigcheck
+=== Verifying contents of configuration file through ldapconfigcheck
 This page describes the `ldapconfigcheck` tool, which validates the syntactic correctness of a Trafodion authentication configuration file. Trafodion does not need to be running to run the tool.
 
 [[enable-security-ldapconfigcheck-considerations]]
-=== Considerations
+==== Considerations
 If the configuration filename is not specified, then the tool  looks for a file using environment variables. Those environment variables and the search order are:
 
 1. `TRAFAUTH_CONFIGFILE`
@@ -455,7 +447,7 @@ Filename `.traf_authentication_config/` is appended to the specified directory
     
 <<<
 [[enable-security-ldapconfigcheck-errors]]
-=== Errors
+==== Errors
 One of the following is output when the tool is run. Only the first error encountered is reported.
 
 [cols="15%l,85%",options="header"]
@@ -489,3 +481,46 @@ Each LDAP connection configuration section must provide at least one unique iden
 | 11     | At least one LDAP connection configuration section must be specified.
 | 12     | Internal error parsing `.traf_authentication_config`.
 |===
+
+[[enable-security-manage-users]]
+== Manage Users
+Kerberos is enabled for installations that require a secure Hadoop environment.  LDAP is enabled to enforce authentication for any 
+user connecting to {project-name}.  The {project-name} database enforces privileges on the database, database schemas, database 
+objects (table, views, etc) and database operations.  Privileges are enforced when authorization is enabled.  When LDAP or Kerberos 
+is enabled, authorization is automatically enabled.  
+
+To determine the status of authentication and authorization, bring up sqlci and perform "env;". 
+
+```
+>>env;
+----------------------------------
+Current Environment
+----------------------------------
+AUTHENTICATION     enabled
+AUTHORIZATION      enabled
+CURRENT DIRECTORY  /.../incubator-trafodion/install/installer
+LIST_COUNT         4294967295
+LOG FILE
+MESSAGEFILE        /.../incubator-trafodion/core/sqf/export/ ...
+MESSAGEFILE LANG   US English
+MESSAGEFILE VRSN   {2016-06-14 22:27 LINUX:host/user} 
+SQL CATALOG        TRAFODION
+SQL SCHEMA         SCH
+SQL USER CONNECTED user not connected
+SQL USER DB NAME   SQLUSER1
+SQL USER ID        33367
+TERMINAL CHARSET   ISO88591
+TRANSACTION ID     
+TRANSACTION STATE  not in progress
+WARNINGS           on
+```
+
+Once authorization is enabled, there is one predefined database user called DB__ROOT associated with your specified LDAP username.
+Please connect to the database and this user and register users that will perform database admin management. The database
+admin can then connect and setup required users, roles, and privileges.
+
+TBD - add pointer to the security best practices guide.
+
+To learn more about how to register users, grant object and component privileges, and manage users and roles, please see the
+{docs-url}/sql_reference/index.html[Trafodion SQL Reference Manual].
+

--- a/docs/provisioning_guide/src/asciidoc/_chapters/enable_security.adoc
+++ b/docs/provisioning_guide/src/asciidoc/_chapters/enable_security.adoc
@@ -26,11 +26,11 @@
 [[enable-security]]
 = Enable Security
 
-{project-name} supports user authentication with LDAP, integrates in Hadoop's Kerberos environment and
+{project-name} supports user authentication with LDAP, integrates with Hadoop's Kerberos environment and
 supports authorization through database grant and revoke requests (privileges).
 
-If this is an initial installation, both LDAP and Kerberos can be configured by running {project-name} installer.
-If {project-name} is already installed, then both LDAP and Kerberos can be configured by running {project-name} 
+If this is an initial installation, both LDAP and Kerberos can be configured by running the {project-name} installer.
+If {project-name} is already installed, then both LDAP and Kerberos can be configured by running the {project-name} 
 security installer. 
 
 * If Hadoop has enabled Kerberos, then {project-name} must also enable Kerberos.
@@ -43,16 +43,16 @@ security installer.
 Kerberos is a protocol for authenticating a request for a service or operation.  It uses the notion of a ticket to verify accessibility.  
 The ticket is proof of identity encrypted with a secret key for the particular requested service.  Tickets exist for a short time and 
 then expire. Therefore, you can use the service as long as your ticket is valid (i.e. not expired).  Hadoop uses Kerberos to provide 
-security for its services, as such {project-name} needs to function properly with Hadoop that has Kerberos enabled.  
+security for its services, as such {project-name} needs to function properly with Hadoop that have Kerberos enabled.  
 
 === Kerberos configuration file
-It is assumed that Kerberos has already been setup on all the nodes by the time Trafodion is installed. 
+It is assumed that Kerberos has already been set up on all the nodes by the time Trafodion is installed. 
 This section briefly discusses the Kerberos configuration file for reference.
 
 The Kerberos configuration file defaults to /etc/krb5.conf and contains, among other attributes:
 
 ```
-* log location: location where Kerberos errors and other information is logged
+* log location: location where Kerberos errors and other information are logged
 * KDC location: host location where the KDC (Key Distribution Center) is located
 * admin server location: host location where the Kerberos admin server is located
 * realm: the set of nodes that share a Kerberos database 
@@ -75,14 +75,14 @@ When Kerberos is enabled in {project-name}, the security installation process:
 * Creates a keytab for each principal and distributes the keytab to each node. The keytab name is the same for all nodes 
 and defaults to a value based on the distribution, for example: etc/trafodion/keytabs/trafodion.service.keytab.
 * Performs a "kinit" on all nodes in the cluster for the `trafodion` user.
-* Add commands to perform "kinit" and to start the ticket renewal procedure to the `trafodion` .bashrc scripts on each node. 
+* Adds commands to perform "kinit" and to start the ticket renewal procedure to the `trafodion` .bashrc scripts on each node. 
 
 The ticket renewal service renews tickets up until the maximum number of renewals allowed.  So if your ticket lifetime is 
 one day and the number of renewals is seven days, the ticket renewal service automatically renews tickets six times.  Once 
 the ticket expires, it must be initialized again to continue running Trafodion.  Connecting to each node as the `trafodion` 
 user initializes the ticket if one does not exist.
 
-TBD - add details on how tickets can be managed at the cluster level.
+TBD - A future update will include details on how tickets can be managed at the cluster level.
 
 === Kerberos installation
 The {project-name} installation scripts automatically determine if Kerberos is enabled on the node.  If it is enabled,
@@ -93,7 +93,7 @@ The following are questions that will be asked related to Kerberos:
 * Enter KDC server address, default is []: – no default
 * Enter admin principal (include realm), default is []:  - no default
 * Enter fully qualified name for HBase keytab, default is []: - Installer searches for a valid keytab based on the distribution
-* Enter fully qualified name for HBase keytab, default is []: - Installer searches for a valid keytab based on the distribution
+* Enter fully qualified name for HDFS keytab, default is []: - Installer searches for a valid keytab based on the distribution
 * Enter max lifetime for Trafodion principal (valid format required), default is [24hours]:
 * Enter renew lifetime for Trafodion principal (valid format required), default is [7days]:
 * Enter Trafodion keytab name, default is []:  - Installer determines default name based on the distribution
@@ -106,7 +106,7 @@ of Guided mode. It does not save this password.
 == Configuring LDAP
 {project-name} does not manage user names and passwords internally but supports authentication via directory servers using
 the OpenLDAP protocol, also known as LDAP servers. You can configure the LDAP servers during installation by answering the {project-name}
-Installer's prompts. To configure LDAP after installation run security installer directly.  Installing LDAP also enables database
+Installer's prompts. To configure LDAP after installation run the {project-name} security installer directly.  Installing LDAP also enables database
 authorization (privilege support). 
 
 Once authentication and authorization are enabled, {project-name} allows users to be registered in the database and allows privileges
@@ -223,7 +223,7 @@ Authentication successful
 [[enable-security-generate-trafodion-certificate]]
 === Generate {project-name} Certificate
 {project-name} clients such as `trafci` encrypt the password before sending it to {project-name}. A self-signed certificate is used to encrypt the password.
-The certificate and key is generated when the `sqgen` script is invoked. By default, the files `server.key` and `server.crt` are located
+The certificate and key are generated when the `sqgen` script is invoked. By default, the files `server.key` and `server.crt` are located
 in `$HOME/sqcert`. If those files are not present and since {project-name} clients does not send unencrypted passwords, then you need to manually generate
 those files. To do so, run the script `sqcertgen` located in `$MY_SQROOT/sql/scripts`. The script runs `openssl` to generate the certificate and key.
 
@@ -519,7 +519,7 @@ Once authorization is enabled, there is one predefined database user called DB__
 Please connect to the database and this user and register users that will perform database admin management. The database
 admin can then connect and setup required users, roles, and privileges.
 
-TBD - add pointer to the security best practices guide.
+TBD - A future update should include a pointer to the security best practices guide.
 
 To learn more about how to register users, grant object and component privileges, and manage users and roles, please see the
 {docs-url}/sql_reference/index.html[Trafodion SQL Reference Manual].

--- a/docs/provisioning_guide/src/asciidoc/_chapters/introduction.adoc
+++ b/docs/provisioning_guide/src/asciidoc/_chapters/introduction.adoc
@@ -67,21 +67,21 @@ more information about managing {project-name} Database Users.
  +
 If your environment has been provisioned with Kerberos, then the following additional information is required. 
 
-* *HDFS keytab location*: {project-name} requires administrator access to HDFS to create directories that store files needed to perform SQL requests 
-such as data loads and backups.  Refer to
-<<enable-security-kerberos,Kerberos>> for more information about the requirements and usage associated with this keytab.
+* *KDC admin principal*: {project-name} requires administrator access to Kerberos to create principals 
+and keytabs for the `trafodion` user, and to look-up principal names for HDFS and HBase keytabs.  Refer to 
+<<enable-security-kerberos,Kerberos>> for more information about the requirements and usage associated with this principal.
 
 * *HBase keytab location*: {project-name} requires administrator access to HBase to grant required privileges to the `trafodion` user.  Refer to
 <<enable-security-kerberos,Kerberos>> for more information about the requirements and usage associated with this keytab.
 
-* *KDC admin principal*: {project-name} requires administrator access to Kerberos to create principals 
-and keytabs for the `trafodion` user, and to look-up principal names for HDFS and HBase keytabs.  Refer to 
-<<enable-security-kerberos,Kerberos>> for more information about the requirements and usage associated with this principal.
+* *HDFS keytab location*: {project-name} requires administrator access to HDFS to create directories that store files needed to perform SQL requests 
+such as data loads and backups.  Refer to
+<<enable-security-kerberos,Kerberos>> for more information about the requirements and usage associated with this keytab.
  +
  +
 If your environment is using LDAP for authentication, then the following additional information is required.
 
-* *LDAP username for database root access*:  When {project-name} is installed, it creates a predefined database user called DB\__ROOT.  
+* *LDAP username for database root access*:  When {project-name} is installed, it creates a predefined database user referred to as the DB\__ROOT user.  
 In order to connect to the database as database root, there must be a mapping between the database user DB__ROOT and an LDAP user. Refer to  
 <<enable-security-ldap,LDAP>> for more information about this option.
 
@@ -123,31 +123,30 @@ administrative tasks if using Recipe-Based Provisioning.
 * *<<requirements,Requirements>>*: Activities and documentation required to install the {project-name} software.
 These activities include tasks such as understanding hardware and operating system requirements,
 Hadoop requirements, what software packages that need to be downloaded, configuration settings that need to be changed,
-user IDs requirements, and so on.
+and user ID requirements.
 
 * *<<prepare,Prepare>>*: Activities to prepare the operating system and the Hadoop ecosystem to run
 {project-name}. These activities include tasks such as installing required software packages, configure
-the {project-name} Installation User, gather information about the Hadoop environment, modify configuration
-for different Hadoop services, and so forth.
+the {project-name} Installation User, gather information about the Hadoop environment, and the modify configuration
+for different Hadoop services.
 
 * *<<install,Install>>*: Activities related to installing the {project-name} software. These activities
 include tasks such as unpacking the {project-name} tar files, creating the {project-name} Runtime User,
-creating {project-name} HDFS directories, installing the {project-name} software, enabling security features and so forth.
+creating {project-name} HDFS directories, installing the {project-name} software, and enabling security features.
 
 * *<<upgrade,Upgrade>>*: Activities related to the upgrading the {project-name} software. These activities
-include tasks such as shutting down {project-name}, installing a new version of the {project-name} software,
-and so on. The upgrade tasks vary depending on the differences between the current and new release of
+include tasks such as shutting down {project-name} and installing a new version of the {project-name} software.
+The upgrade tasks vary depending on the differences between the current and new release of
 {project-name}. For example, an upgrade may or may not include an upgrade of the {project-name} metadata.
 
 * *<<activate,Activate>>*: Activities related to starting the {project-name} software. These actives
-include basic management tasks such as starting and checking the status of the {project-name} components,
-performing basic smoke tests, and so forth.
+include basic management tasks such as starting and checking the status of the {project-name} components and performing basic smoke tests.
 
 * *<<remove,Remove>>*: Activities related to removing {project-name} from your Hadoop cluster.
 
 * *<<enable-security,Enable Security>>*: Activities related to enabling security features on an already installed
 {project-name} installation.  These activities include tasks such as adding Kerberos principals and keytabs,
-setting up LDAP configuration files, and so forth.
+and setting up the LDAP configuration files.
 
 [[introduction-provisioning-master-node]]
 == Provisioning Master Node
@@ -266,7 +265,7 @@ NOTE: Your {project-name} Configuration File contains the password for the {proj
 and for the Distribution Manager. Therefore, we recommend that you secure the file in a manner
 that matches the security policies of your organization. 
 
-NOTE: If you installing {project-name} on a version of Hadoop that has been instrumented with Kerberos,
+NOTE: If you are installing {project-name} on a version of Hadoop that has been instrumented with Kerberos,
 you will be asked for a password associated with a Kerberos administrator.  
 
 ==== Example: Creating a {project-name} Configuration File

--- a/docs/provisioning_guide/src/asciidoc/_chapters/introduction.adoc
+++ b/docs/provisioning_guide/src/asciidoc/_chapters/introduction.adoc
@@ -41,7 +41,7 @@ This guide assumes that a Hadoop environment exists upon which your provisioning
 [[introduction-security-considerations]]
 == Security Considerations
 
-The following users need be considered for {project-name}:
+The following users and principals need be considered for {project-name}:
 
 * *Provisioning User*: A Linux-level user that performs the {project-name} provisioning tasks. This user ID
 requires `sudo` access and passwordless ssh among the nodes where {project-name} is installed. In addition,
@@ -55,30 +55,51 @@ as a user in the Hadoop Distributed File System (HDFS) to store and  access obje
 In addition, this  user ID requires passwordless access among the nodes where {project-name} is installed.
 Refer to <<requirements-trafodion-runtime-user,{project-name} Runtime User>> for more information about this user ID.
 
-* *{project-name} Database Users*: {project-name} users are managed by the {project-name} security features (grant, revoke, etc.),
+* *{project-name} Database Users*: {project-name} users are managed by {project-name} security features (grant, revoke, etc.),
 which can be integrated with LDAP if so desired. These users are referred to as *database users* and
-do not have direct access to the operating system. Refer to 
-{docs-url}/sql_reference/index.html#register_user_statement[Register User],
+do not have direct access to the operating system. Refer to <<enable-security-ldap,LDAP>> for 
+details on enabling LDAP for authenticating database users. 
+Refer to {docs-url}/sql_reference/index.html#register_user_statement[Register User],
 {docs-url}/sql_reference/index.html#grant_statement[Grant], and other SQL statements
 in the {docs-url}/sql_reference/index.html[{project-name} SQL Reference Manual] for
 more information about managing {project-name} Database Users.
  +
  +
-Optionally, you can enable {project-name} Security. If you do not enable security in {project-name}, then a client interface
-to {project-name} may request a user name and password, but {project-name} ignores the user name and password entered in the
-client interface, and the session runs as the database *root* user, `DB__ROOT`, without restrictions. If you want
-to restrict users, restrict access to certain users only, or restrict access to an object or operation, then you must
-enable security, which enforces authentication and authorization. Refer to
-<<enable-security,Enable Security>> for more information about this option.
+If your environment has been provisioned with Kerberos, then the following additional information is required. 
+
+* *HDFS keytab location*: {project-name} requires administrator access to HDFS to create directories that store files needed to perform SQL requests 
+such as data loads and backups.  Refer to
+<<enable-security-kerberos,Kerberos>> for more information about the requirements and usage associated with this keytab.
+
+* *HBase keytab location*: {project-name} requires administrator access to HBase to grant required privileges to the `trafodion` user.  Refer to
+<<enable-security-kerberos,Kerberos>> for more information about the requirements and usage associated with this keytab.
+
+* *KDC admin principal*: {project-name} requires administrator access to Kerberos to create principals 
+and keytabs for the `trafodion` user, and to look-up principal names for HDFS and HBase keytabs.  Refer to 
+<<enable-security-kerberos,Kerberos>> for more information about the requirements and usage associated with this principal.
+ +
+ +
+If your environment is using LDAP for authentication, then the following additional information is required.
+
+* *LDAP username for database root access*:  When {project-name} is installed, it creates a predefined database user called DB\__ROOT.  
+In order to connect to the database as database root, there must be a mapping between the database user DB__ROOT and an LDAP user. Refer to  
+<<enable-security-ldap,LDAP>> for more information about this option.
+
+* *LDAP search user name*: {project-name} optionally requests an LDAP username and password in order to perform LDAP operations 
+such as LDAP search.  Refer to
+<<enable-security-ldap,LDAP>> for more information about this option.
 
 [[introduction-provisioning-options]]
 == Provisioning Options
 
-{project-name} ships with a set of scripts (the {project-name} Installer) that takes care of many of the installation and upgrade
-tasks associated with the {project-name} software and its requirements. There is a separate set of scripts to remove {project-name},
-if needed.
+{project-name} ships with a set of scripts that takes care of many of the installation and upgrade
+tasks associated with the {project-name} software and its requirements. The main features include:
 
-Currently, the {project-name} Installer is able to install {project-name} on select Cloudera and  Hortonworks Hadoop distributions only.
+* *{project-name} installer*: Performs installation and upgrade for {project-name}
+* *{project-name} uninstaller*: Uninstalls {project-name}
+* *{project-name} security installer*: Enables security features including Kerberos and LDAP for an existing {project-name} installation
+
+Currently, the {project-name} Installer is able to install {project-name} on select Cloudera and  Hortonworks Hadoop distributions, and for select vanilla Hadoop installations.
 The {project-name} Installer limitations are noted as they apply in the different chapters below. For example, the {project-name} Installer
 is less capable on SUSE than it is on RedHat/CentOS; you have to install the prerequisite software packages outside the {project-name} Installer.
 
@@ -86,7 +107,7 @@ The {project-name} Installer automates many of the tasks required to install/upg
 installing required software packages and making required changes to your Hadoop environment via creating
 the {project-name} runtime user ID to installing and starting {project-name}. It is, therefore,  highly recommend that
 you use the {project-name} Installer for initial installation and upgrades of {project-name}. These steps are referred to as
-"Script-Based Provisioning" in this guide. Refer to <<introduction-trafodion-installer, {project-name} Installer>> provides
+"Script-Based Provisioning" in this guide. Refer to <<introduction-trafodion-installer, {project-name} Installer>> that provides
 usage information.
 
 If, for any reason, you choose not to use the {project-name} Installer, then separate chapters provide
@@ -111,9 +132,8 @@ for different Hadoop services, and so forth.
 
 * *<<install,Install>>*: Activities related to installing the {project-name} software. These activities
 include tasks such as unpacking the {project-name} tar files, creating the {project-name} Runtime User,
-creating {project-name} HDFS directories, installing the {project-name} software, and so forth.
+creating {project-name} HDFS directories, installing the {project-name} software, enabling security features and so forth.
 
-<<<
 * *<<upgrade,Upgrade>>*: Activities related to the upgrading the {project-name} software. These activities
 include tasks such as shutting down {project-name}, installing a new version of the {project-name} software,
 and so on. The upgrade tasks vary depending on the differences between the current and new release of
@@ -124,6 +144,10 @@ include basic management tasks such as starting and checking the status of the {
 performing basic smoke tests, and so forth.
 
 * *<<remove,Remove>>*: Activities related to removing {project-name} from your Hadoop cluster.
+
+* *<<enable-security,Enable Security>>*: Activities related to enabling security features on an already installed
+{project-name} installation.  These activities include tasks such as adding Kerberos principals and keytabs,
+setting up LDAP configuration files, and so forth.
 
 [[introduction-provisioning-master-node]]
 == Provisioning Master Node
@@ -147,12 +171,6 @@ Next, you unpack the tar file.
 $ mkdir $HOME/trafodion-installer
 $ cd $HOME/trafodion-downloads
 $ tar -zxf apache-trafodion-installer-1.3.0-incubating-bin.tar.gz -C $HOME/trafodion-installer
-$ ls $HOME/trafodion-installer/installer
-bashrc_default           tools                             traf_config_check           trafodion_apache_hadoop_install  traf_package_setup
-build-version-1.3.0.txt  traf_add_user                     traf_config_setup           trafodion_config_default         traf_setup
-dcs_installer            traf_apache_hadoop_config_setup   traf_create_systemdefaults  trafodion_install                traf_sqconfig
-rest_installer           traf_authentication_conf_default  traf_getHadoopNodes         trafodion_license                traf_start
-setup_known_hosts.exp    traf_cloudera_mods98              traf_hortonworks_mods98     trafodion_uninstaller
 $ 
 ```
 
@@ -161,12 +179,14 @@ The {project-name} Installer supports two different modes:
 
 1. *Guided Setup*: Prompts for information as it works through the installation/upgrade process. This mode is recommended for new users.
 2. *Automated Setup*: Required information is provided in a pre-formatted bash-script configuration file, which is provided
-via a command argument when running the {project-name} Installer thereby suppressing all prompts.
+via a command argument when running the {project-name} Installer thereby suppressing all prompts. There is one exception, 
+if Kerberos is enabled on the cluster, then you will always be prompted for the KDC admin password.  We do not store the 
+KDC admin password as part of installation anywhere.
 +
 A template of the configuration file is available here within the installer directory: `trafodion_config_default`.
 Make a copy of the file in your directory and populate the needed information.
 +
-Automated Setup is recommended since it allows you to record the required provisioning information information ahead of time.
+Automated Setup is recommended since it allows you to record the required provisioning information ahead of time.
 Refer to <<introduction-trafodion-automated-setup,Automated Setup>> for information about how to
 populate this file.
 
@@ -246,6 +266,9 @@ NOTE: Your {project-name} Configuration File contains the password for the {proj
 and for the Distribution Manager. Therefore, we recommend that you secure the file in a manner
 that matches the security policies of your organization. 
 
+NOTE: If you installing {project-name} on a version of Hadoop that has been instrumented with Kerberos,
+you will be asked for a password associated with a Kerberos administrator.  
+
 ==== Example: Creating a {project-name} Configuration File
 
 Using the instructions in <<prepare-gather-configuration-information,Gather Configuration Information>>
@@ -255,10 +278,12 @@ in the <<prepare,Prepare>> chapter, you record the following information.
 |===
 | ID                      | Information                                                                                | Setting                       
 | ADMIN                   | Administrator user name for Apache Ambari or Cloudera Manager.                             | admin                         
+| ADMIN_PRINCIPAL         | Kerberos principal for the KDC admin user including the realm.                             |
 | BACKUP_DCS_NODES        | List of nodes where to start the backup DCS Master components.                             | 
 | CLOUD_CONFIG            | Whether you're installing {project-name} on a cloud environment.                                | N 
 | CLOUD_TYPE              | What type of cloud environment you're installing {project-name} on.                             | 
 | CLUSTER_NAME            | The name of the Hadoop Cluster.                                                            | Cluster 1
+| DB_ROOT_NAME            | LDAP name used to connect as database root user | trafodion
 | DCS_BUILD               | Tar file containing the DCS component.                                                     | 
 | DCS_PRIMARY_MASTER_NODE | The node where the primary DCS should run.                                                 | 
 | DCS_SERVER_PARM         | Number of concurrent client sessions per node.                                             | 8
@@ -267,30 +292,38 @@ in the <<prepare,Prepare>> chapter, you record the following information.
 | FLOATING_IP             | IP address if running DCS in HA mode.                                                      | 
 | HADOOP_TYPE             | The type of Hadoop distribution you're installing {project-name} on.                            | cloudera
 | HBASE_GROUP             | Linux group name for the HBASE administrative user.                                         | hbase
+| HBASE_KEYTAB            | Kerberos service keytab for HBase admin principal.                                                      | Default based on distribution
 | HBASE_USER              | Linux user name for the HBASE administrative user.                                          | hbase
+| HDFS_KEYTAB             | Kerberos service keytab for HDFS admin principal.                                                       | Default based on distribution
 | HDFS_USER               | Linux user name for the HDFS administrative user.                                           | hdfs 
 | HOME_DIR                | Root directory under which the `trafodion` home directory should be created.               | /home 
 | INIT_TRAFODION          | Whether to automatically initialize the {project-name} database.                                | Y
 | INTERFACE               | Interface type used for $FLOATING_IP.                                                      | 
 | JAVA_HOME               | Location of Java 1.7.0_65 or higher (JDK).                                                 | /usr/java/jdk1.7.0_67-cloudera
+| KDC_SERVER              | Location of Kerberos server for admin access                                               |
 | LDAP_CERT               | Full path to TLS certificate.                                                              | 
 | LDAP_HOSTS              | List of nodes where LDAP Identity Store servers are running.                               | 
 | LDAP_ID                 | List of LDAP unique identifiers.                                                           | 
 | LDAP_LEVEL              | LDAP Encryption Level.                                                                     | 
 | LDAP_PASSWORD           | Password for LDAP_USER.                                                                    | 
 | LDAP_PORT               | Port used to communicate with LDAP Identity Store.                                         | 
-| LDAP_SECURITY           | Whether to enable simple LDAP authentication.                                            | N   
+| LDAP_SECURITY           | Whether to enable LDAP authentication.                                                     | N   
 | LDAP_USER               | LDAP Search user name.                                                                     | 
 | LOCAL_WORKDIR           | The directory where the {project-name} Installer is located.                                    | /home/centos/trafodion-installer/installer
 | MANAGEMENT_ENABLED      | Whether your installation uses separate management nodes.                                  | N
 | MANAGEMENT_NODES        | The FQDN names of management nodes, if any.                                                | 
+| MAX_LIFETIME            | Kerberos ticket lifetime for {project-name} principal                                      | 24hours
 | NODE_LIST               | The FQDN names of the nodes where {project-name} will be installed.                             | trafodion-1 trafodion-2
 | PASSWORD                | Administrator password for Apache Ambari or Cloudera Manager.                              | admin
+| RENEW_LIFETIME          | Kerberos ticket renewal lifetime for {project-name} principal                              | 7days
 | REST_BUILD              | Tar file containing the REST component.                                                    | 
+| SECURE_HADOOP           | Indicates whether Hadoop has Kerberos enabled                                               | Based on whether Kerberos is enabled for your Hadoop installation
 | SQ_ROOT                 | Target directory for the {project-name} software.                                               | /home/trafodion/apache-trafodion-1.3.0-incubating-bin
 | START                   | Whether to start {project-name} after install/upgrade.                                          | Y
 | SUSE_LINUX              | Whether your installing {project-name} on SUSE Linux.                                           | false
 | TRAF_PACKAGE            | The location of the {project-name} installation package tar file or core installation tar file. | /home/centos/trafodion-download/apache-trafodion-1.3.0-incubating-bin.tar.gz
+| TRAF_KEYTAB             | Kerberos keytab for `trafodion` principal.                                                      | Default keytab based on distribution
+| TRAF_KEYTAB_DIR         | Location of Kerberos keytab for the `trafodion` principal.                                      | Default location based on distribution
 | TRAF_USER               | The {project-name} runtime user ID. Must be `trafodion` in this release.                         | trafodion
 | TRAF_USER_PASSWORD      | The password used for the `trafodion:trafodion` user ID.                                   | traf123
 | URL                     | FQDN and port for the Distribution Manager's REST API.                                     | trafodion-1.apache.org:7180
@@ -436,13 +469,45 @@ export INIT_TRAFODION="Y"
 # Default is to leave as is and this file will be created.
 export SQCONFIG=""
 
-export CONFIG_COMPLETE="true"
+#-----------------  security configuration information -----------------
+#Enter in Kerberos details if Kerberos is enabled on your cluster
 
-#Turn on simple security. MUST have existing LDAP configured.
-export LDAP_SECURITY="N"
+#Indicate Kerberos is enabled
+export SECURE_HADOOP="N"
+
+#Location of Kerberos server for admin access
+export KDC_SERVER=""
+
+#Kerberos Admin principal used to create Trafodion principals and keytabs
+#Please include realm, for example: trafadmin/admin@MYREALM.COM
+export ADMIN_PRINCIPAL=""
+
+#Keytab for HBase admin user, used to grant Trafodion user CRWE privilege
+export HBASE_KEYTAB=""
+
+#Keytab for HDFS admin user, used to create data directories for Trafodion 
+export HDFS_KEYTAB=""
+
+#Kerberos ticket defaults for the Trafodion user
+export MAX_LIFETIME="24hours"
+export RENEW_LIFETIME="7days"
+
+#Trafodion keytab information
+export TRAF_KEYTAB=""
+export TRAF_KEYTAB_DIR=""
+
+#Enter in LDAP configuration information
+#Turn on authentication - MUST have existing LDAP configured.
+export LDAP_SECURITY="Y"
 
 #Name of LDAP Config file
-export LDAP_AUTH_FILE="traf_authentication_config_${HOSTNAME}"
+export LDAP_AUTH_FILE="traf_authentication_config_`hostname -s`"
+
+#LDAP name to map to database user DB__ROOT
+DB_ROOT_NAME="trafodion"
+#-----------------      end security configuration     -----------------
+
+export CONFIG_COMPLETE="true"
 ```
 
 Once completed, run the {project-name} Installer with the `--config_file` option.
@@ -457,8 +522,8 @@ Refer to the following sections for examples:
 
 {project-name} stores its provisioning information in the following directories on each node in the cluster:
 
-* `/etc/trafodion`: Configurtion information.
-* `/usr/lib/trafodion`: Copies of the installer files.
+* `/etc/trafodion`: Configuration information.
+* `/usr/lib/trafodion`: Copies of the files required by the installer.
 
 
 

--- a/docs/provisioning_guide/src/asciidoc/_chapters/prepare.adoc
+++ b/docs/provisioning_guide/src/asciidoc/_chapters/prepare.adoc
@@ -31,10 +31,11 @@ You need to prepare your Hadoop environment before installing {project-name}.
 2. <<configure-installation-user-id,Configure Installation User ID>>
 3. <<prepare-disable-requiretty,Disable requiretty>>
 4. <<prepare-verify-os-requirements-and-recommendations,Verify OS Requirements and Recommendations>>
-5. <<prepare-configure-ldap-identity-store,Configure LDAP Identity Store>>
-6. <<prepare-gather-configuration-information,Gather Configuration Information>>
-7. <<prepare-install-required-software-packages,Install Required Software Packages>>
-8. <<prepare-perform-recipe-based-provisioning-tasks,Perform Recipe-Based Provisioning Tasks>>
+5. <<prepare-configure-kerberos,Configure Kerberos>>
+6. <<prepare-configure-ldap-identity-store,Configure LDAP Identity Store>>
+7. <<prepare-gather-configuration-information,Gather Configuration Information>>
+8. <<prepare-install-required-software-packages,Install Required Software Packages>>
+9. <<prepare-perform-recipe-based-provisioning-tasks,Perform Recipe-Based Provisioning Tasks>>
 
 [[prepare-install-optional-workstation-software]]
 == Install Optional Workstation Software
@@ -96,15 +97,25 @@ Please ensure that the <<requirements-os-requirements-and-recommendations,OS Req
 are met for each node in the cluster where you intend to install {project-name}.
 
 <<<
+[[prepare-configure-kerberos]]
+== Configure Kerberos
+
+If your Hadoop installation has enabled Kerberos, then {project-name} needs to have Kerberos enabled.  If not, 
+then {project-name} will not run. If you plan to enable Kerberos in {project-name}, then you need to have access to a KDC (Kerberos Key Distribution
+Center) and administration credentials so you can create the necessary {project-name} principals and keytabs.
+
+If you wish to manually set up and activate Kerberos principals and keytabs, then refer to the section on
+<<enable-security-kerberos,Kerberos>>.
+
 [[prepare-configure-ldap-identity-store]]
 == Configure LDAP Identity Store
 
-If you plan to enable security in {project-name}, then you need to have an LDAP identity store available to perform authentication.
+If you plan to enable security features in {project-name}, then you need to have an LDAP identity store available to perform authentication.
 The {project-name} Installer prompts you to set up an authentication configuration file that points to an LDAP server (or servers),
 which enables security (that is, authentication and authorization) in the {project-name} database.
 
 If you wish to manually set up the authentication configuration file and enable security, then refer to the section on
-<<enable-security,Enable Security>>.
+<<enable-security-ldap,LDAP>>.
 
 [[prepare-gather-configuration-information]]
 == Gather Configuration Information
@@ -117,10 +128,12 @@ and for recipe-based provisioning. (Listed in alphabetical order to make it easi
 | ID^1^              | Information                                                    | Default                       | Notes
 | ADMIN              | Administrator user name for Apache Ambari or Cloudera Manager. | admin                         | A user that can change configuration and restart services via the
 distribution manager's REST API.
+| ADMIN_PRINCIPAL^2^ | Kerberos admin principal to manage principals and keytabs      | None                          | Required if Kerberos is enabled.
 | BACKUP_DCS_NODES   | List of nodes where to start the backup DCS Master components. | None                          | Blank separated FQDN list. Not needed if $ENABLE_HA = N.
 | CLOUD_CONFIG       | Whether you're installing {project-name} on a cloud environment.    | N                             | N = bare-metal or VM installation.
 | CLOUD_TYPE         | What type of cloud environment you're installing {project-name} on. | None | { AWS \| OpenStack \| Other }. Not applicable for bare-metal or VM installation.
 | CLUSTER_NAME       | The name of the Hadoop Cluster.                                | None | From Apache Ambari or Cloudera Manager.
+| DB_ROOT_NAME^2^    | LDAP name used to connect as database root user                | trafodion                     | Required when LDAP is enabled.
 | DCS_BUILD          | Tar file containing the DCS component.                         | None | Not needed if using a {project-name} package installation tar file.
 | DCS_PRIMARY_MASTER_NODE | The node where the primary DCS should run.                | None | The DCS Master handles JDBC and ODBC connection requests.
 | DCS_SERVER_PARM    | Number of concurrent client sessions per node.                 | 16 | This number specifies the concurrent sessions per node to be supported. Each session could require up to 1GB of physical memory. The number can be changed post-installation. For more information,
@@ -131,7 +144,9 @@ Downloaded automatically by the {project-name} Installer.
 | FLOATING_IP        | IP address if running DCS in HA mode.                          | None                          | Not needed if $ENABLE_HA = N. An FQDN name or IP address.
 | HADOOP_TYPE        | The type of Hadoop distribution you're installing {project-name} on. | None                         | Lowercase. cloudera or hadoop.
 | HBASE_GROUP        | Linux group name for the HBASE administrative user.             | hbase                         | Required in order to provide access to select HDFS directories to this user ID. 
+| HBASE_KEYTAB^2^    | HBase credentials used to grant {project-name} CRWE privileges | based on distribution         | Required if Kerberos is enabled.
 | HBASE_USER         | Linux user name for the HBASE administrative user.              | hbase                         | Required in order to provide access to select HDFS directories to this user ID. 
+| HDFS_KEYTAB^2^     | HDFS credentials used to set privileges on HDFS directories. . | based on distribution         | Required if Kerberos is enabled.
 | HDFS_USER          | Linux user name for the HDFS administrative user.               | hdfs                          | The {project-name} Installer uses `sudo su` to make HDFS
 configuration changes under this user.
 | HOME_DIR           | Root directory under which the `trafodion` home directory should be created. | /home           | *Example* +
@@ -142,25 +157,31 @@ If the home directory of the `trafodion` user is
 | INTERFACE          | Interface type used for $FLOATING_IP.                          | None                          | Not needed if $ENABLE_HA = N. 
 | JAVA_HOME          | Location of Java 1.7.0_65 or higher (JDK).                     | $JAVA_HOME setting            | Fully qualified path of the JDK. For example:
 `/usr/java/jdk1.7.0_67-cloudera`
-| LDAP_CERT^2^       | Full path to TLS certificate.                                  | None                          | Required of $LDAP_LEVEL = 1 or 2.
+| KDC_SERVER^2^      | Location of host where Kerberos server exists                  | None                          | Required if Kerberos enabled.
+| LDAP_CERT^2^       | Full path to TLS certificate.                                  | None                          | Required if $LDAP_LEVEL = 1 or 2.
 | LDAP_HOSTS^2^      | List of nodes where LDAP Identity Store servers are running.   | None                          | Blank separated. FQDN format.
 | LDAP_ID^2^         | List of LDAP unique identifiers.                               | None                          | Blank separated.    
 | LDAP_LEVEL^2^      | LDAP Encryption Level.                                         | 0                             | 0: Encryption not used, 1: SSL, 2: TLS
 | LDAP_PASSWORD^2^   | Password for LDAP_USER.                                        | None                          | If LDAP_USER is required only.
 | LDAP_PORT^2^       | Port used to communicate with LDAP Identity Store.             | None                          | Examples: 389 for no encryption or TLS, 636 for SSL.
 | LDAP_SECURITY^2^   | Whether to enable simple LDAP authentication.                | N                             | If Y, then you need to provide LDAP_HOSTS.
-| LDAP_USER^2^       | LDAP Search user name.                                         | None                          | If required. If so, must provide LDAP_PASSWORD, too.   
+| LDAP_USER^2^       | LDAP Search user name.                                         | None                          | Required if you need additional LDAP functionally such as LDAPSearch. If so, must provide LDAP_PASSWORD, too.   
 | LOCAL_WORKDIR      | The directory where the {project-name} Installer is located.        | None                          | Full path, no environmental variables.
 | MANAGEMENT_ENABLED | Whether your installation uses separate management nodes.      | N                             | Y if using separate management nodes for Apache Ambari or Cloudera Manager.
 | MANAGEMENT_NODES   | The FQDN names of management nodes, if any.                    | None                          | Provide a blank-separated list of node names.
+| MAX_LIFETIME^2^    | Kerberos ticket lifetime for Trafodion principal               | 24hours                       | Can be specified when Kerberos is enabled.   
 | NODE_LIST          | The FQDN names of the nodes where {project-name} will be installed. | None                          | Provide a blank-separated list of node names. The {project-name}
 Provisioning ID must have passwordless and `sudo` access to these nodes.
 | PASSWORD           | Administrator password for Apache Ambari or Cloudera Manager.  | admin                         | A user that can change configuration and restart services via the
 distribution manager's REST API.
+| RENEW_LIFETIME^2^  | Number times Kerberos ticket is for the Trafodion principal    | 7days                         | Can be specified when Kerberos is enabled.   
 | REST_BUILD         | Tar file containing the REST component.                        | None | Not needed if using a {project-name} package installation tar file.
+| SECURE_HADOOP^2^   | Indicates whether Hadoop has enabled Kerberos                   | Y only if Kerberos enabled | Based on whether Kerberos is enabled for your Hadoop installation
 | SQ_ROOT            | Target directory for the {project-name} software.                   | $HOME_DIR/trafodion           | {project-name} is installed in this directory on all nodes in `$NODE_LIST`.
 | START              | Whether to start {project-name} after install/upgrade.              | N                             | Does not apply to Recipe-Based Provisioning.
 | SUSE_LINUX         | Whether your installing {project-name} on SUSE Linux.               | false                         | Auto-detected by the {project-name} Installer.
+| TRAF_KEYTAB^2^     | Name to use when specifying {project-name} keytab              | based on distribution         |  Required if Kerberos is enabled.
+| TRAF_KEYTAB_DIR^2^ | Location  of {project_name} keytab                             | based on distribution         |  Required if Kerberos is enabled.
 | TRAF_PACKAGE       | The location of the {project-name} installation package tar file or core installation tar file. | None | The package file contains the {project-name} server,
 DCS, and REST software while the core installation file contains the {project-name} server software only. If you're using a core installation file, then you need to
 record the location of the DCS and REST installation tar files, too. Normally, you perform {project-name} provisioning using a {project-name} package installation tar file.
@@ -338,7 +359,7 @@ Do the following:
 |===
 | Attribute                                    | Setting
 | hbase.master.distributed.log.splitting       | false 
-| hbase.coprocessor.region.classes             | org.apache.hadoop.hbase.coprocessor.transactional.TrxRegionObserver,org.apache.hadoop.hbase.coprocessor.transactional.TrxRegionEndpoint,
+| hbase.coprocessor.region.classes^b^          | org.apache.hadoop.hbase.coprocessor.transactional.TrxRegionObserver,org.apache.hadoop.hbase.coprocessor.transactional.TrxRegionEndpoint,
 org.apache.hadoop.hbase.coprocessor.AggregateImplementation 
 | hbase.hregion.impl                           | org.apache.hadoop.hbase.regionserver.transactional.TransactionalRegion
 | hbase.regionserver.region.split.policy       | org.apache.hadoop.hbase.regionserver.ConstantSizeRegionSplitPolicy 
@@ -354,5 +375,7 @@ org.apache.hadoop.hbase.coprocessor.AggregateImplementation
 |===
 +
 a) Applies to Cloudera distributions only.
++
+b) Do not overwrite any coprocessors that may already exist.
 
 2. Restart HBase to activate the new configuration setting.

--- a/docs/provisioning_guide/src/asciidoc/_chapters/requirements.adoc
+++ b/docs/provisioning_guide/src/asciidoc/_chapters/requirements.adoc
@@ -31,12 +31,14 @@
 The current release of {project-name} has been tested with:
 
 * 64-bit Red Hat Enterprise Linux (RHEL) or CentOS 6.5, 6.6, and 6.7
-* SUSE SLES 11.3
-* Cloudera CDH 5.2
-* Cloudera CDH 5.3
+* SUSE SLES 11.3 SP2
+* Cloudera CDH 5.4
 * Hortonworks HDP 2.2
+* Hortonworks HDP 2.3
 
-Other OS releases may work, too. The {project-name} project is currently working on better support for non-distribution version of Hadoop.
+
+Other OS releases may work, too. The {project-name} project is currently working on better support for more distribution and non-distribution versions of Hadoop.
+
 
 [[requirements-general-cluster-and-os-requirements-and-recommendations]]
 == General Cluster and OS Requirements and Recommendations
@@ -152,6 +154,8 @@ On top of the ports identified above, you also need the ports required by your H
 * http://www.cloudera.com/content/www/en-us/documentation/enterprise/latest/topics/cdh_ig_ports_cdh5.html[_Cloudera Ports_]
 * http://docs.hortonworks.com/HDPDocuments/HDP2/HDP-2.3.0-Win/bk_HDP_Install_Win/content/ref-79239257-778e-42a9-9059-d982d0c08885.1.html[_Hortonworks Ports_]
 
+If you have Kerberos or LDAP enabled, then ports required by these products need to be opened as well.
+
 Although not all the ports will be used on every node of the cluster, you need to open most of them for all the nodes in the cluster that
 have {project-name}, HBase, or HDFS servers on them.
 
@@ -237,10 +241,8 @@ The {project-name} Installer requires Internet access to install the required so
 
 The `trafodion:trafodion` user ID is created as part of the installation process. The default password is: `traf123`.
 
-{project-name} requires that either HDFS ACL support or Kerberos is enabled. The {project-name} Installer will enable HDFS ACL support.
-Kerberos-based security settings are outside the scope of this guide. Please refer to the security information in
-https://hbase.apache.org/book.html#security[Apache HBase(TM) Reference Guide] for information about how to set up
-HBase security with Kerberos.
+{project-name} requires that either HDFS ACL support or Kerberos is enabled. The {project-name} Installer will enable HDFS ACL and Kerberos support. Refer to <<enable-security-kerberos,Kerberos>> for more information about the requirements and usage of Kerberos in Trafodion.
+Refer to https://hbase.apache.org/book.html#security[Apache HBase(TM) Reference Guide] for security in HBase. 
 
 Also, {project-name} requires `sudo` access to `ip` and `arping` so that floating or elastic IP addresses can be moved from one node to
 another in case of node failures.
@@ -302,15 +304,26 @@ The {project-name} Installer uses `su` to run commands under this user ID.
 
 * HDFS Administrator user name.
 * Write access to home directory on the node where the Distribution Manager is running.
+* For Kerberos enabled installations, location of the keytab for the HDFS service principal.
 
 [[requirements-hbase-administrator-user]]
 ==== HBase Administrator User
-The HBase super user. Required to change directory ownership in HDFS.
+The HBase super user. Required to change directory ownership in HDFS. For Kerberos enabled installations, the HBase super user is needed to grant the `trafodion` user create, read, write, and execute privileges.
 
 *Requirements*:
 
 * HBase Administrator user name and group.
 * Read access to `hbase-site.xml`.
+* For Kerberos enabled installations, location of the keytab for the HBase service principal.
+
+[[requirements-kerberos-administrator-user]]
+==== Kerberos Administrator User
+The Kerberos adminstrator. Required to create Trafodion principals and keytabs on a cluster where Kerberos is enabled. 
+
+*Requirements*:
+
+* Kerberos Administrator admin name including the realm.
+* Kerberos Administrator password
 
 [[requirements-required-configuration-changes]]
 == Required Configuration Changes
@@ -349,6 +362,8 @@ NOTE: These changes require a restart of ZooKeeper on all nodes in the cluster.
 | Setting        | New Value | Purpose
 | maxClientCnxns | 0         | Tell ZooKeeper to impose no limit to the number of connections to enable better {project-name} concurrency.
 |===
+
+NOTE: If Kerberos is enabled, it is not possible to secure the {project-name} data in ZooKeeper at this time. 
 
 [[requirements-hdfs-changes]]
 === HDFS Changes
@@ -403,6 +418,7 @@ NOTE: These changes require a restart of ZooKeeper and HBase on all nodes in the
 &#8226; `/usr/share/cmf/lib/plugins/` (Cloudera) +
 &#8226; `/usr/hdp/current/hbase-regionserver/lib` (Hortonworks) |
 TODO: Add purpose here.
+|For Kerberos enabled clusters, grant `trafodion` user privileges | not applicable | privileges: create, read, write, and execute access |
 |===
 
 The following changes are required in `hbase-site.xml`. Please refer to the 

--- a/docs/provisioning_guide/src/asciidoc/_chapters/script_install.adoc
+++ b/docs/provisioning_guide/src/asciidoc/_chapters/script_install.adoc
@@ -47,12 +47,6 @@ The first step in the installation process is to unpack the {project-name} Insta
 $ mkdir $HOME/trafodion-installer
 $ cd $HOME/trafodion-downloads
 $ tar -zxf apache-trafodion-installer-1.3.0-incubating-bin.tar.gz -C $HOME/trafodion-installer
-$ ls $HOME/trafodion-installer/installer
-bashrc_default           tools                             traf_config_check           trafodion_apache_hadoop_install  traf_package_setup
-build-version-1.3.0.txt  traf_add_user                     traf_config_setup           trafodion_config_default         traf_setup
-dcs_installer            traf_apache_hadoop_config_setup   traf_create_systemdefaults  trafodion_install                traf_sqconfig
-rest_installer           traf_authentication_conf_default  traf_getHadoopNodes         trafodion_license                traf_start
-setup_known_hosts.exp    traf_cloudera_mods98              traf_hortonworks_mods98     trafodion_uninstaller
 $
 ```
 
@@ -65,7 +59,9 @@ in the <<introduction,Introduction>> chapter for instructions of how you edit yo
 Edit your config file using the information you collected in the <<prepare-gather-configuration-information,Gather Configuration Information>>
 step in the <<prepare,Prepare>> chapter. 
 
-The following example shows an automated install of {project-name} on a two-node Hortonworks Hadoop cluster.
+
+The following example shows an automated install of {project-name} on a two-node Hortonworks Hadoop cluster that does not have Kerberos nor LDAP enabled.
+
 
 NOTE: By default, the {project-name} Installer invokes `sqlci` so that you can enter the `initialize trafodion;` command.
 This is shown in the example below.
@@ -243,7 +239,8 @@ operations.
 The {project-name} Installer prompts you for the information you collected in the
 <<prepare-gather-configuration-information, Gather Configuration Information>> step in the <<prepare,Prepare>> chapter.
 
-The following example shows a guided install of {project-name} on a two-node Cloudera Hadoop cluster.
+The following example shows a guided install of {project-name} on a two-node Cloudera Hadoop cluster that does not have Kerberos nor LDAP installed.
+
 
 NOTE: By default, the {project-name} Installer invokes `sqlci` so that you can enter the `initialize trafodion;` command.
 This is shown in the example below.

--- a/docs/provisioning_guide/src/asciidoc/_chapters/script_upgrade.adoc
+++ b/docs/provisioning_guide/src/asciidoc/_chapters/script_upgrade.adoc
@@ -56,12 +56,6 @@ You unpack the updated {project-name} Installer into a new directory.
 $ mkdir $HOME/trafodion-installer-2.0
 $ cd $HOME/trafodion-downloads
 $ tar -zxf apache-trafodion-installer-2.0.0-incubating-bin.tar.gz -C $HOME/trafodion-installer
-$ ls $HOME/trafodion-installer/installer-2.0
-bashrc_default           tools                             traf_config_check           trafodion_apache_hadoop_install  traf_package_setup
-build-version-2.0.0.txt  traf_add_user                     traf_config_setup           trafodion_config_default         traf_setup
-dcs_installer            traf_apache_hadoop_config_setup   traf_create_systemdefaults  trafodion_install                traf_sqconfig
-rest_installer           traf_authentication_conf_default  traf_getHadoopNodes         trafodion_license                traf_start
-setup_known_hosts.exp    traf_cloudera_mods98              traf_hortonworks_mods98     trafodion_uninstaller
 $
 ```
 
@@ -154,7 +148,7 @@ export LOCAL_WORKDIR="/home/centos/trafodion-installer/installer"
 export TRAF_PACKAGE="/home/centos/trafodion-download/apache-trafodion-1.3.0-incubating-bin.tar.gz"
 export SQ_ROOT="/home/trafodion/apache-trafodion-1.3.0-incubating-bin"
 
-$ # Use your favorit editor to modify my_config_2.0
+$ # Use your favorite editor to modify my_config_2.0
 $ emacs my_config_2.0
 $ # Post edit changes
 
@@ -163,8 +157,9 @@ export TRAF_PACKAGE="/home/centos/trafodion-download/apache-trafodion-2.0.0-incu
 export SQ_ROOT="/home/trafodion/apache-trafodion-2.0.0-incubating-bin"
 ```
 
+
 The following example shows an upgrade of {project-name} on a two-node Hortonworks Hadoop cluster using
-Automated Setup mode.
+Automated Setup mode without Kerberos nor LDAP enabled.
 
 NOTE: The {project-name} Installer performs the same configuration changes as it does for an installation,
 including restarting Hadoop services.
@@ -287,7 +282,8 @@ export TRAF_PACKAGE="/home/centos/trafodion-download/apache-trafodion-1.3.0-incu
 export SQ_ROOT="/home/trafodion/apache-trafodion-1.3.0-incubating-bin"
 
 
-The following example shows a guided upgrade of {project-name} on a two-node Cloudera Hadoop cluster.
+
+The following example shows a guided upgrade of {project-name} on a two-node Cloudera Hadoop cluster without Kerberos nor LDAP enabled.
 
 *Example*
 

--- a/docs/shared/revisions.txt
+++ b/docs/shared/revisions.txt
@@ -26,7 +26,8 @@
 [cols="2",options="header"]
 |===
 | Version    | Date
-| 2.0.0      | To be announced.
+| 2.0.1      | To be announced
+| 2.0.0      | June, 6, 2016
 | 1.3.0      | January, 2016  
 |===
 

--- a/docs/sql_reference/src/asciidoc/_chapters/sql_statements.adoc
+++ b/docs/sql_reference/src/asciidoc/_chapters/sql_statements.adoc
@@ -4351,7 +4351,7 @@ only trafodion.
 
 IMPORTANT: The GET COMPONENT PRIVILEGES, GET COMPONENTS, GET ROLES FOR USER, and GET USERS FOR ROLE statements work only when
 authentication and authorization are enabled in {project-name}. For more information, see
-http://trafodion.apache.org/enable-secure-trafodion.html[Enable Secure {project-name}].
+{docs-url}/provisioning_guide/index.html#enable-security [Enable Secure {project-name}].
 
 The GET statement displays delimited object names in their internal format. For example, the GET statement returns the delimited
 name "my ""table""" as my "table".
@@ -4764,7 +4764,7 @@ The GRANT statement grants access privileges on an SQL object to specified users
 
 IMPORTANT: This statement works only when authentication and
 authorization are enabled in {project-name}. For more information, see
-http://trafodion.apache.org/enable-secure-trafodion.html[Enable Secure {project-name}].
+{docs-url}/provisioning_guide/index.html#enable-security [Enable Secure {project-name}].
 
 ```
 GRANT {privilege [,privilege]... |ALL [PRIVILEGES]} 
@@ -4899,7 +4899,7 @@ The GRANT COMPONENT PRIVILEGE statement grants one or more component privileges 
 GRANT COMPONENT PRIVILEGE is a {project-name} SQL extension.
 
 IMPORTANT: This statement works only when authentication and authorization are enabled in {project-name}. For more information, see
-http://trafodion.apache.org/enable-secure-trafodion.html[Enable Secure {project-name}].
+{docs-url}/provisioning_guide/index.html#enable-security [Enable Secure {project-name}].
 
 ```
 GRANT COMPONENT PRIVILEGE {privilege-name [, privilege-name]...} 
@@ -5021,7 +5021,7 @@ GRANT COMPONENT PRIVILEGE CREATE_TABLE ON SQL_OPERATIONS TO sqluser1;
 The GRANT ROLE statement grants one or more roles to a user. See <<roles,Roles>>.
 
 IMPORTANT: This statement works only when authentication and authorization are enabled in {project-name}. For more information, 
-see http://trafodion.apache.org/enable-secure-trafodion.html[Enable Secure {project-name}].
+{docs-url}/provisioning_guide/index.html#enable-security [Enable Secure {project-name}].
 
 ```
 GRANT ROLE {role-name [,role-name ]...}
@@ -5781,7 +5781,7 @@ REGISTER USER "jsmith@company.com";
 The REVOKE statement revokes access privileges on an SQL object from specified users or roles.
 
 IMPORTANT: This statement works only when authentication and authorization are enabled in {project-name}. For more information,
-see http://trafodion.apache.org/enable-secure-trafodion.html[Enable Secure {project-name}].
+{docs-url}/provisioning_guide/index.html#enable-security [Enable Secure {project-name}].
 
 ```
 REVOKE [GRANT OPTION FOR]
@@ -5967,7 +5967,7 @@ privileges from a user or role. See <<privileges,Privileges>> and <<roles,Roles>
 REVOKE COMPONENT PRIVILEGE is a {project-name} SQL extension.
 
 IMPORTANT: This statement works only when authentication and authorization are enabled in {project-name}. For more information,
-see http://trafodion.apache.org/enable-secure-trafodion.html[Enable Secure {project-name}].
+{docs-url}/provisioning_guide/index.html#enable-security [Enable Secure {project-name}].
 
 ```
 REVOKE [GRANT OPTION FOR]
@@ -6059,7 +6059,7 @@ The REVOKE ROLE statement removes one or more roles from a user. See
 <<roles,Roles>>.
 
 IMPORTANT: This statement works only when authentication and authorization are enabled in {project-name}. For more information,
-see http://trafodion.apache.org/enable-secure-trafodion.html[Enable Secure {project-name}].
+{docs-url}/provisioning_guide/index.html#enable-security [Enable Secure {project-name}].
 
 ```
 REVOKE ROLE {role-name [,role-name]...}


### PR DESCRIPTION
Changed the provisioning guide to include provisioning for Kerberos.
Fixed some links to the provisioning guide in the sql reference document.
Fixed a few issues in the provisioning guide found while adding Kerberos