### PR TITLE
[TRAFODION-2128] update installer gitignore file

### DIFF
--- a/install/.gitignore
+++ b/install/.gitignore
@@ -1,3 +1,4 @@
 installer-*.tar.gz
 LICENSE
 NOTICE
+DISCLAIMER


### PR DESCRIPTION
Jenkins automation is supposed to catch when we miss one, but the
check was not catching everything.  It will be updated when this fix is in.