### PR TITLE
[TRAFODION-2092] (Backport to release2.0) Fix installer package name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,7 @@ package-src: $(SRCDIR)-${TRAFODION_VER}-incubating/LICENSE
 	git archive --format tar --prefix $(SRCDIR)-${TRAFODION_VER}-incubating/ HEAD > distribution/$(SRCDIR)-${TRAFODION_VER}-incubating-src.tar
 	tar rf distribution/$(SRCDIR)-${TRAFODION_VER}-incubating-src.tar $^
 	gzip distribution/$(SRCDIR)-${TRAFODION_VER}-incubating-src.tar
+	rm -rf $(SRCDIR)-${TRAFODION_VER}-incubating LICENSE
 
 $(SRCDIR)-${TRAFODION_VER}-incubating/LICENSE:
 	cd licenses && $(MAKE) LICENSE-src

--- a/core/Makefile
+++ b/core/Makefile
@@ -28,7 +28,7 @@ include macros.gmk
 
 # Make Targets
 .PHONY: all dbsecurity foundation $(MPI_TARGET) ndcs ci jdbc_jar jdbc_type2_jar sqroot $(SEAMONSTER_TARGET) verhdr dcs rest odb
-.PHONY: package package-all pkg-product pkg-sql-regress pkg-phx-tests pkg-dcs-tests check-copyrights
+.PHONY: package package-all pkg-product pkg-sql-regress pkg-phx-tests pkg-dcs-tests check-copyrights pkg-installer
 
 ################
 ### Main targets
@@ -37,7 +37,7 @@ include macros.gmk
 # Default target (all components)
 all: $(MPI_TARGET) dbsecurity foundation jdbc_jar $(SEAMONSTER_TARGET) ndcs ci jdbc_type2_jar dcs rest odb lib_mgmt
 
-package: pkg-product pkg-client
+package: pkg-product pkg-client pkg-installer
 
 #############
 # Components
@@ -115,6 +115,7 @@ clean: sqroot
 	cd rest &&			$(MAKE) clean
 	cd conn/odb &&			$(MAKE) clean
 	cd ../dcs &&			$(MAKE) clean 
+	cd ../install &&                $(MAKE) clean
 	$(RM) -r ../${DISTRIBUTION_DIR}
 
 cleanall: sqroot eclipseclean cleantests
@@ -129,6 +130,7 @@ cleanall: sqroot eclipseclean cleantests
 	cd rest &&			$(MAKE) clean
 	cd conn/odb &&			$(MAKE) clean
 	cd ../dcs &&			$(MAKE) clean
+	cd ../install &&                $(MAKE) clean
 	$(RM) -r ../${DISTRIBUTION_DIR}
 
 package-all: package pkg-sql-regress pkg-phx-tests pkg-dcs-tests
@@ -150,6 +152,10 @@ pkg-phx-tests: all
 # Package dcs tests
 pkg-dcs-tests: all
 	cd sqf && $(MAKE) package-dcs 2>&1 | sed -e "s/$$/	##(Package dcs tests)/";exit $${PIPESTATUS[0]}
+
+# Package installer
+pkg-installer: 
+	cd ../install && $(MAKE) 2>&1 | sed -e "s/$$/	##(Package installer)/";exit $${PIPESTATUS[0]}
 
 version:
 	@cd sqf; unset SQ_VERBOSE; source sqenv.sh ; echo "$${TRAFODION_VER}"

--- a/install/Makefile
+++ b/install/Makefile
@@ -14,20 +14,16 @@
 #  limitations under the License.
 #
 # @@@ END COPYRIGHT @@@
-
-# Default version number
-# daily, pre-release, & release builds are named based on build ID (tag or date)
-# Version identifier is two parts:
-#  * Trafodion version supported
-#  * Installer version number (starting from 1 for each Trafodion version)
-#
-# "v000" indicates an internal/development version of installer
-RELEASE_VER ?= 1.0.0_v002
+RELEASE_VER ?= ${TRAFODION_VER}-incubating
+RELEASE_TYPE ?= $(shell echo $(TRAFODION_VER_PROD)| sed -e 's/ /-/g')
+INSTALLER_TARNAME = $(shell echo ${RELEASE_TYPE}_installer-${RELEASE_VER}.tar.gz |tr '[A-Z]' '[a-z]')
 
 all: pkg-installer 
 
 pkg-installer: installer/LICENSE installer/NOTICE installer/DISCLAIMER
-	tar czf installer-$(RELEASE_VER).tar.gz installer --exclude=tools
+	tar czf ${INSTALLER_TARNAME} installer --exclude=tools
+	mkdir -p ../distribution
+	mv ${INSTALLER_TARNAME} ../distribution
 
 installer/LICENSE: ../licenses/LICENSE-install
 	cp -f $? $@
@@ -45,4 +41,4 @@ version:
 	@echo "$(RELEASE_VER)"
 
 clean:
-	rm installer-$(RELEASE_VER).tar.gz
+	rm -f ${INSTALLER_TARNAME} 

--- a/licenses/lic-server-src
+++ b/licenses/lic-server-src
@@ -18,7 +18,7 @@ Copyright (c) 1990, 1993
  are met:
  1. Redistributions of source code must retain the above copyright
     notice, this list of conditions and the following disclaimer.
-. Redistributions in binary form must reproduce the above copyright
+ 2. Redistributions in binary form must reproduce the above copyright
     notice, this list of conditions and the following disclaimer in the
     documentation and/or other materials provided with the distribution.
  3. Neither the name of the University nor the names of its contributors


### PR DESCRIPTION
This is a backport of Anu's changes and mine from master to generate
installer package from the main makefile and name the package correctly.

Also includes the license typo mentioned in TRAFODION-2093.

These changes are backported in case any more patch releases are needed
for 2.0.x.