### PR TITLE
[TRAFODION-2129] Trafodion to avoid use of deprecated HBase APIs/Classes

### DIFF
--- a/core/sqf/src/tm/tmlogging.h
+++ b/core/sqf/src/tm/tmlogging.h
@@ -34,8 +34,6 @@ int tm_init_logging();
 
 int tm_log_write(int pv_event_type, posix_sqlog_severity_t pv_severity, char *err_string, char *exception_stack=NULL, long transid=-1);
 
-int tm_alt_log_write(int eventType, posix_sqlog_severity_t severity, char *msg);
-
 int tm_log_event(int event_type, 
                  posix_sqlog_severity_t severity,
                  const char *temp_string, 


### PR DESCRIPTION
The PR 629 for the above JIRA exposed the following issues.

1) A transaction remained in HUNGABORTED state when a table is created and
dropped in the same transaction. core/TEST116 exhibited one such hung aborted
transaction.

2) The retry logic was not throwing any exception when the allowed number
of retry attempts are exhausted.

3) When a UnknownTransactionException is encountered in the response to co-processor
request, the commit was getting into endless loop. privs1/TEST133 was returning error 97
on commit transaction.

All the above issues have been fixed.

[TRAFODION-1988] Better java exception handling in the java/JNI layer of TM

Cleaned up the exception logging in TM further and allowing more events to
be logged via Common Logger facility.