### PR TITLE
[TRAFODION-2100]SQLGetTypeInfo Catalog API should return identifiers conforming to ODBC 3.0

### DIFF
--- a/core/conn/jdbcT4/src/main/java/org/trafodion/jdbc/t4/T4DatabaseMetaData.java
+++ b/core/conn/jdbcT4/src/main/java/org/trafodion/jdbc/t4/T4DatabaseMetaData.java
@@ -4613,7 +4613,7 @@ public class T4DatabaseMetaData extends TrafT4Handle implements java.sql.Databas
 		connection_.isConnectionOpen();
 
 		getSQLCatalogsInfo(connection_.getServerHandle(), // Server Handle
-				SQL_API_SQLGETTYPEINFO_JDBC, // catalogAPI
+				SQL_API_SQLGETTYPEINFO, // catalogAPI
 				"", // catalog
 				"", // schema
 				"", // table name

--- a/core/conn/odbc/src/odbc/nsksrvrcore/srvrothers.cpp
+++ b/core/conn/odbc/src/odbc/nsksrvrcore/srvrothers.cpp
@@ -4506,24 +4506,21 @@ odbc_SQLSvc_GetSQLCatalogs_sme_(
                        }
                        break;
                 case SQL_API_SQLGETTYPEINFO :
-                case SQL_API_SQLGETTYPEINFO_JDBC :
                      {
-                         SQLSMALLINT SqlTypeCode_Date;
-                         SQLSMALLINT SqlTypeCode_Time;
-                         SQLSMALLINT SqlTypeCode_TimeStamp;
                          char condExpression[20] = {0};
                         
-                         if(APIType == SQL_API_SQLGETTYPEINFO_JDBC)
-                         {
-                             SqlTypeCode_Date = 91;
-                             SqlTypeCode_Time = 92;
-                             SqlTypeCode_TimeStamp = 93;
-                         }
-                         else
-                         {
-                             SqlTypeCode_Date = SQL_DATE;
-                             SqlTypeCode_Time = SQL_TIME;
-                             SqlTypeCode_TimeStamp = SQL_TIMESTAMP;
+                         switch(sqlType) {
+                             case SQL_DATE:
+                                 sqlType == SQL_TYPE_DATE;
+                                 break;
+                             case SQL_TIME:
+                                 sqlType == SQL_TYPE_TIME;
+                                 break;
+                             case SQL_TIMESTAMP:
+                                 sqlType == SQL_TYPE_TIMESTAMP;
+                                 break;
+                             default:
+                                 break;
                          }
 
                          if(sqlType == SQL_ALL_TYPES)
@@ -4559,7 +4556,7 @@ odbc_SQLSvc_GetSQLCatalogs_sme_(
                                  "cast(0 as smallint), cast(0 as smallint), cast(3 as smallint), cast(0 as smallint)),"
                                  "('BIGINT SIGNED', -5, 19, NULL, NULL, NULL, 1, 0, 2, 0, 0, 0, 'LARGEINT', NULL, NULL, 'SIGNED LARGEINT', 10, 19, 20, -402, NULL, NULL, 0, 0, 3, 0),"
                                  "('CHAR', 1, 32000, '''', '''', 'max length', 1, 1, 3, NULL, 0, NULL, 'CHARACTER', NULL, NULL, 'CHARACTER', NULL, -1, -1, 1, NULL, NULL, 0, 0, 3, 0),"
-                                 "('DATE', %d, 10, '{d ''', '''}', NULL, 1, 0, 2, NULL, 0, NULL, 'DATE', NULL, NULL, 'DATE', NULL, 10, 6, 9, 1, NULL, 1, 3, 3, 0),"
+                                 "('DATE', 91, 10, '{d ''', '''}', NULL, 1, 0, 2, NULL, 0, NULL, 'DATE', NULL, NULL, 'DATE', NULL, 10, 6, 9, 1, NULL, 1, 3, 3, 0),"
                                  "('DECIMAL', 3, 18, NULL, NULL, 'precision,scale', 1, 0, 2, 0, 0, 0, 'DECIMAL', 0, 18, 'DECIMAL', 10, -2, -3, 3, NULL, NULL, 0, 0, 3, 0),"
                                  "('DECIMAL SIGNED', 3, 18, NULL, NULL, 'precision,scale', 1, 0, 2, 0, 0, 0, 'DECIMAL', 0, 18, 'SIGNED DECIMAL', 10, -2, -3, 3, NULL, NULL, 0, 0, 3, 0),"
                                  "('DECIMAL UNSIGNED', 3, 18, NULL, NULL, 'precision,scale', 1, 0, 2, 1, 0, 0, 'DECIMAL', 0, 18, 'UNSIGNED DECIMAL', 10, -2, -3, -301, NULL, NULL, 0, 0, 3, 0),"
@@ -4589,16 +4586,16 @@ odbc_SQLSvc_GetSQLCatalogs_sme_(
                                  "('SMALLINT', 5, 5, NULL, NULL, NULL, 1, 0, 2, 0, 0, 0, 'SMALLINT', NULL, NULL, 'SMALLINT', 10, 5, -1, 5, NULL, NULL, 0, 0, 3, 0),"
                                  "('SMALLINT SIGNED', 5, 5, NULL, NULL, NULL, 1, 0, 2, 0, 0, 0, 'SMALLINT', NULL, NULL, 'SIGNED SMALLINT', 10, 5, -1, 5, NULL, NULL, 0, 0, 3, 0),"
                                  "('SMALLINT UNSIGNED', 5, 5, NULL, NULL, NULL, 1, 0, 2, 1, 0, 0, 'SMALLINT', NULL, NULL, 'UNSIGNED SMALLINT', 10, 5, -1, -502, NULL, NULL, 0, 0, 3, 0),"
-                                 "('TIME', %d, 8, '{t ''', '''}', NULL, 1, 0, 2, NULL, 0, NULL, 'TIME', NULL, NULL, 'TIME', NULL, 8, 6, 9, 2, NULL, 4, 6, 3, 0),"
-                                 "('TIMESTAMP', %d, 26, '{ts ''', '''}', NULL, 1, 0, 2, NULL, 0, NULL, 'TIMESTAMP', 0, 6, 'TIMESTAMP', NULL, 19, 16, 9, 3, NULL, 1, 6, 3, 0),"
+                                 "('TIME', 92, 8, '{t ''', '''}', NULL, 1, 0, 2, NULL, 0, NULL, 'TIME', NULL, NULL, 'TIME', NULL, 8, 6, 9, 2, NULL, 4, 6, 3, 0),"
+                                 "('TIMESTAMP', 93, 26, '{ts ''', '''}', NULL, 1, 0, 2, NULL, 0, NULL, 'TIMESTAMP', 0, 6, 'TIMESTAMP', NULL, 19, 16, 9, 3, NULL, 1, 6, 3, 0),"
                                  "('VARCHAR', 12, 32000, '''', '''', 'max length', 1, 1, 3, NULL, 0, NULL, 'VARCHAR', NULL, NULL, 'VARCHAR', NULL, -1, -1, 12, NULL, NULL, 0, 0, 3, 0)"
                                  " ) "
                                  " dt(\"TYPE_NAME\", \"DATA_TYPE\", \"PREC\", \"LITERAL_PREFIX\", \"LITERAL_SUFFIX\", \"CREATE_PARAMS\", \"IS_NULLABLE\", \"CASE_SENSITIVE\", \"SEARCHABLE\","
                                  "\"UNSIGNED_ATTRIBUTE\", \"FIXED_PREC_SCALE\", \"AUTO_UNIQUE_VALUE\", \"LOCAL_TYPE_NAME\", \"MINIMUM_SCALE\", \"MAXIMUM_SCALE\", \"SQL_TYPE_NAME\","
                                  "\"NUM_PREC_RADIX\", \"USEPRECISION\", \"USELENGTH\", \"SQL_DATA_TYPE\", \"SQL_DATETIME_SUB\", \"INTERVAL_PRECISION\", \"DATETIMESTARTFIELD\","
-                               "\"DATETIMEENDFIELD\", \"APPLICATION_VERSION\", \"TRANSLATION_ID\")"
-                               " WHERE %s" 
-                               " ORDER BY 2,1 FOR READ UNCOMMITTED ACCESS ;", SqlTypeCode_Date, SqlTypeCode_Time, SqlTypeCode_TimeStamp, condExpression);
+                                 "\"DATETIMEENDFIELD\", \"APPLICATION_VERSION\", \"TRANSLATION_ID\")"
+                                 " WHERE %s" 
+                                 " ORDER BY 2,1 FOR READ UNCOMMITTED ACCESS ;", condExpression);
                            break;
                      }
 

--- a/core/conn/unixodbc/odbc/odbcclient/unixcli/DrvrManager/drvrmanager.cpp
+++ b/core/conn/unixodbc/odbc/odbcclient/unixcli/DrvrManager/drvrmanager.cpp
@@ -3132,42 +3132,42 @@ SQLRETURN  SQL_API SQLGetTypeInfo_common(SQLHSTMT StatementHandle,
 		RETURNCODE (pstmt, SQL_ERROR);
 		LEAVE_STMT (pstmt, SQL_ERROR);
 	}
-	SQLINTEGER ODBCAppVersion = pstmt->getODBCAppVersion();
-	SQLSMALLINT convDataType = DataType;
-	if (ODBCAppVersion >= SQL_OV_ODBC3)
-	{
-		switch(DataType)
-		{
-		case SQL_DATE:
-			convDataType = SQL_TYPE_DATE;
-			break;
-		case SQL_TIME:
-			convDataType = SQL_TYPE_TIME;
-			break;
-		case SQL_TIMESTAMP:
-			convDataType = SQL_TYPE_TIMESTAMP;
-			break;
-		}
-	}
-	else
-	{
-		switch(DataType)
-		{
-		case SQL_TYPE_DATE:
-			convDataType = SQL_DATE;
-			break;
-		case SQL_TYPE_TIME:
-			convDataType = SQL_TIME;
-			break;
-		case SQL_TYPE_TIMESTAMP:
-			convDataType = SQL_TIMESTAMP;
-			break;
-		}
-	}
-	rc = NeoGetTypeInfo(StatementHandle,convDataType,isWideCall);
-	rc = fun_cata_state_tr (pstmt, en_GetTypeInfo, rc);
-	RETURNCODE (pstmt, rc);
-	LEAVE_STMT (pstmt, rc);
+    SQLINTEGER ODBCAppVersion = pstmt->getODBCAppVersion();
+    SQLSMALLINT convDataType = DataType;
+    if (ODBCAppVersion >= SQL_OV_ODBC3)
+    {
+        switch(DataType)
+        {
+            case SQL_DATE:
+                convDataType = SQL_TYPE_DATE;
+                break;
+            case SQL_TIME:
+                convDataType = SQL_TYPE_TIME;
+                break;
+            case SQL_TIMESTAMP:
+                convDataType = SQL_TYPE_TIMESTAMP;
+                break;
+        }
+    }
+    else
+    {
+        switch(DataType)
+        {
+            case SQL_TYPE_DATE:
+                convDataType = SQL_DATE;
+                break;
+            case SQL_TYPE_TIME:
+                convDataType = SQL_TIME;
+                break;
+            case SQL_TYPE_TIMESTAMP:
+                convDataType = SQL_TIMESTAMP;
+                break;
+        }
+    }
+    rc = NeoGetTypeInfo(StatementHandle,convDataType,isWideCall);
+    rc = fun_cata_state_tr (pstmt, en_GetTypeInfo, rc);
+    RETURNCODE (pstmt, rc);
+    LEAVE_STMT (pstmt, rc);
 }
 
 SQLRETURN  SQL_API SQLGetTypeInfo(SQLHSTMT StatementHandle,
@@ -3836,37 +3836,33 @@ SQLRETURN SQL_API SQLColAttribute_common(SQLHSTMT StatementHandle,
 	rc = NeoColAttribute(StatementHandle,ColumnNumber,FieldIdentifier,CharacterAttributePtr,BufferLength,StringLengthPtr,NumericAttributePtr,isWideCall);
 	if (rc == SQL_SUCCESS && FieldIdentifier == SQL_DESC_CONCISE_TYPE)
 	{
-		SQLINTEGER ODBCAppVersion = pstmt->getODBCAppVersion();
-		if (ODBCAppVersion >= SQL_OV_ODBC3)
-		{
-			switch((SQLINTEGER)*(SQLINTEGER*)NumericAttributePtr)
-			{
-			case SQL_DATE:
-				*(SQLINTEGER*)NumericAttributePtr = SQL_TYPE_DATE;
-				break;
-			case SQL_TIME:
-				*(SQLINTEGER*)NumericAttributePtr = SQL_TYPE_TIME;
-				break;
-			case SQL_TIMESTAMP:
-				*(SQLINTEGER*)NumericAttributePtr = SQL_TYPE_TIMESTAMP;
-				break;
-			}
-		}
-		else
-		{
-			switch((SQLINTEGER)*(SQLINTEGER*)NumericAttributePtr)
-			{
-			case SQL_TYPE_DATE:
-				*(SQLINTEGER*)NumericAttributePtr = SQL_DATE;
-				break;
-			case SQL_TYPE_TIME:
-				*(SQLINTEGER*)NumericAttributePtr = SQL_TIME;
-				break;
-			case SQL_TYPE_TIMESTAMP:
-				*(SQLINTEGER*)NumericAttributePtr = SQL_TIMESTAMP;
-				break;
-			}
-		}
+#if (ODBCVER >= 0x0300)
+        switch((SQLINTEGER)*(SQLINTEGER*)NumericAttributePtr)
+        {
+            case SQL_DATE:
+                *(SQLINTEGER*)NumericAttributePtr = SQL_TYPE_DATE;
+                break;
+            case SQL_TIME:
+                *(SQLINTEGER*)NumericAttributePtr = SQL_TYPE_TIME;
+                break;
+            case SQL_TIMESTAMP:
+                *(SQLINTEGER*)NumericAttributePtr = SQL_TYPE_TIMESTAMP;
+                break;
+        }
+#else
+        switch((SQLINTEGER)*(SQLINTEGER*)NumericAttributePtr)
+        {
+            case SQL_TYPE_DATE:
+                *(SQLINTEGER*)NumericAttributePtr = SQL_DATE;
+                break;
+            case SQL_TYPE_TIME:
+                *(SQLINTEGER*)NumericAttributePtr = SQL_TIME;
+                break;
+            case SQL_TYPE_TIMESTAMP:
+                *(SQLINTEGER*)NumericAttributePtr = SQL_TIMESTAMP;
+                break;
+        }
+#endif
 	}
 	/* state transition */
 	if (pstmt->asyn_on == en_ColAttribute)

--- a/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/cdesc.cpp
+++ b/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/cdesc.cpp
@@ -409,16 +409,13 @@ unsigned long CDescRec::setDescRec(short DescMode, SQLItemDesc_def *SQLItemDesc)
 		break;
 	case SQL_DATE:
 	case SQL_TYPE_DATE:
-		if (ODBCAppVersion >= SQL_OV_ODBC3)
-		{
+#if (ODBCVER >= 0x0300)
 			if(m_DescConciseType == SQL_DATE)
 				m_DescConciseType = SQL_TYPE_DATE;
-		}
-		else
-		{
+#else
 			if(m_DescConciseType == SQL_TYPE_DATE)
 				m_DescConciseType = SQL_DATE;
-		}
+#endif
 		strcpy((char*)m_DescLiteralPrefix,"{d'");
 		strcpy((char*)m_DescLiteralSuffix,"'}");
 		m_DescLength = 10;
@@ -426,16 +423,13 @@ unsigned long CDescRec::setDescRec(short DescMode, SQLItemDesc_def *SQLItemDesc)
 		break;
 	case SQL_TIME:
 	case SQL_TYPE_TIME:
-		if (ODBCAppVersion >= SQL_OV_ODBC3)
-		{
+#if (ODBCVER >= 0x0300)
 			if(m_DescConciseType == SQL_TIME)
 				m_DescConciseType = SQL_TYPE_TIME;
-		}
-		else
-		{
+#else
 			if(m_DescConciseType == SQL_TYPE_TIME)
 				m_DescConciseType = SQL_TIME;
-		}
+#endif
 		strcpy((char*)m_DescLiteralPrefix,"{t'");
 		strcpy((char*)m_DescLiteralSuffix,"'}");
 		m_DescLength = 8;
@@ -447,16 +441,13 @@ unsigned long CDescRec::setDescRec(short DescMode, SQLItemDesc_def *SQLItemDesc)
 		break;
 	case SQL_TYPE_TIMESTAMP:
 	case SQL_TIMESTAMP:
-		if (ODBCAppVersion >= SQL_OV_ODBC3)
-		{
+#if (ODBCVER >= 0x0300)
 			if(m_DescConciseType == SQL_TIMESTAMP)
 				m_DescConciseType = SQL_TYPE_TIMESTAMP;
-		}
-		else
-		{
+#else
 			if(m_DescConciseType == SQL_TYPE_TIMESTAMP)
 				m_DescConciseType = SQL_TIMESTAMP;
-		}
+#endif
 		strcpy((char*)m_DescLiteralPrefix,"{ts'");
 		strcpy((char*)m_DescLiteralSuffix,"'}");
 		m_DescPrecision = SQLItemDesc->precision; // Should come for Server - Must be changed

--- a/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/cstmt.cpp
+++ b/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/cstmt.cpp
@@ -2226,8 +2226,7 @@ SQLRETURN CStmt::SendGetSQLCatalogs(short odbcAPI,
 		m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.fkschemaNm = m_FKSchemaName;
 		m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.fktableNm = m_FKTableName;
 
-		if (getODBCAppVersion() == SQL_OV_ODBC2)
-		{
+#if (ODBCVER < 0x0300)
 			switch (SqlType)
 			{
 				case SQL_TYPE_DATE:
@@ -2282,11 +2281,9 @@ SQLRETURN CStmt::SendGetSQLCatalogs(short odbcAPI,
 					m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = SqlType;
 					break;
 			}
-		}
-		else
-		{
+#else
 			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = SqlType;
-		}
+#endif
 		m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.metadataId = m_MetadataId;
 		m_SrvrCallContext.u.getSQLCatalogsParams.stmtLabel = m_StmtLabel;
 		m_SrvrCallContext.odbcAPI = odbcAPI;

--- a/win-odbc64/odbcclient/drvr35/cdesc.cpp
+++ b/win-odbc64/odbcclient/drvr35/cdesc.cpp
@@ -373,16 +373,13 @@ unsigned long CDescRec::setDescRec(short DescMode, SQLItemDesc_def *SQLItemDesc)
 		break;
 	case SQL_DATE:
 	case SQL_TYPE_DATE:
-		if (ODBCAppVersion >= SQL_OV_ODBC3)
-		{
-			if(m_DescConciseType == SQL_DATE)
-				m_DescConciseType = SQL_TYPE_DATE;
-		}
-		else
-		{
-			if(m_DescConciseType == SQL_TYPE_DATE)
-				m_DescConciseType = SQL_DATE;
-		}
+#if (ODBCVER >= 0x0300)
+		if (m_DescConciseType == SQL_DATE)
+			m_DescConciseType = SQL_TYPE_DATE;
+#else
+		if(m_DescConciseType == SQL_TYPE_DATE)
+			m_DescConciseType = SQL_DATE;
+#endif
 		strcpy((char*)m_DescLiteralPrefix,"{d'");
 		strcpy((char*)m_DescLiteralSuffix,"'}");
 		m_DescLength = 10;
@@ -390,16 +387,13 @@ unsigned long CDescRec::setDescRec(short DescMode, SQLItemDesc_def *SQLItemDesc)
 		break;
 	case SQL_TIME:
 	case SQL_TYPE_TIME:
-		if (ODBCAppVersion >= SQL_OV_ODBC3)
-		{
-			if(m_DescConciseType == SQL_TIME)
-				m_DescConciseType = SQL_TYPE_TIME;
-		}
-		else
-		{
-			if(m_DescConciseType == SQL_TYPE_TIME)
-				m_DescConciseType = SQL_TIME;
-		}
+#if (ODBCVER >= 0x0300)
+		if (m_DescConciseType == SQL_TIME)
+			m_DescConciseType = SQL_TYPE_TIME;
+#else
+		if(m_DescConciseType == SQL_TYPE_TIME)
+			m_DescConciseType = SQL_TIME;
+#endif
 		strcpy((char*)m_DescLiteralPrefix,"{t'");
 		strcpy((char*)m_DescLiteralSuffix,"'}");
 		m_DescLength = 8;
@@ -411,16 +405,13 @@ unsigned long CDescRec::setDescRec(short DescMode, SQLItemDesc_def *SQLItemDesc)
 		break;
 	case SQL_TYPE_TIMESTAMP:
 	case SQL_TIMESTAMP:
-		if (ODBCAppVersion >= SQL_OV_ODBC3)
-		{
-			if(m_DescConciseType == SQL_TIMESTAMP)
-				m_DescConciseType = SQL_TYPE_TIMESTAMP;
-		}
-		else
-		{
-			if(m_DescConciseType == SQL_TYPE_TIMESTAMP)
-				m_DescConciseType = SQL_TIMESTAMP;
-		}
+#if (ODBCVER >= 0x0300)
+		if (m_DescConciseType == SQL_TIMESTAMP)
+			m_DescConciseType = SQL_TYPE_TIMESTAMP;
+#else
+		if(m_DescConciseType == SQL_TYPE_TIMESTAMP)
+			m_DescConciseType = SQL_TIMESTAMP;
+#endif
 		strcpy((char*)m_DescLiteralPrefix,"{ts'");
 		strcpy((char*)m_DescLiteralSuffix,"'}");
 		m_DescPrecision = SQLItemDesc->precision; // Should come for Server - Must be changed

--- a/win-odbc64/odbcclient/drvr35/cstmt.cpp
+++ b/win-odbc64/odbcclient/drvr35/cstmt.cpp
@@ -2157,67 +2157,64 @@ SQLRETURN CStmt::SendGetSQLCatalogs(short odbcAPI,
         m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.fkschemaNm = m_FKSchemaName;
         m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.fktableNm = m_FKTableName;
 
-        if (getODBCAppVersion() == SQL_OV_ODBC2)
-        {
-            switch (SqlType)
-            {
-                case SQL_TYPE_DATE:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = SQL_DATE;
-                    break;
-                case SQL_TYPE_TIME:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = SQL_TIME;
-                    break;
-                case SQL_TYPE_TIMESTAMP:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = SQL_TIMESTAMP;
-                    break;
-                case SQL_INTERVAL_YEAR:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -80;
-                    break;
-                case SQL_INTERVAL_MONTH:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -81;
-                    break;
-                case SQL_INTERVAL_YEAR_TO_MONTH:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -82;
-                    break;
-                case SQL_INTERVAL_DAY:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -83;
-                    break;
-                case SQL_INTERVAL_HOUR:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -84;
-                    break;
-                case SQL_INTERVAL_MINUTE:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -85;
-                    break;
-                case SQL_INTERVAL_SECOND:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -86;
-                    break;
-                case SQL_INTERVAL_DAY_TO_HOUR:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -87;
-                    break;
-                case SQL_INTERVAL_DAY_TO_MINUTE:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -88;
-                    break;
-                case SQL_INTERVAL_DAY_TO_SECOND:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -89;
-                    break;
-                case SQL_INTERVAL_HOUR_TO_MINUTE:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -90;
-                    break;
-                case SQL_INTERVAL_HOUR_TO_SECOND:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -91;
-                    break;
-                case SQL_INTERVAL_MINUTE_TO_SECOND:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -92;
-                    break;
-                default:
-                    m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = SqlType;
-                    break;
-            }
-        }
-        else
-        {
-            m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = SqlType;
-        }
+#if (ODBCVER < 0x0300)
+		switch (SqlType)
+		{
+		case SQL_TYPE_DATE:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = SQL_DATE;
+			break;
+		case SQL_TYPE_TIME:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = SQL_TIME;
+			break;
+		case SQL_TYPE_TIMESTAMP:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = SQL_TIMESTAMP;
+			break;
+		case SQL_INTERVAL_YEAR:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -80;
+			break;
+		case SQL_INTERVAL_MONTH:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -81;
+			break;
+		case SQL_INTERVAL_YEAR_TO_MONTH:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -82;
+			break;
+		case SQL_INTERVAL_DAY:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -83;
+			break;
+		case SQL_INTERVAL_HOUR:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -84;
+			break;
+		case SQL_INTERVAL_MINUTE:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -85;
+			break;
+		case SQL_INTERVAL_SECOND:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -86;
+			break;
+		case SQL_INTERVAL_DAY_TO_HOUR:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -87;
+			break;
+		case SQL_INTERVAL_DAY_TO_MINUTE:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -88;
+			break;
+		case SQL_INTERVAL_DAY_TO_SECOND:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -89;
+			break;
+		case SQL_INTERVAL_HOUR_TO_MINUTE:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -90;
+			break;
+		case SQL_INTERVAL_HOUR_TO_SECOND:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -91;
+			break;
+		case SQL_INTERVAL_MINUTE_TO_SECOND:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = -92;
+			break;
+		default:
+			m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = SqlType;
+			break;
+		}
+#else
+		m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.sqlType = SqlType;
+#endif
         m_SrvrCallContext.u.getSQLCatalogsParams.catalogAPIParams.metadataId = m_MetadataId;
         m_SrvrCallContext.u.getSQLCatalogsParams.stmtLabel = m_StmtLabel;
         m_SrvrCallContext.odbcAPI = odbcAPI;


### PR DESCRIPTION
1.Changed the returned type code of DATE, TIME, TIMESTAMP all to ODBC 3.0 compliance for SQLGetTypeInfo.
2.Changed a few places of using SQL_OV_ODBC3 for ODBC standard version compatibility to use pre-compilation definition ODBCVER for conditioning, which it should be, both Linux and Windows.