### PR TITLE
[TRAFODION-2097] :Adding retry logic when making hdfsOpenFile calls to read an hdfs file [

### DIFF
--- a/core/sql/executor/ExHdfsScan.cpp
+++ b/core/sql/executor/ExHdfsScan.cpp
@@ -585,6 +585,17 @@ ExWorkProcRetcode ExHdfsScanTcb::work()
                    openType //
                    );
                 
+                if ((retcode < 0) &&
+                    ((errno == ENOENT) || (errno == EAGAIN)))
+                  {
+                    ComDiagsArea * diagsArea = NULL;
+                    ExRaiseSqlError(getHeap(), &diagsArea, 
+                                    (ExeErrorCode)(EXE_HIVE_DATA_MOD_CHECK_ERROR));
+                    pentry_down->setDiagsArea(diagsArea);
+                    step_ = HANDLE_ERROR_AND_DONE;
+                    break;
+                  }
+
                 // preopen next range. 
                 if ( (currRangeNum_ + 1) < (beginRangeNum_ + numRanges_) ) 
                   {
@@ -737,7 +748,7 @@ ExWorkProcRetcode ExHdfsScanTcb::work()
 		    ExRaiseSqlError(getHeap(), &diagsArea, 
                                     (ExeErrorCode)(EXE_ERROR_FROM_LOB_INTERFACE), NULL, 
                                     &intParam1, 
-                                    &cliError, 
+                                    &errno, 
                                     NULL, 
                                     "HDFS",
                                     (char*)"ExpLOBInterfaceSelectCursor/read",
@@ -1247,7 +1258,7 @@ ExWorkProcRetcode ExHdfsScanTcb::work()
 		    ExRaiseSqlError(getHeap(), &diagsArea, 
                                     (ExeErrorCode)(EXE_ERROR_FROM_LOB_INTERFACE), NULL, 
                                     &intParam1, 
-                                    &cliError, 
+                                    &errno, 
                                     NULL, 
                                     "HDFS",
                                     (char*)"ExpLOBInterfaceSelectCursor/close",

--- a/core/sql/executor/ExHdfsScan.cpp
+++ b/core/sql/executor/ExHdfsScan.cpp
@@ -631,7 +631,7 @@ ExWorkProcRetcode ExHdfsScanTcb::work()
                 ExRaiseSqlError(getHeap(), &diagsArea, 
                                 (ExeErrorCode)(EXE_ERROR_FROM_LOB_INTERFACE), NULL, 
                                 &intParam1, 
-                                &cliError, 
+                                &errno, 
                                 NULL, 
                                 "HDFS",
                                 (char*)"ExpLOBInterfaceSelectCursor/open",

--- a/core/sql/exp/ExpLOBaccess.cpp
+++ b/core/sql/exp/ExpLOBaccess.cpp
@@ -1401,9 +1401,9 @@ Ex_Lob_Error ExLob::openDataCursor(char *file, LobsCursorType type, Int64 range,
             if (errno == EAGAIN) //retry 3 times
               {
                 short cnt = 0;
-                while(cnt < 3 && (errno == EAGAIN))
+                while(cnt < 3 )
                   {
-                    sleep(5);
+                    sleep(15);
                     fdData_ = hdfsOpenFile(fs_, lobDataFile_, openFlags_, 0, 0, 0);
                     if (fdData_)
                       break;

--- a/core/sql/exp/ExpLOBaccess.cpp
+++ b/core/sql/exp/ExpLOBaccess.cpp
@@ -1370,7 +1370,7 @@ Ex_Lob_Error ExLob::openDataCursor(char *file, LobsCursorType type, Int64 range,
             short cnt = 0;
             while(cnt < 3 )
               {
-                sleep(10);
+                sleep(20);
                 fdData_ = hdfsOpenFile(fs_, lobDataFile_, openFlags_, 0, 0, 0);
                 if (fdData_)
                   break;

--- a/core/sql/exp/ExpLOBaccess.cpp
+++ b/core/sql/exp/ExpLOBaccess.cpp
@@ -1977,14 +1977,16 @@ Ex_Lob_Error ExLob::readDataToMem(char *memAddr,
         {
           if (errno == EAGAIN) //retry 3 times
             {
+              hdfsCloseFile(fs_,lobDataFile_);
               short cnt = 0;
-              while(cnt < 3 && (errno == EAGAIN))
+              while(cnt < 3 )
                  {
-                   sleep(5);
+                   sleep(10);
                    fdData_ = hdfsOpenFile(fs_, lobDataFile_, openFlags_, 0, 0, 0);
                    if (fdData_)
                      break;
                    cnt++;
+                   hdfsCloseFile(fs_,lobDataFile_);
                  }
                if (!fdData_)
                  {

--- a/core/sql/exp/ExpLOBaccess.cpp
+++ b/core/sql/exp/ExpLOBaccess.cpp
@@ -552,25 +552,9 @@ Ex_Lob_Error ExLob::statSourceFile(char *srcfile, Int64 &sourceEOF)
    if (srcType == HDFS_FILE)
      {
        hdfsFile sourceFile = hdfsOpenFile(fs_,srcfile,O_RDONLY,0,0,0);   
-       if (!sourceFile)	
-         {
-           if (errno == EAGAIN) //retry 3 times
-             {
-               short cnt = 0;
-               while(cnt < 3 && (errno == EAGAIN))
-                 {
-                   sleep(5);
-                   sourceFile = hdfsOpenFile(fs_,srcfile,O_RDONLY,0,0,0);
-                   if (sourceFile)
-                     break;
-                   cnt++;
-                 }
-               if (!sourceFile)
-                 return LOB_SOURCE_FILE_OPEN_ERROR;                
-             }
-           else
-             return LOB_SOURCE_FILE_OPEN_ERROR;
-         }										 
+       if (!sourceFile)	           
+         return LOB_SOURCE_FILE_OPEN_ERROR;
+         										 
        hdfsFileInfo *sourceFileInfo = hdfsGetPathInfo(fs_,srcfile);
        // get EOD from source hdfs file.
        if (sourceFileInfo)
@@ -686,26 +670,9 @@ Ex_Lob_Error ExLob::readHdfsSourceFile(char *srcfile, char *&fileData, Int32 &si
    
      int openFlags = O_RDONLY;
      hdfsFile fdSrcFile = hdfsOpenFile(fs_,srcfile, openFlags,0,0,0);
-     if (fdSrcFile == NULL) {
-       if (errno == EAGAIN) //retry 3 times
-             {
-               short cnt = 0;
-               while(cnt < 3 && (errno == EAGAIN))
-                 {
-                   sleep(5);
-                   fdSrcFile = hdfsOpenFile(fs_,srcfile,openFlags,0,0,0);
-                   if (fdSrcFile)
-                     break;
-                   cnt++;
-                 }
-               if (!fdSrcFile)
-                 return LOB_SOURCE_FILE_OPEN_ERROR;                
-             }
-           else
-             return LOB_SOURCE_FILE_OPEN_ERROR;
-     }
-
-     
+     if (fdSrcFile == NULL) 
+       return LOB_SOURCE_FILE_OPEN_ERROR;
+         
      fileData = (char *) (getLobGlobalHeap())->allocateMemory(size);
      if (fileData == (char *)-1) {
        return LOB_SOURCE_DATA_ALLOC_ERROR;
@@ -1398,12 +1365,12 @@ Ex_Lob_Error ExLob::openDataCursor(char *file, LobsCursorType type, Int64 range,
         fdData_ = hdfsOpenFile(fs_, lobDataFile_, openFlags_, 0, 0, 0);
         if (!fdData_) 
           {
-            if (errno == EAGAIN) //retry 3 times
+            if ((errno == EAGAIN) || (errno == ENOENT)) //retry 3 times
               {
                 short cnt = 0;
                 while(cnt < 3 )
                   {
-                    sleep(15);
+                    sleep(5);
                     fdData_ = hdfsOpenFile(fs_, lobDataFile_, openFlags_, 0, 0, 0);
                     if (fdData_)
                       break;
@@ -1608,10 +1575,10 @@ Ex_Lob_Error ExLob::compactLobDataFile(ExLobInMemoryDescChunksEntry *dcArray,Int
   hdfsFile  fdData = hdfsOpenFile(fs, lobDataFile_, O_RDONLY, 0, 0,0);
   if (!fdData) 
     {   
-      if (errno == EAGAIN) //retry 3 times
+      if ((errno == EAGAIN) || (errno == ENOENT)) //retry 3 times
         {
           short cnt = 0;
-          while(cnt < 3 && (errno == EAGAIN))
+          while(cnt < 3 )
             {
               sleep(5);
               fdData = hdfsOpenFile(fs, lobDataFile_, O_RDONLY, 0, 0,0);
@@ -1853,10 +1820,10 @@ Ex_Lob_Error ExLob::readCursorData(char *tgt, Int64 tgtSize, cursor_t &cursor, I
          fdData_ = hdfsOpenFile(fs_, lobDataFile_, openFlags_, 0, 0, 0);
          if (!fdData_) 
            {
-             if (errno == EAGAIN) //retry 3 times
+             if ((errno == EAGAIN) ||(errno ==ENOENT))//retry 3 times
                {
                  short cnt = 0;
-                 while(cnt < 3 && (errno == EAGAIN))
+                 while(cnt < 3 )
                    {
                      sleep(5);
                      fdData_ = hdfsOpenFile(fs_, lobDataFile_, openFlags_, 0, 0, 0);
@@ -1945,12 +1912,12 @@ Ex_Lob_Error ExLob::readDataToMem(char *memAddr,
       fdData_ = hdfsOpenFile(fs_, lobDataFile_, openFlags_, 0, 0, 0);
       if (!fdData_) 
         {
-          if (errno == EAGAIN) //retry 3 times
+          if ((errno == EAGAIN) || (errno == ENOENT)) //retry 3 times
             {
               short cnt = 0;
               while(cnt < 3 )
                  {
-                   sleep(10);
+                   sleep(5);
                    fdData_ = hdfsOpenFile(fs_, lobDataFile_, openFlags_, 0, 0, 0);
                    if (fdData_)
                      break;
@@ -1975,13 +1942,13 @@ Ex_Lob_Error ExLob::readDataToMem(char *memAddr,
       fdData_ = hdfsOpenFile(fs_, lobDataFile_, openFlags_, 0, 0, 0);
       if (!fdData_) 
         {
-          if (errno == EAGAIN) //retry 3 times
+          if ((errno == EAGAIN) ||(errno ==ENOENT))//retry 3 times
             {
               
               short cnt = 0;
               while(cnt < 3 )
                  {
-                   sleep(10);
+                   sleep(5);
                    fdData_ = hdfsOpenFile(fs_, lobDataFile_, openFlags_, 0, 0, 0);
                    if (fdData_)
                      break;

--- a/core/sql/exp/ExpLOBaccess.cpp
+++ b/core/sql/exp/ExpLOBaccess.cpp
@@ -1948,9 +1948,9 @@ Ex_Lob_Error ExLob::readDataToMem(char *memAddr,
           if (errno == EAGAIN) //retry 3 times
             {
               short cnt = 0;
-              while(cnt < 3 && (errno == EAGAIN))
+              while(cnt < 3 )
                  {
-                   sleep(5);
+                   sleep(10);
                    fdData_ = hdfsOpenFile(fs_, lobDataFile_, openFlags_, 0, 0, 0);
                    if (fdData_)
                      break;
@@ -1977,7 +1977,7 @@ Ex_Lob_Error ExLob::readDataToMem(char *memAddr,
         {
           if (errno == EAGAIN) //retry 3 times
             {
-              hdfsCloseFile(fs_,lobDataFile_);
+              
               short cnt = 0;
               while(cnt < 3 )
                  {
@@ -1986,7 +1986,7 @@ Ex_Lob_Error ExLob::readDataToMem(char *memAddr,
                    if (fdData_)
                      break;
                    cnt++;
-                   hdfsCloseFile(fs_,lobDataFile_);
+                   
                  }
                if (!fdData_)
                  {

--- a/core/sql/exp/ExpLOBaccess.cpp
+++ b/core/sql/exp/ExpLOBaccess.cpp
@@ -1370,7 +1370,7 @@ Ex_Lob_Error ExLob::openDataCursor(char *file, LobsCursorType type, Int64 range,
             short cnt = 0;
             while(cnt < 3 )
               {
-                sleep(5);
+                sleep(10);
                 fdData_ = hdfsOpenFile(fs_, lobDataFile_, openFlags_, 0, 0, 0);
                 if (fdData_)
                   break;
@@ -1573,7 +1573,7 @@ Ex_Lob_Error ExLob::compactLobDataFile(ExLobInMemoryDescChunksEntry *dcArray,Int
       short cnt = 0;
       while(cnt < 3 )
         {
-          sleep(5);
+          sleep(10);
           fdData = hdfsOpenFile(fs, lobDataFile_, O_RDONLY, 0, 0,0);
           if (fdData)
             break;
@@ -1809,7 +1809,7 @@ Ex_Lob_Error ExLob::readCursorData(char *tgt, Int64 tgtSize, cursor_t &cursor, I
              short cnt = 0;
              while(cnt < 3 )
                {
-                 sleep(5);
+                 sleep(10);
                  fdData_ = hdfsOpenFile(fs_, lobDataFile_, openFlags_, 0, 0, 0);
                  if (fdData_)
                    break;
@@ -1894,7 +1894,7 @@ Ex_Lob_Error ExLob::readDataToMem(char *memAddr,
           short cnt = 0;
           while(cnt < 3 )
             {
-              sleep(5);
+              sleep(10);
               fdData_ = hdfsOpenFile(fs_, lobDataFile_, openFlags_, 0, 0, 0);
               if (fdData_)
                 break;
@@ -1916,7 +1916,7 @@ Ex_Lob_Error ExLob::readDataToMem(char *memAddr,
           short cnt = 0;
           while(cnt < 3 )
             {
-              sleep(5);
+              sleep(10);
               fdData_ = hdfsOpenFile(fs_, lobDataFile_, openFlags_, 0, 0, 0);
               if (fdData_)
                 break;

--- a/core/sql/exp/ExpLOBaccess.cpp
+++ b/core/sql/exp/ExpLOBaccess.cpp
@@ -1370,7 +1370,8 @@ Ex_Lob_Error ExLob::openDataCursor(char *file, LobsCursorType type,
         if (!fdData_)
           {
             openFlags_ = -1;
-            *hdfsDetailError = errno;
+            if (hdfsDetailError)
+              *hdfsDetailError = errno;
             lobCursorLock_.unlock();
             return LOB_DATA_FILE_OPEN_ERROR;
           }                

--- a/core/sql/exp/ExpLOBaccess.cpp
+++ b/core/sql/exp/ExpLOBaccess.cpp
@@ -1365,30 +1365,24 @@ Ex_Lob_Error ExLob::openDataCursor(char *file, LobsCursorType type, Int64 range,
         fdData_ = hdfsOpenFile(fs_, lobDataFile_, openFlags_, 0, 0, 0);
         if (!fdData_) 
           {
-            if ((errno == EAGAIN) || (errno == ENOENT)) //retry 3 times
+            //retry 3 times
+              
+            short cnt = 0;
+            while(cnt < 3 )
               {
-                short cnt = 0;
-                while(cnt < 3 )
-                  {
-                    sleep(5);
-                    fdData_ = hdfsOpenFile(fs_, lobDataFile_, openFlags_, 0, 0, 0);
-                    if (fdData_)
-                      break;
-                    cnt++;
-                  }
-                if (!fdData_)
-                  {
-                    openFlags_ = -1;
-                    lobCursorLock_.unlock();
-                    return LOB_DATA_FILE_OPEN_ERROR;
-                  }                
+                sleep(5);
+                fdData_ = hdfsOpenFile(fs_, lobDataFile_, openFlags_, 0, 0, 0);
+                if (fdData_)
+                  break;
+                cnt++;
               }
-            else
+            if (!fdData_)
               {
                 openFlags_ = -1;
                 lobCursorLock_.unlock();
                 return LOB_DATA_FILE_OPEN_ERROR;
-              }
+              }                
+             
           }
       }
 
@@ -1575,28 +1569,17 @@ Ex_Lob_Error ExLob::compactLobDataFile(ExLobInMemoryDescChunksEntry *dcArray,Int
   hdfsFile  fdData = hdfsOpenFile(fs, lobDataFile_, O_RDONLY, 0, 0,0);
   if (!fdData) 
     {   
-      if ((errno == EAGAIN) || (errno == ENOENT)) //retry 3 times
+      
+      short cnt = 0;
+      while(cnt < 3 )
         {
-          short cnt = 0;
-          while(cnt < 3 )
-            {
-              sleep(5);
-              fdData = hdfsOpenFile(fs, lobDataFile_, O_RDONLY, 0, 0,0);
-              if (fdData)
-                break;
-              cnt++;
-            }
-          if (!fdData)
-            {
-              str_sprintf(logBuf,"Could not open file:%s",lobDataFile_);
-              lobDebugInfo(logBuf,0,__LINE__,lobTrace_);
-              hdfsCloseFile(fs,fdData);
-              fdData = NULL;
-              return LOB_DATA_FILE_OPEN_ERROR;
-            }
-                          
+          sleep(5);
+          fdData = hdfsOpenFile(fs, lobDataFile_, O_RDONLY, 0, 0,0);
+          if (fdData)
+            break;
+          cnt++;
         }
-      else
+      if (!fdData)
         {
           str_sprintf(logBuf,"Could not open file:%s",lobDataFile_);
           lobDebugInfo(logBuf,0,__LINE__,lobTrace_);
@@ -1604,6 +1587,8 @@ Ex_Lob_Error ExLob::compactLobDataFile(ExLobInMemoryDescChunksEntry *dcArray,Int
           fdData = NULL;
           return LOB_DATA_FILE_OPEN_ERROR;
         }
+                          
+        
     }
   
   hdfsFile fdTemp = hdfsOpenFile(fs, tmpLobDataFile,O_WRONLY|O_CREAT,0,0,0);
@@ -1820,28 +1805,22 @@ Ex_Lob_Error ExLob::readCursorData(char *tgt, Int64 tgtSize, cursor_t &cursor, I
          fdData_ = hdfsOpenFile(fs_, lobDataFile_, openFlags_, 0, 0, 0);
          if (!fdData_) 
            {
-             if ((errno == EAGAIN) ||(errno ==ENOENT))//retry 3 times
+                           
+             short cnt = 0;
+             while(cnt < 3 )
                {
-                 short cnt = 0;
-                 while(cnt < 3 )
-                   {
-                     sleep(5);
-                     fdData_ = hdfsOpenFile(fs_, lobDataFile_, openFlags_, 0, 0, 0);
-                     if (fdData_)
-                       break;
-                     cnt++;
-                   }
-                 if (!fdData_)
-                   {
-                     openFlags_ = -1;
-                     return LOB_DATA_FILE_OPEN_ERROR;                 
-                   }               
+                 sleep(5);
+                 fdData_ = hdfsOpenFile(fs_, lobDataFile_, openFlags_, 0, 0, 0);
+                 if (fdData_)
+                   break;
+                 cnt++;
                }
-             else
+             if (!fdData_)
                {
                  openFlags_ = -1;
-                 return LOB_DATA_FILE_OPEN_ERROR;
-               }
+                 return LOB_DATA_FILE_OPEN_ERROR;                 
+               }               
+             
            }
       }
 
@@ -1911,64 +1890,48 @@ Ex_Lob_Error ExLob::readDataToMem(char *memAddr,
       openFlags_ = O_RDONLY;
       fdData_ = hdfsOpenFile(fs_, lobDataFile_, openFlags_, 0, 0, 0);
       if (!fdData_) 
-        {
-          if ((errno == EAGAIN) || (errno == ENOENT)) //retry 3 times
+        {          
+          short cnt = 0;
+          while(cnt < 3 )
             {
-              short cnt = 0;
-              while(cnt < 3 )
-                 {
-                   sleep(5);
-                   fdData_ = hdfsOpenFile(fs_, lobDataFile_, openFlags_, 0, 0, 0);
-                   if (fdData_)
-                     break;
-                   cnt++;
-                 }
-               if (!fdData_)
-                 {
-                   openFlags_ = -1;
-                   return LOB_DATA_FILE_OPEN_ERROR;
-                 }
-                                 
-             }
-           else
-             {
-               openFlags_ = -1;
-               return LOB_DATA_FILE_OPEN_ERROR;
-             }
+              sleep(5);
+              fdData_ = hdfsOpenFile(fs_, lobDataFile_, openFlags_, 0, 0, 0);
+              if (fdData_)
+                break;
+              cnt++;
+            }
+          if (!fdData_)
+            {
+              openFlags_ = -1;
+              return LOB_DATA_FILE_OPEN_ERROR;
+            }
+                                           
         }
     }
   else
     {
       fdData_ = hdfsOpenFile(fs_, lobDataFile_, openFlags_, 0, 0, 0);
       if (!fdData_) 
-        {
-          if ((errno == EAGAIN) ||(errno ==ENOENT))//retry 3 times
+        {         
+          short cnt = 0;
+          while(cnt < 3 )
             {
-              
-              short cnt = 0;
-              while(cnt < 3 )
-                 {
-                   sleep(5);
-                   fdData_ = hdfsOpenFile(fs_, lobDataFile_, openFlags_, 0, 0, 0);
-                   if (fdData_)
-                     break;
-                   cnt++;
-                   
-                 }
-               if (!fdData_)
-                 {
-                   openFlags_ = -1;
-                   return LOB_DATA_FILE_OPEN_ERROR;
-                 }                                
-             }
-           else
-             {
-               openFlags_ = -1;
-               return LOB_DATA_FILE_OPEN_ERROR;
-             }
+              sleep(5);
+              fdData_ = hdfsOpenFile(fs_, lobDataFile_, openFlags_, 0, 0, 0);
+              if (fdData_)
+                break;
+              cnt++;                   
+            }
+          if (!fdData_)
+            {
+              openFlags_ = -1;
+              return LOB_DATA_FILE_OPEN_ERROR;
+            }                                
         }
-	
+          
     }
+	
+
     
   
   if (!multipleChunks)

--- a/core/sql/exp/ExpLOBaccess.h
+++ b/core/sql/exp/ExpLOBaccess.h
@@ -429,7 +429,7 @@ class ExLob
     bool hasNoOpenCursors() { return lobCursors_.empty(); }
   Ex_Lob_Error openCursor(char *handleIn, Int32 handleInLen,Int64 transId);
     Ex_Lob_Error openDataCursor(char *fileName, LobsCursorType type, Int64 range, 
-                                Int64 bytesLeft, Int64 bufMaxSize, Int64 prefetch, ExLobGlobals *lobGlobals);
+                                Int64 bytesLeft, Int64 bufMaxSize, Int64 prefetch, ExLobGlobals *lobGlobals, Int32 *hdfsDetailError = NULL);
     Ex_Lob_Error deleteCursor(char *cursorName, ExLobGlobals *lobGlobals);
   Ex_Lob_Error fetchCursor(char *handleIn, Int32 handleLenIn, Int64 &outOffset, Int64 &outSize,NABoolean &isEOD,Int64 transId);
   Ex_Lob_Error insertData(char *data, Int64 size, LobsSubOper so,Int64 headDescNum, Int64 &operLen, Int64 lobMaxSize, Int64 lobMaxChunkMemSize,char *handleIn,Int32 handleInLen, char *blackBox, Int32 blackBoxLen, char * handleOut, Int32 &handleOutLen, void *lobGlobals);

--- a/core/sql/exp/ExpLOBinterface.cpp
+++ b/core/sql/exp/ExpLOBinterface.cpp
@@ -884,7 +884,8 @@ Lng32 ExpLOBInterfaceSelectCursor(void * exLobGlob,
 			          Int64 &outLen, char * lobData,
 				  
 				  Lng32 oper, // 1: open. 2: fetch. 3: close
-                                  Lng32 openType // 0: not applicable. 1: preOpen. 2: mustOpen.
+                                  Lng32 openType, // 0: not applicable. 1: preOpen. 2: mustOpen.
+                                  Int32 *hdfsDetailError
 				  )
 {
   Ex_Lob_Error err;
@@ -942,7 +943,7 @@ Lng32 ExpLOBInterfaceSelectCursor(void * exLobGlob,
                    waitedOp,
 		   exLobGlob,
 		   0,
-		   NULL, 0,0,0,0,0,0,0,
+		   hdfsDetailError, 0,0,0,0,0,0,0,
                    openType
 		   );
 

--- a/core/sql/exp/ExpLOBinterface.h
+++ b/core/sql/exp/ExpLOBinterface.h
@@ -274,7 +274,8 @@ Lng32 ExpLOBInterfaceSelectCursor(void * lobGlob,
 			          Int64 &outLen, char * lobData,
 				  
 				  Lng32 oper, // 1: open. 2: fetch. 3: close
-                                  Lng32 openType // 0: not applicable. 1: preOpen. 2: mustOpen. 
+                                  Lng32 openType, // 0: not applicable. 1: preOpen. 2: mustOpen. 
+                                  Int32 *hdfsDetailError = NULL
 				  );
 
 Lng32 ExpLOBinterfaceStats(void * lobGlob, 

--- a/core/sql/regress/hive/EXPECTED018
+++ b/core/sql/regress/hive/EXPECTED018
@@ -150,9 +150,9 @@ Task:  CLEANUP         Status: Started    Object: TRAFODION.HBASE.CUSTOMER_ADDRE
 Task:  CLEANUP         Status: Ended      Object: TRAFODION.HBASE.CUSTOMER_ADDRESS
 Task:  PREPARATION     Status: Started    Object: TRAFODION.HBASE.CUSTOMER_ADDRESS
        Rows Processed: 50000 
-Task:  PREPARATION     Status: Ended      ET: 00:00:10.156
+Task:  PREPARATION     Status: Ended      ET: 00:00:09.733
 Task:  COMPLETION      Status: Started    Object: TRAFODION.HBASE.CUSTOMER_ADDRESS
-Task:  COMPLETION      Status: Ended      ET: 00:00:00.404
+Task:  COMPLETION      Status: Ended      ET: 00:00:00.398
 
 --- 50000 row(s) loaded.
 >>--
@@ -181,9 +181,9 @@ Task:  CLEANUP         Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOG
 Task:  CLEANUP         Status: Ended      Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS
 Task:  PREPARATION     Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS
        Rows Processed: 20000 
-Task:  PREPARATION     Status: Ended      ET: 00:00:11.022
+Task:  PREPARATION     Status: Ended      ET: 00:00:12.160
 Task:  COMPLETION      Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS
-Task:  COMPLETION      Status: Ended      ET: 00:00:00.279
+Task:  COMPLETION      Status: Ended      ET: 00:00:00.362
 
 --- 20000 row(s) loaded.
 >>--
@@ -213,9 +213,9 @@ Task:  CLEANUP         Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOG
 Task:  CLEANUP         Status: Ended      Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS_SALT
 Task:  PREPARATION     Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS_SALT
        Rows Processed: 20000 
-Task:  PREPARATION     Status: Ended      ET: 00:00:08.435
+Task:  PREPARATION     Status: Ended      ET: 00:00:08.208
 Task:  COMPLETION      Status: Started    Object: TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS_SALT
-Task:  COMPLETION      Status: Ended      ET: 00:00:00.266
+Task:  COMPLETION      Status: Ended      ET: 00:00:00.327
 
 --- 20000 row(s) loaded.
 >>--                                                                              
@@ -235,9 +235,9 @@ Task:  CLEANUP         Status: Started    Object: TRAFODION.HBASE.CUSTOMER_SALT
 Task:  CLEANUP         Status: Ended      Object: TRAFODION.HBASE.CUSTOMER_SALT
 Task:  PREPARATION     Status: Started    Object: TRAFODION.HBASE.CUSTOMER_SALT
        Rows Processed: 100000 
-Task:  PREPARATION     Status: Ended      ET: 00:00:10.885
+Task:  PREPARATION     Status: Ended      ET: 00:00:10.404
 Task:  COMPLETION      Status: Started    Object: TRAFODION.HBASE.CUSTOMER_SALT
-Task:  COMPLETION      Status: Ended      ET: 00:00:00.258
+Task:  COMPLETION      Status: Ended      ET: 00:00:00.332
 
 --- 100000 row(s) loaded.
 >>--
@@ -266,9 +266,9 @@ Task:  CLEANUP         Status: Started    Object: TRAFODION.HBASE.STORE_SALES_SA
 Task:  CLEANUP         Status: Ended      Object: TRAFODION.HBASE.STORE_SALES_SALT
 Task:  PREPARATION     Status: Started    Object: TRAFODION.HBASE.STORE_SALES_SALT
        Rows Processed: 160756 
-Task:  PREPARATION     Status: Ended      ET: 00:00:13.092
+Task:  PREPARATION     Status: Ended      ET: 00:00:13.314
 Task:  COMPLETION      Status: Started    Object: TRAFODION.HBASE.STORE_SALES_SALT
-Task:  COMPLETION      Status: Ended      ET: 00:00:00.843
+Task:  COMPLETION      Status: Ended      ET: 00:00:00.309
 
 --- 160756 row(s) loaded.
 >>--
@@ -356,10 +356,10 @@ a
 +>   select * from null_format_src;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.005
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.004
 Task:  EXTRACT         Status: Started
        Rows Processed: 10 
-Task:  EXTRACT         Status: Ended      ET: 00:00:00.284
+Task:  EXTRACT         Status: Ended      ET: 00:00:00.334
 
 --- 10 row(s) unloaded.
 >>select * from hive.hive.null_format_default;
@@ -385,10 +385,10 @@ a
 +>   select * from null_format_src;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.004
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.008
 Task:  EXTRACT         Status: Started
        Rows Processed: 10 
-Task:  EXTRACT         Status: Ended      ET: 00:00:00.366
+Task:  EXTRACT         Status: Ended      ET: 00:00:00.325
 
 --- 10 row(s) unloaded.
 >>select * from hive.hive.null_format_empty;
@@ -417,7 +417,7 @@ Task:  EMPTY TARGET    Status: Started
 Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.005
 Task:  EXTRACT         Status: Started
        Rows Processed: 10 
-Task:  EXTRACT         Status: Ended      ET: 00:00:00.293
+Task:  EXTRACT         Status: Ended      ET: 00:00:00.409
 
 --- 10 row(s) unloaded.
 >>select * from hive.hive.null_format_colon;
@@ -471,12 +471,12 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 +>;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.011
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.005
 Task:  EXTRACT         Status: Started
        Rows Processed: 50000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:03.450
+Task:  EXTRACT         Status: Ended      ET: 00:00:04.200
 Task:  MERGE FILES     Status: Started
-Task:  MERGE FILES     Status: Ended      ET: 00:00:00.042
+Task:  MERGE FILES     Status: Ended      ET: 00:00:00.064
 
 --- 50000 row(s) unloaded.
 >>log;
@@ -509,12 +509,12 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 +><<+ cardinality 10e10 >>;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.005
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.006
 Task:  EXTRACT         Status: Started
        Rows Processed: 20000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:00.976
+Task:  EXTRACT         Status: Ended      ET: 00:00:01.146
 Task:  MERGE FILES     Status: Started
-Task:  MERGE FILES     Status: Ended      ET: 00:00:00.034
+Task:  MERGE FILES     Status: Ended      ET: 00:00:00.039
 
 --- 20000 row(s) unloaded.
 >>log;
@@ -533,12 +533,12 @@ cat /tmp/merged_customer_demogs | wc -l
 +><<+ cardinality 10e10 >>;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.005
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.006
 Task:  EXTRACT         Status: Started
        Rows Processed: 20000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:01.204
+Task:  EXTRACT         Status: Ended      ET: 00:00:00.983
 Task:  MERGE FILES     Status: Started
-Task:  MERGE FILES     Status: Ended      ET: 00:00:00.031
+Task:  MERGE FILES     Status: Ended      ET: 00:00:00.024
 
 --- 20000 row(s) unloaded.
 >>log;
@@ -570,12 +570,12 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 +><<+ cardinality 10e10 >>;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.005
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.010
 Task:  EXTRACT         Status: Started
        Rows Processed: 20000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:01.108
+Task:  EXTRACT         Status: Ended      ET: 00:00:01.386
 Task:  MERGE FILES     Status: Started
-Task:  MERGE FILES     Status: Ended      ET: 00:00:00.040
+Task:  MERGE FILES     Status: Ended      ET: 00:00:00.052
 
 --- 20000 row(s) unloaded.
 >>
@@ -596,9 +596,9 @@ Task:  EMPTY TARGET    Status: Started
 Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.004
 Task:  EXTRACT         Status: Started
        Rows Processed: 20000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:00.873
+Task:  EXTRACT         Status: Ended      ET: 00:00:00.911
 Task:  MERGE FILES     Status: Started
-Task:  MERGE FILES     Status: Ended      ET: 00:00:00.039
+Task:  MERGE FILES     Status: Ended      ET: 00:00:00.049
 
 --- 20000 row(s) unloaded.
 >>
@@ -631,10 +631,10 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 +><<+ cardinality 10e10 >>;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.007
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.005
 Task:  EXTRACT         Status: Started
        Rows Processed: 20000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:00.803
+Task:  EXTRACT         Status: Ended      ET: 00:00:01.244
 
 --- 20000 row(s) unloaded.
 >>
@@ -654,12 +654,12 @@ regrhadoop.ksh fs -ls /bulkload/customer_demographics_salt/file* |  grep file | 
 +><<+ cardinality 10e10 >>;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.011
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.010
 Task:  EXTRACT         Status: Started
        Rows Processed: 20000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:00.838
+Task:  EXTRACT         Status: Ended      ET: 00:00:01.058
 Task:  MERGE FILES     Status: Started
-Task:  MERGE FILES     Status: Ended      ET: 00:00:00.046
+Task:  MERGE FILES     Status: Ended      ET: 00:00:00.057
 
 --- 20000 row(s) unloaded.
 >>
@@ -792,12 +792,12 @@ CD_DEMO_SK   CD_GENDER                                                          
 +><<+ cardinality 10e10 >>;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.004
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.005
 Task:  EXTRACT         Status: Started
        Rows Processed: 20000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:00.837
+Task:  EXTRACT         Status: Ended      ET: 00:00:00.982
 Task:  MERGE FILES     Status: Started
-Task:  MERGE FILES     Status: Ended      ET: 00:00:00.042
+Task:  MERGE FILES     Status: Ended      ET: 00:00:00.048
 
 --- 20000 row(s) unloaded.
 >>log;
@@ -832,15 +832,15 @@ regrhadoop.ksh fs -ls /bulkload/customer_demographics_salt/merged* | grep merge 
 +><<+ cardinality 10e10 >>;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.004
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.007
 Task:  EXTRACT         Status: Started
        Rows Processed: 20000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:00.836
+Task:  EXTRACT         Status: Ended      ET: 00:00:01.064
 Task:  MERGE FILES     Status: Started
-Task:  MERGE FILES     Status: Ended      ET: 00:00:00.040
+Task:  MERGE FILES     Status: Ended      ET: 00:00:00.059
 
 --- 20000 row(s) unloaded.
->>sh sleep 10;
+>>--sh sleep 10;
 >>select count(*) from hive.hive.unload_customer_demographics;
 
 (EXPR)              
@@ -887,13 +887,13 @@ CD_DEMO_SK   CD_GENDER                                                          
 +><<+ cardinality 10e10 >>;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.005
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.004
 Task:  EXTRACT         Status: Started
        Rows Processed: 20000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:00.946
+Task:  EXTRACT         Status: Ended      ET: 00:00:00.995
 
 --- 20000 row(s) unloaded.
->>sh sleep 10;
+>>--sh sleep 10;
 >>select count(*) from hive.hive.unload_customer_demographics;
 
 *** WARNING[8597] Statement was automatically retried 1 time(s). Delay before each retry was 0 seconds. See next entry for the error that caused this retry.
@@ -941,13 +941,13 @@ CD_DEMO_SK   CD_GENDER                                                          
 +>select * from trafodion.hbase.customer_address ;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.007
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.004
 Task:  EXTRACT         Status: Started
        Rows Processed: 50000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:02.325
+Task:  EXTRACT         Status: Ended      ET: 00:00:02.475
 
 --- 50000 row(s) unloaded.
->>sh sleep 10;
+>>--sh sleep 10;
 >>select count(*) from hive.hive.unload_customer_address;
 
 (EXPR)              
@@ -997,10 +997,10 @@ Task:  EMPTY TARGET    Status: Started
 Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.005
 Task:  EXTRACT         Status: Started
        Rows Processed: 50000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:02.438
+Task:  EXTRACT         Status: Ended      ET: 00:00:02.595
 
 --- 50000 row(s) unloaded.
->>sh sleep 10;
+>>--sh sleep 10;
 >>select count(*) from hive.hive.unload_customer_address;
 
 *** WARNING[8597] Statement was automatically retried 1 time(s). Delay before each retry was 0 seconds. See next entry for the error that caused this retry.
@@ -1063,10 +1063,10 @@ Task:  EMPTY TARGET    Status: Started
 Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.006
 Task:  EXTRACT         Status: Started
        Rows Processed: 100000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:07.083
+Task:  EXTRACT         Status: Ended      ET: 00:00:07.642
 
 --- 100000 row(s) unloaded.
->>sh sleep 10;
+>>--sh sleep 10;
 >>select count(*) from hive.hive.unload_customer;
 
 (EXPR)              
@@ -1114,13 +1114,13 @@ C_CUSTOMER_SK  C_CUSTOMER_ID                                                    
 +>select * from trafodion.hbase.customer_demographics_salt;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.010
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.019
 Task:  EXTRACT         Status: Started
        Rows Processed: 20000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:01.226
+Task:  EXTRACT         Status: Ended      ET: 00:00:01.228
 
 --- 20000 row(s) unloaded.
->>sh sleep 10;
+>>--sh sleep 10;
 >>select count(*) from hive.hive.unload_customer_demographics;
 
 (EXPR)              
@@ -1167,12 +1167,12 @@ CD_DEMO_SK   CD_GENDER                                                          
 +>select * from trafodion.hbase.customer_address where ca_address_sk < 100;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.006
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.003
 Task:  EXTRACT         Status: Started
        Rows Processed: 99 
-Task:  EXTRACT         Status: Ended      ET: 00:00:00.244
+Task:  EXTRACT         Status: Ended      ET: 00:00:00.216
 Task:  MERGE FILES     Status: Started
-Task:  MERGE FILES     Status: Ended      ET: 00:00:00.024
+Task:  MERGE FILES     Status: Ended      ET: 00:00:00.023
 
 --- 99 row(s) unloaded.
 >>
@@ -1211,10 +1211,10 @@ Task:  EMPTY TARGET    Status: Started
 Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.004
 Task:  EXTRACT         Status: Started
        Rows Processed: 12349 
-Task:  EXTRACT         Status: Ended      ET: 00:00:07.776
+Task:  EXTRACT         Status: Ended      ET: 00:00:10.062
 
 --- 12349 row(s) unloaded.
->>sh sleep 10;
+>>--sh sleep 10;
 >>select  [first 100] * from hive.hive.unload_store_sales_summary order by  ss_sold_date_sk,ss_store_sk;
 
 SS_SOLD_DATE_SK  SS_STORE_SK  SS_QUANTITY
@@ -1333,10 +1333,10 @@ Task:  EMPTY TARGET    Status: Started
 Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.005
 Task:  EXTRACT         Status: Started
        Rows Processed: 100000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:08.464
+Task:  EXTRACT         Status: Ended      ET: 00:00:09.838
 
 --- 100000 row(s) unloaded.
->>sh sleep 10;
+>>--sh sleep 10;
 >>select count(*) from hive.hive.unload_customer_and_address;
 
 (EXPR)              
@@ -1381,13 +1381,13 @@ C_CUSTOMER_SK  C_CUSTOMER_ID                                                    
 +>select * from customer_address where ca_address_sk < 1000 union select * from customer_address where ca_address_sk > 40000  and ca_address_sk < 41000;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.008
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.004
 Task:  EXTRACT         Status: Started
        Rows Processed: 1998 
 Task:  EXTRACT         Status: Ended      ET: 00:00:00.695
 
 --- 1998 row(s) unloaded.
->>sh sleep 10;
+>>--sh sleep 10;
 >>select count(*) from hive.hive.unload_customer_address;
 
 (EXPR)              
@@ -1495,7 +1495,7 @@ ESP_EXCHANGE ==============================  SEQ_NO 3        ONLY CHILD 2
   use_snapshot_scan ...... TRUE
   full_table_name ........ TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS_SALT
   snapshot_name .......... TRAFODION.HBASE.CUSTOMER_DEMOGRAPHICS_SALT_SNAP111
-  snapshot_temp_location   /bulkload/20160706204232/
+  snapshot_temp_location   /bulkload/20160708212424/
 grep -i -e 'explain reg' -e snapshot -e full_table_name  -e esp_exchange  LOG018_REGULAR_SCAN_PLAN.TXT | grep -v snapshot_scan_run_id
 >>--no snapshot
 >>explain reg;
@@ -1575,7 +1575,7 @@ grep -i -e 'explain snp' -e snapshot -e full_table_name -e esp_exchange LOG018_S
   use_snapshot_scan ...... TRUE
   full_table_name ........ TRAFODION.HBASE.CUSTOMER_ADDRESS
   snapshot_name .......... TRAFODION.HBASE.CUSTOMER_ADDRESS_SNAP111
-  snapshot_temp_location   /bulkload/20160706204243/
+  snapshot_temp_location   /bulkload/20160708212436/
 grep -i -e 'explain reg' -e snapshot -e full_table_name  -e esp_exchange  LOG018_REGULAR_SCAN_PLAN.TXT | grep -v snapshot_scan_run_id
 >>--no snapshot
 >>explain reg;
@@ -1657,11 +1657,11 @@ grep -i -e 'explain snp' -e snapshot -e full_table_name -e esp_exchange LOG018_S
   use_snapshot_scan ...... TRUE
   full_table_name ........ TRAFODION.HBASE.CUSTOMER_SALT
   snapshot_name .......... TRAFODION.HBASE.CUSTOMER_SALT_SNAP111
-  snapshot_temp_location   /bulkload/20160706204314/
+  snapshot_temp_location   /bulkload/20160708212512/
   use_snapshot_scan ...... TRUE
   full_table_name ........ TRAFODION.HBASE.CUSTOMER_ADDRESS
   snapshot_name .......... TRAFODION.HBASE.CUSTOMER_ADDRESS_SNAP111
-  snapshot_temp_location   /bulkload/20160706204314/
+  snapshot_temp_location   /bulkload/20160708212512/
 grep -i -e 'explain reg' -e snapshot -e full_table_name  -e esp_exchange  LOG018_REGULAR_SCAN_PLAN.TXT | grep -v snapshot_scan_run_id
 >>--no snapshot
 >>explain reg;
@@ -1774,13 +1774,13 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 +><<+ cardinality 10e10 >>;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.005
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.025
 Task:  VERIFY SNAPSHO  Status: Started
        Snapshots verified: 1 
-Task:  VERIFY SNAPSHO  Status: Ended      ET: 00:00:00.425
+Task:  VERIFY SNAPSHO  Status: Ended      ET: 00:00:00.494
 Task:  EXTRACT         Status: Started
        Rows Processed: 50000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:02.515
+Task:  EXTRACT         Status: Ended      ET: 00:00:03.271
 
 --- 50000 row(s) unloaded.
 >>
@@ -1852,13 +1852,13 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 +>select * from trafodion.hbase.customer_demographics_salt <<+ cardinality 10e10 >>;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.003
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.002
 Task:  VERIFY SNAPSHO  Status: Started
        Snapshots verified: 1 
-Task:  VERIFY SNAPSHO  Status: Ended      ET: 00:00:00.333
+Task:  VERIFY SNAPSHO  Status: Ended      ET: 00:00:00.374
 Task:  EXTRACT         Status: Started
        Rows Processed: 20000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:02.008
+Task:  EXTRACT         Status: Ended      ET: 00:00:02.347
 
 --- 20000 row(s) unloaded.
 >>
@@ -1906,16 +1906,16 @@ CD_DEMO_SK   CD_GENDER                                                          
 +>select * from trafodion.hbase.customer_demographics_salt <<+ cardinality 10e10 >>;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.016
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.008
 Task:  CREATE SNAPSHO  Status: Started
        Snapshots created: 1 
-Task:  CREATE SNAPSHO  Status: Ended      ET: 00:00:00.707
+Task:  CREATE SNAPSHO  Status: Ended      ET: 00:00:01.520
 Task:  EXTRACT         Status: Started
        Rows Processed: 20000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:01.166
+Task:  EXTRACT         Status: Ended      ET: 00:00:01.725
 Task:  DELETE SNAPSHO  Status: Started
        Snapshots deleted: 1 
-Task:  DELETE SNAPSHO  Status: Ended      ET: 00:00:00.026
+Task:  DELETE SNAPSHO  Status: Ended      ET: 00:00:00.028
 
 --- 20000 row(s) unloaded.
 >>
@@ -1970,13 +1970,13 @@ Task:  EMPTY TARGET    Status: Started
 Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.009
 Task:  CREATE SNAPSHO  Status: Started
        Snapshots created: 1 
-Task:  CREATE SNAPSHO  Status: Ended      ET: 00:00:01.515
+Task:  CREATE SNAPSHO  Status: Ended      ET: 00:00:01.458
 Task:  EXTRACT         Status: Started
        Rows Processed: 20000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:01.263
+Task:  EXTRACT         Status: Ended      ET: 00:00:01.347
 Task:  DELETE SNAPSHO  Status: Started
        Snapshots deleted: 1 
-Task:  DELETE SNAPSHO  Status: Ended      ET: 00:00:00.019
+Task:  DELETE SNAPSHO  Status: Ended      ET: 00:00:00.006
 
 --- 20000 row(s) unloaded.
 >>
@@ -2029,16 +2029,16 @@ CD_DEMO_SK   CD_GENDER                                                          
 +>select * from customer_address where ca_address_sk < 1000 union select * from customer_address where ca_address_sk > 40000  and ca_address_sk < 41000;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.005
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.006
 Task:  CREATE SNAPSHO  Status: Started
        Snapshots created: 1 
-Task:  CREATE SNAPSHO  Status: Ended      ET: 00:00:01.233
+Task:  CREATE SNAPSHO  Status: Ended      ET: 00:00:01.079
 Task:  EXTRACT         Status: Started
        Rows Processed: 1998 
-Task:  EXTRACT         Status: Ended      ET: 00:00:00.847
+Task:  EXTRACT         Status: Ended      ET: 00:00:00.725
 Task:  DELETE SNAPSHO  Status: Started
        Snapshots deleted: 1 
-Task:  DELETE SNAPSHO  Status: Ended      ET: 00:00:00.006
+Task:  DELETE SNAPSHO  Status: Ended      ET: 00:00:00.005
 
 --- 1998 row(s) unloaded.
 >>
@@ -2113,19 +2113,19 @@ CA_ADDRESS_SK  CA_ADDRESS_ID                                                    
 +>select * from trafodion.hbase.customer_salt c join trafodion.hbase.customer_address ca on c.c_current_addr_sk = ca.ca_address_sk ;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.048
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.004
 Task:  CREATE SNAPSHO  Status: Started
        Snapshots created: 2 
-Task:  CREATE SNAPSHO  Status: Ended      ET: 00:00:02.709
+Task:  CREATE SNAPSHO  Status: Ended      ET: 00:00:03.077
 Task:  EXTRACT         Status: Started
        Rows Processed: 100000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:09.569
+Task:  EXTRACT         Status: Ended      ET: 00:00:09.442
 Task:  DELETE SNAPSHO  Status: Started
        Snapshots deleted: 2 
-Task:  DELETE SNAPSHO  Status: Ended      ET: 00:00:00.010
+Task:  DELETE SNAPSHO  Status: Ended      ET: 00:00:00.009
 
 --- 100000 row(s) unloaded.
->>sh sleep 10;
+>>--sh sleep 10;
 >>select count(*) from hive.hive.unload_customer_and_address;
 
 (EXPR)              
@@ -2190,19 +2190,19 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 +>select c_first_name,c_last_name from trafodion.hbase.customer_salt;
 Task: UNLOAD           Status: Started
 Task:  EMPTY TARGET    Status: Started
-Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.004
+Task:  EMPTY TARGET    Status: Ended      ET: 00:00:00.005
 Task:  CREATE SNAPSHO  Status: Started
        Snapshots created: 1 
-Task:  CREATE SNAPSHO  Status: Ended      ET: 00:00:01.410
+Task:  CREATE SNAPSHO  Status: Ended      ET: 00:00:00.640
 Task:  EXTRACT         Status: Started
        Rows Processed: 100000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:01.589
+Task:  EXTRACT         Status: Ended      ET: 00:00:01.597
 Task:  DELETE SNAPSHO  Status: Started
        Snapshots deleted: 1 
-Task:  DELETE SNAPSHO  Status: Ended      ET: 00:00:00.006
+Task:  DELETE SNAPSHO  Status: Ended      ET: 00:00:00.007
 
 --- 100000 row(s) unloaded.
->>sh sleep 10;
+>>--sh sleep 10;
 >>select count(*) from hive.hive.unload_customer_name;
 
 (EXPR)              
@@ -2272,7 +2272,7 @@ unload with delimiter 0 into '/bulkload/test' select * from CUSTOMER_ADDRESS;
 Task: UNLOAD           Status: Started
 Task:  EXTRACT         Status: Started
        Rows Processed: 50000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:02.253
+Task:  EXTRACT         Status: Ended      ET: 00:00:02.827
 
 --- 50000 row(s) unloaded.
 >>--unload  24 -- should give an error
@@ -2337,10 +2337,10 @@ regrhadoop.ksh fs -rm /user/hive/exttables/unload_customer_demographics/*
 Task: UNLOAD           Status: Started
 Task:  EXTRACT         Status: Started
        Rows Processed but NOT Written to Disk: 20000 
-Task:  EXTRACT         Status: Ended      ET: 00:00:00.840
+Task:  EXTRACT         Status: Ended      ET: 00:00:00.904
 
 --- 20000 row(s) unloaded.
->>sh sleep 10;
+>>--sh sleep 10;
 >>select count(*) from hive.hive.unload_customer_demographics;
 
 (EXPR)              

--- a/core/sql/regress/hive/TEST018
+++ b/core/sql/regress/hive/TEST018
@@ -446,7 +446,7 @@ MERGE FILE  'merged_customer_demographics' OVERWRITE
 INTO '/user/hive/exttables/unload_customer_demographics'
 select * from trafodion.hbase.customer_demographics_salt 
 <<+ cardinality 10e10 >>;
-sh sleep 10;
+--sh sleep 10;
 select count(*) from hive.hive.unload_customer_demographics;
 select [first 20] * from hive.hive.unload_customer_demographics where cd_demo_sk < 100 order by cd_demo_sk;
 
@@ -458,7 +458,7 @@ WITH PURGEDATA FROM TARGET
 INTO '/user/hive/exttables/unload_customer_demographics'
 select * from trafodion.hbase.customer_demographics_salt 
 <<+ cardinality 10e10 >>;
-sh sleep 10;
+--sh sleep 10;
 select count(*) from hive.hive.unload_customer_demographics;
 select [first 20] * from hive.hive.unload_customer_demographics where cd_demo_sk <100  order by cd_demo_sk;
 
@@ -467,7 +467,7 @@ UNLOAD
 WITH PURGEDATA FROM TARGET
 INTO '/user/hive/exttables/unload_customer_address'
 select * from trafodion.hbase.customer_address ;
-sh sleep 10;
+--sh sleep 10;
 select count(*) from hive.hive.unload_customer_address;
 select [first 20] * from hive.hive.unload_customer_address where ca_address_sk <100 order by ca_address_sk;
 
@@ -477,7 +477,7 @@ UNLOAD
 WITH PURGEDATA FROM TARGET DELIMITER 124  RECORD_SEPARATOR 10
 INTO '/user/hive/exttables/unload_customer_address'
 select * from trafodion.hbase.customer_address ;
-sh sleep 10;
+--sh sleep 10;
 select count(*) from hive.hive.unload_customer_address;
 select [first 20] * from hive.hive.unload_customer_address where ca_address_sk < 100 order by ca_address_sk;
 
@@ -492,7 +492,7 @@ WITH PURGEDATA FROM TARGET
 --COMPRESSION GZIP
 INTO '/user/hive/exttables/unload_customer'
 select * from trafodion.hbase.customer_salt;
-sh sleep 10;
+--sh sleep 10;
 select count(*) from hive.hive.unload_customer;
 select [first 20] * from hive.hive.unload_customer where c_customer_sk < 100 order by c_customer_sk;
 
@@ -503,7 +503,7 @@ WITH PURGEDATA FROM TARGET
 --COMPRESSION GZIP
 INTO '/user/hive/exttables/unload_customer_demographics'
 select * from trafodion.hbase.customer_demographics_salt;
-sh sleep 10;
+--sh sleep 10;
 select count(*) from hive.hive.unload_customer_demographics;
 select [first 20] * from hive.hive.unload_customer_demographics where cd_demo_sk < 100 order by cd_demo_sk;
 
@@ -540,7 +540,7 @@ WITH
  PURGEDATA FROM TARGET DELIMITER '|' RECORD_SEPARATOR '\n' 
 INTO '/user/hive/exttables/unload_store_sales_summary'
 select ss_sold_date_sk,ss_store_sk, sum (ss_quantity) from store_sales_salt group by  ss_sold_date_sk ,ss_store_sk; 
-sh sleep 10;
+--sh sleep 10;
 select  [first 100] * from hive.hive.unload_store_sales_summary order by  ss_sold_date_sk,ss_store_sk; 
 
 --unload 18
@@ -548,7 +548,7 @@ UNLOAD
 WITH PURGEDATA FROM TARGET
 INTO '/user/hive/exttables/unload_customer_and_address'
 select * from trafodion.hbase.customer_salt c join trafodion.hbase.customer_address ca on c.c_current_addr_sk = ca.ca_address_sk ;
-sh sleep 10;
+--sh sleep 10;
 select count(*) from hive.hive.unload_customer_and_address;
 select [first 20] * from hive.hive.unload_customer_and_address order by ca_address_sk,c_customer_sk;
 
@@ -558,7 +558,7 @@ WITH
  PURGEDATA FROM TARGET 
 INTO '/user/hive/exttables/unload_customer_address'
 select * from customer_address where ca_address_sk < 1000 union select * from customer_address where ca_address_sk > 40000  and ca_address_sk < 41000;
-sh sleep 10;
+--sh sleep 10;
 select count(*) from hive.hive.unload_customer_address;
 select [first 20] * from hive.hive.unload_customer_address order by ca_address_sk;
 select [first 20] * from hive.hive.unload_customer_address order by ca_address_sk desc;
@@ -695,7 +695,7 @@ WITH PURGEDATA FROM TARGET
  NEW SNAPSHOT HAVING  SUFFIX 'SNAP'
 INTO '/user/hive/exttables/unload_customer_and_address'
 select * from trafodion.hbase.customer_salt c join trafodion.hbase.customer_address ca on c.c_current_addr_sk = ca.ca_address_sk ;
-sh sleep 10;
+--sh sleep 10;
 select count(*) from hive.hive.unload_customer_and_address;
 select [first 20] * from hive.hive.unload_customer_and_address order by ca_address_sk,c_customer_sk;
 
@@ -711,7 +711,7 @@ WITH PURGEDATA FROM TARGET
  NEW SNAPSHOT HAVING SUFFIX 'SNAP111' 
 INTO '/user/hive/exttables/unload_customer_name'
 select c_first_name,c_last_name from trafodion.hbase.customer_salt;
-sh sleep 10;
+--sh sleep 10;
 select count(*) from hive.hive.unload_customer_name;
 select [first 20] * from hive.hive.unload_customer_name order by c_first_name,c_last_name;
 
@@ -753,7 +753,7 @@ UNLOAD
 WITH PURGEDATA FROM TARGET
 INTO '/user/hive/exttables/unload_customer_demographics'
 (select * from trafodion.hbase.customer_demographics_salt) ;
-sh sleep 10;
+--sh sleep 10;
 select count(*) from hive.hive.unload_customer_demographics;
 
 CQD TRAF_UNLOAD_SKIP_WRITING_TO_FILES reset;


### PR DESCRIPTION
Added a retry loop for hdfs opens to avoid 8442 errors seen on slower  machines intermittently due  to  potential EAGAIN errors. [TRAFODION-2097]

The "sleep" introduced in hive/TEST018 has now been removed so this retry can handle the EAGAIN errors. 