### PR TITLE
[TRAFODION-2112] Avoid hard-coding DNS name in local Hadoop install

### DIFF
--- a/core/sqf/sql/scripts/install_hadoop_regr_test_env
+++ b/core/sqf/sql/scripts/install_hadoop_regr_test_env
@@ -200,11 +200,8 @@ fi
   ./dsdgen -force $FORCE -dir $MY_TPCDS_DATA_DIR -scale $SCALE -table store       >>${MY_LOG_FILE} 2>&1
   ./dsdgen -force $FORCE -dir $MY_TPCDS_DATA_DIR -scale $SCALE -table promotion   >>${MY_LOG_FILE} 2>&1
 
-  ./dsdgen -force $FORCE -dir $MY_TPCDS_DATA_DIR -scale $SCALE -table store_returns >>${MY_LOG_FILE} 2>&1
   ./dsdgen -force $FORCE -dir $MY_TPCDS_DATA_DIR -scale $SCALE -table catalog_sales >>${MY_LOG_FILE} 2>&1
-  ./dsdgen -force $FORCE -dir $MY_TPCDS_DATA_DIR -scale $SCALE -table catalog_returns >>${MY_LOG_FILE} 2>&1
   ./dsdgen -force $FORCE -dir $MY_TPCDS_DATA_DIR -scale $SCALE -table web_sales   >>${MY_LOG_FILE} 2>&1
-  ./dsdgen -force $FORCE -dir $MY_TPCDS_DATA_DIR -scale $SCALE -table web_returns >>${MY_LOG_FILE} 2>&1
   ./dsdgen -force $FORCE -dir $MY_TPCDS_DATA_DIR -scale $SCALE -table inventory   >>${MY_LOG_FILE} 2>&1
   ./dsdgen -force $FORCE -dir $MY_TPCDS_DATA_DIR -scale $SCALE -table call_center >>${MY_LOG_FILE} 2>&1
   ./dsdgen -force $FORCE -dir $MY_TPCDS_DATA_DIR -scale $SCALE -table catalog_page >>${MY_LOG_FILE} 2>&1

--- a/core/sqf/sql/scripts/install_local_hadoop
+++ b/core/sqf/sql/scripts/install_local_hadoop
@@ -1303,7 +1303,7 @@ lc-messages-dir=${MY_SW_ROOT}/mysql/share
 
 # Enable logging by default to help find problems
 general-log=1
-general-log-file=${MY_SW_ROOT}/log/mysql-general.${HOSTNAME}.log
+general-log-file=${MY_SW_ROOT}/log/mysql-general.\${HOSTNAME}.log
 
 EOF
 
@@ -1551,7 +1551,7 @@ echo "$MY_LOCAL_SW_DIST/${HBASE_TAR}"
   </property>
   <property>
    <name>hbase.zookeeper.quorum</name>
-   <value>${HOSTNAME}</value>
+   <value>${MY_HOST_1}</value>
  </property>
  <property>
     <name>hbase.zookeeper.property.dataDir</name>


### PR DESCRIPTION
Also removed three dsdgen calls, the *_returns tables are created
together with the *_sales tables, calling dsdgen for those tables will
give an error.