### PR TITLE
[TRAFODION-1673] support with clause

### DIFF
--- a/core/sql/bin/SqlciErrors.txt
+++ b/core/sql/bin/SqlciErrors.txt
@@ -410,6 +410,7 @@
 1430 3F000 99999 BEGINNER MAJOR DBADMIN A schema name that starts and ends with an "_"(underscore) is reserved for internal usage. It cannot be used to create a user schema.
 1431 ZZZZZ 99999 BEGINNER MINOR DBADMIN Object $0~String0 exists in HBase. This could be due to a concurrent transactional ddl operation in progress on this table.
 1432 ZZZZZ 99999 BEGINNER MINOR DBADMIN Input LOB type $0~Int0 does not match column's storage type: $1~Int1 Column name: $0~String0 .
+1433 ZZZZZ 99999 BEGINNER MINOR DBADMIN WITH clause redefined. WITH name $0~String0 .
 1500 ZZZZZ 99999 ADVANCED CRTCL DIALOUT The CATSYS - CAT_REFERENCES system schema relationship for catalog $0~CatalogName might be corrupt.
 1501 ZZZZZ 99999 UUUUUUUU UUUUU UUUUUUU --- unused as of 5/7/12 ---
 1502 ZZZZZ 99999 ADVANCED CRTCL DIALOUT The OBJECTS - REPLICAS definition schema relationship for $0~String0 $1~TableName might be corrupt.

--- a/core/sql/bin/SqlciErrors.txt
+++ b/core/sql/bin/SqlciErrors.txt
@@ -410,7 +410,6 @@
 1430 3F000 99999 BEGINNER MAJOR DBADMIN A schema name that starts and ends with an "_"(underscore) is reserved for internal usage. It cannot be used to create a user schema.
 1431 ZZZZZ 99999 BEGINNER MINOR DBADMIN Object $0~String0 exists in HBase. This could be due to a concurrent transactional ddl operation in progress on this table.
 1432 ZZZZZ 99999 BEGINNER MINOR DBADMIN Input LOB type $0~Int0 does not match column's storage type: $1~Int1 Column name: $0~String0 .
-1433 ZZZZZ 99999 BEGINNER MINOR DBADMIN WITH clause redefined. WITH name $0~String0 .
 1500 ZZZZZ 99999 ADVANCED CRTCL DIALOUT The CATSYS - CAT_REFERENCES system schema relationship for catalog $0~CatalogName might be corrupt.
 1501 ZZZZZ 99999 UUUUUUUU UUUUU UUUUUUU --- unused as of 5/7/12 ---
 1502 ZZZZZ 99999 ADVANCED CRTCL DIALOUT The OBJECTS - REPLICAS definition schema relationship for $0~String0 $1~TableName might be corrupt.
@@ -1027,6 +1026,7 @@ $1~String1 --------------------------------
 3285 ZZZZZ 99999 BEGINNER MINOR DBADMIN The C interface for this type of routine is deprecated, please consider migrating to a TMUDF with a C++ or Java interface.
 3286 ZZZZZ 99999 BEGINNER MINOR DBADMIN The routine language that was either specified or implied from the library file name is not supported for this type of routine.
 3287 42000 99999 BEGINNER MINOR DBADMIN The $0~string0 option is not supported for this type of routine.
+3288 42000 99999 BEGINNER MINOR DBADMIN A syntax error occurred. WITH clause redefined. WITH name $0~String0 .
 3300 42000 99999 BEGINNER MAJOR DBADMIN --- available ---
 3301 42000 99999 BEGINNER MAJOR DBADMIN $0~string0 is too long (longer than $1~int0 $2~string1).
 

--- a/core/sql/parser/ParKeyWords.cpp
+++ b/core/sql/parser/ParKeyWords.cpp
@@ -848,7 +848,7 @@ ParKeyWord ParKeyWords::keyWords_[] = {
   ParKeyWord("RECORD_SEPARATOR",   TOK_RECORD_SEPARATOR, NONRESTOKEN_),
   ParKeyWord("RECOVER",            TOK_RECOVER,     NONRESTOKEN_),
   ParKeyWord("RECOVERY",           TOK_RECOVERY,    NONRESTOKEN_),
-  ParKeyWord("RECURSIVE",          IDENTIFIER,      POTANS_|RESWORD_),
+  ParKeyWord("RECURSIVE",          TOK_RECURSIVE,      POTANS_|RESWORD_),
   ParKeyWord("REDEFTIME",          TOK_REDEFTIME,   FLAGSNONE_),
   ParKeyWord("REF",                IDENTIFIER,      POTANS_|RESWORD_),
   ParKeyWord("REFERENCES",         TOK_REFERENCES,  ANS_|RESWORD_),

--- a/core/sql/parser/sqlparser.y
+++ b/core/sql/parser/sqlparser.y
@@ -7055,14 +7055,10 @@ with_clause_element : correlation_name TOK_AS '(' query_expression ')'
                           {
                             *SqlParser_Diags << DgSqlCode(-3288)
                                              << DgString0((*$1).toCharStar());
-                             delete $1;
-                             delete $4;
                              YYERROR;
                           }
 
                           SqlParser_CurrentParser->insertWithDefinition($1 , $$);
-                          delete $1;
-                          delete $4;
                       }
 
 rel_subquery_as_clause_and_col_list : rel_subquery as_clause '(' derived_column_list ')'

--- a/core/sql/regress/compGeneral/EXPECTED005
+++ b/core/sql/regress/compGeneral/EXPECTED005
@@ -71,6 +71,12 @@
 
 --- SQL operation complete.
 >>
+>>create table witht1 (c1 int, c2 int);
+
+--- SQL operation complete.
+>>create table witht2 (c1 int, c2 int);
+
+--- SQL operation complete.
 >>?section populate_tables 
 >>-- Populate t005t01
 >>insert into t005t01 values (30, 33);
@@ -194,7 +200,36 @@
 
 --- 1 row(s) inserted.
 >>
->>
+>>insert into witht1 values(1,1);
+
+--- 1 row(s) inserted.
+>>insert into witht1 values(2,2);
+
+--- 1 row(s) inserted.
+>>insert into witht1 values(3,3);
+
+--- 1 row(s) inserted.
+>>insert into witht1 values(4,4);
+
+--- 1 row(s) inserted.
+>>insert into witht1 values(5,5);
+
+--- 1 row(s) inserted.
+>>insert into witht2 values(3,3);
+
+--- 1 row(s) inserted.
+>>insert into witht2 values(4,4);
+
+--- 1 row(s) inserted.
+>>insert into witht2 values(5,5);
+
+--- 1 row(s) inserted.
+>>insert into witht2 values(6,6);
+
+--- 1 row(s) inserted.
+>>insert into witht2 values(7,7);
+
+--- 1 row(s) inserted.
 >>
 >>?section prep
 >>control query default query_cache '0';
@@ -1018,6 +1053,61 @@ DNO                   DNAME                 ENO          DNO
 *** ERROR[8822] The statement was not prepared.
 
 >>
+>>cqd mode_special_4 'on';
+
+--- SQL operation complete.
+>>with w1 as (select * from witht1),
++>w2 as (select * from w1)
++>select * from w2;
+
+C1 C2
+----------
+
+ 1 1
+ 2 2
+ 3 3
+ 4 4
+ 5 5
+
+--- SQL operation complete.
+>>
+>>with w1 as (select c1, c2 from witht1),
++>w2 as (select c1,c2 from witht2)
++>select * from w1 , w2 where w1.c1 = w2.c1;
+
+C1 C2 C1 C2
+----------
+
+ 3 3 3 3
+ 4 4 4 4
+ 5 5 5 5
+
+--- SQL operation complete.
+>>
+>>with w1 as (select * from witht1)
++>select * from w1
++>union all
++>select * from w1;
+
+C1 C2
+----------
+
+ 1 1
+ 1 1
+ 2 2
+ 2 2
+ 3 3
+ 3 3
+ 4 4
+ 4 4
+ 5 5
+ 5 5
+
+--- SQL operation complete.
+>>
+>>cqd mode_special_4 reset;
+
+--- SQL operation complete.
 >>
 >>?section cleanup
 >>
@@ -1051,7 +1141,12 @@ DNO                   DNAME                 ENO          DNO
 >>drop table t005_fx;
 
 --- SQL operation complete.
->>
+>>drop table witht1;
+
+--- SQL operation complete.
+>>drop table witht2;
+
+--- SQL operation complete.
 >>exit;
 
 End of MXCI Session

--- a/core/sql/regress/compGeneral/EXPECTED005
+++ b/core/sql/regress/compGeneral/EXPECTED005
@@ -1105,6 +1105,18 @@ C1 C2
 
 --- SQL operation complete.
 >>
+>>with recursive w1 as (select c1, c2 from witht1 union all select origin.c1 , origin.c2 from w1 join t1 origin on origin.c1 = w1.c1 );
+
+*** ERROR[3022] The WITH RECURSIVE operator is not yet supported.
+
+*** ERROR[8822] The statement was not prepared.
+
+>>with w1 as (select * from witht1), w1 as (select * from witht2) select * from w1;
+
+*** ERROR[3288] A syntax error occurred. WITH clause redefined. WITH name W1 .
+
+*** ERROR[8822] The statement was not prepared.
+
 >>cqd mode_special_4 reset;
 
 --- SQL operation complete.

--- a/core/sql/regress/compGeneral/TEST005
+++ b/core/sql/regress/compGeneral/TEST005
@@ -41,6 +41,8 @@ drop table t005_ex;
 drop table t005_gx;
 drop table t005_hx;
 drop table t005_fx;
+drop table witht1;
+drop table witht2;
 
 log LOG005 clear;
 
@@ -98,6 +100,8 @@ create table t005_hx (
 	h3 decimal(10,0) not null
 ) no partition;
 
+create table witht1 (c1 int, c2 int);
+create table witht2 (c1 int, c2 int);
 ?section populate_tables 
 -- Populate t005t01
 insert into t005t01 values (30, 33);
@@ -147,7 +151,16 @@ insert into t005_hx values(2,2,1);
 insert into t005_hx values(2,2,2);
 insert into t005_hx values(2,2,3);
         
-
+insert into witht1 values(1,1);
+insert into witht1 values(2,2);
+insert into witht1 values(3,3);
+insert into witht1 values(4,4);
+insert into witht1 values(5,5);
+insert into witht2 values(3,3);
+insert into witht2 values(4,4);
+insert into witht2 values(5,5);
+insert into witht2 values(6,6);
+insert into witht2 values(7,7);
 
 ?section prep
 control query default query_cache '0';
@@ -476,6 +489,21 @@ create materialized view T_MV1
         select A.dno,B.eno
         from t005t02 A full outer join t005t01 B on A.dno = B.dno;
 
+cqd mode_special_4 'on';
+with w1 as (select * from witht1),
+w2 as (select * from w1)
+select * from w2; 
+ 
+with w1 as (select c1, c2 from witht1),
+w2 as (select c1,c2 from witht2)
+select * from w1 , w2 where w1.c1 = w2.c1;
+
+with w1 as (select * from witht1)
+select * from w1
+union all
+select * from w1;
+
+cqd mode_special_4 reset;
 
 ?section cleanup
 
@@ -491,4 +519,5 @@ drop table t005_ex;
 drop table t005_gx;
 drop table t005_hx;
 drop table t005_fx;
-
+drop table witht1;
+drop table witht2;

--- a/core/sql/regress/compGeneral/TEST005
+++ b/core/sql/regress/compGeneral/TEST005
@@ -503,6 +503,8 @@ select * from w1
 union all
 select * from w1;
 
+with recursive w1 as (select c1, c2 from witht1 union all select origin.c1 , origin.c2 from w1 join t1 origin on origin.c1 = w1.c1 );
+with w1 as (select * from witht1), w1 as (select * from witht2) select * from w1;
 cqd mode_special_4 reset;
 
 ?section cleanup

--- a/core/sql/regress/core/EXPECTED037.SB
+++ b/core/sql/regress/core/EXPECTED037.SB
@@ -919,18 +919,6 @@ SELECT PROTECTED PROTECTED from (values(0)) PROTECTED(PROTECTED);
 
 >>
 >>-- Expect error [3128]
->>prepare s1 from SELECT RECURSIVE RECURSIVE from (values(0)) RECURSIVE(RECURSIVE);
-
-*** ERROR[3128] RECURSIVE is a reserved word.  It must be delimited by double-quotes to be used as an identifier.
-
-*** ERROR[15001] A syntax error occurred at or before: 
-SELECT RECURSIVE RECURSIVE from (values(0)) RECURSIVE(RECURSIVE);
-                         ^ (26 characters from start of SQL statement)
-
-*** ERROR[8822] The statement was not prepared.
-
->>
->>-- Expect error [3128]
 >>prepare s1 from SELECT REF REF from (values(0)) REF(REF);
 
 *** ERROR[3128] REF is a reserved word.  It must be delimited by double-quotes to be used as an identifier.

--- a/core/sql/regress/core/TEST037
+++ b/core/sql/regress/core/TEST037
@@ -344,9 +344,6 @@ prepare s1 from SELECT PRIVATE PRIVATE from (values(0)) PRIVATE(PRIVATE);
 prepare s1 from SELECT PROTECTED PROTECTED from (values(0)) PROTECTED(PROTECTED);
 
 -- Expect error [3128]
-prepare s1 from SELECT RECURSIVE RECURSIVE from (values(0)) RECURSIVE(RECURSIVE);
-
--- Expect error [3128]
 prepare s1 from SELECT REF REF from (values(0)) REF(REF);
 
 -- Expect error [3128]

--- a/core/sql/sqlci/sqlci_lex.ll
+++ b/core/sql/sqlci/sqlci_lex.ll
@@ -425,6 +425,7 @@ B			[ \t\n]+
 [Ww][Hh][Ii][Ll][Ee]                   return_IDENT_or_TOKEN(WHILE, 0);
 [Ss][Ii][Gg][Nn][Aa][Ll]	       return_IDENT_or_TOKEN(SIGNAL, 0);
 [Ww][Ii][Tt][Hh][Oo][Uu][Tt]           return_IDENT_or_TOKEN(WITHOUT, 0);
+[Ww][Ii][Tt][Hh]                       return_IDENT_or_TOKEN(WITH, 0);
 [Hh][Oo][Ll][Dd]                       return_IDENT_or_TOKEN(HOLD, 0);
 [Pp][Aa][Rr][Ss][Ee][Rr][Ff][Ll][Aa][Gg][Ss] return_IDENT_or_TOKEN(PARSERFLAGS, 0);
 [Tt][Ee][Rr][Mm][Ii][Nn][Aa][Ll]_[Cc][Hh][Aa][Rr][Ss][Ee][Tt] return_IDENT_or_TOKEN(TERMINAL_CHARSET, 0);

--- a/core/sql/sqlci/sqlci_yacc.y
+++ b/core/sql/sqlci/sqlci_yacc.y
@@ -510,6 +510,7 @@ static char * FCString (const char *idString, int isFC)
 %token TERMINAL_CHARSET
 %token TRANSFORM
 %token TRUNCATE
+%token WITH 
 %token UNLOCK
 %token UPD_STATS
 %token UPD_HIST_STATS
@@ -2231,6 +2232,7 @@ dml_type :
 	|	DUP			{$$ = DML_DDL_TYPE;}
 	|	PURGEDATA		{$$ = DML_DDL_TYPE;}
 	|	TRUNCATE		{$$ = DML_DDL_TYPE;}
+	|	WITH                    {$$ = DML_DDL_TYPE;}
 	|	POPULATE		{$$ = DML_DDL_TYPE;}
         |       VALIDATEtoken           {$$ = DML_DDL_TYPE;}
 	|	RECOVER 		{$$ = DML_DDL_TYPE;}

--- a/core/sql/sqlcomp/parser.cpp
+++ b/core/sql/sqlcomp/parser.cpp
@@ -101,6 +101,11 @@ void Parser::reset(NABoolean on_entry_reset_was_needed)
     Set_SqlParser_Flags(0);
 }
 
+ULng32 cmmHashFunc_NAString(const NAString& str)
+{
+  return (ULng32) NAString::hash(str);
+}
+
 
 Parser::Parser(const CmpContext* cmpContext) 
 {
@@ -151,6 +156,10 @@ Parser::Parser(const CmpContext* cmpContext)
   clearHasOlapFunctions();
 
   HQCKey_ = NULL;
+
+  Lng32 initsize = 10;
+  with_clauses_ =  new (wHeap_) NAHashDictionary<NAString,RelExpr>(&cmmHashFunc_NAString, initsize , TRUE, wHeap_) ;
+
 }
 
 Parser::~Parser()

--- a/core/sql/sqlcomp/parser.h
+++ b/core/sql/sqlcomp/parser.h
@@ -261,8 +261,20 @@ ItemExpr *get_w_ItemExprTree(const NAWchar * str,
   NABoolean isHQCCacheable()
     { return HQCKey_?HQCKey_->isCacheable():FALSE;  }
 
-  NAHashDictionary<NAString,RelExpr> *with_clauses_;
+  NABoolean hasWithDefinition(NAString* key)
+    { if(with_clauses_->contains(key) ) return TRUE;
+      else return FALSE;
+    }
 
+  void insertWithDefinition(NAString* key,  RelExpr* val)
+    {
+       with_clauses_->insert(key,val);
+    }
+
+  RelExpr * getWithDefinition(NAString *key)
+    {
+       return with_clauses_->getFirstValue(key);
+    }
 private:
 
   HQCParseKey* HQCKey_;
@@ -313,6 +325,13 @@ private:
 
   LIST(NABoolean )  hasOlapFunctions_;
   LIST(NABoolean )  hasTDFunctions_;
+  /* 
+   * hashmap to save WITH clause definition 
+   * key is the name of the with clause
+   * value is the RelExpr structure
+   */
+  NAHashDictionary<NAString,RelExpr> *with_clauses_;
+
 };
 
 #define PARSERASSERT(b) \

--- a/core/sql/sqlcomp/parser.h
+++ b/core/sql/sqlcomp/parser.h
@@ -261,6 +261,8 @@ ItemExpr *get_w_ItemExprTree(const NAWchar * str,
   NABoolean isHQCCacheable()
     { return HQCKey_?HQCKey_->isCacheable():FALSE;  }
 
+  NAHashDictionary<NAString,RelExpr> *with_clauses_;
+
 private:
 
   HQCParseKey* HQCKey_;


### PR DESCRIPTION
initial support new SQL syntax 'WITH', which required in many use cases, for example, in 35 TPCDS queries.
This change will transform the WITH definition into table typed sub-query, so can be used in later compile phases.
As tested, in 35 TPCDS queries that contains WITH, this change pass 19 of them , others due to other syntax gap, like rollup. The passed TPCDS queries include:
 q1
q2
q4
q11
q23
q24
q30
q31
q33
q51
q54
q56
q58
q59
q60
q64
q81
q83
q97

Since still not widely tested, this syntax is still protected by MODE_SPECIAL_4 CQD.

Please help to code review it. 