### PR TITLE
[TRAFODION-2100]SQLGetTypeInfo Catalog API should return identifiers conforming to ODBC 3.0

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 /distribution/
 /licenses/LICENSE*
 /licenses/NOTICE*
+/licenses/DISCLAIMER*
 LICENSE
 /apache-*incubating/

--- a/core/conn/Makefile
+++ b/core/conn/Makefile
@@ -34,7 +34,7 @@ endif
 .PHONY: all
 all: pkg-clients
 
-pkg-clients: clients/LICENSE clients/NOTICE
+pkg-clients: clients/LICENSE clients/NOTICE clients/DISCLAIMER
 	mkdir -p $$(dirname $(CLIENT_TAR))
 	tar -zcvf $(CLIENT_TAR) clients
 
@@ -45,6 +45,9 @@ clients/LICENSE: ../../licenses/LICENSE-clients
 	cd $(@D) && $(MAKE) $(@F)
 
 clients/NOTICE: ../../NOTICE
+	cp -f $? $@
+
+clients/DISCLAIMER: ../../DISCLAIMER
 	cp -f $? $@
 
 clean:	

--- a/core/conn/jdbcT4/src/main/java/org/trafodion/jdbc/t4/T4DatabaseMetaData.java
+++ b/core/conn/jdbcT4/src/main/java/org/trafodion/jdbc/t4/T4DatabaseMetaData.java
@@ -4613,7 +4613,7 @@ public class T4DatabaseMetaData extends TrafT4Handle implements java.sql.Databas
 		connection_.isConnectionOpen();
 
 		getSQLCatalogsInfo(connection_.getServerHandle(), // Server Handle
-				SQL_API_SQLGETTYPEINFO_JDBC, // catalogAPI
+				SQL_API_SQLGETTYPEINFO, // catalogAPI
 				"", // catalog
 				"", // schema
 				"", // table name

--- a/core/conn/odbc/src/odbc/nsksrvrcore/srvrothers.cpp
+++ b/core/conn/odbc/src/odbc/nsksrvrcore/srvrothers.cpp
@@ -4506,24 +4506,21 @@ odbc_SQLSvc_GetSQLCatalogs_sme_(
                        }
                        break;
                 case SQL_API_SQLGETTYPEINFO :
-                case SQL_API_SQLGETTYPEINFO_JDBC :
                      {
-                         SQLSMALLINT SqlTypeCode_Date;
-                         SQLSMALLINT SqlTypeCode_Time;
-                         SQLSMALLINT SqlTypeCode_TimeStamp;
                          char condExpression[20] = {0};
                         
-                         if(APIType == SQL_API_SQLGETTYPEINFO_JDBC)
-                         {
-                             SqlTypeCode_Date = 91;
-                             SqlTypeCode_Time = 92;
-                             SqlTypeCode_TimeStamp = 93;
-                         }
-                         else
-                         {
-                             SqlTypeCode_Date = SQL_DATE;
-                             SqlTypeCode_Time = SQL_TIME;
-                             SqlTypeCode_TimeStamp = SQL_TIMESTAMP;
+                         switch(sqlType) {
+                             case SQL_DATE:
+                                 sqlType == SQL_TYPE_DATE;
+                                 break;
+                             case SQL_TIME:
+                                 sqlType == SQL_TYPE_TIME;
+                                 break;
+                             case SQL_TIMESTAMP:
+                                 sqlType == SQL_TYPE_TIMESTAMP;
+                                 break;
+                             default:
+                                 break;
                          }
 
                          if(sqlType == SQL_ALL_TYPES)
@@ -4559,7 +4556,7 @@ odbc_SQLSvc_GetSQLCatalogs_sme_(
                                  "cast(0 as smallint), cast(0 as smallint), cast(3 as smallint), cast(0 as smallint)),"
                                  "('BIGINT SIGNED', -5, 19, NULL, NULL, NULL, 1, 0, 2, 0, 0, 0, 'LARGEINT', NULL, NULL, 'SIGNED LARGEINT', 10, 19, 20, -402, NULL, NULL, 0, 0, 3, 0),"
                                  "('CHAR', 1, 32000, '''', '''', 'max length', 1, 1, 3, NULL, 0, NULL, 'CHARACTER', NULL, NULL, 'CHARACTER', NULL, -1, -1, 1, NULL, NULL, 0, 0, 3, 0),"
-                                 "('DATE', %d, 10, '{d ''', '''}', NULL, 1, 0, 2, NULL, 0, NULL, 'DATE', NULL, NULL, 'DATE', NULL, 10, 6, 9, 1, NULL, 1, 3, 3, 0),"
+                                 "('DATE', 91, 10, '{d ''', '''}', NULL, 1, 0, 2, NULL, 0, NULL, 'DATE', NULL, NULL, 'DATE', NULL, 10, 6, 9, 1, NULL, 1, 3, 3, 0),"
                                  "('DECIMAL', 3, 18, NULL, NULL, 'precision,scale', 1, 0, 2, 0, 0, 0, 'DECIMAL', 0, 18, 'DECIMAL', 10, -2, -3, 3, NULL, NULL, 0, 0, 3, 0),"
                                  "('DECIMAL SIGNED', 3, 18, NULL, NULL, 'precision,scale', 1, 0, 2, 0, 0, 0, 'DECIMAL', 0, 18, 'SIGNED DECIMAL', 10, -2, -3, 3, NULL, NULL, 0, 0, 3, 0),"
                                  "('DECIMAL UNSIGNED', 3, 18, NULL, NULL, 'precision,scale', 1, 0, 2, 1, 0, 0, 'DECIMAL', 0, 18, 'UNSIGNED DECIMAL', 10, -2, -3, -301, NULL, NULL, 0, 0, 3, 0),"
@@ -4589,16 +4586,16 @@ odbc_SQLSvc_GetSQLCatalogs_sme_(
                                  "('SMALLINT', 5, 5, NULL, NULL, NULL, 1, 0, 2, 0, 0, 0, 'SMALLINT', NULL, NULL, 'SMALLINT', 10, 5, -1, 5, NULL, NULL, 0, 0, 3, 0),"
                                  "('SMALLINT SIGNED', 5, 5, NULL, NULL, NULL, 1, 0, 2, 0, 0, 0, 'SMALLINT', NULL, NULL, 'SIGNED SMALLINT', 10, 5, -1, 5, NULL, NULL, 0, 0, 3, 0),"
                                  "('SMALLINT UNSIGNED', 5, 5, NULL, NULL, NULL, 1, 0, 2, 1, 0, 0, 'SMALLINT', NULL, NULL, 'UNSIGNED SMALLINT', 10, 5, -1, -502, NULL, NULL, 0, 0, 3, 0),"
-                                 "('TIME', %d, 8, '{t ''', '''}', NULL, 1, 0, 2, NULL, 0, NULL, 'TIME', NULL, NULL, 'TIME', NULL, 8, 6, 9, 2, NULL, 4, 6, 3, 0),"
-                                 "('TIMESTAMP', %d, 26, '{ts ''', '''}', NULL, 1, 0, 2, NULL, 0, NULL, 'TIMESTAMP', 0, 6, 'TIMESTAMP', NULL, 19, 16, 9, 3, NULL, 1, 6, 3, 0),"
+                                 "('TIME', 92, 8, '{t ''', '''}', NULL, 1, 0, 2, NULL, 0, NULL, 'TIME', NULL, NULL, 'TIME', NULL, 8, 6, 9, 2, NULL, 4, 6, 3, 0),"
+                                 "('TIMESTAMP', 93, 26, '{ts ''', '''}', NULL, 1, 0, 2, NULL, 0, NULL, 'TIMESTAMP', 0, 6, 'TIMESTAMP', NULL, 19, 16, 9, 3, NULL, 1, 6, 3, 0),"
                                  "('VARCHAR', 12, 32000, '''', '''', 'max length', 1, 1, 3, NULL, 0, NULL, 'VARCHAR', NULL, NULL, 'VARCHAR', NULL, -1, -1, 12, NULL, NULL, 0, 0, 3, 0)"
                                  " ) "
                                  " dt(\"TYPE_NAME\", \"DATA_TYPE\", \"PREC\", \"LITERAL_PREFIX\", \"LITERAL_SUFFIX\", \"CREATE_PARAMS\", \"IS_NULLABLE\", \"CASE_SENSITIVE\", \"SEARCHABLE\","
                                  "\"UNSIGNED_ATTRIBUTE\", \"FIXED_PREC_SCALE\", \"AUTO_UNIQUE_VALUE\", \"LOCAL_TYPE_NAME\", \"MINIMUM_SCALE\", \"MAXIMUM_SCALE\", \"SQL_TYPE_NAME\","
                                  "\"NUM_PREC_RADIX\", \"USEPRECISION\", \"USELENGTH\", \"SQL_DATA_TYPE\", \"SQL_DATETIME_SUB\", \"INTERVAL_PRECISION\", \"DATETIMESTARTFIELD\","
-                               "\"DATETIMEENDFIELD\", \"APPLICATION_VERSION\", \"TRANSLATION_ID\")"
-                               " WHERE %s" 
-                               " ORDER BY 2,1 FOR READ UNCOMMITTED ACCESS ;", SqlTypeCode_Date, SqlTypeCode_Time, SqlTypeCode_TimeStamp, condExpression);
+                                 "\"DATETIMEENDFIELD\", \"APPLICATION_VERSION\", \"TRANSLATION_ID\")"
+                                 " WHERE %s" 
+                                 " ORDER BY 2,1 FOR READ UNCOMMITTED ACCESS ;", condExpression);
                            break;
                      }
 

--- a/core/conn/unixodbc/odbc/odbcclient/unixcli/DrvrManager/drvrmanager.cpp
+++ b/core/conn/unixodbc/odbc/odbcclient/unixcli/DrvrManager/drvrmanager.cpp
@@ -3132,42 +3132,38 @@ SQLRETURN  SQL_API SQLGetTypeInfo_common(SQLHSTMT StatementHandle,
 		RETURNCODE (pstmt, SQL_ERROR);
 		LEAVE_STMT (pstmt, SQL_ERROR);
 	}
-	SQLINTEGER ODBCAppVersion = pstmt->getODBCAppVersion();
 	SQLSMALLINT convDataType = DataType;
-	if (ODBCAppVersion >= SQL_OV_ODBC3)
-	{
-		switch(DataType)
-		{
-		case SQL_DATE:
-			convDataType = SQL_TYPE_DATE;
-			break;
-		case SQL_TIME:
-			convDataType = SQL_TYPE_TIME;
-			break;
-		case SQL_TIMESTAMP:
-			convDataType = SQL_TYPE_TIMESTAMP;
-			break;
-		}
-	}
-	else
-	{
-		switch(DataType)
-		{
-		case SQL_TYPE_DATE:
-			convDataType = SQL_DATE;
-			break;
-		case SQL_TYPE_TIME:
-			convDataType = SQL_TIME;
-			break;
-		case SQL_TYPE_TIMESTAMP:
-			convDataType = SQL_TIMESTAMP;
-			break;
-		}
-	}
-	rc = NeoGetTypeInfo(StatementHandle,convDataType,isWideCall);
-	rc = fun_cata_state_tr (pstmt, en_GetTypeInfo, rc);
-	RETURNCODE (pstmt, rc);
-	LEAVE_STMT (pstmt, rc);
+#if (ODBCVER >= 0x0300)
+    switch(DataType)
+    {
+        case SQL_DATE:
+            convDataType = SQL_TYPE_DATE;
+            break;
+        case SQL_TIME:
+            convDataType = SQL_TYPE_TIME;
+            break;
+        case SQL_TIMESTAMP:
+            convDataType = SQL_TYPE_TIMESTAMP;
+            break;
+    }
+#else
+    switch(DataType)
+    {
+        case SQL_TYPE_DATE:
+            convDataType = SQL_DATE;
+            break;
+        case SQL_TYPE_TIME:
+            convDataType = SQL_TIME;
+            break;
+        case SQL_TYPE_TIMESTAMP:
+            convDataType = SQL_TIMESTAMP;
+            break;
+    }
+#endif
+    rc = NeoGetTypeInfo(StatementHandle,convDataType,isWideCall);
+    rc = fun_cata_state_tr (pstmt, en_GetTypeInfo, rc);
+    RETURNCODE (pstmt, rc);
+    LEAVE_STMT (pstmt, rc);
 }
 
 SQLRETURN  SQL_API SQLGetTypeInfo(SQLHSTMT StatementHandle,
@@ -3836,37 +3832,33 @@ SQLRETURN SQL_API SQLColAttribute_common(SQLHSTMT StatementHandle,
 	rc = NeoColAttribute(StatementHandle,ColumnNumber,FieldIdentifier,CharacterAttributePtr,BufferLength,StringLengthPtr,NumericAttributePtr,isWideCall);
 	if (rc == SQL_SUCCESS && FieldIdentifier == SQL_DESC_CONCISE_TYPE)
 	{
-		SQLINTEGER ODBCAppVersion = pstmt->getODBCAppVersion();
-		if (ODBCAppVersion >= SQL_OV_ODBC3)
-		{
-			switch((SQLINTEGER)*(SQLINTEGER*)NumericAttributePtr)
-			{
-			case SQL_DATE:
-				*(SQLINTEGER*)NumericAttributePtr = SQL_TYPE_DATE;
-				break;
-			case SQL_TIME:
-				*(SQLINTEGER*)NumericAttributePtr = SQL_TYPE_TIME;
-				break;
-			case SQL_TIMESTAMP:
-				*(SQLINTEGER*)NumericAttributePtr = SQL_TYPE_TIMESTAMP;
-				break;
-			}
-		}
-		else
-		{
-			switch((SQLINTEGER)*(SQLINTEGER*)NumericAttributePtr)
-			{
-			case SQL_TYPE_DATE:
-				*(SQLINTEGER*)NumericAttributePtr = SQL_DATE;
-				break;
-			case SQL_TYPE_TIME:
-				*(SQLINTEGER*)NumericAttributePtr = SQL_TIME;
-				break;
-			case SQL_TYPE_TIMESTAMP:
-				*(SQLINTEGER*)NumericAttributePtr = SQL_TIMESTAMP;
-				break;
-			}
-		}
+#if (ODBCVER >= 0x0300)
+        switch((SQLINTEGER)*(SQLINTEGER*)NumericAttributePtr)
+        {
+            case SQL_DATE:
+                *(SQLINTEGER*)NumericAttributePtr = SQL_TYPE_DATE;
+                break;
+            case SQL_TIME:
+                *(SQLINTEGER*)NumericAttributePtr = SQL_TYPE_TIME;
+                break;
+            case SQL_TIMESTAMP:
+                *(SQLINTEGER*)NumericAttributePtr = SQL_TYPE_TIMESTAMP;
+                break;
+        }
+#else
+        switch((SQLINTEGER)*(SQLINTEGER*)NumericAttributePtr)
+        {
+            case SQL_TYPE_DATE:
+                *(SQLINTEGER*)NumericAttributePtr = SQL_DATE;
+                break;
+            case SQL_TYPE_TIME:
+                *(SQLINTEGER*)NumericAttributePtr = SQL_TIME;
+                break;
+            case SQL_TYPE_TIMESTAMP:
+                *(SQLINTEGER*)NumericAttributePtr = SQL_TIMESTAMP;
+                break;
+        }
+#endif
 	}
 	/* state transition */
 	if (pstmt->asyn_on == en_ColAttribute)

--- a/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/cdesc.cpp
+++ b/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/cdesc.cpp
@@ -409,16 +409,13 @@ unsigned long CDescRec::setDescRec(short DescMode, SQLItemDesc_def *SQLItemDesc)
 		break;
 	case SQL_DATE:
 	case SQL_TYPE_DATE:
-		if (ODBCAppVersion >= SQL_OV_ODBC3)
-		{
+#if (ODBCVER >= 0x0300)
 			if(m_DescConciseType == SQL_DATE)
 				m_DescConciseType = SQL_TYPE_DATE;
-		}
-		else
-		{
+#else
 			if(m_DescConciseType == SQL_TYPE_DATE)
 				m_DescConciseType = SQL_DATE;
-		}
+#endif
 		strcpy((char*)m_DescLiteralPrefix,"{d'");
 		strcpy((char*)m_DescLiteralSuffix,"'}");
 		m_DescLength = 10;
@@ -426,16 +423,13 @@ unsigned long CDescRec::setDescRec(short DescMode, SQLItemDesc_def *SQLItemDesc)
 		break;
 	case SQL_TIME:
 	case SQL_TYPE_TIME:
-		if (ODBCAppVersion >= SQL_OV_ODBC3)
-		{
+#if (ODBCVER >= 0x0300)
 			if(m_DescConciseType == SQL_TIME)
 				m_DescConciseType = SQL_TYPE_TIME;
-		}
-		else
-		{
+#else
 			if(m_DescConciseType == SQL_TYPE_TIME)
 				m_DescConciseType = SQL_TIME;
-		}
+#endif
 		strcpy((char*)m_DescLiteralPrefix,"{t'");
 		strcpy((char*)m_DescLiteralSuffix,"'}");
 		m_DescLength = 8;
@@ -447,16 +441,13 @@ unsigned long CDescRec::setDescRec(short DescMode, SQLItemDesc_def *SQLItemDesc)
 		break;
 	case SQL_TYPE_TIMESTAMP:
 	case SQL_TIMESTAMP:
-		if (ODBCAppVersion >= SQL_OV_ODBC3)
-		{
+#if (ODBCVER >= 0x0300)
 			if(m_DescConciseType == SQL_TIMESTAMP)
 				m_DescConciseType = SQL_TYPE_TIMESTAMP;
-		}
-		else
-		{
+#else
 			if(m_DescConciseType == SQL_TYPE_TIMESTAMP)
 				m_DescConciseType = SQL_TIMESTAMP;
-		}
+#endif
 		strcpy((char*)m_DescLiteralPrefix,"{ts'");
 		strcpy((char*)m_DescLiteralSuffix,"'}");
 		m_DescPrecision = SQLItemDesc->precision; // Should come for Server - Must be changed

--- a/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/cstmt.cpp
+++ b/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/cstmt.cpp
@@ -2226,8 +2226,7 @@ SQLRETURN CStmt::SendGetSQLCatalogs(short odbcAPI,
 		m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.fkschemaNm = m_FKSchemaName;
 		m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.fktableNm = m_FKTableName;
 
-		if (getODBCAppVersion() == SQL_OV_ODBC2)
-		{
+#if (ODBCVER < 0x0300)
 			switch (SqlType)
 			{
 				case SQL_TYPE_DATE:
@@ -2282,11 +2281,9 @@ SQLRETURN CStmt::SendGetSQLCatalogs(short odbcAPI,
 					m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = SqlType;
 					break;
 			}
-		}
-		else
-		{
+#else
 			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = SqlType;
-		}
+#endif
 		m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.metadataId = m_MetadataId;
 		m_SrvrCallContext.u.getSQLCatalogsParams.stmtLabel = m_StmtLabel;
 		m_SrvrCallContext.odbcAPI = odbcAPI;

--- a/core/sqf/.gitignore
+++ b/core/sqf/.gitignore
@@ -67,6 +67,8 @@ Linux-x86_64/
 # derived license
 /LICENSE
 /NOTICE
+/DISCLAIMER
+sqf/DISCLAIMER
 
 # bundled component links
 /dcs-*

--- a/core/sqf/Makefile
+++ b/core/sqf/Makefile
@@ -283,7 +283,7 @@ PKG_BIN_OBJS ?= export/bin$(SQ_MBTYPE) export/include export/lib export/lib$(SQ_
 PKG_BIN_OBJS += trafci
 PKG_BIN_OBJS += samples
 PKG_BIN_OBJS += export/limited-support-tools
-PKG_BIN_OBJS += LICENSE NOTICE
+PKG_BIN_OBJS += LICENSE NOTICE DISCLAIMER
 PKG_BIN_OBJS += rest-${TRAFODION_VER} dcs-${TRAFODION_VER}
 
 PKG_BIN_DIRS ?= sql export
@@ -324,6 +324,12 @@ NOTICE: ../../licenses/NOTICE-server
 ../../licenses/NOTICE-server:
 	cd $(@D) && $(MAKE) $(@F)
 
+DISCLAIMER: ../../licenses/DISCLAIMER-server
+	cp -f $? $@
+
+../../licenses/DISCLAIMER-server:
+	cd $(@D) && $(MAKE) $(@F)
+
 rest-${TRAFODION_VER}:
 	ln -s ../rest/target/$@/$@ $@
 
@@ -342,7 +348,7 @@ pkglist-files: pkglist-symlinks
 	find -L $(PKG_BIN_OBJS) -type d -o -type f | grep -v -xf pkglist-symlinks > $@
 
 # simple symlinks that point to filename (does not start with . or /)
-pkglist-symlinks: LICENSE NOTICE rest-${TRAFODION_VER} dcs-${TRAFODION_VER}
+pkglist-symlinks: LICENSE NOTICE DISCLAIMER rest-${TRAFODION_VER} dcs-${TRAFODION_VER}
 	find $(PKG_BIN_OBJS) -lname '[^./]*' > $@
 
 #	Targets to tar/gzip the self installer

--- a/core/sqf/conf/install_features
+++ b/core/sqf/conf/install_features
@@ -64,4 +64,6 @@
 export CDH_5_3_HDP_2_2_SUPPORT="N"
 export HDP_2_3_SUPPORT="Y"
 export CDH_5_4_SUPPORT="Y"
+export CDH_5_5_SUPPORT="Y"
 export APACHE_1_0_X_SUPPORT="Y"
+export APACHE_1_1_X_SUPPORT="Y"

--- a/core/sqf/sqenvcom.sh
+++ b/core/sqf/sqenvcom.sh
@@ -139,19 +139,30 @@ export MY_SQROOT=$PWD
 export SQ_HOME=$PWD
 
 # set common version to be consistent between shared lib and maven dependencies
-export HBASE_DEP_VER_CDH=1.0.0-cdh5.4.4
-export HIVE_DEP_VER_CDH=1.1.0-cdh5.4.4
+export HBASE_DEP_VER_CDH=1.0.0-cdh5.5.1
+export HIVE_DEP_VER_CDH=1.1.0-cdh5.5.1
+export HBASE_TRX_ID_CDH=hbase-trx-cdh5_5
+if [[ "$HBASE_DISTRO" = "CDH5.4" ]]; then
+   export HBASE_DEP_VER_CDH=1.0.0-cdh5.4.4
+   export HIVE_DEP_VER_CDH=1.1.0-cdh5.4.4
+   export HBASE_TRX_ID_CDH=hbase-trx-cdh5_4
+fi
+
+export HBASE_DEP_VER_APACHE=1.1.2
+export HIVE_DEP_VER_APACHE=1.1.0
+export HBVER=apache1_1_2
+if [[ "$HBASE_DISTRO" = "APACHE1.0" ]]; then
+   export HBASE_DEP_VER_APACHE=1.0.2
+   export HBVER=apache1_0_2
+fi
+export HBASE_TRX_ID_APACHE=hbase-trx-${HBVER}
+
 export HBASE_DEP_VER_HDP=1.1.2
 export HIVE_DEP_VER_HDP=1.2.1
-export HBASE_DEP_VER_APACHE=1.0.2
-export HIVE_DEP_VER_APACHE=1.1.0
-export HBASE_TRX_ID_CDH=hbase-trx-cdh5_4
-export HBASE_TRX_ID_APACHE=hbase-trx-apache1_0_2
 export HBASE_TRX_ID_HDP=hbase-trx-hdp2_3
 export THRIFT_DEP_VER=0.9.0
 export HIVE_DEP_VER=0.13.1
 export HADOOP_DEP_VER=2.6.0
-
 # staged build-time dependencies
 export HADOOP_BLD_LIB=${TOOLSDIR}/hadoop-${HADOOP_DEP_VER}/lib/native
 export HADOOP_BLD_INC=${TOOLSDIR}/hadoop-${HADOOP_DEP_VER}/include
@@ -164,16 +175,15 @@ export SQL_JAR=trafodion-sql-${TRAFODION_VER}.jar
 export UTIL_JAR=trafodion-utility-${TRAFODION_VER}.jar
 export JDBCT4_JAR=jdbcT4-${TRAFODION_VER}.jar
 
-HBVER=""
+
 if [[ "$HBASE_DISTRO" = "HDP" ]]; then
     export HBASE_TRX_JAR=${HBASE_TRX_ID_HDP}-${TRAFODION_VER}.jar
     HBVER="hdp2_3"
     export DTM_COMMON_JAR=trafodion-dtm-${HBVER}-${TRAFODION_VER}.jar
     export SQL_JAR=trafodion-sql-${HBVER}-${TRAFODION_VER}.jar
 fi
-if [[ "$HBASE_DISTRO" = "APACHE" ]]; then
+if [[ "$HBASE_DISTRO" =~ "APACHE" ]]; then
     export HBASE_TRX_JAR=${HBASE_TRX_ID_APACHE}-${TRAFODION_VER}.jar
-    HBVER="apache1_0_2"
     export DTM_COMMON_JAR=trafodion-dtm-${HBVER}-${TRAFODION_VER}.jar
     export SQL_JAR=trafodion-sql-${HBVER}-${TRAFODION_VER}.jar
 fi
@@ -464,6 +474,12 @@ else
   function vanilla_apache_usage {
 
   cat <<EOF
+    If you haven't set HBASE_DISTRO, please set it before source current file
+      export HBASE_DISTRO=APACHE1.0 (APACHE HBASE1.0)
+      export HBASE_DISTRO=APACHE1.1 (APACHE HBASE1.1)
+      export HBASE_DISTRO=CDH5.4    (cloudera 1.0.0-cdh5.4.4) 
+      export HBASE_DISTRO=CDH5.5    (cloudera 1.0.0-cdh5.5.1) 
+      export HBASE_DISTRO=HDP       (hortonworks 2.3)
 
     If you are ready to build Trafodion, perform one of the following options:
 
@@ -556,7 +572,6 @@ EOF
 
     # end of code for Apache Hadoop/HBase installation w/o distro
     export HBASE_TRX_JAR=${HBASE_TRX_ID_APACHE}-${TRAFODION_VER}.jar
-    HBVER="apache1_0_2"
     export DTM_COMMON_JAR=trafodion-dtm-${HBVER}-${TRAFODION_VER}.jar
     export SQL_JAR=trafodion-sql-${HBVER}-${TRAFODION_VER}.jar
   else
@@ -833,8 +848,18 @@ if [[ -n "$HADOOP_CNF_DIR" ]]; then SQ_CLASSPATH="$SQ_CLASSPATH:$HADOOP_CNF_DIR"
 if [[ -n "$HBASE_CNF_DIR"  ]]; then SQ_CLASSPATH="$SQ_CLASSPATH:$HBASE_CNF_DIR";  fi
 if [[ -n "$HIVE_CNF_DIR"   ]]; then SQ_CLASSPATH="$SQ_CLASSPATH:$HIVE_CNF_DIR";   fi
 if [[ -n "$SQ_CLASSPATH"   ]]; then SQ_CLASSPATH="$SQ_CLASSPATH:";   fi
+
+# set Trx in classpath only incase of workstation env.
+# In case of cluster, correct version of trx is already installed by
+# installer and hbase classpath already contains the correct trx jar.
+# In future, installer can put additional hints in bashrc to cleanup
+# and fine tune these adjustments for many other jars.
+if [[ -e $MY_SQROOT/sql/scripts/sw_env.sh ]]; then
+        SQ_CLASSPATH=${SQ_CLASSPATH}:${HBASE_TRXDIR}/${HBASE_TRX_JAR}
+fi
+
+
 SQ_CLASSPATH=${SQ_CLASSPATH}:\
-${HBASE_TRXDIR}/${HBASE_TRX_JAR}:\
 $MY_SQROOT/export/lib/${DTM_COMMON_JAR}:\
 $MY_SQROOT/export/lib/${SQL_JAR}:\
 $MY_SQROOT/export/lib/${UTIL_JAR}:\

--- a/core/sqf/sql/scripts/install_local_hadoop
+++ b/core/sqf/sql/scripts/install_local_hadoop
@@ -582,12 +582,15 @@ fi
 # See JIRA TRAFODION-1512 that will eliminate this check
   
 HADOOP_MIRROR_URL=http://archive.cloudera.com/cdh5/cdh/5
-HADOOP_TAR=hadoop-2.6.0-cdh5.4.4.tar.gz
+HADOOP_TAR=hadoop-2.6.0-cdh5.5.1.tar.gz
+if [[ "$HBASE_DISTRO" = "CDH5.4" ]]; then
+    HADOOP_TAR=hadoop-2.6.0-cdh5.4.4.tar.gz
+fi
 
 if [[ "$HBASE_DISTRO" = "HDP" ]]; then
     HADOOP_TAR=hadoop-2.7.1.2.3.2.0-2950.tar.gz
 fi
-if [[ "$HBASE_DISTRO" = "APACHE" ]]; then
+if [[ "$HBASE_DISTRO" =~ "APACHE" ]]; then
     HADOOP_TAR=hadoop-2.5.2.tar.gz
 fi
 
@@ -603,7 +606,7 @@ MYSQL_JDBC_TAR=mysql-connector-java-5.1.23.tar.gz
 
 HIVE_MIRROR_URL=http://archive.cloudera.com/cdh5/cdh/5
 HIVE_PREFIX=hive-${HIVE_DEP_VER_CDH}
-if [[ "$HBASE_DISTRO" = "APACHE" ]]; then
+if [[ "$HBASE_DISTRO" =~ "APACHE" ]]; then
     HIVE_MIRROR_URL=https://archive.apache.org/dist/hive/hive-${HIVE_DEP_VER_APACHE}
     HIVE_PREFIX=apache-hive-${HIVE_DEP_VER_APACHE}-bin
 fi
@@ -617,7 +620,7 @@ HBASE_TAR=hbase-${HBASE_DEP_VER_CDH}.tar.gz
 if [[ "$HBASE_DISTRO" = "HDP" ]]; then
     HBASE_TAR=hbase-${HBASE_DEP_VER_HDP}.tar.gz
 fi
-if [[ "$HBASE_DISTRO" = "APACHE" ]]; then
+if [[ "$HBASE_DISTRO" =~ "APACHE" ]]; then
     HBASE_MIRROR_URL=https://archive.apache.org/dist/hbase/hbase-${HBASE_DEP_VER_APACHE}
     HBASE_TAR=hbase-${HBASE_DEP_VER_APACHE}-bin.tar.gz
 fi

--- a/core/sqf/src/seatrans/hbase-trx/Makefile
+++ b/core/sqf/src/seatrans/hbase-trx/Makefile
@@ -21,11 +21,13 @@
 
 # This Makefile is just a thin shell to Maven, which is used to do the real build
 
-BLD_HBASE_APACHE_TRX_JARNAME     =hbase-trx-apache1_0_2-$(TRAFODION_VER).jar
-BLD_HBASE_CDH_TRX_JARNAME        =hbase-trx-cdh5_4-$(TRAFODION_VER).jar
-BLD_HBASE_MAPR_TRX_JARNAME       =hbase-trx-mapr4_0-$(TRAFODION_VER).jar
-BLD_HBASE_HDP_TRX_JARNAME        =hbase-trx-hdp2_3-$(TRAFODION_VER).jar
-BLD_HBASE_SSCC_TRX_JARNAME       =hbase-trx-sscc-$(TRAFODION_VER).jar
+BLD_HBASE_APACHE10_TRX_JARNAME     =hbase-trx-apache1_0_2-$(TRAFODION_VER).jar
+BLD_HBASE_APACHE11_TRX_JARNAME     =hbase-trx-apache1_1_2-$(TRAFODION_VER).jar
+BLD_HBASE_CDH54_TRX_JARNAME        =hbase-trx-cdh5_4-$(TRAFODION_VER).jar
+BLD_HBASE_CDH55_TRX_JARNAME        =hbase-trx-cdh5_5-$-$(TRAFODION_VER).jar
+BLD_HBASE_MAPR_TRX_JARNAME         =hbase-trx-mapr4_0-$(TRAFODION_VER).jar
+BLD_HBASE_HDP_TRX_JARNAME          =hbase-trx-hdp2_3-$(TRAFODION_VER).jar
+BLD_HBASE_SSCC_TRX_JARNAME         =hbase-trx-sscc-$(TRAFODION_VER).jar
 
 VFILE			    =hbase-trx.jar.versions
 GENVERS			    =./genvers
@@ -36,13 +38,22 @@ REINSTATE_ORIG   	    =./reinstate_orig
 
 all: build_all
 
-jdk_1_7_cdh: build_chk_cdh
+jdk_1_7_cdh54: build_chk_cdh54
 	$(REINSTATE_ORIG)
-	$(UNCOMMENT_STRING) CDH1.0
-	$(MAKE) build_chk_cdh
-	set -o pipefail && $(MAVEN) -f pom.xml.cdh package install -DskipTests | tee -a build_trx.log
+	$(UNCOMMENT_STRING) CDH5.4
+	echo "$(MAVEN) package -DskipTests"
+	echo "### For full Maven output, see file build_trx.log"
+	set -o pipefail && $(MAVEN) -f pom.xml.cdh54 package install -DskipTests | tee -a build_trx.log
 	mkdir -p $(MY_SQROOT)/export/lib
-	cp -pf target/$(BLD_HBASE_CDH_TRX_JARNAME) $(MY_SQROOT)/export/lib
+	cp -pf target/$(BLD_HBASE_CDH54_TRX_JARNAME) $(MY_SQROOT)/export/lib
+	$(RM) $(VFILE)
+
+jdk_1_7_cdh55: build_chk_cdh55
+	$(REINSTATE_ORIG)
+	$(UNCOMMENT_STRING) CDH5.5
+	set -o pipefail && $(MAVEN) -f pom.xml.cdh55 package install -DskipTests | tee -a build_trx.log
+	mkdir -p $(MY_SQROOT)/export/lib
+	cp -pf target/$(BLD_HBASE_CDH55_TRX_JARNAME) $(MY_SQROOT)/export/lib
 	$(RM) $(VFILE)
 
 jdk_1_7_mapr: build_chk_mapr
@@ -54,35 +65,49 @@ jdk_1_7_mapr: build_chk_mapr
 jdk_1_7_hdp: build_chk_hdp
 	$(REINSTATE_ORIG)
 	$(UNCOMMENT_STRING) HDP2.3 
-	$(MAKE) build_chk_hdp
 	set -o pipefail && $(MAVEN) -f pom.xml.hdp package -DskipTests | tee -a build_trx.log
 	mkdir -p $(MY_SQROOT)/export/lib
 	cp -pf target/$(BLD_HBASE_HDP_TRX_JARNAME) $(MY_SQROOT)/export/lib
 	$(RM) $(VFILE)
 
-jdk_1_7_apache: build_chk_apache
+jdk_1_7_apache10: build_chk_apache10
 	$(REINSTATE_ORIG)
-	$(UNCOMMENT_STRING) APACHE
-	$(MAKE) build_chk_apache
-	echo "$(MAVEN) package -DskipTests"
-	echo "### For full Maven output, see file build_trx.log"
-	set -o pipefail && $(MAVEN) -f pom.xml.apache package -DskipTests | tee build_trx.log
+	$(UNCOMMENT_STRING) HBASE1.0
+	set -o pipefail && $(MAVEN) -f pom.xml.apache10 package -DskipTests | tee build_trx.log
 	mkdir -p $(MY_SQROOT)/export/lib
-	cp -pf target/$(BLD_HBASE_APACHE_TRX_JARNAME) $(MY_SQROOT)/export/lib
+	cp -pf target/$(BLD_HBASE_APACHE10_TRX_JARNAME) $(MY_SQROOT)/export/lib
 	$(RM) $(VFILE)
+
+jdk_1_7_apache11: build_chk_apache11
 	$(REINSTATE_ORIG)
+	$(UNCOMMENT_STRING) HBASE1.1
+	set -o pipefail && $(MAVEN) -f pom.xml.apache11 package -DskipTests | tee build_trx.log
+	mkdir -p $(MY_SQROOT)/export/lib
+	cp -pf target/$(BLD_HBASE_APACHE11_TRX_JARNAME) $(MY_SQROOT)/export/lib
+	$(RM) $(VFILE)
 
-build_all: jdk_1_7_apache jdk_1_7_hdp jdk_1_7_cdh
+build_all: jdk_1_7_cdh54 jdk_1_7_cdh55 jdk_1_7_hdp jdk_1_7_apache10 jdk_1_7_apache11
+#jdk_1_7_cdh54 jdk_1_7_cdh55 jdk_1_7_hdp jdk_1_7_apache10 jdk_1_7_apache11
 
-build_chk_apache:
+build_chk_apache10:
 	$(GENVERS) > $(VFILE)
-	@if [ $(GENVERS) -nt target/$(BLD_HBASE_APACHE_TRX_JARNAME) ]; then echo "update manifest"; $(RM) -f target/$(BLD_HBASE_APACHE_TRX_JARNAME); fi
-	@if [ $(MY_SQROOT)/export/include/SCMBuildStr.h -nt target/$(BLD_HBASE_APACHE_TRX_JARNAME) ]; then echo "update manifest"; $(RM) -f target/$(BLD_HBASE_APACHE_TRX_JARNAME); fi
+	@if [ $(GENVERS) -nt target/$(BLD_HBASE_APACHE10_TRX_JARNAME) ]; then echo "update manifest"; $(RM) -f target/$(BLD_HBASE_APACHE10_TRX_JARNAME); fi
+	@if [ $(MY_SQROOT)/export/include/SCMBuildStr.h -nt target/$(BLD_HBASE_APACHE10_TRX_JARNAME) ]; then echo "update manifest"; $(RM) -f target/$(BLD_HBASE_APACHE10_TRX_JARNAME); fi
 
-build_chk_cdh:
+build_chk_apache11:
 	$(GENVERS) > $(VFILE)
-	@if [ $(GENVERS) -nt target/$(BLD_HBASE_CDH_TRX_JARNAME) ]; then echo "update manifest"; $(RM) -f target/$(BLD_HBASE_CDH_TRX_JARNAME); fi
-	@if [ $(MY_SQROOT)/export/include/SCMBuildStr.h -nt target/$(BLD_HBASE_CDH_TRX_JARNAME) ]; then echo "update manifest"; $(RM) -f target/$(BLD_HBASE_CDH_TRX_JARNAME); fi
+	@if [ $(GENVERS) -nt target/$(BLD_HBASE_APACHE11_TRX_JARNAME) ]; then echo "update manifest"; $(RM) -f target/$(BLD_HBASE_APACHE11_TRX_JARNAME); fi
+	@if [ $(MY_SQROOT)/export/include/SCMBuildStr.h -nt target/$(BLD_HBASE_APACHE11_TRX_JARNAME) ]; then echo "update manifest"; $(RM) -f target/$(BLD_HBASE_APACHE11_TRX_JARNAME); fi
+
+build_chk_cdh54:
+	$(GENVERS) > $(VFILE)
+	@if [ $(GENVERS) -nt target/$(BLD_HBASE_CDH54_TRX_JARNAME) ]; then echo "update manifest"; $(RM) -f target/$(BLD_HBASE_CDH54_TRX_JARNAME); fi
+	@if [ $(MY_SQROOT)/export/include/SCMBuildStr.h -nt target/$(BLD_HBASE_CDH54_TRX_JARNAME) ]; then echo "update manifest"; $(RM) -f target/$(BLD_HBASE_CDH54_TRX_JARNAME); fi
+
+build_chk_cdh55:
+	$(GENVERS) > $(VFILE)
+	@if [ $(GENVERS) -nt target/$(BLD_HBASE_CDH55_TRX_JARNAME) ]; then echo "update manifest"; $(RM) -f target/$(BLD_HBASE_CDH55_TRX_JARNAME); fi
+	@if [ $(MY_SQROOT)/export/include/SCMBuildStr.h -nt target/$(BLD_HBASE_CDH55_TRX_JARNAME) ]; then echo "update manifest"; $(RM) -f target/$(BLD_HBASE_CDH55_TRX_JARNAME); fi
 
 build_chk_mapr:
 	$(GENVERS) > $(VFILE)
@@ -95,13 +120,17 @@ build_chk_hdp:
 	@if [ $(MY_SQROOT)/export/include/SCMBuildStr.h -nt target/$(BLD_HBASE_HDP_TRX_JARNAME) ]; then echo "update manifest"; $(RM) -f target/$(BLD_HBASE_HDP_TRX_JARNAME); fi
 
 clean:
-	$(RM) $(MY_SQROOT)/export/lib/$(BLD_HBASE_APACHE_TRX_JARNAME)
-	$(RM) $(MY_SQROOT)/export/lib/$(BLD_HBASE_CDH_TRX_JARNAME)
+	$(RM) $(MY_SQROOT)/export/lib/$(BLD_HBASE_APACHE10_TRX_JARNAME)
+	$(RM) $(MY_SQROOT)/export/lib/$(BLD_HBASE_APACHE11_TRX_JARNAME)
+	$(RM) $(MY_SQROOT)/export/lib/$(BLD_HBASE_CDH54_TRX_JARNAME)
+	$(RM) $(MY_SQROOT)/export/lib/$(BLD_HBASE_CDH55_TRX_JARNAME)
 	$(RM) $(MY_SQROOT)/export/lib/$(BLD_HBASE_MAPR_TRX_JARNAME)
 	$(RM) $(MY_SQROOT)/export/lib/$(BLD_HBASE_HDP_TRX_JARNAME)
 	$(REINSTATE_ORIG)
-	-$(MAVEN) -f pom.xml.apache clean | grep ERROR
-	-$(MAVEN) -f pom.xml.cdh clean | grep ERROR
+	-$(MAVEN) -f pom.xml.apache10 clean | grep ERROR
+	-$(MAVEN) -f pom.xml.apache11 clean | grep ERROR
+	-$(MAVEN) -f pom.xml.cdh54 clean | grep ERROR
+	-$(MAVEN) -f pom.xml.cdh55 clean | grep ERROR
 	-$(MAVEN) -f pom.xml.mapr clean | grep ERROR
 	-$(MAVEN) -f pom.xml.hdp clean | grep ERROR
 	$(RM) build_trx.log

--- a/core/sqf/src/seatrans/hbase-trx/pom.xml.apache10
+++ b/core/sqf/src/seatrans/hbase-trx/pom.xml.apache10
@@ -1,0 +1,336 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <!--
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+  <repositories>
+    <repository>
+      <id>Apache</id>
+      <url>http://mvnrepository.com/artifact/</url>
+      <layout>default</layout>
+    </repository>
+  </repositories> 
+
+  <properties>
+    <hadoop.version>2.4.0</hadoop.version>
+    <hbase.version>1.0.2</hbase.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <protobuf.version>2.5.0</protobuf.version>                                                                                              
+    <protocVersion>2.5.0</protocVersion>                                                                                                    
+    <java.version>1.7</java.version>
+    <trx-suffix>apache</trx-suffix>
+  </properties>
+
+  <groupId>org.apache</groupId>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>hbase-trx-apache1_0_2</artifactId>
+  <version>${env.TRAFODION_VER}</version>
+  <name>HBase - Trx</name>
+  <description>Trx of HBase usage</description>
+
+  <build>
+    <defaultGoal>package</defaultGoal>
+      <!-- allow for different build targets with separate classes directories and
+           output jars, used for Java 6 compile for now -->
+      <outputDirectory>${project.build.directory}/classes_${trx-suffix}</outputDirectory>
+      <finalName>${project.artifactId}-${project.version}</finalName>
+      <!-- Some plugins (javadoc for example) can be used in the normal build- and the site phase.
+           These plugins inherit their options from the <reporting> section below. These settings
+           can be overwritten here. -->
+    <plugins>
+      <plugin>
+        <!--Make it so assembly:single does nothing in here-->
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>2.2-beta-5</version>
+        <configuration>
+          <skipAssembly>true</skipAssembly>
+        </configuration>
+      </plugin>
+        <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>2.5</version>
+            <configuration>
+                <!-- Have to set the groups here because we only do
+    split tests in this package, so groups on live in this module -->
+                <groups>${surefire.firstPartGroups}</groups>
+            </configuration>
+        </plugin>
+        <!-- Make a jar and put the sources in the jar -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>2.1.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <configuration>
+            <archive>
+               <manifestFile>hbase-trx.jar.versions</manifestFile>
+            </archive>
+          </configuration>
+        </plugin>
+    </plugins>
+  </build>
+
+
+
+  <dependencies>
+    <dependency>
+        <groupId>org.apache.hbase</groupId>
+        <artifactId>hbase-common</artifactId>
+        <version>${hbase.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.hbase</groupId>
+        <artifactId>hbase-protocol</artifactId>
+        <version>${hbase.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.hbase</groupId>
+        <artifactId>hbase-client</artifactId>
+        <version>${hbase.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-server</artifactId>
+      <version>${hbase.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-thrift</artifactId>
+      <version>${hbase.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-annotations</artifactId>
+      <version>${hbase.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.hbase</groupId>
+        <artifactId>hbase-testing-util</artifactId>
+        <scope>test</scope>
+      <version>${hbase.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libthrift</artifactId>
+      <version>0.9.1</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>1.1.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.zookeeper</groupId>
+      <artifactId>zookeeper</artifactId>
+      <version>3.4.5</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>2.5.0</version>
+    </dependency>
+ </dependencies>
+ <profiles>
+     <!-- Skip the tests in this module -->
+     <profile>
+         <id>skipTrxTests</id>
+         <activation>
+             <property>
+                 <name>skipTrxTests</name>
+             </property>
+         </activation>
+         <properties>
+             <surefire.skipFirstPart>true</surefire.skipFirstPart>
+             <surefire.skipSecondPart>true</surefire.skipSecondPart>
+         </properties>
+     </profile>
+
+     <!-- Profiles for building against different hadoop versions -->
+     <!-- There are a lot of common dependencies used here, should investigate
+if we can combine these profiles somehow -->
+     <!-- profile against Hadoop 1.1.x: This is the default. It has to have the same
+  activation property as the parent Hadoop 1.1.x profile to make sure it gets run at
+  the same time. -->
+     <profile>
+         <id>hadoop-1.1</id>
+         <activation>
+             <property>
+            <!--Below formatting for dev-support/generate-hadoopX-poms.sh-->
+            <!--h1--><name>hadoop.profile</name><value>1.1</value>
+             </property>
+         </activation>
+         <dependencies>
+             <dependency>
+                 <groupId>org.apache.hadoop</groupId>
+                 <artifactId>hadoop-core</artifactId>
+             </dependency>
+             <dependency>
+                 <groupId>org.apache.hadoop</groupId>
+                 <artifactId>hadoop-test</artifactId>
+             </dependency>
+         </dependencies>
+     </profile>
+     <!--
+       profile for building against Hadoop 2.0.0-alpha. Activate using:
+        mvn -Dhadoop.profile=2.0
+     -->
+     <profile>
+         <id>hadoop-2.0</id>
+         <activation>
+             <property>
+            <!--Below formatting for dev-support/generate-hadoopX-poms.sh-->
+            <!--h2--><name>!hadoop.profile</name>
+             </property>
+         </activation>
+         <dependencies>
+             <dependency>
+                 <groupId>org.apache.hadoop</groupId>
+                 <artifactId>hadoop-mapreduce-client-core</artifactId>
+                 <version>${hadoop.version}</version>
+             </dependency>
+             <dependency>
+                 <groupId>org.apache.hadoop</groupId>
+                 <artifactId>hadoop-common</artifactId>
+                 <version>${hadoop.version}</version>
+             </dependency>
+         </dependencies>
+         <build>
+             <plugins>
+                 <plugin>
+                     <artifactId>maven-dependency-plugin</artifactId>
+                     <executions>
+                         <execution>
+                             <id>create-mrapp-generated-classpath</id>
+                             <phase>generate-test-resources</phase>
+                             <goals>
+                                 <goal>build-classpath</goal>
+                             </goals>
+                             <configuration>
+                                 <!-- needed to run the unit test for DS to generate
+                                 the required classpath that is required in the env
+                                 of the launch container in the mini mr/yarn cluster
+                                 -->
+                                 <outputFile>${project.build.directory}/test-classes/mrapp-generated-classpath</outputFile>
+                             </configuration>
+                         </execution>
+                     </executions>
+                 </plugin>
+             </plugins>
+         </build>
+     </profile>
+     <!--
+       profile for building against Hadoop 3.0.x. Activate using:
+        mvn -Dhadoop.profile=3.0
+     -->
+     <profile>
+         <id>hadoop-3.0</id>
+         <activation>
+             <property>
+                 <name>hadoop.profile</name>
+                 <value>3.0</value>
+             </property>
+         </activation>
+         <properties>
+             <hadoop.version>3.0-SNAPSHOT</hadoop.version>
+         </properties>
+         <dependencies>
+             <dependency>
+                 <groupId>org.apache.hadoop</groupId>
+                 <artifactId>hadoop-common</artifactId>
+             </dependency>
+             <dependency>
+                 <groupId>org.apache.hadoop</groupId>
+                 <artifactId>hadoop-annotations</artifactId>
+             </dependency>
+             <dependency>
+                 <groupId>org.apache.hadoop</groupId>
+                 <artifactId>hadoop-minicluster</artifactId>
+             </dependency>
+         </dependencies>
+         <build>
+             <plugins>
+                 <plugin>
+                     <artifactId>maven-dependency-plugin</artifactId>
+                     <executions>
+                         <execution>
+                             <id>create-mrapp-generated-classpath</id>
+                             <phase>generate-test-resources</phase>
+                             <goals>
+                                 <goal>build-classpath</goal>
+                             </goals>
+                             <configuration>
+                                 <!-- needed to run the unit test for DS to generate
+                                 the required classpath that is required in the env
+                                 of the launch container in the mini mr/yarn cluster
+                                 -->
+                                 <outputFile>${project.build.directory}/test-classes/mrapp-generated-classpath</outputFile>
+                             </configuration>
+                         </execution>
+                     </executions>
+                 </plugin>
+             </plugins>
+         </build>
+     </profile>
+    <profile>
+      <id>compile-protobuf</id>
+      <activation>
+        <property>
+          <name>compile-protobuf</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-maven-plugins</artifactId>
+            <executions>
+              <execution>
+                <id>compile-protoc</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>protoc</goal>
+                </goals>
+                <configuration>
+                  <protobuf.version>2.5.0</protobuf.version>
+                  <protocVersion>2.5.0</protocVersion>
+                  <imports>
+                    <param>${basedir}/src/main/protobuf</param>
+                    <param>${basedir}/hbase-protocol/src/main/protobuf</param>
+                  </imports>
+                  <source>
+                    <directory>${basedir}/src/main/protobuf</directory>
+                    <includes>
+                      <include>TrxRegion.proto</include>
+                      <include>SsccRegion.proto</include>
+                    </includes>
+                  </source>
+                  <output>${basedir}/src/main/java/</output>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/core/sqf/src/seatrans/hbase-trx/pom.xml.apache11
+++ b/core/sqf/src/seatrans/hbase-trx/pom.xml.apache11
@@ -1,0 +1,336 @@
+<?xml version="1.0"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <!--
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+  <repositories>
+    <repository>
+      <id>Apache</id>
+      <url>http://mvnrepository.com/artifact/</url>
+      <layout>default</layout>
+    </repository>
+  </repositories> 
+
+  <properties>
+    <hadoop.version>2.4.0</hadoop.version>
+    <hbase.version>1.1.2</hbase.version>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    <protobuf.version>2.5.0</protobuf.version>                                                                                              
+    <protocVersion>2.5.0</protocVersion>                                                                                                    
+    <java.version>1.7</java.version>
+    <trx-suffix>apache</trx-suffix>
+  </properties>
+
+  <groupId>org.apache</groupId>
+  <modelVersion>4.0.0</modelVersion>
+  <artifactId>hbase-trx-apache1_1_2</artifactId>
+  <version>${env.TRAFODION_VER}</version>
+  <name>HBase - Trx</name>
+  <description>Trx of HBase usage</description>
+
+  <build>
+    <defaultGoal>package</defaultGoal>
+      <!-- allow for different build targets with separate classes directories and
+           output jars, used for Java 6 compile for now -->
+      <outputDirectory>${project.build.directory}/classes_${trx-suffix}</outputDirectory>
+      <finalName>${project.artifactId}-${project.version}</finalName>
+      <!-- Some plugins (javadoc for example) can be used in the normal build- and the site phase.
+           These plugins inherit their options from the <reporting> section below. These settings
+           can be overwritten here. -->
+    <plugins>
+      <plugin>
+        <!--Make it so assembly:single does nothing in here-->
+        <artifactId>maven-assembly-plugin</artifactId>
+        <version>2.2-beta-5</version>
+        <configuration>
+          <skipAssembly>true</skipAssembly>
+        </configuration>
+      </plugin>
+        <plugin>
+            <artifactId>maven-surefire-plugin</artifactId>
+            <version>2.5</version>
+            <configuration>
+                <!-- Have to set the groups here because we only do
+    split tests in this package, so groups on live in this module -->
+                <groups>${surefire.firstPartGroups}</groups>
+            </configuration>
+        </plugin>
+        <!-- Make a jar and put the sources in the jar -->
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-source-plugin</artifactId>
+          <version>2.1.1</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-jar-plugin</artifactId>
+          <configuration>
+            <archive>
+               <manifestFile>hbase-trx.jar.versions</manifestFile>
+            </archive>
+          </configuration>
+        </plugin>
+    </plugins>
+  </build>
+
+
+
+  <dependencies>
+    <dependency>
+        <groupId>org.apache.hbase</groupId>
+        <artifactId>hbase-common</artifactId>
+        <version>${hbase.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.hbase</groupId>
+        <artifactId>hbase-protocol</artifactId>
+        <version>${hbase.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.hbase</groupId>
+        <artifactId>hbase-client</artifactId>
+        <version>${hbase.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-server</artifactId>
+      <version>${hbase.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-thrift</artifactId>
+      <version>${hbase.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-annotations</artifactId>
+      <version>${hbase.version}</version>
+    </dependency>
+    <dependency>
+        <groupId>org.apache.hbase</groupId>
+        <artifactId>hbase-testing-util</artifactId>
+        <scope>test</scope>
+      <version>${hbase.version}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>org.apache.thrift</groupId>
+      <artifactId>libthrift</artifactId>
+      <version>0.9.1</version>
+    </dependency>
+    <dependency>
+      <groupId>commons-logging</groupId>
+      <artifactId>commons-logging</artifactId>
+      <version>1.1.3</version>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.zookeeper</groupId>
+      <artifactId>zookeeper</artifactId>
+      <version>3.4.5</version>
+    </dependency>
+    <dependency>
+      <groupId>com.google.protobuf</groupId>
+      <artifactId>protobuf-java</artifactId>
+      <version>2.5.0</version>
+    </dependency>
+ </dependencies>
+ <profiles>
+     <!-- Skip the tests in this module -->
+     <profile>
+         <id>skipTrxTests</id>
+         <activation>
+             <property>
+                 <name>skipTrxTests</name>
+             </property>
+         </activation>
+         <properties>
+             <surefire.skipFirstPart>true</surefire.skipFirstPart>
+             <surefire.skipSecondPart>true</surefire.skipSecondPart>
+         </properties>
+     </profile>
+
+     <!-- Profiles for building against different hadoop versions -->
+     <!-- There are a lot of common dependencies used here, should investigate
+if we can combine these profiles somehow -->
+     <!-- profile against Hadoop 1.1.x: This is the default. It has to have the same
+  activation property as the parent Hadoop 1.1.x profile to make sure it gets run at
+  the same time. -->
+     <profile>
+         <id>hadoop-1.1</id>
+         <activation>
+             <property>
+            <!--Below formatting for dev-support/generate-hadoopX-poms.sh-->
+            <!--h1--><name>hadoop.profile</name><value>1.1</value>
+             </property>
+         </activation>
+         <dependencies>
+             <dependency>
+                 <groupId>org.apache.hadoop</groupId>
+                 <artifactId>hadoop-core</artifactId>
+             </dependency>
+             <dependency>
+                 <groupId>org.apache.hadoop</groupId>
+                 <artifactId>hadoop-test</artifactId>
+             </dependency>
+         </dependencies>
+     </profile>
+     <!--
+       profile for building against Hadoop 2.0.0-alpha. Activate using:
+        mvn -Dhadoop.profile=2.0
+     -->
+     <profile>
+         <id>hadoop-2.0</id>
+         <activation>
+             <property>
+            <!--Below formatting for dev-support/generate-hadoopX-poms.sh-->
+            <!--h2--><name>!hadoop.profile</name>
+             </property>
+         </activation>
+         <dependencies>
+             <dependency>
+                 <groupId>org.apache.hadoop</groupId>
+                 <artifactId>hadoop-mapreduce-client-core</artifactId>
+                 <version>${hadoop.version}</version>
+             </dependency>
+             <dependency>
+                 <groupId>org.apache.hadoop</groupId>
+                 <artifactId>hadoop-common</artifactId>
+                 <version>${hadoop.version}</version>
+             </dependency>
+         </dependencies>
+         <build>
+             <plugins>
+                 <plugin>
+                     <artifactId>maven-dependency-plugin</artifactId>
+                     <executions>
+                         <execution>
+                             <id>create-mrapp-generated-classpath</id>
+                             <phase>generate-test-resources</phase>
+                             <goals>
+                                 <goal>build-classpath</goal>
+                             </goals>
+                             <configuration>
+                                 <!-- needed to run the unit test for DS to generate
+                                 the required classpath that is required in the env
+                                 of the launch container in the mini mr/yarn cluster
+                                 -->
+                                 <outputFile>${project.build.directory}/test-classes/mrapp-generated-classpath</outputFile>
+                             </configuration>
+                         </execution>
+                     </executions>
+                 </plugin>
+             </plugins>
+         </build>
+     </profile>
+     <!--
+       profile for building against Hadoop 3.0.x. Activate using:
+        mvn -Dhadoop.profile=3.0
+     -->
+     <profile>
+         <id>hadoop-3.0</id>
+         <activation>
+             <property>
+                 <name>hadoop.profile</name>
+                 <value>3.0</value>
+             </property>
+         </activation>
+         <properties>
+             <hadoop.version>3.0-SNAPSHOT</hadoop.version>
+         </properties>
+         <dependencies>
+             <dependency>
+                 <groupId>org.apache.hadoop</groupId>
+                 <artifactId>hadoop-common</artifactId>
+             </dependency>
+             <dependency>
+                 <groupId>org.apache.hadoop</groupId>
+                 <artifactId>hadoop-annotations</artifactId>
+             </dependency>
+             <dependency>
+                 <groupId>org.apache.hadoop</groupId>
+                 <artifactId>hadoop-minicluster</artifactId>
+             </dependency>
+         </dependencies>
+         <build>
+             <plugins>
+                 <plugin>
+                     <artifactId>maven-dependency-plugin</artifactId>
+                     <executions>
+                         <execution>
+                             <id>create-mrapp-generated-classpath</id>
+                             <phase>generate-test-resources</phase>
+                             <goals>
+                                 <goal>build-classpath</goal>
+                             </goals>
+                             <configuration>
+                                 <!-- needed to run the unit test for DS to generate
+                                 the required classpath that is required in the env
+                                 of the launch container in the mini mr/yarn cluster
+                                 -->
+                                 <outputFile>${project.build.directory}/test-classes/mrapp-generated-classpath</outputFile>
+                             </configuration>
+                         </execution>
+                     </executions>
+                 </plugin>
+             </plugins>
+         </build>
+     </profile>
+    <profile>
+      <id>compile-protobuf</id>
+      <activation>
+        <property>
+          <name>compile-protobuf</name>
+        </property>
+      </activation>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-maven-plugins</artifactId>
+            <executions>
+              <execution>
+                <id>compile-protoc</id>
+                <phase>generate-sources</phase>
+                <goals>
+                  <goal>protoc</goal>
+                </goals>
+                <configuration>
+                  <protobuf.version>2.5.0</protobuf.version>
+                  <protocVersion>2.5.0</protocVersion>
+                  <imports>
+                    <param>${basedir}/src/main/protobuf</param>
+                    <param>${basedir}/hbase-protocol/src/main/protobuf</param>
+                  </imports>
+                  <source>
+                    <directory>${basedir}/src/main/protobuf</directory>
+                    <includes>
+                      <include>TrxRegion.proto</include>
+                      <include>SsccRegion.proto</include>
+                    </includes>
+                  </source>
+                  <output>${basedir}/src/main/java/</output>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+  </profiles>
+</project>

--- a/core/sqf/src/seatrans/hbase-trx/pom.xml.cdh54
+++ b/core/sqf/src/seatrans/hbase-trx/pom.xml.cdh54
@@ -21,28 +21,29 @@
 -->
   <repositories>
     <repository>
-      <id>Apache</id>
-      <url>http://mvnrepository.com/artifact/</url>
-      <layout>default</layout>
+      <id>cloudera</id>
+      <url>https://repository.cloudera.com/artifactory/cloudera-repos/</url>
     </repository>
-  </repositories> 
+  </repositories>
 
   <properties>
-    <hadoop.version>2.4.0</hadoop.version>
-    <hbase.version>${env.HBASE_DEP_VER_APACHE}</hbase.version>
+    <hadoop.version>2.6.0</hadoop.version>
+    <hbase.version>1.0.0-cdh5.4.4</hbase.version>
+    <protobuf.version>2.5.0</protobuf.version>
+    <protocVersion>2.5.0</protocVersion>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-    <protobuf.version>2.5.0</protobuf.version>                                                                                              
-    <protocVersion>2.5.0</protocVersion>                                                                                                    
     <java.version>1.7</java.version>
-    <trx-suffix>apache</trx-suffix>
+    <trx-suffix>cdh5_4</trx-suffix>
   </properties>
+
 
   <groupId>org.apache</groupId>
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>hbase-trx-apache1_0_2</artifactId>
+  <artifactId>hbase-trx-cdh5_4</artifactId>
   <version>${env.TRAFODION_VER}</version>
   <name>HBase - Trx</name>
   <description>Trx of HBase usage</description>
+
 
   <build>
     <defaultGoal>package</defaultGoal>
@@ -115,11 +116,6 @@
     <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-thrift</artifactId>
-      <version>${hbase.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-annotations</artifactId>
       <version>${hbase.version}</version>
     </dependency>
     <dependency>

--- a/core/sqf/src/seatrans/hbase-trx/pom.xml.cdh55
+++ b/core/sqf/src/seatrans/hbase-trx/pom.xml.cdh55
@@ -28,18 +28,18 @@
 
   <properties>
     <hadoop.version>2.6.0</hadoop.version>
-    <hbase.version>${env.HBASE_DEP_VER_CDH}</hbase.version>
+    <hbase.version>1.0.0-cdh5.5.1</hbase.version>
     <protobuf.version>2.5.0</protobuf.version>
     <protocVersion>2.5.0</protocVersion>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <java.version>1.7</java.version>
-    <trx-suffix>cdh5_4</trx-suffix>
+    <trx-suffix>cdh5_5</trx-suffix>
   </properties>
 
 
   <groupId>org.apache</groupId>
   <modelVersion>4.0.0</modelVersion>
-  <artifactId>hbase-trx-cdh5_4</artifactId>
+  <artifactId>hbase-trx-cdh5_5</artifactId>
   <version>${env.TRAFODION_VER}</version>
   <name>HBase - Trx</name>
   <description>Trx of HBase usage</description>

--- a/core/sqf/src/seatrans/hbase-trx/pp.awk
+++ b/core/sqf/src/seatrans/hbase-trx/pp.awk
@@ -19,29 +19,35 @@
 # under the License.
 #
 # @@@ END COPYRIGHT @@@
-##  The following example has been tested to work.
+#  The following example has been tested to work.
 #  If the file f1 contains the following, run this script
 #  as follows:    
 #   awk -f pp.awk -v distro=HDP2.3 f1 > f2
-#  contents of  file f1:
-#  #ifdef HDP2.3
-#  this is HDP2.3 specific code
-#  #else
-#  this is other than HDP2.3 code
-#  #endif
 #
-#  #ifndef HDP2.3
-#  this is other than HDP2.3 code partof ifndef
-#  #else
-#  this is HDP2.3 code part of ifndef else
+#  contents of  file f1:
+#   #ifdef HDP2.3
+#   this is HDP2.3 specific code
+#   #else
+#   this is anything other than  HDP2.3 code
 #   #endif
 #
-#  this is common code
-#  this is common code 2
+#   #ifndef HDP2.3
+#   this is anything other than HDP2.3 code partof ifndef construct
+#   #else
+#   this is HDP2.3 code part of ifndef else construct
+#   #endif
 #
-#  #ifdef CDH1.0
-#  this is CDH specific code
-#  #endif
+#   this is common code for all cases
+#
+#   #ifdef CDH5.4
+#   this is CDH5.4 specific code
+#   #endif
+#
+#   #ifdef CDH5.5 HDP2.3 HBASE1.1
+#   this is common CDH5.5 or HDP2.3 or HBASE1.1
+#   #else
+#   this is anything other than CDH5.5 or HDP2.3 or HBASE1.1 code
+#   #endif
 
 BEGIN{
 printline=1      #print current line or not.
@@ -99,7 +105,7 @@ ifndefpattern = "#ifndef"
 
   if($0 ~ ifdefpattern)
    {
-     if( $2 ~ distro)
+     if( $2 ~ distro || $3 ~ distro || $4 ~ distro)
      {
        printline = 0
        matchBegun = 1
@@ -112,7 +118,7 @@ ifndefpattern = "#ifndef"
    }
  if($0 ~ ifndefpattern)
   {
-    if($2 ~ distro)
+    if($2 ~ distro || $3 ~ distro || $4 ~ distro)
     {
       printline = 0
       unmatchBegun = 1

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/ClientScanner98.java.tmpl
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/ClientScanner98.java.tmpl
@@ -468,7 +468,7 @@ public class ClientScanner98 extends AbstractClientScanner {
       }
       closed = true;
     }
-#ifndef CDH1.0
+#ifndef CDH5.4 CDH5.5
     @Override
     public boolean renewLease() {
       if (callable != null) {

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/PatchClientScanner.java.tmpl
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/PatchClientScanner.java.tmpl
@@ -69,7 +69,7 @@ public class PatchClientScanner extends ClientScanner {
     super(conf, scan, tableName, connection, rpcFactory, controllerFactory, pool, primaryOperationTimeout);
   }
 
-#ifndef HDP2.3
+#ifdef CDH5.4 HBASE1.0
   @Override
   protected void loadCache() throws IOException {
 	    Result[] values = null;

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/TrafParallelClientScanner.java.tmpl
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/TrafParallelClientScanner.java.tmpl
@@ -190,7 +190,7 @@ public class TrafParallelClientScanner extends AbstractClientScanner implements 
     // interrupt all running threads, don't wait for completion
     pool.shutdownNow();
   }
-#ifndef CDH1.0
+#ifndef CDH5.4 CDH5.5
   @Override
   public boolean renewLease() {return false;}//fake, never needed.
 #endif

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/coprocessor/transactional/SsccRegionEndpoint.java.tmpl
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/coprocessor/transactional/SsccRegionEndpoint.java.tmpl
@@ -3420,7 +3420,7 @@ CoprocessorService, Coprocessor {
     if (LOG.isTraceEnabled()) LOG.trace("SsccRegionEndpoint coprocessor: start");
     RegionCoprocessorEnvironment tmp_env = 
       (RegionCoprocessorEnvironment)env;
-#ifdef HDP2.3
+#ifdef HDP2.3 HBASE1.1
     this.m_Region = (HRegion)
        tmp_env.getRegion();
 #else
@@ -3582,7 +3582,7 @@ CoprocessorService, Coprocessor {
 
     try {
           if (LOG.isTraceEnabled()) LOG.trace("SsccRegionEndpoint coprocessor:  Trafodion Recovery:  Flushing cache in startRegionAfterRecovery " + m_Region.getRegionInfo().getRegionNameAsString());
-#ifdef HDP2.3
+#ifdef HDP2.3 HBASE1.1
           m_Region.flush(true);
 #else
           m_Region.flushcache();

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/coprocessor/transactional/TrxRegionEndpoint.java.tmpl
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/coprocessor/transactional/TrxRegionEndpoint.java.tmpl
@@ -3497,7 +3497,7 @@ CoprocessorService, Coprocessor {
     if (LOG.isTraceEnabled()) LOG.trace("TrxRegionEndpoint coprocessor: start");
     RegionCoprocessorEnvironment tmp_env = 
       (RegionCoprocessorEnvironment)env;
-#ifdef HDP2.3
+#ifdef HDP2.3 HBASE1.1
     this.m_Region = (HRegion)
        tmp_env.getRegion();
 #else
@@ -4018,7 +4018,7 @@ CoprocessorService, Coprocessor {
 
     try {
           if (LOG.isTraceEnabled()) LOG.trace("TrxRegionEndpoint coprocessor: Trafodion Recovery:  Flushing cache in startRegionAfterRecovery " + m_Region.getRegionInfo().getRegionNameAsString());
-#ifdef HDP2.3
+#ifdef HDP2.3 HBASE1.1
           m_Region.flush(true);
 #else
           m_Region.flushcache();

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/coprocessor/transactional/TrxRegionObserver.java.tmpl
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/coprocessor/transactional/TrxRegionObserver.java.tmpl
@@ -85,8 +85,10 @@ import org.apache.hadoop.hbase.client.Mutation;
 import java.util.ListIterator;
 import org.apache.hadoop.hbase.Cell;
 
-#ifdef HDP2.3
+#ifdef HDP2.3 HBASE1.1 CDH5.5
 import org.apache.hadoop.hbase.regionserver.ScannerContext;
+#endif
+#ifdef HDP2.3 HBASE1.1
 import org.apache.hadoop.hbase.regionserver.Region;
 #endif
 
@@ -184,7 +186,7 @@ public void start(CoprocessorEnvironment e) throws IOException {
 
     RegionCoprocessorEnvironment regionCoprEnv = (RegionCoprocessorEnvironment)e;
     RegionCoprocessorEnvironment re = (RegionCoprocessorEnvironment) e;
-#ifdef HDP2.3
+#ifdef HDP2.3 HBASE1.1
     my_Region = (HRegion) re.getRegion();
 #else
     my_Region = re.getRegion();
@@ -696,7 +698,7 @@ public void createRecoveryzNode(int node, String encodedName, byte [] data) thro
     }
 
     @Override
-#ifdef HDP2.3
+#ifdef HDP2.3 HBASE1.1
     public void postSplit(ObserverContext<RegionCoprocessorEnvironment> e, Region l, Region r) {
 #else
     public void	postSplit(ObserverContext<RegionCoprocessorEnvironment> e, HRegion l, HRegion r) {
@@ -757,7 +759,7 @@ public void createRecoveryzNode(int node, String encodedName, byte [] data) thro
                 blockNonPhase2.set(true);
 
 	        if(LOG.isInfoEnabled()) {
-#ifdef HDP2.3
+#ifdef HDP2.3 HBASE1.1
                     HRegion region = (HRegion) c.getEnvironment().getRegion();
 #else
 	            HRegion region = c.getEnvironment().getRegion();
@@ -765,7 +767,7 @@ public void createRecoveryzNode(int node, String encodedName, byte [] data) thro
 	            LOG.debug("preClose -- setting close var to true on: " + region.getRegionInfo().getRegionNameAsString());
 	        }
 	        try {
-	          sbHelper.pendingAndScannersWait(commitPendingTransactions, scanners, transactionsById, pendingDelayLen);
+                 sbHelper.pendingAndScannersWait(commitPendingTransactions, scanners, transactionsById, pendingDelayLen);
 	        } catch(IOException ioe) {
 	          LOG.error("Encountered exception when calling pendingAndScannersWait(): " + ioe);
 	        }
@@ -867,7 +869,7 @@ public void createRecoveryzNode(int node, String encodedName, byte [] data) thro
             }
 
             @Override
-#ifdef HDP2.3
+#ifdef HDP2.3 HBASE1.1 CDH5.5
             public boolean next(List<Cell> result, ScannerContext scannerContext) throws IOException {
               if (LOG.isTraceEnabled()) LOG.trace("preCompact: call next with scannerContext limit " + scannerContext);
 #else
@@ -878,7 +880,7 @@ public void createRecoveryzNode(int node, String encodedName, byte [] data) thro
                 boolean skip=false;
                 ConcurrentHashMap<String, Integer>  verCountByCol = new ConcurrentHashMap<String,Integer>();
                 try {
-#ifdef HDP2.3
+#ifdef HDP2.3 HBASE1.1 CDH5.5
   		    ret = s.next(result,scannerContext);
 #else
                     ret = s.next(result,limit);

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/regionserver/transactional/CleanOldTransactionsChore.java.tmpl
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/regionserver/transactional/CleanOldTransactionsChore.java.tmpl
@@ -27,7 +27,7 @@ import java.io.IOException;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-#ifdef HDP2.3
+#ifdef HDP2.3 HBASE1.1 CDH5.5
 import org.apache.hadoop.hbase.ScheduledChore;
 #else
 import org.apache.hadoop.hbase.Chore;
@@ -40,7 +40,7 @@ import org.apache.hadoop.hbase.coprocessor.transactional.TrxRegionEndpoint;
  * Cleans up committed transactions when they are no longer needed to verify
  * pending transactions.
  */
-#ifdef HDP2.3
+#ifdef HDP2.3 HBASE1.1 CDH5.5
 public class CleanOldTransactionsChore extends ScheduledChore {
 #else
 public class CleanOldTransactionsChore extends Chore {
@@ -57,7 +57,7 @@ public class CleanOldTransactionsChore extends Chore {
   public CleanOldTransactionsChore(final TrxRegionEndpoint trx_Region,
                                    final int timer,  
                                    final Stoppable stoppable) {
-#ifdef HDP2.3
+#ifdef HDP2.3 HBASE1.1 CDH5.5
     super("CleanOldTransactionsChore", stoppable, timer);
 #else
     super("CleanOldTransactionsChore", timer, stoppable);

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/regionserver/transactional/IdTm.java
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/regionserver/transactional/IdTm.java
@@ -116,7 +116,7 @@ public class IdTm implements IdTmCb {
      * @exception IdTmException exception
      */
     public void id(int timeout, IdTmId id) throws IdTmException {
-        if (LOG.isDebugEnabled()) LOG.debug("id begin");
+        if (LOG.isDebugEnabled()) LOG.debug("id begin with timeout " + timeout);
         try {
            int err = native_id(timeout, id);
            if (LOG.isDebugEnabled()) LOG.debug("id returned: " + id.val + ", error: " + err);

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/regionserver/transactional/KeyValueListScanner.java.tmpl
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/regionserver/transactional/KeyValueListScanner.java.tmpl
@@ -158,7 +158,7 @@ public class KeyValueListScanner implements KeyValueScanner {
   public boolean backwardSeek(Cell seekKey) throws IOException {
     throw new NotImplementedException("Not implemented");
   }
-#ifndef CDH1.0
+#ifndef CDH5.4
   @Override
 #endif
   public Cell getNextIndexedKey() {

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/regionserver/transactional/MemoryUsageChore.java.tmpl
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/regionserver/transactional/MemoryUsageChore.java.tmpl
@@ -28,7 +28,7 @@ import java.io.IOException;
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
 
-#ifdef HDP2.3
+#ifdef HDP2.3 HBASE1.1 CDH5.5
 import org.apache.hadoop.hbase.ScheduledChore;
 #else
 import org.apache.hadoop.hbase.Chore;
@@ -40,7 +40,7 @@ import org.apache.hadoop.hbase.coprocessor.transactional.TrxRegionEndpoint;
 /**
  * Manages the MemoryMXBean to determine a regionserver's memory usage.
  */
-#ifdef HDP2.3
+#ifdef HDP2.3 HBASE1.1 CDH5.5
 public class MemoryUsageChore extends ScheduledChore {
 #else
 public class MemoryUsageChore extends Chore {
@@ -57,7 +57,7 @@ public class MemoryUsageChore extends Chore {
   public MemoryUsageChore(final TrxRegionEndpoint trx_Region,
                           final int timer,  
                           final Stoppable stoppable) {
-#ifdef HDP2.3
+#ifdef HDP2.3 HBASE1.1 CDH5.5
     super("MemoryUsageChore", stoppable, timer);
 #else
     super("MemoryUsageChore", timer, stoppable);

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/regionserver/transactional/TrxTransactionState.java.tmpl
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/regionserver/transactional/TrxTransactionState.java.tmpl
@@ -71,7 +71,7 @@ import org.apache.hadoop.hbase.regionserver.RegionCoprocessorHost;
 import org.apache.hadoop.hbase.regionserver.ScanQueryMatcher;
 import org.apache.hadoop.hbase.regionserver.ScanType;
 import org.apache.hadoop.hbase.regionserver.ScanInfo;
-#ifdef HDP2.3
+#ifdef HDP2.3 HBASE1.1 CDH5.5
 import org.apache.hadoop.hbase.regionserver.ScannerContext;
 #endif
 import org.apache.hadoop.hbase.regionserver.wal.WALEdit;
@@ -677,7 +677,7 @@ public class TrxTransactionState extends TransactionState {
             //Store.ScanInfo scaninfo = new Store.ScanInfo(null, 0, 1, HConstants.FOREVER, false, 0, Cell.COMPARATOR);
             ScanInfo scaninfo = new ScanInfo(null, 0, 1, HConstants.FOREVER,KeepDeletedCells.FALSE, 0, KeyValue.COMPARATOR);
            
-#ifdef HDP2.3
+#ifdef HDP2.3 HBASE1.1
             //Hbase 1.1.2 and beyond has optimization in TimeRange.compare(cell) to return true for all time ranges if TimeRange.isAllTime() is true.
             //scan.setTimeRange(min, max) instantiates TimeRange with a different constructor (isAllTime is false in this case). This is set 
             //in scan object by the client if specific time range is needed. In all other cases, a default TimeRange() (isAllTime is true)
@@ -730,7 +730,7 @@ public class TrxTransactionState extends TransactionState {
          * @param limit
          * @return true if there are more rows, false if scanner is done
          */
-#ifndef HDP2.3
+#ifdef HBASE1.0 CDH5.4
         @Override
 #endif
         public synchronized boolean next(final List<Cell> outResult, final int limit) throws IOException {          	
@@ -796,13 +796,13 @@ public class TrxTransactionState extends TransactionState {
             return false;
         }
 
-#ifndef HDP2.3
+#ifndef HDP2.3 HBASE1.1
         @Override
 #endif
         public synchronized boolean next(final List<Cell> results) throws IOException {
           return next(results, -1);
         }
-#ifdef HDP2.3
+#ifdef HDP2.3 HBASE1.1 CDH5.5
         @Override
         public boolean next(List<Cell> results, ScannerContext scannerContext) throws IOException {
             return next(results, -1);

--- a/core/sqf/src/tm/idtmsrv.cpp
+++ b/core/sqf/src/tm/idtmsrv.cpp
@@ -434,7 +434,18 @@ void do_req(BMS_SRE *pp_sre) {
         lv_ferr = BMSG_READDATA_(pp_sre->sre_msgId,      // msgid
                                  (char *) &lv_req,       // reqdata
                                  (int) sizeof(lv_req));  // bytecount
-        assert(lv_ferr == XZFIL_ERR_OK);
+        if (lv_ferr != XZFIL_ERR_OK){
+           printf("srv: received lv_ferr %d in do_req \n", lv_ferr);
+           if((lv_ferr = XMSG_ISCANCELED_(pp_sre->sre_msgId))){
+              printf("srv: XMSG_ISCANCELED_ returned %d in do_req.  Most likely the client timeout was exceeded \n", lv_ferr);
+              return;
+           }
+           else{
+              printf("srv: XMSG_ISCANCELED_ returned %d in do_req after FEEOF on BMSG_READDATA_.  ABORTING \n", lv_ferr);
+              abort();
+           }
+        }
+
         if (gv_verbose) {
             switch (lv_req.iv_req_type) {
             case GID_REQ_PING:

--- a/core/sql/common/swscanf.cpp
+++ b/core/sql/common/swscanf.cpp
@@ -1,4 +1,6 @@
-/* -*-C++-*- 
+/* -*-C++-*-
+ * $OpenBSD: vfscanf.c,v 1.21 2006/01/13 21:33:28 millert Exp $ 
+ *-
  * Copyright (c) 1990, 1993
  *	The Regents of the University of California.  All rights reserved.
  *
@@ -13,11 +15,7 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 3. All advertising materials mentioning features or use of this software
- *    must display the following acknowledgement:
- *	This product includes software developed by the University of
- *	California, Berkeley and its contributors.
- * 4. Neither the name of the University nor the names of its contributors
+ * 3. Neither the name of the University nor the names of its contributors
  *    may be used to endorse or promote products derived from this software
  *    without specific prior written permission.
  *
@@ -39,7 +37,7 @@
   * File:         swscanf.h
   * Description:  SQL/MX wide-char swscanf() function, modified based on 
   *               NetBSD __svfscanf.c found at 
-  *               http://www.ajk.tele.fi/libc/stdio/vfscanf.c.html#__svfscanf
+  *               http://ftp.stu.edu.tw/BSD/OpenBSD/src/lib/libc/stdio/vfscanf.c
   * Created:      2/13/2002
   * Language:     C++
   * Limitation:   
@@ -49,8 +47,6 @@
   *
   *****************************************************************************
  */
-
-//LCOV_EXCL_START  // Used only by .../sqlutils/metamigr/MIGRATE.cpp which is not used in SQ
 
 /* commented out the useless static data structure.*/
 //#if defined(LIBC_SCCS) && !defined(lint)
@@ -864,5 +860,4 @@ Int32 na_swscanf(const NAWchar *str, NAWchar const *fmt, ...)
 	va_end(ap);
 	return (ret);
 }
-//LCOV_EXCL_STOP // Used only by .../sqlutils/metamigr/MIGRATE.cpp which is not used in SQ
 

--- a/core/sql/common/swsprintf.cpp
+++ b/core/sql/common/swsprintf.cpp
@@ -1,7 +1,8 @@
 /* -*-C++-*-
+ * $OpenBSD: sprintf.c,v 1.13 2005/10/10 12:00:52 espie Exp $ 
  *-
- * Copyright (c) 1990 The Regents of the University of California.
- * All rights reserved.
+ * Copyright (c) 1990, 1993
+ *	The Regents of the University of California.  All rights reserved.
  *
  * This code is derived from software contributed to Berkeley by
  * Chris Torek.
@@ -14,11 +15,7 @@
  * 2. Redistributions in binary form must reproduce the above copyright
  *    notice, this list of conditions and the following disclaimer in the
  *    documentation and/or other materials provided with the distribution.
- * 3. All advertising materials mentioning features or use of this software
- *    must display the following acknowledgement:
- *	This product includes software developed by the University of
- *	California, Berkeley and its contributors.
- * 4. Neither the name of the University nor the names of its contributors
+ * 3. Neither the name of the University nor the names of its contributors
  *    may be used to endorse or promote products derived from this software
  *    without specific prior written permission.
  *
@@ -34,14 +31,11 @@
  * OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
  * SUCH DAMAGE.
  */
-
-/*	$NetBSD: vfprintf.c,v 1.18 1997/04/02 12:50:25 kleink Exp $	*/
-
 /*****************************************************************************
  *
  * File:         swsprintf.h
  * Description:  SQL/MX wide-char swsprintf() function, adapted from NetBSD vfprintf.c
- *               found at http://www.ajk.tele.fi/libc/stdio/vfprintf.c.html#vfprintf.
+ *               found at http://ftp.stu.edu.tw/BSD/OpenBSD/src/lib/libc/stdio/sprintf.c 
  * Created:      2/13/2002
  * Language:     C++
  * Limitation:   Floating point numbers are not supported. 

--- a/core/sql/regress/core/FILTERRTS
+++ b/core/sql/regress/core/FILTERRTS
@@ -77,9 +77,14 @@ s/SSCP Request Message Count[ ]*[0-9,]*/SSCP Request Message Count @sscpRequestM
 s/SSCP Request Message Bytes[ ]*[0-9,]*/SSCP Request Message Bytes @sscpRequestMessageBytes@/
 s/SSCP Reply Message Count[ ]*[0-9,]*/SSCP Reply Message Count @sscpReplytMessageCount@/
 s/SSCP Reply Message Bytes[ ]*[0-9,]*/SSCP Reply Message Bytes @sscpReplyMessageBytes@/
-s/No. Query Invalidation Keys[ ]*[0-9]*/No. Query Invalidation Keys/
-s/EXE Memory[ ]*[A-z]*[0-9]*/@exeMemory@/
-s/IPC Memory[ ]*[A-z]*[0-9]*/@exeMemory@/
+s/Query Invalidation Keys[ ]*[0-9]*/Query Invalidation Keys/
+s/IPC Memory Allocated[ 0-9]*/IPC Memory Allocated @exeMemory@/
+s/EXE Memory Allocated[ 0-9]*/EXE Memory Allocated @ipcMemory@/
+s/IPC Memory Used High WM[ 0-9]*/IPC Memory Used High WM @exeMemory@/
+s/EXE Memory Used High WM[ 0-9]*/EXE Memory Used High WM @ipcMemory@/
+s/IPC Memory Used[ 0-9]*/IPC Memory Used @exeMemory@/
+s/EXE Memory Used[ 0-9]*/EXE Memory Used @ipcMemory@/
+s/PID[0-9 ]*/PID @pid@/
 s/RMS Stats Reset Timestamp[ ]*[0-9]*\/[0-9]*\/[0-9]* [0-9]*:[0-9]*:[0-9]*.[0-9]*/RMS Stats Reset Timestamp @rmsStatsResetTimestamp@/
 /8 EX_HASH_GRBY[A-Z ]*/{N
 s/8 EX_HASH_GRBY[A-Z ]*\n[0-9, -]*/8 #ex_hash_grby bmoStats/

--- a/core/sql/src/main/java/org/trafodion/sql/HTableClient.java
+++ b/core/sql/src/main/java/org/trafodion/sql/HTableClient.java
@@ -345,7 +345,8 @@ public class HTableClient {
 	    }
 
 	    table = new RMInterface(tblName);
-	    if (logger.isDebugEnabled()) logger.debug("Exit HTableClient::init, table object: " + table);
+	    if (logger.isDebugEnabled()) logger.debug("Exit HTableClient::init, useTRex: " + this.useTRex + ", useTRexScanner: "
+	              + this.useTRexScanner + ", table object: " + table);
 	    return true;
 	}
 

--- a/install/Makefile
+++ b/install/Makefile
@@ -20,7 +20,7 @@ INSTALLER_TARNAME = $(shell echo ${RELEASE_TYPE}_installer-${RELEASE_VER}.tar.gz
 
 all: pkg-installer 
 
-pkg-installer: installer/LICENSE installer/NOTICE
+pkg-installer: installer/LICENSE installer/NOTICE installer/DISCLAIMER
 	tar czf ${INSTALLER_TARNAME} installer --exclude=tools
 	mkdir -p ../distribution
 	mv ${INSTALLER_TARNAME} ../distribution
@@ -32,6 +32,9 @@ installer/LICENSE: ../licenses/LICENSE-install
 	cd $(@D) && $(MAKE) $(@F)
 
 installer/NOTICE: ../NOTICE
+	cp -f $? $@
+
+installer/DISCLAIMER: ../DISCLAIMER
 	cp -f $? $@
 
 version:

--- a/install/installer/traf_apache_mods
+++ b/install/installer/traf_apache_mods
@@ -48,7 +48,11 @@ sudo chmod 777 $TRAF_CONFIG
 source $TRAF_CONFIG
 
 
-hbase_trx_jar="hbase-trx-apache*.jar"
+hbase_trx_jar="hbase-trx-apache1_1_2*.jar"
+
+if [[ $hbaseVersion =~1.0]]; then
+   hbase_trx_jar="hbase-trx-apache1_0_2*.jar"
+fi
 
 traf_util_jar="trafodion-utility-*.jar"
 

--- a/install/installer/traf_config_check
+++ b/install/installer/traf_config_check
@@ -623,7 +623,15 @@ source $TRAF_CONFIG
 
 function setHBaseDistro {
 
-export HBASE_DISTRO="APACHE" 
+if [[ $HADOOP_TYPE == "apache" ]]; then
+   HBASE_DISTRO="APACHE"$APACHE_VERSION
+elif [[ $HADOOP_TYPE == "hortonworks" ]]; then
+   HBASE_DISTRO="HDP"$HDP_VERSION
+elif [[ $HADOOP_TYPE == "cloudera" ]]; then
+   HBASE_DISTRO="CDH"$CDH_VERSION
+fi
+
+export HBASE_DISTRO 
 
 sudo chmod 777 $TRAF_CONFIG
 sed -i '/HBASE_DISTRO\=/d' $TRAF_CONFIG
@@ -678,6 +686,11 @@ do
          checkClouderaVersion
          checkRoleGroups
       fi
+
+      if [[ $HADOOP_TYPE == "apache" ]]; then
+         checkApacheVersion
+      fi
+   
       break;
    fi
 done
@@ -698,11 +711,13 @@ function checkRoleGroups {
 
 
 function checkClouderaVersion {
-
+cdhVersion=$(ssh -q -n $node grep "Version" $HOME/hbaseVersion.txt | grep -o "cdh[0-9]\.[0-9]")
+#get cdh version,eg:5.5 or 5.7
+CDH_VERSION=${cdhVersion:3:5}
 if [[ $CDH_5_3_HDP_2_2_SUPPORT == "N" ]]; then
    #Check that Cloudera 5.2 or 5.3 are not installed.
-   if [[ "$CDH_5_4_SUPPORT" == "Y" ]]; then
-      nameOfVersion=$(ssh -q -n $node grep "Version" $HOME/hbaseVersion.txt | sed 's/,.*//' | sed 's/.*\-//' | grep cdh5.4.*)
+   if [[ "$CDH_5_4_SUPPORT" == "Y" ]] || [[ "$CDH_5_5_SUPPORT" == "Y" ]]; then
+      nameOfVersion=$(ssh -q -n $node grep "Version" $HOME/hbaseVersion.txt | sed 's/,.*//' | sed 's/.*\-//' | grep cdh5.[4-6].*)
       #Check that Cloudera 5.[n>4].* is not installed.
       if [[ -z $nameOfVersion ]]; then
          versionInstalled=$(ssh -q -n $node grep "Version" $HOME/hbaseVersion.txt | sed 's/,.*//' | sed 's/.*\-//' | grep cdh[5-9].[7-9].* | wc -l)
@@ -740,14 +755,22 @@ else
    fi
 fi
 
+hbaseVersion=$(ssh -q -n $node grep "Version" $HOME/hbaseVersion.txt | sed 's/-.*//' | awk {'print$2'})
+
 echo "***INFO: nameOfVersion=$nameOfVersion"
 sudo chmod 777 $TRAF_CONFIG
+sed -i '/hbaseVersion\=/d' $TRAF_CONFIG
+echo "export hbaseVersion=\"$hbaseVersion\"" >> $TRAF_CONFIG
+sed -i '/CDH_VERSION\=/d' $TRAF_CONFIG
+echo "export CDH_VERSION=\"$CDH_VERSION\"" >> $TRAF_CONFIG
 source $TRAF_CONFIG
 
 }
 
 function checkHDPVersion {
- 
+version=$(ssh -q -n $node grep "Version" $HOME/hbaseVersion.txt | sed 's/-.*//' | awk {'print$2'})
+#get hdp version,eg:2.1 or 2.3
+HDP_VERSION=${version:6:3}
 if [[ $CDH_5_3_HDP_2_2_SUPPORT == "N" ]]; then
    if [[ $HDP_2_3_SUPPORT == "N" ]]; then
       #Check that Hortonworks 2.2 is not installed
@@ -800,13 +823,49 @@ if [[ -z $nameOfVersion ]]; then
    fi
 fi
 
+hbaseVersion=$(ssh -q -n $node grep "Version" $HOME/hbaseVersion.txt | sed 's/-.*//' | awk {'print$2'})
+
 echo "***INFO: nameOfVersion=$nameOfVersion"
 echo "***INFO: HADOOP_PATH=$HADOOP_PATH"
+
+sudo chmod 777 $TRAF_CONFIG
+sed -i '/hbaseVersion\=/d' $TRAF_CONFIG
+echo "export hbaseVersion=\"$hbaseVersion\"" >> $TRAF_CONFIG
+sed -i '/HDP_VERSION\=/d' $TRAF_CONFIG
+echo "export HDP_VERSION=\"$HDP_VERSION\"" >> $TRAF_CONFIG
 source $TRAF_CONFIG
 
 }
 
+function checkApacheVersion {
+version=$(ssh -q -n $node grep "Version" $HOME/hbaseVersion.txt | awk {'print $2'})
+APACHE_VERSION=${version:0:3}
+if [[ $APACHE_1_0_X_SUPPORT=="Y" || $APACHE_1_1_X_SUPPORT=="Y" ]]; then
+   nameOfVersion=$(ssh -q -n $node grep "Version" $HOME/hbaseVersion.txt | awk {'print $2'})
+   #Check that hbase 1.x.x is not installed.
+   if [[ -z $nameOfVersion ]]; then
+      versionInstalled=$(ssh -q -n $node grep "Version" $HOME/hbaseVersion.txt | awk {'print $2'} | grep [1].[0-1].* | wc -l)
+      if [[ $versionInstalled -gt "0" ]]; then
+         errorFound=1
+         echo "HADOOP VERSION" >> $ERROR_LOG
+         echo "***ERROR: Trafodion and apache hbase versions may not be compatible" >> $ERROR_LOG
+         echo "***ERROR: Detected apache hbase version:" >> $ERROR_LOG
+         ssh -q -n $node cat $HOME/hbaseVersion.txt >> $ERROR_LOG
+      fi
+   fi
+fi
 
+hbaseVersion=$(ssh -q -n $node grep "Version" $HOME/hbaseVersion.txt | sed 's/-.*//' | awk {'print$2'}|sed s/,//g)
+
+echo "***INFO: nameOfVersion=$nameOfVersion"
+sudo chmod 777 $TRAF_CONFIG
+sed -i '/hbaseVersion\=/d' $TRAF_CONFIG
+echo "export hbaseVersion=\"$hbaseVersion\"" >> $TRAF_CONFIG
+sed -i '/APACHE_VERSION\=/d' $TRAF_CONFIG
+echo "export APACHE_VERSION=\"$APACHE_VERSION\"" >> $TRAF_CONFIG
+source $TRAF_CONFIG
+
+}
 function checkHadoopNames {
 if [[ -z "$HDFS_USER" ]]; then
    errorFound=1
@@ -928,6 +987,7 @@ else
 
 fi
 
+install_features_path=$(tar -tf $TRAF_BUILD_PATH | grep "install_features")
 
 if [[ ! -z $install_features_path ]]; then
    if [[ "$ONE_TAR_INSTALL" == "N" ]]; then
@@ -1047,8 +1107,8 @@ fi
 
 if [[ "$HADOOP_TYPE" == "apache" ]]; then
    setPath
-   setHBaseDistro
 fi
+setHBaseDistro
 
 getHadoopNodes
 

--- a/licenses/Makefile
+++ b/licenses/Makefile
@@ -19,7 +19,7 @@
 #
 # @@@ END COPYRIGHT @@@
 
-all: LICENSE-src LICENSE-server LICENSE-install LICENSE-clients NOTICE-server
+all: LICENSE-src LICENSE-server LICENSE-install LICENSE-clients NOTICE-server DISCLAIMER-server
 
 # All source code included in Trafodion source
 LICENSE-src:
@@ -32,6 +32,9 @@ LICENSE-server:
 
 NOTICE-server:
 	cat ../NOTICE note-server-bin > $@
+
+DISCLAIMER-server:
+	cat ../DISCLAIMER > $@
 
 LICENSE-install:
 	cat Apache > $@

--- a/licenses/lic-server-src
+++ b/licenses/lic-server-src
@@ -3,16 +3,15 @@ The core component of Apache Trafodion uses several BSD-like and MIT-like licens
 
 +++++++++++++++++++++++++++++
 
-BSD-4 clause for files:
+BSD-3 clause for files:
    incubator-trafodion/core/sql/common/swsprintf.cpp
    incubator-trafodion/core/sql/common/swscanf.cpp
 
-The third clause of this license has since been rescinded. See the
-Historical Background section at https://opensource.org/licenses/BSD-3-Clause.
+Copyright (c) 1990, 1993
+   The Regents of the University of California.  All rights reserved.
 
- Copyright (c) 1990 The Regents of the University of California.
- Copyright (c) 1990, 1993 The Regents of the University of California.
- This code is derived from software contributed to Berkeley by Chris Torek.
+ This code is derived from software contributed to Berkeley by
+ Chris Torek.
 
  Redistribution and use in source and binary forms, with or without
  modification, are permitted provided that the following conditions
@@ -22,11 +21,7 @@ Historical Background section at https://opensource.org/licenses/BSD-3-Clause.
  2. Redistributions in binary form must reproduce the above copyright
     notice, this list of conditions and the following disclaimer in the
     documentation and/or other materials provided with the distribution.
- 3. All advertising materials mentioning features or use of this software
-    must display the following acknowledgement:
-      This product includes software developed by the University of
-      California, Berkeley and its contributors.
- 4. Neither the name of the University nor the names of its contributors
+ 3. Neither the name of the University nor the names of its contributors
     may be used to endorse or promote products derived from this software
     without specific prior written permission.
 

--- a/win-odbc64/odbcclient/drvr35/cdesc.cpp
+++ b/win-odbc64/odbcclient/drvr35/cdesc.cpp
@@ -373,16 +373,13 @@ unsigned long CDescRec::setDescRec(short DescMode, SQLItemDesc_def *SQLItemDesc)
 		break;
 	case SQL_DATE:
 	case SQL_TYPE_DATE:
-		if (ODBCAppVersion >= SQL_OV_ODBC3)
-		{
-			if(m_DescConciseType == SQL_DATE)
-				m_DescConciseType = SQL_TYPE_DATE;
-		}
-		else
-		{
-			if(m_DescConciseType == SQL_TYPE_DATE)
-				m_DescConciseType = SQL_DATE;
-		}
+#if (ODBCVER >= 0x0300)
+		if (m_DescConciseType == SQL_DATE)
+			m_DescConciseType = SQL_TYPE_DATE;
+#else
+		if(m_DescConciseType == SQL_TYPE_DATE)
+			m_DescConciseType = SQL_DATE;
+#endif
 		strcpy((char*)m_DescLiteralPrefix,"{d'");
 		strcpy((char*)m_DescLiteralSuffix,"'}");
 		m_DescLength = 10;
@@ -390,16 +387,13 @@ unsigned long CDescRec::setDescRec(short DescMode, SQLItemDesc_def *SQLItemDesc)
 		break;
 	case SQL_TIME:
 	case SQL_TYPE_TIME:
-		if (ODBCAppVersion >= SQL_OV_ODBC3)
-		{
-			if(m_DescConciseType == SQL_TIME)
-				m_DescConciseType = SQL_TYPE_TIME;
-		}
-		else
-		{
-			if(m_DescConciseType == SQL_TYPE_TIME)
-				m_DescConciseType = SQL_TIME;
-		}
+#if (ODBCVER >= 0x0300)
+		if (m_DescConciseType == SQL_TIME)
+			m_DescConciseType = SQL_TYPE_TIME;
+#else
+		if(m_DescConciseType == SQL_TYPE_TIME)
+			m_DescConciseType = SQL_TIME;
+#endif
 		strcpy((char*)m_DescLiteralPrefix,"{t'");
 		strcpy((char*)m_DescLiteralSuffix,"'}");
 		m_DescLength = 8;
@@ -411,16 +405,13 @@ unsigned long CDescRec::setDescRec(short DescMode, SQLItemDesc_def *SQLItemDesc)
 		break;
 	case SQL_TYPE_TIMESTAMP:
 	case SQL_TIMESTAMP:
-		if (ODBCAppVersion >= SQL_OV_ODBC3)
-		{
-			if(m_DescConciseType == SQL_TIMESTAMP)
-				m_DescConciseType = SQL_TYPE_TIMESTAMP;
-		}
-		else
-		{
-			if(m_DescConciseType == SQL_TYPE_TIMESTAMP)
-				m_DescConciseType = SQL_TIMESTAMP;
-		}
+#if (ODBCVER >= 0x0300)
+		if (m_DescConciseType == SQL_TIMESTAMP)
+			m_DescConciseType = SQL_TYPE_TIMESTAMP;
+#else
+		if(m_DescConciseType == SQL_TYPE_TIMESTAMP)
+			m_DescConciseType = SQL_TIMESTAMP;
+#endif
 		strcpy((char*)m_DescLiteralPrefix,"{ts'");
 		strcpy((char*)m_DescLiteralSuffix,"'}");
 		m_DescPrecision = SQLItemDesc->precision; // Should come for Server - Must be changed

--- a/win-odbc64/odbcclient/drvr35/cstmt.cpp
+++ b/win-odbc64/odbcclient/drvr35/cstmt.cpp
@@ -2157,67 +2157,64 @@ SQLRETURN CStmt::SendGetSQLCatalogs(short odbcAPI,
         m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.fkschemaNm = m_FKSchemaName;
         m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.fktableNm = m_FKTableName;
 
-        if (getODBCAppVersion() == SQL_OV_ODBC2)
-        {
-            switch (SqlType)
-            {
-                case SQL_TYPE_DATE:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = SQL_DATE;
-                    break;
-                case SQL_TYPE_TIME:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = SQL_TIME;
-                    break;
-                case SQL_TYPE_TIMESTAMP:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = SQL_TIMESTAMP;
-                    break;
-                case SQL_INTERVAL_YEAR:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -80;
-                    break;
-                case SQL_INTERVAL_MONTH:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -81;
-                    break;
-                case SQL_INTERVAL_YEAR_TO_MONTH:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -82;
-                    break;
-                case SQL_INTERVAL_DAY:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -83;
-                    break;
-                case SQL_INTERVAL_HOUR:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -84;
-                    break;
-                case SQL_INTERVAL_MINUTE:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -85;
-                    break;
-                case SQL_INTERVAL_SECOND:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -86;
-                    break;
-                case SQL_INTERVAL_DAY_TO_HOUR:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -87;
-                    break;
-                case SQL_INTERVAL_DAY_TO_MINUTE:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -88;
-                    break;
-                case SQL_INTERVAL_DAY_TO_SECOND:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -89;
-                    break;
-                case SQL_INTERVAL_HOUR_TO_MINUTE:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -90;
-                    break;
-                case SQL_INTERVAL_HOUR_TO_SECOND:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -91;
-                    break;
-                case SQL_INTERVAL_MINUTE_TO_SECOND:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -92;
-                    break;
-                default:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = SqlType;
-                    break;
-            }
-        }
-        else
-        {
-            m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = SqlType;
-        }
+#if (ODBCVER < 0x0300)
+		switch (SqlType)
+		{
+		case SQL_TYPE_DATE:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = SQL_DATE;
+			break;
+		case SQL_TYPE_TIME:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = SQL_TIME;
+			break;
+		case SQL_TYPE_TIMESTAMP:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = SQL_TIMESTAMP;
+			break;
+		case SQL_INTERVAL_YEAR:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -80;
+			break;
+		case SQL_INTERVAL_MONTH:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -81;
+			break;
+		case SQL_INTERVAL_YEAR_TO_MONTH:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -82;
+			break;
+		case SQL_INTERVAL_DAY:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -83;
+			break;
+		case SQL_INTERVAL_HOUR:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -84;
+			break;
+		case SQL_INTERVAL_MINUTE:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -85;
+			break;
+		case SQL_INTERVAL_SECOND:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -86;
+			break;
+		case SQL_INTERVAL_DAY_TO_HOUR:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -87;
+			break;
+		case SQL_INTERVAL_DAY_TO_MINUTE:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -88;
+			break;
+		case SQL_INTERVAL_DAY_TO_SECOND:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -89;
+			break;
+		case SQL_INTERVAL_HOUR_TO_MINUTE:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -90;
+			break;
+		case SQL_INTERVAL_HOUR_TO_SECOND:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -91;
+			break;
+		case SQL_INTERVAL_MINUTE_TO_SECOND:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -92;
+			break;
+		default:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = SqlType;
+			break;
+		}
+#else
+		m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = SqlType;
+#endif
         m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.metadataId = m_MetadataId;
         m_SrvrCallContext.u.getSQLCatalogsParams.stmtLabel = m_StmtLabel;
         m_SrvrCallContext.odbcAPI = odbcAPI;


### PR DESCRIPTION
1. Changed the returned type code of DATE, TIME, TIMESTAMP all to ODBC 3.0 compliance for SQLGetTypeInfo.
2. Changed a few places of using SQL_OV_ODBC3 for ODBC standard version compatibility to use pre-compilation definition ODBCVER for conditioning, which it should be.