### PR TITLE
[TRAFODION-2119] DDL warning/error if using store by on utf8 column

### DIFF
--- a/core/sql/optimizer/EncodedKeyValue.cpp
+++ b/core/sql/optimizer/EncodedKeyValue.cpp
@@ -66,7 +66,7 @@ NAString * getMinMaxValue(desc_struct * column,
   if (NAColumn::createNAType(&column->body.columns_desc, NULL, type, NULL))
     return NULL;
   
-  Lng32 buflen = type->getTotalSize() - type->getSQLnullHdrSize();
+  Lng32 buflen = type->getTotalSize(); 
   char * buf = new char[buflen]; // deleted at the end of this method
 
   if (type->supportsSQLnullPhysical())

--- a/core/sql/optimizer/EncodedKeyValue.cpp
+++ b/core/sql/optimizer/EncodedKeyValue.cpp
@@ -66,15 +66,22 @@ NAString * getMinMaxValue(desc_struct * column,
   if (NAColumn::createNAType(&column->body.columns_desc, NULL, type, NULL))
     return NULL;
   
-  Lng32 buflen = type->getTotalSize();
+  Lng32 buflen = type->getTotalSize() - type->getSQLnullHdrSize();
   char * buf = new char[buflen]; // deleted at the end of this method
+
+  if (type->supportsSQLnullPhysical())
+  {
+      Lng32 nullHdrSize = type->getSQLnullHdrSize();
+      buf[0] = buf[1] = '\0';
+      buflen-= nullHdrSize;
+  }
 
   NABoolean nullValue = FALSE;
   if (highKey == FALSE)
     {
       // low key needed
       if (key->body.keys_desc.ordering == 0) // ascending
-	type->minRepresentableValue(buf, &buflen, 
+	type->minRepresentableValue(buf + type->getSQLnullHdrSize(), &buflen, 
 				    &minMaxValue,
 				    h) ;
       else
@@ -86,7 +93,7 @@ NAString * getMinMaxValue(desc_struct * column,
 	    }
 	  else
 	    {
-	      type->maxRepresentableValue(buf, &buflen, 
+	      type->maxRepresentableValue(buf + type->getSQLnullHdrSize(), &buflen, 
 					  &minMaxValue,
 					  h) ;
 	    }
@@ -103,12 +110,12 @@ NAString * getMinMaxValue(desc_struct * column,
 	      nullValue = TRUE;
 	    }
 	  else
-	    type->maxRepresentableValue(buf, &buflen, 
+	    type->maxRepresentableValue(buf + type->getSQLnullHdrSize(), &buflen, 
 					&minMaxValue,
 					h) ;
 	}
       else
-	type->minRepresentableValue(buf, &buflen, 
+	type->minRepresentableValue(buf + type->getSQLnullHdrSize(), &buflen, 
 				    &minMaxValue,
 				    h) ;
     }

--- a/core/sql/optimizer/EncodedKeyValue.cpp
+++ b/core/sql/optimizer/EncodedKeyValue.cpp
@@ -72,7 +72,8 @@ NAString * getMinMaxValue(desc_struct * column,
   if (type->supportsSQLnullPhysical())
   {
       Lng32 nullHdrSize = type->getSQLnullHdrSize();
-      buf[0] = buf[1] = '\0';
+      for(int i = 0; i < nullHdrSize; i++)
+        buf[i] = '\0';
       buflen-= nullHdrSize;
   }
 

--- a/core/sql/regress/qat/eqatddl01
+++ b/core/sql/regress/qat/eqatddl01
@@ -224,4 +224,21 @@
 
 --- SQL operation complete.
 >>---------------------------------------------------------------------
+>>  CQD allow_nullable_unique_key_constraint 'on' ;
+
+--- SQL operation complete.
+>>  DROP TABLE IF EXISTS t1s ;
+
+--- SQL operation complete.
+>>  CREATE TABLE t1s (
++>         c1 char(12) character set utf8  ,
++>         c2 char(8) character set utf8
++>        )
++>        STORE BY (c1)
++>        SALT USING 4 PARTITIONS ON (c1)
++>     ;
+
+--- SQL operation complete.
+>>---------------------------------------------------------------------
+>>
 >>LOG;

--- a/core/sql/regress/qat/qatddl01
+++ b/core/sql/regress/qat/qatddl01
@@ -191,4 +191,15 @@ LOG aqatddl01 Clear;
         )
      ;
 ---------------------------------------------------------------------
+  CQD allow_nullable_unique_key_constraint 'on' ;
+  DROP TABLE IF EXISTS t1s ;
+  CREATE TABLE t1s (
+         c1 char(12) character set utf8  , 
+         c2 char(8) character set utf8  
+        )
+        STORE BY (c1)
+        SALT USING 4 PARTITIONS ON (c1)
+     ;
+---------------------------------------------------------------------
+
 LOG;


### PR DESCRIPTION
If 'store by' is used in a DDL and the column is not set 'not null', there will be an extra null indicator header. So the generated hbase split by string will contain un-initialized character and sometime raise warning or error.

The calling to type->minRepresentableValue should pass the buf address that take null indicator buffer into account, good examples are in:
-EncodedValue::minMaxValue()
-ConstValue::ConstValue()

but getMinMaxValue() is wrong. 

Although the calling conversion is not clear, this will be a fix to the issue, there are other some places to invoke minRepresentatbleValue, so keep the current semantics is good from my point of view. 