### PR TITLE
Modified Provisioning Guide and fixed build errors.

### DIFF
--- a/docs/client_install/pom.xml
+++ b/docs/client_install/pom.xml
@@ -36,7 +36,7 @@
   <parent>
     <groupId>org.apache.trafodion</groupId>
     <artifactId>trafodion</artifactId>
-    <version>1.3.0</version>
+    <version>2.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
@@ -79,18 +79,21 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
+    <dependency.locations.enabled>false</dependency.locations.enabled>
   </properties>
 
   <repositories>
     <repository>
-      <id>rubygems-proxy-releases</id>
-      <name>RubyGems.org Proxy (Releases)</name>
+      <id>rubygems-proxy</id>
+      <name>Rubygems Proxy</name>
       <url>http://rubygems-proxy.torquebox.org/releases</url>
-      <releases>
+      <layout>default</layout>
+        <releases>
         <enabled>true</enabled>
       </releases>
       <snapshots>
         <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
       </snapshots>
     </repository>
   </repositories>

--- a/docs/client_install/pom.xml
+++ b/docs/client_install/pom.xml
@@ -36,7 +36,7 @@
   <parent>
     <groupId>org.apache.trafodion</groupId>
     <artifactId>trafodion</artifactId>
-    <version>2.0.0</version>
+    <version>1.3.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
@@ -79,21 +79,18 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
-    <!--dependency.locations.enabled>false</dependency.locations.enabled-->
   </properties>
 
   <repositories>
     <repository>
-      <id>rubygems-proxy</id>
-      <name>Rubygems Proxy</name>
+      <id>rubygems-proxy-releases</id>
+      <name>RubyGems.org Proxy (Releases)</name>
       <url>http://rubygems-proxy.torquebox.org/releases</url>
-      <layout>default</layout>
-        <releases>
+      <releases>
         <enabled>true</enabled>
       </releases>
       <snapshots>
         <enabled>false</enabled>
-        <updatePolicy>never</updatePolicy>
       </snapshots>
     </repository>
   </repositories>

--- a/docs/client_install/pom.xml
+++ b/docs/client_install/pom.xml
@@ -79,6 +79,7 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
+    <dependency.locations.enabled>false</dependency.locations.enabled>
   </properties>
 
   <repositories>

--- a/docs/client_install/pom.xml
+++ b/docs/client_install/pom.xml
@@ -79,7 +79,7 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
-    <dependency.locations.enabled>false</dependency.locations.enabled>
+    <!--dependency.locations.enabled>false</dependency.locations.enabled-->
   </properties>
 
   <repositories>

--- a/docs/command_interface/pom.xml
+++ b/docs/command_interface/pom.xml
@@ -79,6 +79,7 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
+    <dependency.locations.enabled>false</dependency.locations.enabled>
   </properties>
 
   <repositories>

--- a/docs/command_interface/pom.xml
+++ b/docs/command_interface/pom.xml
@@ -37,7 +37,7 @@
     <groupId>org.apache.trafodion</groupId>
     <artifactId>trafodion</artifactId>
     <relativePath>../../pom.xml</relativePath>
-    <version>1.3.0</version>
+    <version>2.0.0</version>
   </parent>
 
 
@@ -79,18 +79,21 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
+    <dependency.locations.enabled>false</dependency.locations.enabled>
   </properties>
 
   <repositories>
     <repository>
-      <id>rubygems-proxy-releases</id>
-      <name>RubyGems.org Proxy (Releases)</name>
+      <id>rubygems-proxy</id>
+      <name>Rubygems Proxy</name>
       <url>http://rubygems-proxy.torquebox.org/releases</url>
-      <releases>
+      <layout>default</layout>
+        <releases>
         <enabled>true</enabled>
       </releases>
       <snapshots>
         <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
       </snapshots>
     </repository>
   </repositories>

--- a/docs/command_interface/pom.xml
+++ b/docs/command_interface/pom.xml
@@ -79,7 +79,7 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
-    <dependency.locations.enabled>false</dependency.locations.enabled>
+    <!--dependency.locations.enabled>false</dependency.locations.enabled-->
   </properties>
 
   <repositories>

--- a/docs/command_interface/pom.xml
+++ b/docs/command_interface/pom.xml
@@ -37,7 +37,7 @@
     <groupId>org.apache.trafodion</groupId>
     <artifactId>trafodion</artifactId>
     <relativePath>../../pom.xml</relativePath>
-    <version>2.0.0</version>
+    <version>1.3.0</version>
   </parent>
 
 
@@ -79,21 +79,18 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
-    <!--dependency.locations.enabled>false</dependency.locations.enabled-->
   </properties>
 
   <repositories>
     <repository>
-      <id>rubygems-proxy</id>
-      <name>Rubygems Proxy</name>
+      <id>rubygems-proxy-releases</id>
+      <name>RubyGems.org Proxy (Releases)</name>
       <url>http://rubygems-proxy.torquebox.org/releases</url>
-      <layout>default</layout>
-        <releases>
+      <releases>
         <enabled>true</enabled>
       </releases>
       <snapshots>
         <enabled>false</enabled>
-        <updatePolicy>never</updatePolicy>
       </snapshots>
     </repository>
   </repositories>

--- a/docs/cqd_reference/pom.xml
+++ b/docs/cqd_reference/pom.xml
@@ -39,7 +39,7 @@
     <groupId>org.apache.trafodion</groupId>
     <artifactId>trafodion</artifactId>
     <relativePath>../../pom.xml</relativePath>
-    <version>1.3.0</version>
+    <version>2.0.0</version>
   </parent>
 
 
@@ -81,18 +81,21 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
+    <dependency.locations.enabled>false</dependency.locations.enabled>
   </properties>
 
   <repositories>
     <repository>
-      <id>rubygems-proxy-releases</id>
-      <name>RubyGems.org Proxy (Releases)</name>
+      <id>rubygems-proxy</id>
+      <name>Rubygems Proxy</name>
       <url>http://rubygems-proxy.torquebox.org/releases</url>
-      <releases>
+      <layout>default</layout>
+        <releases>
         <enabled>true</enabled>
       </releases>
       <snapshots>
         <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
       </snapshots>
     </repository>
   </repositories>

--- a/docs/cqd_reference/pom.xml
+++ b/docs/cqd_reference/pom.xml
@@ -81,7 +81,7 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
-    <dependency.locations.enabled>false</dependency.locations.enabled>
+    <!--dependency.locations.enabled>false</dependency.locations.enabled-->
   </properties>
 
   <repositories>

--- a/docs/cqd_reference/pom.xml
+++ b/docs/cqd_reference/pom.xml
@@ -39,7 +39,7 @@
     <groupId>org.apache.trafodion</groupId>
     <artifactId>trafodion</artifactId>
     <relativePath>../../pom.xml</relativePath>
-    <version>2.0.0</version>
+    <version>1.3.0</version>
   </parent>
 
 
@@ -81,21 +81,18 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
-    <!--dependency.locations.enabled>false</dependency.locations.enabled-->
   </properties>
 
   <repositories>
     <repository>
-      <id>rubygems-proxy</id>
-      <name>Rubygems Proxy</name>
+      <id>rubygems-proxy-releases</id>
+      <name>RubyGems.org Proxy (Releases)</name>
       <url>http://rubygems-proxy.torquebox.org/releases</url>
-      <layout>default</layout>
-        <releases>
+      <releases>
         <enabled>true</enabled>
       </releases>
       <snapshots>
         <enabled>false</enabled>
-        <updatePolicy>never</updatePolicy>
       </snapshots>
     </repository>
   </repositories>

--- a/docs/cqd_reference/pom.xml
+++ b/docs/cqd_reference/pom.xml
@@ -81,6 +81,7 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
+    <dependency.locations.enabled>false</dependency.locations.enabled>
   </properties>
 
   <repositories>

--- a/docs/jdbct4ref_guide/pom.xml
+++ b/docs/jdbct4ref_guide/pom.xml
@@ -36,7 +36,7 @@
   <parent>
     <groupId>org.apache.trafodion</groupId>
     <artifactId>trafodion</artifactId>
-    <version>1.3.0</version>
+    <version>2.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
@@ -79,18 +79,21 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
+    <dependency.locations.enabled>false</dependency.locations.enabled>
   </properties>
 
   <repositories>
     <repository>
-      <id>rubygems-proxy-releases</id>
-      <name>RubyGems.org Proxy (Releases)</name>
+      <id>rubygems-proxy</id>
+      <name>Rubygems Proxy</name>
       <url>http://rubygems-proxy.torquebox.org/releases</url>
-      <releases>
+      <layout>default</layout>
+        <releases>
         <enabled>true</enabled>
       </releases>
       <snapshots>
         <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
       </snapshots>
     </repository>
   </repositories>

--- a/docs/jdbct4ref_guide/pom.xml
+++ b/docs/jdbct4ref_guide/pom.xml
@@ -36,7 +36,7 @@
   <parent>
     <groupId>org.apache.trafodion</groupId>
     <artifactId>trafodion</artifactId>
-    <version>2.0.0</version>
+    <version>1.3.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
@@ -79,21 +79,18 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
-    <!--dependency.locations.enabled>false</dependency.locations.enabled-->
   </properties>
 
   <repositories>
     <repository>
-      <id>rubygems-proxy</id>
-      <name>Rubygems Proxy</name>
+      <id>rubygems-proxy-releases</id>
+      <name>RubyGems.org Proxy (Releases)</name>
       <url>http://rubygems-proxy.torquebox.org/releases</url>
-      <layout>default</layout>
-        <releases>
+      <releases>
         <enabled>true</enabled>
       </releases>
       <snapshots>
         <enabled>false</enabled>
-        <updatePolicy>never</updatePolicy>
       </snapshots>
     </repository>
   </repositories>

--- a/docs/jdbct4ref_guide/pom.xml
+++ b/docs/jdbct4ref_guide/pom.xml
@@ -79,6 +79,7 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
+    <dependency.locations.enabled>false</dependency.locations.enabled>
   </properties>
 
   <repositories>

--- a/docs/jdbct4ref_guide/pom.xml
+++ b/docs/jdbct4ref_guide/pom.xml
@@ -79,7 +79,7 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
-    <dependency.locations.enabled>false</dependency.locations.enabled>
+    <!--dependency.locations.enabled>false</dependency.locations.enabled-->
   </properties>
 
   <repositories>

--- a/docs/load_transform/pom.xml
+++ b/docs/load_transform/pom.xml
@@ -79,6 +79,7 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
+    <dependency.locations.enabled>false</dependency.locations.enabled>
   </properties>
 
   <repositories>

--- a/docs/load_transform/pom.xml
+++ b/docs/load_transform/pom.xml
@@ -37,7 +37,7 @@
     <groupId>org.apache.trafodion</groupId>
     <artifactId>trafodion</artifactId>
     <relativePath>../../pom.xml</relativePath>
-    <version>1.3.0</version>
+    <version>2.0.0</version>
   </parent>
 
 
@@ -79,18 +79,21 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
+    <dependency.locations.enabled>false</dependency.locations.enabled>
   </properties>
 
   <repositories>
     <repository>
-      <id>rubygems-proxy-releases</id>
-      <name>RubyGems.org Proxy (Releases)</name>
+      <id>rubygems-proxy</id>
+      <name>Rubygems Proxy</name>
       <url>http://rubygems-proxy.torquebox.org/releases</url>
-      <releases>
+      <layout>default</layout>
+        <releases>
         <enabled>true</enabled>
       </releases>
       <snapshots>
         <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
       </snapshots>
     </repository>
   </repositories>

--- a/docs/load_transform/pom.xml
+++ b/docs/load_transform/pom.xml
@@ -79,7 +79,7 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
-    <dependency.locations.enabled>false</dependency.locations.enabled>
+    <!--dependency.locations.enabled>false</dependency.locations.enabled-->
   </properties>
 
   <repositories>

--- a/docs/load_transform/pom.xml
+++ b/docs/load_transform/pom.xml
@@ -37,7 +37,7 @@
     <groupId>org.apache.trafodion</groupId>
     <artifactId>trafodion</artifactId>
     <relativePath>../../pom.xml</relativePath>
-    <version>2.0.0</version>
+    <version>1.3.0</version>
   </parent>
 
 
@@ -79,21 +79,18 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
-    <!--dependency.locations.enabled>false</dependency.locations.enabled-->
   </properties>
 
   <repositories>
     <repository>
-      <id>rubygems-proxy</id>
-      <name>Rubygems Proxy</name>
+      <id>rubygems-proxy-releases</id>
+      <name>RubyGems.org Proxy (Releases)</name>
       <url>http://rubygems-proxy.torquebox.org/releases</url>
-      <layout>default</layout>
-        <releases>
+      <releases>
         <enabled>true</enabled>
       </releases>
       <snapshots>
         <enabled>false</enabled>
-        <updatePolicy>never</updatePolicy>
       </snapshots>
     </repository>
   </repositories>

--- a/docs/messages_guide/pom.xml
+++ b/docs/messages_guide/pom.xml
@@ -37,7 +37,7 @@
     <groupId>org.apache.trafodion</groupId>
     <artifactId>trafodion</artifactId>
     <relativePath>../../pom.xml</relativePath>
-    <version>2.0.0</version>
+    <version>1.3.0</version>
   </parent>
 
   <licenses>
@@ -78,21 +78,18 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
-    <!--dependency.locations.enabled>false</dependency.locations.enabled-->
   </properties>
 
   <repositories>
     <repository>
-      <id>rubygems-proxy</id>
-      <name>Rubygems Proxy</name>
+      <id>rubygems-proxy-releases</id>
+      <name>RubyGems.org Proxy (Releases)</name>
       <url>http://rubygems-proxy.torquebox.org/releases</url>
-      <layout>default</layout>
-        <releases>
+      <releases>
         <enabled>true</enabled>
       </releases>
       <snapshots>
         <enabled>false</enabled>
-        <updatePolicy>never</updatePolicy>
       </snapshots>
     </repository>
   </repositories>

--- a/docs/messages_guide/pom.xml
+++ b/docs/messages_guide/pom.xml
@@ -78,7 +78,7 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
-    <dependency.locations.enabled>false</dependency.locations.enabled>
+    <!--dependency.locations.enabled>false</dependency.locations.enabled-->
   </properties>
 
   <repositories>

--- a/docs/messages_guide/pom.xml
+++ b/docs/messages_guide/pom.xml
@@ -78,6 +78,7 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
+    <dependency.locations.enabled>false</dependency.locations.enabled>
   </properties>
 
   <repositories>

--- a/docs/messages_guide/pom.xml
+++ b/docs/messages_guide/pom.xml
@@ -37,7 +37,7 @@
     <groupId>org.apache.trafodion</groupId>
     <artifactId>trafodion</artifactId>
     <relativePath>../../pom.xml</relativePath>
-    <version>1.3.0</version>
+    <version>2.0.0</version>
   </parent>
 
   <licenses>
@@ -78,18 +78,21 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
+    <dependency.locations.enabled>false</dependency.locations.enabled>
   </properties>
 
   <repositories>
     <repository>
-      <id>rubygems-proxy-releases</id>
-      <name>RubyGems.org Proxy (Releases)</name>
+      <id>rubygems-proxy</id>
+      <name>Rubygems Proxy</name>
       <url>http://rubygems-proxy.torquebox.org/releases</url>
-      <releases>
+      <layout>default</layout>
+        <releases>
         <enabled>true</enabled>
       </releases>
       <snapshots>
         <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
       </snapshots>
     </repository>
   </repositories>

--- a/docs/odb_user/pom.xml
+++ b/docs/odb_user/pom.xml
@@ -36,7 +36,7 @@
     <groupId>org.apache.trafodion</groupId>
     <artifactId>trafodion</artifactId>
     <relativePath>../../pom.xml</relativePath>
-    <version>2.0.0</version>
+    <version>1.3.0</version>
   </parent>
 
 
@@ -78,21 +78,18 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
-    <!--dependency.locations.enabled>false</dependency.locations.enabled-->
   </properties>
 
   <repositories>
     <repository>
-      <id>rubygems-proxy</id>
-      <name>Rubygems Proxy</name>
+      <id>rubygems-proxy-releases</id>
+      <name>RubyGems.org Proxy (Releases)</name>
       <url>http://rubygems-proxy.torquebox.org/releases</url>
-      <layout>default</layout>
-        <releases>
+      <releases>
         <enabled>true</enabled>
       </releases>
       <snapshots>
         <enabled>false</enabled>
-        <updatePolicy>never</updatePolicy>
       </snapshots>
     </repository>
   </repositories>

--- a/docs/odb_user/pom.xml
+++ b/docs/odb_user/pom.xml
@@ -36,7 +36,7 @@
     <groupId>org.apache.trafodion</groupId>
     <artifactId>trafodion</artifactId>
     <relativePath>../../pom.xml</relativePath>
-    <version>1.3.0</version>
+    <version>2.0.0</version>
   </parent>
 
 
@@ -78,18 +78,21 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
+    <dependency.locations.enabled>false</dependency.locations.enabled>
   </properties>
 
   <repositories>
     <repository>
-      <id>rubygems-proxy-releases</id>
-      <name>RubyGems.org Proxy (Releases)</name>
+      <id>rubygems-proxy</id>
+      <name>Rubygems Proxy</name>
       <url>http://rubygems-proxy.torquebox.org/releases</url>
-      <releases>
+      <layout>default</layout>
+        <releases>
         <enabled>true</enabled>
       </releases>
       <snapshots>
         <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
       </snapshots>
     </repository>
   </repositories>

--- a/docs/odb_user/pom.xml
+++ b/docs/odb_user/pom.xml
@@ -78,7 +78,7 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
-    <dependency.locations.enabled>false</dependency.locations.enabled>
+    <!--dependency.locations.enabled>false</dependency.locations.enabled-->
   </properties>
 
   <repositories>

--- a/docs/odb_user/pom.xml
+++ b/docs/odb_user/pom.xml
@@ -78,6 +78,7 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
+    <dependency.locations.enabled>false</dependency.locations.enabled>
   </properties>
 
   <repositories>

--- a/docs/provisioning_guide/pom.xml
+++ b/docs/provisioning_guide/pom.xml
@@ -79,6 +79,7 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
+    <dependency.locations.enabled>false</dependency.locations.enabled>
   </properties>
 
   <repositories>

--- a/docs/provisioning_guide/pom.xml
+++ b/docs/provisioning_guide/pom.xml
@@ -37,7 +37,7 @@
     <groupId>org.apache.trafodion</groupId>
     <artifactId>trafodion</artifactId>
     <relativePath>../../pom.xml</relativePath>
-    <version>1.3.0</version>
+    <version>2.0.0</version>
   </parent>
 
 
@@ -79,18 +79,21 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
+    <dependency.locations.enabled>false</dependency.locations.enabled>
   </properties>
 
   <repositories>
     <repository>
-      <id>rubygems-proxy-releases</id>
-      <name>RubyGems.org Proxy (Releases)</name>
+      <id>rubygems-proxy</id>
+      <name>Rubygems Proxy</name>
       <url>http://rubygems-proxy.torquebox.org/releases</url>
-      <releases>
+      <layout>default</layout>
+        <releases>
         <enabled>true</enabled>
       </releases>
       <snapshots>
         <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
       </snapshots>
     </repository>
   </repositories>

--- a/docs/provisioning_guide/pom.xml
+++ b/docs/provisioning_guide/pom.xml
@@ -79,7 +79,7 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
-    <dependency.locations.enabled>false</dependency.locations.enabled>
+    <!--dependency.locations.enabled>false</dependency.locations.enabled-->
   </properties>
 
   <repositories>

--- a/docs/provisioning_guide/pom.xml
+++ b/docs/provisioning_guide/pom.xml
@@ -37,7 +37,7 @@
     <groupId>org.apache.trafodion</groupId>
     <artifactId>trafodion</artifactId>
     <relativePath>../../pom.xml</relativePath>
-    <version>2.0.0</version>
+    <version>1.3.0</version>
   </parent>
 
 
@@ -79,21 +79,18 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
-    <!--dependency.locations.enabled>false</dependency.locations.enabled-->
   </properties>
 
   <repositories>
     <repository>
-      <id>rubygems-proxy</id>
-      <name>Rubygems Proxy</name>
+      <id>rubygems-proxy-releases</id>
+      <name>RubyGems.org Proxy (Releases)</name>
       <url>http://rubygems-proxy.torquebox.org/releases</url>
-      <layout>default</layout>
-        <releases>
+      <releases>
         <enabled>true</enabled>
       </releases>
       <snapshots>
         <enabled>false</enabled>
-        <updatePolicy>never</updatePolicy>
       </snapshots>
     </repository>
   </repositories>

--- a/docs/provisioning_guide/src/asciidoc/_chapters/prepare.adoc
+++ b/docs/provisioning_guide/src/asciidoc/_chapters/prepare.adoc
@@ -76,7 +76,7 @@ After running these commands, do the following:
 
 * If necessary, create the `$HOME/.ssh` directory on the other nodes in your cluster and secure it private to yourself (`chmod 700`).
 * If necessary, create the `$HOME/.ssh/authorized_keys` file on the other nodes in your cluster. Secure it with `chmod 600 $HOME/.ssh/authorized_keys`.
-* Copy the content of the `$HOME/.ssh/authorized_keys` file on the Provisioning Master Node and append the to the
+* Copy the content of the `$HOME/.ssh/id_rsa.pub` file on the Provisioning Master Node and append the to the
 `$HOME/.ssh/authorized_keys` file on the other nodes in your cluster.
 * `ssh` to the other nodes in the cluster. Answer `y` to the prompt asking you whether to continue the connection.
 This adds the node to the `$HOME/.ssh/known_hosts` file completing the passwordless ssh setup.
@@ -213,46 +213,9 @@ If none of these situations exist, then we highly recommend that you use the {pr
 
 You perform this step as a user with `root` or `sudo` access.
 
-Install the packages listed in <<requirements-software-packages,Software Packages>> above on all nodes in the cluster. Note the special
-handling for `log4c&#43;&#43;`. See <<prepare-install-log4cplusplus, Install log4c++>> below for more information.
+Install the packages listed in <<requirements-software-packages,Software Packages>> above on all nodes in the cluster. 
 
 <<<
-[[prepare-install-log4cplusplus]]
-=== Install log4c++
-
-You perform this step as a user with `root` or `sudo` access.
-
-This step is required regardless of the <<introduction-provisioning-options,Provisioning Options>> used.
-
-1. Download the log4c&#43;&#43; RPM from the {project-name} {download-url}[Download] page.
-
-2. Copy and Install the log4c&#43;&#43; RPM on All Nodes
-+
-Use either `rpm -U` or `yum install`.
-+
-*Example*
-+
-```
-# Repeat for all nodes in the cluster from the Provisioning Master Node
-scp log4cxx-0.10.0-13.el6.x86_64.rpm <other-node>:$PWD
-
-ssh <other-node>
-sudo yum -y install log4cxx-0.10.0-13.el6.x86_64.rpm
-exit
-
-```
-+
-<<<
-3. Verify RPM Installation on Every Node
-+
-Use the following command to verify that `log4c&#43;&#43;` has been installed on every node in the cluster.
-+
-```
-# Repeat for all nodes in the cluster
-sudo rpm -qa | grep log4cxx
-log4cxx-0.10.0-13.el6.x86_64
-```
-
 [[prepare-download-trafodion-binaries]]
 == Download {project-name} Binaries
 
@@ -266,8 +229,6 @@ NOTE: You can download and install the {project-name} Clients once you've instal
 {docs-url}/client_install/index.html[{project-name} Client Install Guide] for instructions.
 
 *Example*
-
-http://apache.cs.utah.edu/incubator/celix/celix-1.0.0.incubating/celix-1.0.0.incubating.tar.gz
 
 ```
 $ mkdir $HOME/trafodion-download

--- a/docs/provisioning_guide/src/asciidoc/_chapters/quickstart.adoc
+++ b/docs/provisioning_guide/src/asciidoc/_chapters/quickstart.adoc
@@ -1,0 +1,597 @@
+////
+/**
+* @@@ START COPYRIGHT @@@
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+* @@@ END COPYRIGHT @@@
+*/
+////
+[[quickstart]]
+= Quick Start
+
+This chapter provides a quick start for how to use the {project-name} Installer to install {project-name}. 
+
+You need the following before using the information herein:
+
+* A supported and running Hadoop enviroment with HDFS, HBase, and Hive. Refer to the 
+http://trafodion.apache.org/release-notes.html[Release Notes] for information about supported versions.
+* A user ID with passwordless SSH among all the nodes in the cluster. This user ID must have sudo access.
+
+NOTE: The {project-name} Installer modifies and restarts your Hadoop environment.
+
+== Download Binaries
+You download the {project-name} binaries from the {project-name} {download-url}[Download] page. 
+Download the following packages:
+
+* {project-name} Installer (if planning to use the {project-name} Installer)
+* {project-name} Server
+
+NOTE: You can download and install the {project-name} Clients once you've installed and activated {project-name}. Refer to the
+{docs-url}/client_install/index.html[{project-name} Client Install Guide] for instructions.
+
+*Example*
+
+```
+$ mkdir $HOME/trafodion-download
+$ cd $HOME/trafodion-download
+$ # Download the Trafodion Installer binaries
+$ wget http://apache.cs.utah.edu/incubator/trafodion/trafodion-1.3.0.incubating/apache-trafodion-installer-1.3.0-incubating-bin.tar.gz
+Resolving http://apache.cs.utah.edu... 192.168.1.56
+Connecting to http://apache.cs.utah.edu|192.168.1.56|:80... connected.
+HTTP request sent, awaiting response... 200 OK
+Length: 68813 (67K) [application/x-gzip]
+Saving to: "apache-trafodion-installer-1.3.0-incubating-bin.tar.gz"
+
+100%[=====================================================================================================================>] 68,813       124K/s   in 0.5s
+
+2016-02-14 04:19:42 (124 KB/s) - "apache-trafodion-installer-1.3.0-incubating-bin.tar.gz" saved [68813/68813]
+```
+
+<<<
+```
+$ # Download the Trafodion Server binaries
+$ wget http://apache.cs.utah.edu/incubator/trafodion/trafodion-1.3.0.incubating/apache-trafodion-1.3.0-incubating-bin.tar.gz
+Resolving http://apache.cs.utah.edu... 192.168.1.56
+Connecting to http://apache.cs.utah.edu|192.168.1.56|:80... connected.
+HTTP request sent, awaiting response... 200 OK
+Length: 214508243 (205M) [application/x-gzip]
+Saving to: "apache-trafodion-1.3.0-incubating-bin.tar.gz"
+
+100%[=====================================================================================================================>] 214,508,243 3.90M/s   in 55s
+
+2016-02-14 04:22:14 (3.72 MB/s) - "apache-trafodion-1.3.0-incubating-bin.tar.gz" saved [214508243/214508243]
+
+$ ls -l
+total 209552
+-rw-rw-r-- 1 centos centos 214508243 Jan 12 20:10 apache-trafodion-1.3.0-incubating-bin.tar.gz
+-rw-rw-r-- 1 centos centos     68813 Jan 12 20:10 apache-trafodion-installer-1.3.0-incubating-bin.tar.gz
+$
+```
+
+[[quickstart-unpack-installer]]
+== Unpack Installer
+
+The first step in the installation process is to unpack the {project-name} Installer tar file.
+
+*Example*
+
+```
+$ mkdir $HOME/trafodion-installer
+$ cd $HOME/trafodion-downloads
+$ tar -zxf apache-trafodion-installer-1.3.0-incubating-bin.tar.gz -C $HOME/trafodion-installer
+$ ls $HOME/trafodion-installer/installer
+bashrc_default           tools                             traf_config_check           trafodion_apache_hadoop_install  traf_package_setup
+build-version-1.3.0.txt  traf_add_user                     traf_config_setup           trafodion_config_default         traf_setup
+dcs_installer            traf_apache_hadoop_config_setup   traf_create_systemdefaults  trafodion_install                traf_sqconfig
+rest_installer           traf_authentication_conf_default  traf_getHadoopNodes         trafodion_license                traf_start
+setup_known_hosts.exp    traf_cloudera_mods98              traf_hortonworks_mods98     trafodion_uninstaller
+$
+```
+
+[[quickstart-collect-information]]
+== Collect Information
+
+Collect/decide the following information:
+
+=== Location of {project-name} Server-Side Binary
+
+You need the fully-qualified name of the {project-name} server-side binary. 
+
+*Example*
+
+```
+/home/trafodion-downloads/apache-trafodion-installer-1.3.0-incubating-bin.tar.gz
+```
+
+=== Java Location
+
+You need to record the location of the Java. For example, use `ps -ef | grep java | grep hadoop | grep hbase` to determine what version HBase is running.
+
+*Example*
+
+```
+ps -ef | grep java | grep hadoop | grep hbase
+hbase     17302  17288  1 20:35 ?        00:00:10 /usr/jdk64/jdk1.7.0_67/bin/java -Dproc_master -XX:OnOutOfMemoryError=kill -9 %p -Dhdp.version=2.3.6.0-3796 -XX:+UseConcMarkSweepGC -XX:ErrorFile=/var/log/hbase/hs_err_pid%p.log -Djava.io.tmpdir=/tmp -verbose:gc -XX:+PrintGCDetails -XX:+PrintGCDateStamps -Xloggc:/var/log/hbase/gc.log-201606302035 -Xmx1024m -XX:PermSize=128m -XX:MaxPermSize=128m -Dhbase.log.dir=/var/log/hbase -Dhbase.log.file=hbase-hbase-master-ip-172-31-56-238.log -Dhbase.home.dir=/usr/hdp/current/hbase-master/bin/.. -Dhbase.id.str=hbase -Dhbase.root.logger=INFO,RFA -Djava.library.path=:/usr/hdp/2.3.6.0-3796/hadoop/lib/native/Linux-amd64-64:/usr/hdp/2.3.6.0-3796/hadoop/lib/native -Dhbase.security.logger=INFO,RFAS org.apache.hadoop.hbase.master.HMaster start
+```
+
+The Java location is: `/usr/jdk64/jdk1.7.0_67`
+
+<<<
+=== Data Nodes
+
+{projet-name} is installed on all data nodes in your Hadoop cluster. You need to record the fully-qualified domain name node for each node.
+For example, refer to `/etc/hosts`.
+
+*Example*
+
+```
+$ cat /etc/hosts
+127.0.0.1   localhost localhost.localdomain localhost4 localhost4.localdomain4
+::1         localhost localhost.localdomain localhost6 localhost6.localdomain6
+
+172.31.56.238	      ip-172-31-56-238.ec2.internal node01
+172.31.61.110	      ip-172-31-61-110.ec2.internal node02
+172.31.57.143	      ip-172-31-57-143.ec2.internal node03
+```
+
+Record the node names in a space-separated list.
+
+*Example*
+
+```
+ip-172-31-56-238.ec2.internal ip-172-31-61-110.ec2.internal ip-172-31-57-143.ec2.internal
+```
+
+=== {project-name} Runtime User Home Directory
+
+The Installer creates the `trafodion` user ID. You need to decide the home directory for this user. 
+
+The default is: `/home`
+
+=== Distribution Manager URL
+
+The Installer interacts with the Distribution Manager (for example, Apache Ambari or Cloudera Manager) to modify the
+Hadoop configuration. 
+
+*Example*
+
+Apache Ambari URL
+
+```
+http://myhost.com:8080
+```
+
+<<<
+[[quickstart-run-installer]]
+== Run Installer
+
+You run the Installer once you've collected the base information as described in 
+<<quickstart-collect-information, Collect Information>> above.
+
+The following example shows a guided install of {project-name} on a three-node Hortonworks Hadoop cluster.
+
+NOTE: By default, the {project-name} Installer invokes `sqlci` so that you can enter the `initialize trafodion;` command.
+This is shown in the example below.
+
+*Example*
+
+1. Run the {project-name} Installer in guided mode.
++
+```
+$ cd $HOME/trafodion-installer/installer
+$ ./trafodion_install 2>&1 | tee install.log
+******************************
+ TRAFODION INSTALLATION START
+******************************
+
+***INFO: testing sudo access
+***INFO: Log file located at /var/log/trafodion/trafodion_install_2016-06-30-21-02-38.log
+***INFO: Config directory: /etc/trafodion
+***INFO: Working directory: /usr/lib/trafodion
+
+************************************
+ Trafodion Configuration File Setup
+************************************
+
+***INFO: Please press [Enter] to select defaults.
+
+Is this a cloud environment (Y/N), default is [N]: N
+Enter trafodion password, default is [traf123]: 
+Enter list of data nodes (blank separated), default []: ip-172-31-56-238.ec2.internal ip-172-31-61-110.ec2.internal ip-172-31-57-143.ec2.internal
+Do you h ave a set of management nodes (Y/N), default is N: N
+Enter Trafodion userid's home directory prefix, default is [/home]: /opt
+Specify  location of Java 1.7.0_65 or higher (JDK), default is []: /usr/jdk64/jdk1.7.0_67
+Enter full path (including .tar or .tar.gz) of trafodion tar file []: /home/trafodion-downloads/apache-trafodion_server-2.0.1-incubating.tar.gz
+Enter Backup/Restore username (can be Trafodion), default is [trafodion]: 
+Specify the Hadoop distribut ion installed (1: Cloudera, 2: Hortonworks, 3: Other): 2
+Enter Hadoop admin username, default is [admin]: Enter Hadoop admin pas sword, default is [admin]: 
+Enter full Hadoop external network URL:port (include 'http://' or 'https://), default is []: http://ip-172-31-56-238.ec2.internal:8080
+Enter  HDFS username or username running HDFS, default is [hdfs]: 
+Enter HBase username or username running HBase, default is [hbase]:
+Enter HBase group, default is [hbase]: 
+Enter Zookeeper username or username running Zookeeper, default is [zookeeper]: 
+Enter  directory to install trafodion to, default is [/opt/trafodion/apache-trafodion_server-2.0.1-incubating]: 
+Start Trafodion after install (Y/N), default is Y: 
+Total number of client connections per cluster, default [24]: 96
+Enter the node of primary DcsMaste r, default [ip-172-31-56-238.ec2.internal]: 
+Enable High Availability (Y/N), default is N: 
+Enable simple LDAP security (Y/N), d efault is N: 
+***INFO: Trafodion configuration setup complete
+***INFO: Trafodion Configuration File Check
+***INFO: Testing sudo access on node ip-172-31-56-238
+***INFO: Testing sudo access on node ip-172-31-61-110
+***INFO: Testing sudo access on node ip-172-31-57-143
+***INFO: Testing ssh on ip-172-31-56-238
+***INFO: Testing ssh on ip-172-31-61-110
+***INFO: Testing ssh on ip-172-31-57-143
+#!/bin/bash
+#
+# @@@ START COPYRIGHT @@@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+.
+.
+.
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer, and
+charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify, defend,
+and hold each Contributor harmless for any liability incurred by,
+or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+BY TYPING "ACCEPT" YOU AGREE TO THE TERMS OF THIS AGREEMENT: ***INFO: testing sudo access
+***INFO: Starting Trafodion Package Setup (2016-06-30-21-06-40)
+***INFO: Installing required packages
+***INFO: Log file located in /var/log/trafodion
+***INFO: ... pdsh on node ip-172-31-56-238
+***INFO: ... pdsh on node ip-172-31-61-110
+***INFO: ... pdsh on node ip-172-31-57-143
+***INFO: Checking if apr is installed ...
+***INFO: Checking if apr-util is installed ...
+***INFO: Checking if sqlite is installed ...
+***INFO: Checking if expect is installed ...
+***INFO: Checking if perl-DBD-SQLite* is installed ...
+***INFO: Checking if protobuf is installed ...
+***INFO: Checking if xerces-c is installed ...
+***INFO: Checking if perl-Params-Validate is installed ...
+***INFO: Checking if perl-Time-HiRes is installed ...
+***INFO: Checking if gzip is installed ...
+***INFO: Checking if lzo is installed ...
+***INFO: Checking if lzop is installed ...
+***INFO: Checking if unzip is installed ...
+***INFO: modifying limits in /usr/lib/trafodion/trafodion.conf on all nodes
+***INFO: create Trafodion userid "trafodion" 
+***INFO: Trafodion userid's (trafodion) home directory: /opt/trafodion
+***INFO: testing sudo access
+Generating public/private rsa key pair.
+Created directory '/opt/trafodion/.ssh'.
+Your identification has been saved in /opt/trafodion/.ssh/id_rsa.
+Your public key has been saved in /opt/trafodion/.ssh/id_rsa.pub.
+The key fingerprint is:
+12:59:ab:d7:59:a2:0e:e8:38:1c:e9:e1:86:f6:18:23 trafodion@ip-172-31-56-238
+The key's randomart image is:
++--[ RSA 2048]----+
+|        .        |
+|       o .       |
+|      o . . .    |
+|   . . o o +     |
+|  + . + S o      |
+| = =   =         |
+|E+B .   .        |
+|o.=.             |
+| . .             |
++-----------------+
+***INFO: creating .bashrc file
+***INFO: Setting up userid trafodion on all other nodes in cluster
+***INFO: Creating known_hosts file for all nodes
+ip-172-31-56-238
+ip-172-31-56-238 ip-172-31-61-110 ip-172-31-57-143
+ip-172-31-61-110
+ip-172-31-56-238 ip-172-31-61-110 ip-172-31-57-143
+ip-172-31-57-143
+ip-172-31-56-238 ip-172-31-61-110 ip-172-31-57-143
+***INFO: trafodion user added successfully
+***INFO: Trafodion environment setup completed
+***INFO: creating sqconfig file
+***INFO: Reserving DCS ports
+
+***INFO: Creating trafodion sudo access file
+
+
+******************************
+ TRAFODION MODS
+******************************
+
+***INFO: Hortonworks installed will run traf_hortonworks_mods
+***INFO: copying hbase-trx-hdp2_3-*.jar to all nodes
+***INFO: hbase-trx-hdp2_3-*.jar copied correctly! Huzzah.
+USERID=admin
+PASSWORD=admin
+PORT=:8080
+########## Performing 'set' hbase.master.distributed.log.splitting:true on (Site:hbase-site, Tag:version1)
+########## PUTting json into: doSet_version1467320863286001262.json
+  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
+                                 Dload  Upload   Total   Spent    Left  Speed
+101  5757  102  3588  103  2169    98k  60930 --:--:-- --:--:-- --:--:--  100k
+{
+  "resources" : [
+    {
+      "href" : "http://ip-172-31-56-238.ec2.internal:8080/api/v1/clusters/trafodion/configurations/service_config_versions?ser
+vice_name=HBASE&service_config_version=2",
+.
+.
+.
+    {
+      "href" : "http://ip-172-31-56-238.ec2.internal:8080/api/v1/clusters/trafodion/requests/12/tasks/128",
+      "Tasks" : {
+        "cluster_name" : "trafodion",
+        "id" : 128,
+        "request_id" : 12,
+        "stage_id" : 2
+      }
+    },
+    {
+      "href" : "http://ip-172-31-56-238.ec2.internal:8080/api/v1/clusters/trafodion/requests/12/tasks/129",
+      "Tasks" : {
+        "cluster_name" : "trafodion",
+        "id" : 129,
+        "request_id" : 12,
+        "stage_id" : 2
+      }
+    },
+    {
+      "href" : "http://ip-172-31-56-238.ec2.internal:8080/api/v1/clusters/trafodion/requests/12/tasks/130",
+      "Tasks" : {
+        "cluster_name" : "trafodion",
+        "id" : 130,
+        "request_id" : 12,
+        "stage_id" : 2
+      }
+    }
+  ],
+  "stages" : [
+    {
+      "href" : "http://ip-172-31-56-238.ec2.internal:8080/api/v1/clusters/trafodion/requests/12/stages/0",
+      "Stage" : {
+        "cluster_name" : "trafodion",
+        "request_id" : 12,
+        "stage_id" : 0
+      }
+    },
+    {
+      "href" : "http://ip-172-31-56-238.ec2.internal:8080/api/v1/clusters/trafodion/requests/12/stages/1",
+      "Stage" : {
+        "cluster_name" : "trafodion",
+        "request_id" : 12,
+        "stage_id" : 1
+      }
+    },
+    {
+      "href" : "http://ip-172-31-56-238.ec2.internal:8080/api/v1/clusters/trafodion/requests/12/stages/2",
+      "Stage" : {
+        "cluster_name" : "trafodion",
+        "request_id" : 12,
+        "stage_id" : 2
+      }
+    }
+  ]
+}***INFO: ...polling every 30 seconds until HBase start is completed.
+***INFO: HBase restart completed
+***INFO: Setting HDFS ACLs for snapshot scan support
+cp: `trafodion_config' and `/home/trafinstall/trafodion-2.0.1/installer/trafodion_config' are the same file
+***INFO: Trafodion Mods ran successfully.
+
+******************************
+ TRAFODION CONFIGURATION
+******************************
+
+/usr/lib/trafodion/installer/..
+/opt/trafodion/apache-trafodion_server-2.0.1-incubating
+***INFO: untarring file  to /opt/trafodion/apache-trafodion_server-2.0.1-incubating
+***INFO: modifying .bashrc to set Trafodion environment variables
+***INFO: copying .bashrc file to all nodes
+***INFO: copying sqconfig file (/opt/trafodion/sqconfig) to /opt/trafodion/apache-trafodion_server-2.0.1-incubating/sql/script
+s/sqconfig
+***INFO: Creating /opt/trafodion/apache-trafodion_server-2.0.1-incubating directory on all nodes
+***INFO: Start of DCS install
+***INFO: DCS Install Directory: /opt/trafodion/apache-trafodion_server-2.0.1-incubating/dcs-2.0.1
+***INFO: modifying /opt/trafodion/apache-trafodion_server-2.0.1-incubating/dcs-2.0.1/conf/dcs-env.sh
+***INFO: modifying /opt/trafodion/apache-trafodion_server-2.0.1-incubating/dcs-2.0.1/conf/dcs-site.xml
+***INFO: creating /opt/trafodion/apache-trafodion_server-2.0.1-incubating/dcs-2.0.1/conf/servers file
+***INFO: End of DCS install.
+***INFO: Start of REST Server install
+***INFO: Rest Install Directory: /opt/trafodion/apache-trafodion_server-2.0.1-incubating/rest-2.0.1
+***INFO: modifying /opt/trafodion/apache-trafodion_server-2.0.1-incubating/rest-2.0.1/conf/rest-site.xml
+***INFO: End of REST Server install.
+***INFO: starting sqgen
+ip-172-31-56-238,ip-172-31-57-143,ip-172-31-61-110
+
+Creating directories on cluster nodes
+/usr/bin/pdsh -R exec -w ip-172-31-56-238,ip-172-31-57-143,ip-172-31-61-110 -x ip-172-31-56-238 ssh -q -n %h mkdir -p /opt/tra
+fodion/apache-trafodion_server-2.0.1-incubating/etc 
+/usr/bin/pdsh -R exec -w ip-172-31-56-238,ip-172-31-57-143,ip-172-31-61-110 -x ip-172-31-56-238 ssh -q -n %h mkdir -p /opt/tra
+fodion/apache-trafodion_server-2.0.1-incubating/logs 
+/usr/bin/pdsh -R exec -w ip-172-31-56-238,ip-172-31-57-143,ip-172-31-61-110 -x ip-172-31-56-238 ssh -q -n %h mkdir -p /opt/tra
+fodion/apache-trafodion_server-2.0.1-incubating/tmp 
+/usr/bin/pdsh -R exec -w ip-172-31-56-238,ip-172-31-57-143,ip-172-31-61-110 -x ip-172-31-56-238 ssh -q -n %h mkdir -p /opt/tra
+fodion/apache-trafodion_server-2.0.1-incubating/sql/scripts 
+
+Generating SQ environment variable file: /opt/trafodion/apache-trafodion_server-2.0.1-incubating/etc/ms.env
+
+Note: Using cluster.conf format type 2.
+
+Generating SeaMonster environment variable file: /opt/trafodion/apache-trafodion_server-2.0.1-incubating/etc/seamonster.env
+
+
+Generated SQ startup script file: ./gomon.cold
+Generated SQ startup script file: ./gomon.warm
+Generated SQ cluster config file: /opt/trafodion/apache-trafodion_server-2.0.1-incubating/tmp/cluster.conf
+Generated SQ Shell          file: sqshell
+Generated RMS Startup       file: rmsstart
+Generated RMS Stop          file: rmsstop
+Generated RMS Check         file: rmscheck.sql
+Generated SSMP Startup      file: ssmpstart
+Generated SSMP Stop         file: ssmpstop
+Generated SSCP Startup      file: sscpstart
+Generated SSCP Stop         file: sscpstop
+
+
+Copying the generated files to all the nodes in the cluster
+.
+.
+.
+SQ Startup script (/opt/trafodion/apache-trafodion_server-2.0.1-incubating/sql/scripts/gomon.cold) ran successfully. Performin
+g further checks...
+Checking if processes are up.
+Checking attempt: 1; user specified max: 2. Execution time in seconds: 0.
+
+The SQ environment is up!
+
+
+Process		Configured	Actual	    Down
+-------		----------	------	    ----
+DTM		3		3	    
+RMS		6		6	    
+DcsMaster	1		0	    1
+DcsServer	3		0	    3
+mxosrvr		96		0	    96
+
+Thu Jun 30 21:15:29 UTC 2016
+Checking if processes are up.
+Checking attempt: 1; user specified max: 1. Execution time in seconds: 0.
+
+The SQ environment is up!
+
+
+Process		Configured	Actual	    Down
+-------		----------	------	    ----
+DTM		3		3	    
+RMS		6		6	    
+DcsMaster	1		0	    1
+DcsServer	3		0	    3
+mxosrvr		96		0	    96
+
+Starting the DCS environment now
+starting master, logging to /opt/trafodion/apache-trafodion_server-2.0.1-incubating/dcs-2.0.1/bin/../logs/dcs-trafodion-1-mast
+er-ip-172-31-56-238.out
+ip-172-31-56-238: starting server, logging to /opt/trafodion/apache-trafodion_server-2.0.1-incubating/dcs-2.0.1/bin/../logs/dc
+s-trafodion-1-server-ip-172-31-56-238.out
+ip-172-31-57-143: starting server, logging to /opt/trafodion/apache-trafodion_server-2.0.1-incubating/dcs-2.0.1/bin/../logs/dc
+s-trafodion-3-server-ip-172-31-57-143.out
+ip-172-31-61-110: starting server, logging to /opt/trafodion/apache-trafodion_server-2.0.1-incubating/dcs-2.0.1/bin/../logs/dc
+s-trafodion-2-server-ip-172-31-61-110.out
+Checking if processes are up.
+Checking attempt: 1; user specified max: 2. Execution time in seconds: 1.
+
+The SQ environment is up!
+
+
+Process		Configured	Actual	    Down
+-------		----------	------	    ----
+DTM		3		3	    
+RMS		6		6	    
+DcsMaster	1		1	    
+DcsServer	3		3	    
+mxosrvr		96		7	    89
+
+Starting the REST environment now
+starting rest, logging to /opt/trafodion/apache-trafodion_server-2.0.1-incubating/rest-2.0.1/bin/../logs/rest-trafodion-1-rest
+-ip-172-31-56-238.out
+
+
+
+Zookeeper listen port: 2181
+DcsMaster listen port: 23400
+
+Configured Primary DcsMaster: "ip-172-31-56-238.ec2.internal"
+Active DcsMaster            : "ip-172-31-56-238"
+
+Process		Configured	Actual		Down
+---------	----------	------		----
+DcsMaster	1		1		
+DcsServer	3		3		
+mxosrvr		96		94		2
+
+
+You can monitor the SQ shell log file : /opt/trafodion/apache-trafodion_server-2.0.1-incubating/logs/sqmon.log
+
+
+Startup time  0 hour(s) 2 minute(s) 19 second(s)
+Apache Trafodion Conversational Interface 2.0.1
+Copyright (c) 2015-2016 Apache Software Foundation
+>>
+--- SQL operation complete.
+>>
+
+End of MXCI Session
+
+***INFO: Installation setup completed successfully.
+
+******************************
+ TRAFODION INSTALLATION END
+******************************
+```
+
+2. Switch to the {project-name} Runtime User and check the status of {project-name}.
++
+```
+$ sudo su - trafodion
+$ sqcheck
+Checking if processes are up.
+Checking attempt: 1; user specified max: 2. Execution time in seconds: 0.
+
+The SQ environment is up!
+
+
+Process		Configured	Actual	    Down
+-------		----------	------	    ----
+DTM		3		3	    
+RMS		6		6	    
+DcsMaster	1		1	    
+DcsServer	3		3	    
+mxosrvr		96		96	    
+$
+```
+
+{project-name} is now running on your Hadoop cluster. Please refer to the <<activate,Activate>> chapter for
+basic instructions on how to verify the {project-name} management and how to perform basic management
+operations.
+

--- a/docs/provisioning_guide/src/asciidoc/_chapters/requirements.adoc
+++ b/docs/provisioning_guide/src/asciidoc/_chapters/requirements.adoc
@@ -31,11 +31,8 @@
 The current release of {project-name} has been tested with:
 
 * 64-bit Red Hat Enterprise Linux (RHEL) or CentOS 6.5, 6.6, and 6.7
-* SUSE SLES 11.3 SP2
 * Cloudera CDH 5.4
-* Hortonworks HDP 2.2
 * Hortonworks HDP 2.3
-
 
 Other OS releases may work, too. The {project-name} project is currently working on better support for more distribution and non-distribution versions of Hadoop.
 
@@ -180,9 +177,8 @@ The following distributions have been tested with {project-name}.^1^
 [cols="25%,15%,10%,50%",options="header"]
 |===
 | Distribution                                        | Version        | HBase Version | Installation Documentation
-| Cloudera Distribution Including Apache Hadoop (CDH) | 5.2 or 5.3     | 0.98          | http://www.cloudera.com/downloads/manager/5-2-0.html[CHD 5.2 Installation] +
-http://www.cloudera.com/downloads/manager/5-3-0.html[CDH 5.3 Installation]^2^ 
-| Hortonworks Data Platform (HDP)                     | 2.2            | 0.98          | http://hortonworks.com/products/releases/hdp-2-2/#install[HDP 2.2 Installation]
+| Cloudera Distribution Including Apache Hadoop (CDH) | 5.4            | 1.0           | http://www.cloudera.com/downloads/manager/5-4-0.html[CHD 5.4 Installation] 
+| Hortonworks Data Platform (HDP)                     | 2.3            | 1.1           | http://hortonworks.com/products/data-center/hdp/[HDP 2.3 Installation]
 |===
 
 1. Future releases of {project-name} will move away from distribution-specific integration. Instead, {project-name} will be tested with

--- a/docs/provisioning_guide/src/asciidoc/_chapters/script_install.adoc
+++ b/docs/provisioning_guide/src/asciidoc/_chapters/script_install.adoc
@@ -29,9 +29,6 @@
 This chapter describes how to use the {project-name} Installer to install {project-name}. You use the {project-name} Provisioning ID
 to run the {project-name} Installer.
 
-NOTE: Prior to version 2.0.0, you *must* install log4c&#43;&#43; on all nodes in the cluster prior to running the {project-name} Installer. Refer
-to <<prepare-build-and-install-log4cplusplus,Build and Install log4c++>> for instructions.
-
 [[install-unpack-installer]]
 == Unpack Installer
 
@@ -50,189 +47,7 @@ $ tar -zxf apache-trafodion-installer-1.3.0-incubating-bin.tar.gz -C $HOME/trafo
 $
 ```
 
-[[install-automated-install]]
-== Automated Install
-
-The `--config_file` option runs the {project-name} in Automated Setup mode. Refer to <<introduction-trafodion-installer,{project-name} Installer>>
-in the <<introduction,Introduction>> chapter for instructions of how you edit your configuration file.
-
-Edit your config file using the information you collected in the <<prepare-gather-configuration-information,Gather Configuration Information>>
-step in the <<prepare,Prepare>> chapter. 
-
-
-The following example shows an automated install of {project-name} on a two-node Hortonworks Hadoop cluster that does not have Kerberos nor LDAP enabled.
-
-
-NOTE: By default, the {project-name} Installer invokes `sqlci` so that you can enter the `initialize trafodion;` command.
-This is shown in the example below.
-
-*Example*
-
-1. Run the {project-name} Installer in Automated Setup mode.
-+
-```
-$ cd $HOME/trafodion-installer/installer
-$ ./trafodion_install --config_file my
-******************************
- TRAFODION INSTALLATION START
-******************************
-
-***INFO: testing sudo access
-***INFO: Log file located at /var/log/trafodion/trafodion_install_2016-02-16-21-12-03.log
-***INFO: Config directory: /etc/trafodion
-***INFO: Working directory: /usr/lib/trafodion
-
-************************************
- Trafodion Configuration File Check
-************************************
-
-
-***INFO: Testing sudo access on node trafodion-1
-***INFO: Testing sudo access on node trafodion-2
-***INFO: Testing ssh on trafodion-1
-***INFO: Testing ssh on trafodion-2
-***INFO: Getting list of all hortonworks nodes
-***INFO: Getting list of all hortonworks nodes
-***INFO: hortonworks list of nodes:  trafodion-1 trafodion-2
-***INFO: Testing ssh on trafodion-1
-***INFO: Testing ssh on trafodion-2
-***INFO: Testing sudo access on trafodion-1
-***INFO: Testing sudo access on trafodion-2
-***DEBUG: trafodionFullName=trafodion_server-1.3.0.tgz
-***INFO: Trafodion version = 1.3.0
-***DEBUG: HBase's java_exec=/usr/jdk64/jdk1.7.0_67/bin/java
-
-******************************
- TRAFODION SETUP
-******************************
-
-***INFO: Starting Trafodion environment setup (2016-02-16-21-12-31)
-=== 2016-02-16-21-12-31 ===
-# @@@ START COPYRIGHT @@@
-#
-# Licensed to the Apache Software Foundation (ASF) under one
-# or more contributor license agreements.  See the NOTICE file
-# distributed with this work for additional information
-# regarding copyright ownership.  The ASF licenses this file
-# to you under the Apache License, Version 2.0 (the
-# "License"); you may not use this file except in compliance
-# with the License.  You may obtain a copy of the License at
-.
-.
-.
-9. Accepting Warranty or Additional Liability. While redistributing
-the Work or Derivative Works thereof, You may choose to offer, and
-charge a fee for, acceptance of support, warranty, indemnity, or
-other liability obligations and/or rights consistent with this
-License. However, in accepting such obligations, You may act only
-on Your own behalf and on Your sole responsibility, not on behalf
-of any other Contributor, and only if You agree to indemnify, defend,
-and hold each Contributor harmless for any liability incurred by,
-or claims asserted against, such Contributor by reason of your
-accepting any such warranty or additional liability.
-
-END OF TERMS AND CONDITIONS
-
-BY TYPING "ACCEPT" YOU AGREE TO THE TERMS OF THIS AGREEMENT: ***INFO: testing sudo access
-***INFO: Checking all nodes in specified node list
-trafodion-1
-trafodion-2
-***INFO: Total number of nodes = 2
-***INFO: Starting Trafodion Package Setup (2016-02-16-21-12-35)
-***INFO: Installing required packages
-***INFO: Log file located in /var/log/trafodion
-***INFO: ... EPEL rpm
-***INFO: ... pdsh on node trafodion-1
-***INFO: ... pdsh on node trafodion-2
-***INFO: Checking if log4cxx is installed ...
-***INFO: Checking if sqlite is installed ...
-***INFO: Checking if expect is installed ...
-.
-.
-.
-***INFO: trafodion user added successfully
-***INFO: Trafodion environment setup completed
-***INFO: creating sqconfig file
-***INFO: Reserving DCS ports
-
-******************************
- TRAFODION MODS
-******************************
-
-***INFO: Hortonworks installed will run traf_hortonworks_mods98
-***INFO: Detected JAVA version 1.7
-***INFO: copying hbase-trx-hdp2_2-1.3.0.jar to all nodes
-PORT=:8080
-########## Performing 'set' hbase.master.distributed.log.splitting:false on (Site:hbase-site, Tag:version1)
-########## PUTting json into: doSet_version1455657199513777160.json
-.
-.
-.
-Starting the REST environment now
-starting rest, logging to /home/trafodion/apache-trafodion-1.3.0-incubating-bin/rest-1.3.0/bin/../logs/rest-trafodion-1-rest-trafodion-1.out
-SLF4J: Class path contains multiple SLF4J bindings.
-SLF4J: Found binding in [jar:file:/home/trafodion/apache-trafodion-1.3.0-incubating-bin/rest-1.3.0/lib/slf4j-log4j12-1.7.5.jar!/org/slf4j/impl/StaticLoggerBinder.class]
-SLF4J: Found binding in [jar:file:/usr/hdp/2.2.9.0-3393/hadoop/lib/slf4j-log4j12-1.7.5.jar!/org/slf4j/impl/StaticLoggerBinder.class]
-SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
-SLF4J: Actual binding is of type [org.slf4j.impl.Log4jLoggerFactory]
-
-
-DcsMaster is not started. Please start DCS using 'dcsstart' command...
-
-Process         Configured      Actual          Down
----------       ----------      ------          ----
-DcsMaster       1               0               1
-DcsServer       2               0               2
-mxosrvr         8               8
-
-
-You can monitor the SQ shell log file : /home/trafodion/apache-trafodion-1.3.0-incubating-bin/logs/sqmon.log
-
-
-Startup time  0 hour(s) 1 minute(s) 9 second(s)
-Apache Trafodion Conversational Interface 1.3.0
-Copyright (c) 2015 Apache Software Foundation
->> initialize trafodion;
---- SQL operation complete.
->>
-
-End of MXCI Session
-
-***INFO: Installation completed successfully.
-
-*********************************
- TRAFODION INSTALLATION COMPLETE
-*********************************
-
-$ 
-```
-
-2. Switch to the {project-name} Runtime User and check the status of {project-name}.
-+
-*Example*
-+
-```
-$ sudo su - trafodion
-$ sqcheck
-Checking if processes are up.
-Checking attempt: 1; user specified max: 2. Execution time in seconds: 0.
-
-The SQ environment is up!
-
-
-Process         Configured      Actual      Down
--------         ----------      ------      ----
-DTM             2               2
-RMS             4               4
-MXOSRVR         8               8
-
-$
-```
-
-{project-name} is now running on your Hadoop cluster. Please refer to the <<activate,Activate>> chapter for
-basic instructions on how to verify the {project-name} management and how to perform basic management
-operations.
-
+<<<
 [[install-guided-install]]
 == Guided Install
 
@@ -240,10 +55,6 @@ The {project-name} Installer prompts you for the information you collected in th
 <<prepare-gather-configuration-information, Gather Configuration Information>> step in the <<prepare,Prepare>> chapter.
 
 The following example shows a guided install of {project-name} on a two-node Cloudera Hadoop cluster that does not have Kerberos nor LDAP installed.
-
-
-NOTE: By default, the {project-name} Installer invokes `sqlci` so that you can enter the `initialize trafodion;` command.
-This is shown in the example below.
 
 *Example*
 
@@ -483,6 +294,186 @@ $
 ```
 
 2. Switch to the {project-name} Runtime User and check the status of {project-name}.
++
+```
+$ sudo su - trafodion
+$ sqcheck
+Checking if processes are up.
+Checking attempt: 1; user specified max: 2. Execution time in seconds: 0.
+
+The SQ environment is up!
+
+
+Process         Configured      Actual      Down
+-------         ----------      ------      ----
+DTM             2               2
+RMS             4               4
+MXOSRVR         8               8
+
+$
+```
+
+{project-name} is now running on your Hadoop cluster. Please refer to the <<activate,Activate>> chapter for
+basic instructions on how to verify the {project-name} management and how to perform basic management
+operations.
+
+<<<
+[[install-automated-install]]
+== Automated Install
+
+The `--config_file` option runs the {project-name} in Automated Setup mode. Refer to <<introduction-trafodion-installer,{project-name} Installer>>
+in the <<introduction,Introduction>> chapter for instructions of how you edit your configuration file.
+
+Edit your config file using the information you collected in the <<prepare-gather-configuration-information,Gather Configuration Information>>
+step in the <<prepare,Prepare>> chapter. 
+
+
+The following example shows an automated install of {project-name} on a two-node Hortonworks Hadoop cluster that does not have Kerberos nor LDAP enabled.
+
+*Example*
+
+1. Run the {project-name} Installer in Automated Setup mode.
++
+```
+$ cd $HOME/trafodion-installer/installer
+$ ./trafodion_install --config_file my
+******************************
+ TRAFODION INSTALLATION START
+******************************
+
+***INFO: testing sudo access
+***INFO: Log file located at /var/log/trafodion/trafodion_install_2016-02-16-21-12-03.log
+***INFO: Config directory: /etc/trafodion
+***INFO: Working directory: /usr/lib/trafodion
+
+************************************
+ Trafodion Configuration File Check
+************************************
+
+
+***INFO: Testing sudo access on node trafodion-1
+***INFO: Testing sudo access on node trafodion-2
+***INFO: Testing ssh on trafodion-1
+***INFO: Testing ssh on trafodion-2
+***INFO: Getting list of all hortonworks nodes
+***INFO: Getting list of all hortonworks nodes
+***INFO: hortonworks list of nodes:  trafodion-1 trafodion-2
+***INFO: Testing ssh on trafodion-1
+***INFO: Testing ssh on trafodion-2
+***INFO: Testing sudo access on trafodion-1
+***INFO: Testing sudo access on trafodion-2
+***DEBUG: trafodionFullName=trafodion_server-1.3.0.tgz
+***INFO: Trafodion version = 1.3.0
+***DEBUG: HBase's java_exec=/usr/jdk64/jdk1.7.0_67/bin/java
+
+******************************
+ TRAFODION SETUP
+******************************
+
+***INFO: Starting Trafodion environment setup (2016-02-16-21-12-31)
+=== 2016-02-16-21-12-31 ===
+# @@@ START COPYRIGHT @@@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+.
+.
+.
+9. Accepting Warranty or Additional Liability. While redistributing
+the Work or Derivative Works thereof, You may choose to offer, and
+charge a fee for, acceptance of support, warranty, indemnity, or
+other liability obligations and/or rights consistent with this
+License. However, in accepting such obligations, You may act only
+on Your own behalf and on Your sole responsibility, not on behalf
+of any other Contributor, and only if You agree to indemnify, defend,
+and hold each Contributor harmless for any liability incurred by,
+or claims asserted against, such Contributor by reason of your
+accepting any such warranty or additional liability.
+
+END OF TERMS AND CONDITIONS
+
+BY TYPING "ACCEPT" YOU AGREE TO THE TERMS OF THIS AGREEMENT: ***INFO: testing sudo access
+***INFO: Checking all nodes in specified node list
+trafodion-1
+trafodion-2
+***INFO: Total number of nodes = 2
+***INFO: Starting Trafodion Package Setup (2016-02-16-21-12-35)
+***INFO: Installing required packages
+***INFO: Log file located in /var/log/trafodion
+***INFO: ... EPEL rpm
+***INFO: ... pdsh on node trafodion-1
+***INFO: ... pdsh on node trafodion-2
+***INFO: Checking if log4cxx is installed ...
+***INFO: Checking if sqlite is installed ...
+***INFO: Checking if expect is installed ...
+.
+.
+.
+***INFO: trafodion user added successfully
+***INFO: Trafodion environment setup completed
+***INFO: creating sqconfig file
+***INFO: Reserving DCS ports
+
+******************************
+ TRAFODION MODS
+******************************
+
+***INFO: Hortonworks installed will run traf_hortonworks_mods98
+***INFO: Detected JAVA version 1.7
+***INFO: copying hbase-trx-hdp2_2-1.3.0.jar to all nodes
+PORT=:8080
+########## Performing 'set' hbase.master.distributed.log.splitting:false on (Site:hbase-site, Tag:version1)
+########## PUTting json into: doSet_version1455657199513777160.json
+.
+.
+.
+Starting the REST environment now
+starting rest, logging to /home/trafodion/apache-trafodion-1.3.0-incubating-bin/rest-1.3.0/bin/../logs/rest-trafodion-1-rest-trafodion-1.out
+SLF4J: Class path contains multiple SLF4J bindings.
+SLF4J: Found binding in [jar:file:/home/trafodion/apache-trafodion-1.3.0-incubating-bin/rest-1.3.0/lib/slf4j-log4j12-1.7.5.jar!/org/slf4j/impl/StaticLoggerBinder.class]
+SLF4J: Found binding in [jar:file:/usr/hdp/2.2.9.0-3393/hadoop/lib/slf4j-log4j12-1.7.5.jar!/org/slf4j/impl/StaticLoggerBinder.class]
+SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
+SLF4J: Actual binding is of type [org.slf4j.impl.Log4jLoggerFactory]
+
+
+DcsMaster is not started. Please start DCS using 'dcsstart' command...
+
+Process         Configured      Actual          Down
+---------       ----------      ------          ----
+DcsMaster       1               0               1
+DcsServer       2               0               2
+mxosrvr         8               8
+
+
+You can monitor the SQ shell log file : /home/trafodion/apache-trafodion-1.3.0-incubating-bin/logs/sqmon.log
+
+
+Startup time  0 hour(s) 1 minute(s) 9 second(s)
+Apache Trafodion Conversational Interface 1.3.0
+Copyright (c) 2015 Apache Software Foundation
+>> initialize trafodion;
+--- SQL operation complete.
+>>
+
+End of MXCI Session
+
+***INFO: Installation completed successfully.
+
+*********************************
+ TRAFODION INSTALLATION COMPLETE
+*********************************
+
+$ 
+```
+
+2. Switch to the {project-name} Runtime User and check the status of {project-name}.
++
+*Example*
 +
 ```
 $ sudo su - trafodion

--- a/docs/provisioning_guide/src/asciidoc/_chapters/script_upgrade.adoc
+++ b/docs/provisioning_guide/src/asciidoc/_chapters/script_upgrade.adoc
@@ -123,151 +123,6 @@ $
 ```
 
 <<<
-[[upgrade-automated-upgrade]]
-== Automated Upgrade
-
-You perform this step as the {project-name} Provisioning User.
-
-The `--config_file` option runs the {project-name} in Automated Setup mode. Refer to <<introduction-trafodion-installer,{project-name} Installer>>
-in the <<introduction,Introduction>> chapter for instructions of how you edit your configuration file.
-
-At a minimum, you need to change the following settings:
-
-* `LOCAL_WORKDIR`
-* `TRAF_PACKAGE`
-* `SQ_ROOT`
-
-*Example*
-
-```
-$ cd $HOME/trafodion-configuration
-$ cp my_config my_config_2.0
-$ # Pre edit content
-
-export LOCAL_WORKDIR="/home/centos/trafodion-installer/installer"
-export TRAF_PACKAGE="/home/centos/trafodion-download/apache-trafodion-1.3.0-incubating-bin.tar.gz"
-export SQ_ROOT="/home/trafodion/apache-trafodion-1.3.0-incubating-bin"
-
-$ # Use your favorite editor to modify my_config_2.0
-$ emacs my_config_2.0
-$ # Post edit changes
-
-export LOCAL_WORKDIR="/home/centos/trafodion-installer-2.0/installer"
-export TRAF_PACKAGE="/home/centos/trafodion-download/apache-trafodion-2.0.0-incubating-bin.tar.gz"
-export SQ_ROOT="/home/trafodion/apache-trafodion-2.0.0-incubating-bin"
-```
-
-
-The following example shows an upgrade of {project-name} on a two-node Hortonworks Hadoop cluster using
-Automated Setup mode without Kerberos nor LDAP enabled.
-
-NOTE: The {project-name} Installer performs the same configuration changes as it does for an installation,
-including restarting Hadoop services.
-
-*Example*
-
-1. Run the updated {project-name} Installer using the modified my_config_2.0 file.
-+
-```
-$ cd $HOME/trafodion-installer-2.0/installer
-$ ./trafodion_install --config_file $HOME/trafodion-configuration/my_config_2.0
-******************************
- TRAFODION INSTALLATION START
-******************************
-
-***INFO: Testing sudo access on node trafodion-1
-***INFO: Testing sudo access on node trafodion-2
-***INFO: Testing ssh on trafodion-1
-***INFO: Testing ssh on trafodion-2
-***INFO: Getting list of all hortonworks nodes
-***INFO: Getting list of all hortonworks nodes
-***INFO: hortonworks list of nodes:  trafodion-1 trafodion-2
-***INFO: Testing ssh on trafodion-1
-***INFO: Testing ssh on trafodion-2
-***INFO: Testing sudo access on trafodion-1
-***INFO: Testing sudo access on trafodion-2
-***INFO: Trafodion scanner will not be run.
-***DEBUG: trafodionFullName=trafodion_server-2.0.0.tgz
-***INFO: Trafodion version = 2.0.0
-***DEBUG: HBase's java_exec=/usr/jdk64/jdk1.7.0_67/bin/java
-
-******************************
- TRAFODION SETUP
-******************************
-
-***INFO: Installing required RPM packages
-***INFO: Starting Trafodion Package Setup (2016-02-17-05-33-29)
-***INFO: Installing required packages
-***INFO: Log file located in /var/log/trafodion
-***INFO: ... pdsh on node trafodion-1
-***INFO: ... pdsh on node trafodion-2
-***INFO: Checking if log4cxx is installed ...
-.
-.
-.
-DcsMaster is not started. Please start DCS using 'dcsstart' command...
-
-Process         Configured      Actual          Down
----------       ----------      ------          ----
-DcsMaster       1               0               1
-DcsServer       2               0               2
-mxosrvr         8               8
-
-
-You can monitor the SQ shell log file : /home/trafodion/apache-trafodion-2.0.0-incubating-bin/logs/sqmon.log
-
-
-Startup time  0 hour(s) 1 minute(s) 9 second(s)
-Apache Trafodion Conversational Interface 1.3.0
-Copyright (c) 2015 Apache Software Foundation
->>Metadata Upgrade: started
-
-Version Check: started
-  Metadata is already at Version 1.1.
-Version Check: done
-
-Metadata Upgrade: done
-
-
---- SQL operation complete.
->>
-
-End of MXCI Session
-
-***INFO: Installation completed successfully.
-
-*********************************
- TRAFODION INSTALLATION COMPLETE
-*********************************
-
-$
-```
-
-2. Switch to the {project-name} Runtime User and check the status of {project-name}.
-+
-```
-$ sudo su - trafodion
-$ sqcheck
-Checking if processes are up.
-Checking attempt: 1; user specified max: 2. Execution time in seconds: 0.
-
-The SQ environment is up!
-
-
-Process         Configured      Actual      Down
--------         ----------      ------      ----
-DTM             2               2
-RMS             4               4
-MXOSRVR         8               8
-
-$
-```
-
-{project-name} is now running on your Hadoop cluster. Please refer to the <<activate,Activate>> chapter for
-basic instructions on how to verify the {project-name} management and how to perform basic management
-operations.
-
-<<<
 [[upgrade-guided-upgrade]]
 == Guided Upgrade
 
@@ -276,12 +131,6 @@ You perform this step as the {project-name} Provisioning User.
 As in the case with an installation, the {project-name} Installer prompts you for the information you collected in the
 <<prepare-gather-configuration-information, Gather Configuration Information>> step in the <<prepare,Prepare>> chapter.
 Some of the prompts are populated with the current values.
-
-export LOCAL_WORKDIR="/home/centos/trafodion-installer/installer"
-export TRAF_PACKAGE="/home/centos/trafodion-download/apache-trafodion-1.3.0-incubating-bin.tar.gz"
-export SQ_ROOT="/home/trafodion/apache-trafodion-1.3.0-incubating-bin"
-
-
 
 The following example shows a guided upgrade of {project-name} on a two-node Cloudera Hadoop cluster without Kerberos nor LDAP enabled.
 
@@ -435,4 +284,149 @@ $
 basic instructions on how to verify the {project-name} management and how to perform basic management
 operations.
 
+
+<<<
+[[upgrade-automated-upgrade]]
+== Automated Upgrade
+
+You perform this step as the {project-name} Provisioning User.
+
+The `--config_file` option runs the {project-name} in Automated Setup mode. Refer to <<introduction-trafodion-installer,{project-name} Installer>>
+in the <<introduction,Introduction>> chapter for instructions of how you edit your configuration file.
+
+At a minimum, you need to change the following settings:
+
+* `LOCAL_WORKDIR`
+* `TRAF_PACKAGE`
+* `SQ_ROOT`
+
+*Example*
+
+```
+$ cd $HOME/trafodion-configuration
+$ cp my_config my_config_2.0
+$ # Pre edit content
+
+export LOCAL_WORKDIR="/home/centos/trafodion-installer/installer"
+export TRAF_PACKAGE="/home/centos/trafodion-download/apache-trafodion-1.3.0-incubating-bin.tar.gz"
+export SQ_ROOT="/home/trafodion/apache-trafodion-1.3.0-incubating-bin"
+
+$ # Use your favorite editor to modify my_config_2.0
+$ emacs my_config_2.0
+$ # Post edit changes
+
+export LOCAL_WORKDIR="/home/centos/trafodion-installer-2.0/installer"
+export TRAF_PACKAGE="/home/centos/trafodion-download/apache-trafodion-2.0.0-incubating-bin.tar.gz"
+export SQ_ROOT="/home/trafodion/apache-trafodion-2.0.0-incubating-bin"
+```
+
+
+The following example shows an upgrade of {project-name} on a two-node Hortonworks Hadoop cluster using
+Automated Setup mode without Kerberos nor LDAP enabled.
+
+NOTE: The {project-name} Installer performs the same configuration changes as it does for an installation,
+including restarting Hadoop services.
+
+*Example*
+
+1. Run the updated {project-name} Installer using the modified my_config_2.0 file.
++
+```
+$ cd $HOME/trafodion-installer-2.0/installer
+$ ./trafodion_install --config_file $HOME/trafodion-configuration/my_config_2.0
+******************************
+ TRAFODION INSTALLATION START
+******************************
+
+***INFO: Testing sudo access on node trafodion-1
+***INFO: Testing sudo access on node trafodion-2
+***INFO: Testing ssh on trafodion-1
+***INFO: Testing ssh on trafodion-2
+***INFO: Getting list of all hortonworks nodes
+***INFO: Getting list of all hortonworks nodes
+***INFO: hortonworks list of nodes:  trafodion-1 trafodion-2
+***INFO: Testing ssh on trafodion-1
+***INFO: Testing ssh on trafodion-2
+***INFO: Testing sudo access on trafodion-1
+***INFO: Testing sudo access on trafodion-2
+***INFO: Trafodion scanner will not be run.
+***DEBUG: trafodionFullName=trafodion_server-2.0.0.tgz
+***INFO: Trafodion version = 2.0.0
+***DEBUG: HBase's java_exec=/usr/jdk64/jdk1.7.0_67/bin/java
+
+******************************
+ TRAFODION SETUP
+******************************
+
+***INFO: Installing required RPM packages
+***INFO: Starting Trafodion Package Setup (2016-02-17-05-33-29)
+***INFO: Installing required packages
+***INFO: Log file located in /var/log/trafodion
+***INFO: ... pdsh on node trafodion-1
+***INFO: ... pdsh on node trafodion-2
+***INFO: Checking if log4cxx is installed ...
+.
+.
+.
+DcsMaster is not started. Please start DCS using 'dcsstart' command...
+
+Process         Configured      Actual          Down
+---------       ----------      ------          ----
+DcsMaster       1               0               1
+DcsServer       2               0               2
+mxosrvr         8               8
+
+
+You can monitor the SQ shell log file : /home/trafodion/apache-trafodion-2.0.0-incubating-bin/logs/sqmon.log
+
+
+Startup time  0 hour(s) 1 minute(s) 9 second(s)
+Apache Trafodion Conversational Interface 1.3.0
+Copyright (c) 2015 Apache Software Foundation
+>>Metadata Upgrade: started
+
+Version Check: started
+  Metadata is already at Version 1.1.
+Version Check: done
+
+Metadata Upgrade: done
+
+
+--- SQL operation complete.
+>>
+
+End of MXCI Session
+
+***INFO: Installation completed successfully.
+
+*********************************
+ TRAFODION INSTALLATION COMPLETE
+*********************************
+
+$
+```
+
+2. Switch to the {project-name} Runtime User and check the status of {project-name}.
++
+```
+$ sudo su - trafodion
+$ sqcheck
+Checking if processes are up.
+Checking attempt: 1; user specified max: 2. Execution time in seconds: 0.
+
+The SQ environment is up!
+
+
+Process         Configured      Actual      Down
+-------         ----------      ------      ----
+DTM             2               2
+RMS             4               4
+MXOSRVR         8               8
+
+$
+```
+
+{project-name} is now running on your Hadoop cluster. Please refer to the <<activate,Activate>> chapter for
+basic instructions on how to verify the {project-name} management and how to perform basic management
+operations.
 

--- a/docs/provisioning_guide/src/asciidoc/index.adoc
+++ b/docs/provisioning_guide/src/asciidoc/index.adoc
@@ -47,6 +47,7 @@ include::../../shared/license.txt[]
 include::../../shared/revisions.txt[]
 
 include::asciidoc/_chapters/about.adoc[]
+include::asciidoc/_chapters/quickstart.adoc[]
 include::asciidoc/_chapters/introduction.adoc[]
 include::asciidoc/_chapters/requirements.adoc[]
 include::asciidoc/_chapters/prepare.adoc[]

--- a/docs/spj_guide/pom.xml
+++ b/docs/spj_guide/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
- <!-- 
+<!-- 
 * @@@ START COPYRIGHT @@@                                                       
 *
 * Licensed to the Apache Software Foundation (ASF) under one
@@ -79,7 +79,7 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
-    <dependency.locations.enabled>false</dependency.locations.enabled>
+    <!--dependency.locations.enabled>false</dependency.locations.enabled-->
   </properties>
 
   <repositories>

--- a/docs/spj_guide/pom.xml
+++ b/docs/spj_guide/pom.xml
@@ -36,7 +36,7 @@
   <parent>
     <groupId>org.apache.trafodion</groupId>
     <artifactId>trafodion</artifactId>
-    <version>1.3.0</version>
+    <version>2.0.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
@@ -79,18 +79,21 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
+    <dependency.locations.enabled>false</dependency.locations.enabled>
   </properties>
 
   <repositories>
     <repository>
-      <id>rubygems-proxy-releases</id>
-      <name>RubyGems.org Proxy (Releases)</name>
+      <id>rubygems-proxy</id>
+      <name>Rubygems Proxy</name>
       <url>http://rubygems-proxy.torquebox.org/releases</url>
-      <releases>
+      <layout>default</layout>
+        <releases>
         <enabled>true</enabled>
       </releases>
       <snapshots>
         <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
       </snapshots>
     </repository>
   </repositories>

--- a/docs/spj_guide/pom.xml
+++ b/docs/spj_guide/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/maven-v4_0_0.xsd">
-<!-- 
+ <!-- 
 * @@@ START COPYRIGHT @@@                                                       
 *
 * Licensed to the Apache Software Foundation (ASF) under one
@@ -36,7 +36,7 @@
   <parent>
     <groupId>org.apache.trafodion</groupId>
     <artifactId>trafodion</artifactId>
-    <version>2.0.0</version>
+    <version>1.3.0</version>
     <relativePath>../../pom.xml</relativePath>
   </parent>
 
@@ -79,21 +79,18 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
-    <!--dependency.locations.enabled>false</dependency.locations.enabled-->
   </properties>
 
   <repositories>
     <repository>
-      <id>rubygems-proxy</id>
-      <name>Rubygems Proxy</name>
+      <id>rubygems-proxy-releases</id>
+      <name>RubyGems.org Proxy (Releases)</name>
       <url>http://rubygems-proxy.torquebox.org/releases</url>
-      <layout>default</layout>
-        <releases>
+      <releases>
         <enabled>true</enabled>
       </releases>
       <snapshots>
         <enabled>false</enabled>
-        <updatePolicy>never</updatePolicy>
       </snapshots>
     </repository>
   </repositories>

--- a/docs/spj_guide/pom.xml
+++ b/docs/spj_guide/pom.xml
@@ -79,6 +79,7 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
+    <dependency.locations.enabled>false</dependency.locations.enabled>
   </properties>
 
   <repositories>

--- a/docs/sql_reference/pom.xml
+++ b/docs/sql_reference/pom.xml
@@ -39,7 +39,7 @@
     <groupId>org.apache.trafodion</groupId>
     <artifactId>trafodion</artifactId>
     <relativePath>../../pom.xml</relativePath>
-    <version>1.3.0</version>
+    <version>2.0.0</version>
   </parent>
 
 
@@ -81,18 +81,21 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
+    <dependency.locations.enabled>false</dependency.locations.enabled>
   </properties>
 
   <repositories>
     <repository>
-      <id>rubygems-proxy-releases</id>
-      <name>RubyGems.org Proxy (Releases)</name>
+      <id>rubygems-proxy</id>
+      <name>Rubygems Proxy</name>
       <url>http://rubygems-proxy.torquebox.org/releases</url>
-      <releases>
+      <layout>default</layout>
+        <releases>
         <enabled>true</enabled>
       </releases>
       <snapshots>
         <enabled>false</enabled>
+        <updatePolicy>never</updatePolicy>
       </snapshots>
     </repository>
   </repositories>

--- a/docs/sql_reference/pom.xml
+++ b/docs/sql_reference/pom.xml
@@ -81,7 +81,7 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
-    <dependency.locations.enabled>false</dependency.locations.enabled>
+    <!--dependency.locations.enabled>false</dependency.locations.enabled-->
   </properties>
 
   <repositories>

--- a/docs/sql_reference/pom.xml
+++ b/docs/sql_reference/pom.xml
@@ -39,7 +39,7 @@
     <groupId>org.apache.trafodion</groupId>
     <artifactId>trafodion</artifactId>
     <relativePath>../../pom.xml</relativePath>
-    <version>2.0.0</version>
+    <version>1.3.0</version>
   </parent>
 
 
@@ -81,21 +81,18 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
-    <!--dependency.locations.enabled>false</dependency.locations.enabled-->
   </properties>
 
   <repositories>
     <repository>
-      <id>rubygems-proxy</id>
-      <name>Rubygems Proxy</name>
+      <id>rubygems-proxy-releases</id>
+      <name>RubyGems.org Proxy (Releases)</name>
       <url>http://rubygems-proxy.torquebox.org/releases</url>
-      <layout>default</layout>
-        <releases>
+      <releases>
         <enabled>true</enabled>
       </releases>
       <snapshots>
         <enabled>false</enabled>
-        <updatePolicy>never</updatePolicy>
       </snapshots>
     </repository>
   </repositories>

--- a/docs/sql_reference/pom.xml
+++ b/docs/sql_reference/pom.xml
@@ -81,6 +81,7 @@
     <asciidoctorj.version>1.5.4</asciidoctorj.version>
     <rubygems.prawn.version>2.0.2</rubygems.prawn.version>
     <jruby.version>9.0.4.0</jruby.version>
+    <dependency.locations.enabled>false</dependency.locations.enabled>
   </properties>
 
   <repositories>


### PR DESCRIPTION
Provisioning Guide now has a quick-start chapter. Also, fixed minor error
and reordered guided vs. automated mode in install and upgrade chapters.

Changes apply to 2.0.0 and 2.0.1 documentation. Please update website accordingly.