### PR TITLE
[TRAFODION-2126] Add OS version and processor type to package names

### DIFF
--- a/core/conn/Makefile
+++ b/core/conn/Makefile
@@ -24,10 +24,15 @@
 include ../macros.gmk #top level
 
 RM      = /bin/rm
+
+OS_TYPE = RH
+OS_MAJOR ?=  $(shell lsb_release -rs | cut -f1 -d.)
+P_TYPE = $(shell uname -p)
+
 ifeq ($(SQ_BUILD_TYPE),release)
-  CLIENT_TAR	?= ../../${DISTRIBUTION_DIR}/apache-trafodion_clients-$(TRAFODION_VER)-incubating.tar.gz
+  CLIENT_TAR	?= ../../${DISTRIBUTION_DIR}/apache-trafodion_clients-$(TRAFODION_VER)-${OS_TYPE}${OS_MAJOR}-${P_TYPE}-incubating.tar.gz
 else
-  CLIENT_TAR	?= ../../${DISTRIBUTION_DIR}/apache-trafodion_clients-$(TRAFODION_VER)-debug.tar.gz
+  CLIENT_TAR	?= ../../${DISTRIBUTION_DIR}/apache-trafodion_clients-$(TRAFODION_VER)-${OS_TYPE}${OS_MAJOR}-${P_TYPE}-debug.tar.gz
 endif
 
 

--- a/core/sqf/Makefile
+++ b/core/sqf/Makefile
@@ -263,11 +263,14 @@ genverhdr: buildinfo
 PKG_PROD = apache-trafodion
 PKG_PHX = phoenix
 PKG_DCS = dcs
+OS_TYPE = RH
+OS_MAJOR ?=  $(shell lsb_release -rs | cut -f1 -d.)
+P_TYPE = $(shell uname -p)
 
 ifeq ($(SQ_BUILD_TYPE),release)
-  PKG_TYPE="server-$(TRAFODION_VER)-incubating"
+  PKG_TYPE="server-$(TRAFODION_VER)-${OS_TYPE}${OS_MAJOR}-${P_TYPE}-incubating"
 else
-  PKG_TYPE="server-$(TRAFODION_VER)-debug"
+  PKG_TYPE="server-$(TRAFODION_VER)-${OS_TYPE}${OS_MAJOR}-${P_TYPE}-debug"
 endif
 
 PKG_BIN ?= "${PKG_PROD}.bin"

--- a/core/sqf/sqenvcom.sh
+++ b/core/sqf/sqenvcom.sh
@@ -110,6 +110,8 @@ fi
 REQ_JDK_VER="1.7.0_67"
 if [[ -z "$JAVA_HOME" && -d "${TOOLSDIR}/jdk${REQ_JDK_VER}" ]]; then
   export JAVA_HOME="${TOOLSDIR}/jdk${REQ_JDK_VER}"
+elif [[ -z "$JAVA_HOME" && -d /usr/lib/jvm/java-1.7.0-openjdk/ ]]; then
+  export JAVA_HOME="/usr/lib/jvm/java-1.7.0-openjdk"
 elif [[ -z "$JAVA_HOME" && -d /usr/lib/jvm/java-1.7.0-openjdk.x86_64/ ]]; then
   export JAVA_HOME="/usr/lib/jvm/java-1.7.0-openjdk.x86_64"
 elif [[ -z "$JAVA_HOME" ]]; then


### PR DESCRIPTION
Add RH6-x86_64 to the server and client package names. This gives us
differentiation when we start building on RedHat 7 (TRAFODION-1861).

I also fixed the setting of JAVA_HOME in CentOS 7 environment, which
does not include x86_64 in the path name.

The build does not yet work on CentOS/RedHat 7, due to compiler
differences (TRAFODION-1868).