### PR TITLE
[TRAFODION-2119] DDL warning/error if using store by on utf8 column

### DIFF
--- a/core/sql/common/CharType.cpp
+++ b/core/sql/common/CharType.cpp
@@ -1153,7 +1153,9 @@ void CharType::minMaxRepresentableValue(void* bufPtr,
 {
   Int32 i;
   Int32 vcLenHdrSize = getVarLenHdrSize();
-  char *valPtr       = reinterpret_cast<char *>(bufPtr) + vcLenHdrSize;
+  //valPtr point to the starting position of the data buffer
+  //header may include vcHeader and Null indicator byte
+  char *valPtr       = reinterpret_cast<char *>(bufPtr) + vcLenHdrSize + getSQLnullHdrSize();
   Int32 valBufLen    = getNominalSize();
   Int32 valLen       = valBufLen; // output length of min/max value
   char minmax_char;

--- a/core/sql/regress/qat/eqatddl01
+++ b/core/sql/regress/qat/eqatddl01
@@ -224,4 +224,21 @@
 
 --- SQL operation complete.
 >>---------------------------------------------------------------------
+>>  CQD allow_nullable_unique_key_constraint 'on' ;
+
+--- SQL operation complete.
+>>  DROP TABLE IF EXISTS t1s ;
+
+--- SQL operation complete.
+>>  CREATE TABLE t1s (
++>         c1 char(12) character set utf8  ,
++>         c2 char(8) character set utf8
++>        )
++>        STORE BY (c1)
++>        SALT USING 4 PARTITIONS ON (c1)
++>     ;
+
+--- SQL operation complete.
+>>---------------------------------------------------------------------
+>>
 >>LOG;

--- a/core/sql/regress/qat/qatddl01
+++ b/core/sql/regress/qat/qatddl01
@@ -191,4 +191,15 @@ LOG aqatddl01 Clear;
         )
      ;
 ---------------------------------------------------------------------
+  CQD allow_nullable_unique_key_constraint 'on' ;
+  DROP TABLE IF EXISTS t1s ;
+  CREATE TABLE t1s (
+         c1 char(12) character set utf8  , 
+         c2 char(8) character set utf8  
+        )
+        STORE BY (c1)
+        SALT USING 4 PARTITIONS ON (c1)
+     ;
+---------------------------------------------------------------------
+
 LOG;


### PR DESCRIPTION
If store by is used and the column is not set 'not null', there will be an extra null indicator header. So the generated hbase split by string will contain un-initialized character and sometime raise warning or error.