### PR TITLE
[TRAFODION-2094] Truncate option slow in ODB

### DIFF
--- a/core/conn/odb/Makefile
+++ b/core/conn/odb/Makefile
@@ -29,7 +29,7 @@ include $(MY_SQROOT)/macros.gmk #top level
 # Standard Linux flags
 #--------------------------------------------------------------------------
 CFLAGS_LNX = -rdynamic -pipe -pthread \
-			 -fomit-frame-pointer -pedantic -Wall -Wextra -Wshadow \
+			 -fomit-frame-pointer -pedantic -Wall -Wextra \
 			 -Wno-missing-field-initializers -Wformat=2 \
 			 -Wunused -Wpragmas -Wstack-protector -Wcast-qual \
 			 -Wl,-allow-shlib-undefined \

--- a/core/conn/odb/src/odb.c
+++ b/core/conn/odb/src/odb.c
@@ -139,6 +139,7 @@ char *odbauth = "Trafodion Dev <trafodion-development@lists.launchpad.net>";
     #include <unistd.h>
     #define SIZET_SPEC "%zu"
     #include <pthread.h>
+    #include <strings.h>
     #ifdef __hpux
         #define Sleep(x) \
             if ( x > 1000 ) { \
@@ -12394,6 +12395,7 @@ static unsigned int checkdb(int eid, SQLHDBC *Ocn, char *c, char *s)
                 Oerr(eid, tid, __LINE__, Ostmt, SQL_HANDLE_STMT);
             if (!SQL_SUCCEEDED(Oret=SQLFetch(Ostmt)))
                 Oerr(eid, tid, __LINE__, Ostmt, SQL_HANDLE_STMT);
+	} 
     } else if ( !strcmp((char *)Obuff, dbscmds[8].dbname) ) 
     {   /* Trafodion */
         dbt = 8;
@@ -12412,7 +12414,6 @@ static unsigned int checkdb(int eid, SQLHDBC *Ocn, char *c, char *s)
                 s[i] = '\0';
             }
         }
-    }
     }
 
     /* If this is the Interpreter get the object types list */


### PR DESCRIPTION
Mispaced paranthesis causes us to take the generic database codepath,
with dbt = 0, instead of dbt = 8 for Trafodion.
All compiler warnings for ODB are now fixed or suppressed.