### PR TITLE
TRAFODION-2148 fix : create drop request error codes never reach SQL

### DIFF
--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/RMInterface.java
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/RMInterface.java
@@ -96,10 +96,10 @@ public class RMInterface {
     }
 
     private native void registerRegion(int port, byte[] hostname, long startcode, byte[] regionInfo);
-    private native void createTableReq(byte[] lv_byte_htabledesc, byte[][] keys, int numSplits, int keyLength, long transID, byte[] tblName);
-    private native void dropTableReq(byte[] lv_byte_tblname, long transID);
-    private native void truncateOnAbortReq(byte[] lv_byte_tblName, long transID); 
-    private native void alterTableReq(byte[] lv_byte_tblname, Object[] tableOptions, long transID);
+    private native int createTableReq(byte[] lv_byte_htabledesc, byte[][] keys, int numSplits, int keyLength, long transID, byte[] tblName);
+    private native int dropTableReq(byte[] lv_byte_tblname, long transID);
+    private native int truncateOnAbortReq(byte[] lv_byte_tblName, long transID); 
+    private native int alterTableReq(byte[] lv_byte_tblname, Object[] tableOptions, long transID);
 
     public static void main(String[] args) {
       System.out.println("MAIN ENTRY");
@@ -229,28 +229,49 @@ public class RMInterface {
         byte[] lv_byte_desc = desc.toByteArray();
         byte[] lv_byte_tblname = desc.getNameAsString().getBytes();
         if (LOG.isTraceEnabled()) LOG.trace("createTable: htabledesc bytearray: " + lv_byte_desc + "desc in hex: " + Hex.encodeHexString(lv_byte_desc));
-        createTableReq(lv_byte_desc, keys, numSplits, keyLength, transID, lv_byte_tblname);
+        int ret = createTableReq(lv_byte_desc, keys, numSplits, keyLength, transID, lv_byte_tblname);
+        if(ret != 0)
+        {
+        	LOG.error("createTable exception. Unable to create table " + desc.getNameAsString() + " txid " + transID);
+        	throw new IOException("createTable exception. Unable to create table " + desc.getNameAsString());
+        }
         if (LOG.isTraceEnabled()) LOG.trace("Exit createTable, txid: " + transID + " Table: " + desc.getNameAsString());
     }
 
     public void truncateTableOnAbort(String tblName, long transID) throws IOException {
-        if (LOG.isTraceEnabled()) LOG.trace("truncateTableOnAbort ENTER: ");
-            byte[] lv_byte_tblName = tblName.getBytes();
-            truncateOnAbortReq(lv_byte_tblName, transID);
+		if (LOG.isTraceEnabled()) LOG.trace("Enter truncateTableOnAbort, txid: " + transID + " Table: " + tblName);
+        byte[] lv_byte_tblName = tblName.getBytes();
+        int ret = truncateOnAbortReq(lv_byte_tblName, transID);
+        if(ret != 0)
+        {
+        	LOG.error("truncateTableOnAbort exception. Unable to truncate table" + tblName + " txid " + transID);
+        	throw new IOException("truncateTableOnAbort exception. Unable to truncate table" + tblName);
+        }
+        if (LOG.isTraceEnabled()) LOG.trace("Exit truncateTableOnAbort, txid: " + transID + " Table: " + tblName);
     }
 
     public void dropTable(String tblName, long transID) throws IOException {
-        if (LOG.isTraceEnabled()) LOG.trace("dropTable ENTER: ");
-
-            byte[] lv_byte_tblname = tblName.getBytes();
-            dropTableReq(lv_byte_tblname, transID);
+    	if (LOG.isTraceEnabled()) LOG.trace("Enter dropTable, txid: " + transID + " Table: " + tblName);
+        byte[] lv_byte_tblname = tblName.getBytes();
+        int ret = dropTableReq(lv_byte_tblname, transID);
+        if(ret != 0)
+        {
+        	LOG.error("dropTable exception. Unable to drop table" + tblName + " txid " + transID);
+        	throw new IOException("dropTable exception. Unable to drop table" + tblName);
+        }
+        if (LOG.isTraceEnabled()) LOG.trace("Exit dropTable, txid: " + transID + " Table: " + tblName);
     }
 
     public void alter(String tblName, Object[] tableOptions, long transID) throws IOException {
-        if (LOG.isTraceEnabled()) LOG.trace("alter ENTER: ");
-
-            byte[] lv_byte_tblname = tblName.getBytes();
-            alterTableReq(lv_byte_tblname, tableOptions, transID);
+    	if (LOG.isTraceEnabled()) LOG.trace("Enter alterTable, txid: " + transID + " Table: " + tblName);
+        byte[] lv_byte_tblname = tblName.getBytes();
+        int ret = alterTableReq(lv_byte_tblname, tableOptions, transID);
+        if(ret != 0)
+        {
+        	LOG.error("alter Table exception. Unable to alter table" + tblName + " txid " + transID);
+        	throw new IOException("alter Table exception. Unable to alter table" + tblName);
+        }
+        if (LOG.isTraceEnabled()) LOG.trace("Exit alterTable, txid: " + transID + " Table: " + tblName);
     }   
 
     static public void clearTransactionStates(final long transactionID) {

--- a/core/sqf/src/tm/tmddlrequests.cpp
+++ b/core/sqf/src/tm/tmddlrequests.cpp
@@ -24,6 +24,7 @@
 #include "dtm/tm.h"
 #include <string.h>
 #include <iostream>
+#include "../../inc/fs/feerrors.h" 
 
 using namespace std;
 
@@ -33,7 +34,7 @@ using namespace std;
 * Signature: ([B)V
 */
 
-JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInterface_createTableReq
+JNIEXPORT jint JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInterface_createTableReq
   (JNIEnv *pp_env, jobject pv_object, jbyteArray pv_tableDescriptor, jobjectArray pv_keys, jint pv_numSplits, jint pv_keyLength, jlong pv_transid, jbyteArray pv_tblname){
 
    char la_tbldesc[TM_MAX_DDLREQUEST_STRING];
@@ -42,6 +43,7 @@ JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInter
    str_key = new char[TM_MAX_DDLREQUEST_STRING];
    char** la_keys;
    la_keys = new char *[TM_MAX_DDLREQUEST_STRING];
+   int lv_error = FEOK;
 
    int lv_tblname_len = pp_env->GetArrayLength(pv_tblname);
    if(lv_tblname_len > TM_MAX_DDLREQUEST_STRING) {
@@ -75,11 +77,12 @@ JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInter
          pp_env->DeleteLocalRef(jba_keyarray);
       }
 
-      CREATETABLE(la_tbldesc, lv_tbldesc_length, la_tblname, la_keys, lv_numSplits, lv_keyLength, lv_transid);
+      lv_error  = CREATETABLE(la_tbldesc, lv_tbldesc_length, la_tblname, la_keys, lv_numSplits, lv_keyLength, lv_transid);
 
       pp_env->ReleaseByteArrayElements(pv_tableDescriptor, lp_tbldesc, 0);
       pp_env->ReleaseByteArrayElements(pv_tblname, lp_tblname, 0);
-   }   
+   }
+   return lv_error;
 }
 
 
@@ -88,10 +91,11 @@ JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInter
  * Method:    dropTableReq
  * Signature: ([BJ)V
  */
-JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInterface_dropTableReq
+JNIEXPORT jint JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInterface_dropTableReq
   (JNIEnv *pp_env, jobject pv_object, jbyteArray pv_tblname, jlong pv_transid) {
 
    char la_tblname[TM_MAX_DDLREQUEST_STRING];
+   int lv_error = FEOK;
 
    int lv_tblname_len = pp_env->GetArrayLength(pv_tblname);
    if(lv_tblname_len > TM_MAX_DDLREQUEST_STRING) {
@@ -104,9 +108,10 @@ JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInter
 
       long lv_transid = (long) pv_transid;
 
-      DROPTABLE(la_tblname, lv_tblname_len, lv_transid);
+      lv_error = DROPTABLE(la_tblname, lv_tblname_len, lv_transid);
       pp_env->ReleaseByteArrayElements(pv_tblname, lp_tblname, 0);
    }
+   return lv_error;
 }
 
 /*
@@ -114,10 +119,11 @@ JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInter
  * Method:    truncateOnAbortReq
  * Signature: ([BJ)V
  */
-JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInterface_truncateOnAbortReq
+JNIEXPORT jint JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInterface_truncateOnAbortReq
   (JNIEnv *pp_env, jobject pv_object, jbyteArray pv_tblname, jlong pv_transid) {
 
    char la_tblname[TM_MAX_DDLREQUEST_STRING];
+   int lv_error = FEOK;
 
    int lv_tblname_len = pp_env->GetArrayLength(pv_tblname);
    if(lv_tblname_len > TM_MAX_DDLREQUEST_STRING) {
@@ -130,9 +136,10 @@ JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInter
 
       long lv_transid = (long) pv_transid;
 
-      REGTRUNCATEONABORT(la_tblname, lv_tblname_len, lv_transid);
+      lv_error = REGTRUNCATEONABORT(la_tblname, lv_tblname_len, lv_transid);
       pp_env->ReleaseByteArrayElements(pv_tblname, lp_tblname, 0);
    }
+   return lv_error;
 }
 
 /*
@@ -140,9 +147,10 @@ JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInter
  * Method:    alterTableReq
  * Signature: ([B[Ljava/lang/Object;J)V
  */
-JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInterface_alterTableReq
+JNIEXPORT jint JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInterface_alterTableReq
   (JNIEnv *pp_env, jobject pv_object, jbyteArray pv_tblName, jobjectArray pv_tableOptions, jlong pv_transID) {
 
+   int lv_error = FEOK;
    int tblopts_len =0;
    char la_tblname[TM_MAX_DDLREQUEST_STRING];
 
@@ -182,8 +190,9 @@ JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInter
       }
 
       long lv_transid = (long) pv_transID;
-      ALTERTABLE(la_tblname, lv_tblname_len, tbl_options, tblopts_len, tbloptions_cnt, lv_transid);
+      lv_error = ALTERTABLE(la_tblname, lv_tblname_len, tbl_options, tblopts_len, tbloptions_cnt, lv_transid);
       pp_env->ReleaseByteArrayElements(pv_tblName, lp_tblname, 0);
    }
+   return lv_error;
 }
  

--- a/core/sqf/src/tm/tmddlrequests.h
+++ b/core/sqf/src/tm/tmddlrequests.h
@@ -13,7 +13,7 @@ extern "C" {
  * Method:    createTableReq
  * Signature: ([B[[BIIJ[B)V
  */
-JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInterface_createTableReq
+JNIEXPORT jint JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInterface_createTableReq
   (JNIEnv *, jobject, jbyteArray, jobjectArray, jint, jint, jlong, jbyteArray);
 
 /*
@@ -21,7 +21,7 @@ JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInter
  * Method:    dropTableReq
  * Signature: ([BJ)V
  */
-JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInterface_dropTableReq
+JNIEXPORT jint JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInterface_dropTableReq
   (JNIEnv *, jobject, jbyteArray, jlong);
 
 
@@ -31,7 +31,7 @@ JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInter
  * Method:    dropTableReq
  * Signature: ([BJ)V
  */
-JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInterface_truncateOnAbortReq
+JNIEXPORT jint JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInterface_truncateOnAbortReq
   (JNIEnv *pp_env, jobject pv_object, jbyteArray pv_tblname, jlong pv_transid);
 
 
@@ -40,7 +40,7 @@ JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInter
  * Method:    alterTableReq
  * Signature: ([B[Ljava/lang/Object;J)V
  */
-JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInterface_alterTableReq
+JNIEXPORT jint JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInterface_alterTableReq
   (JNIEnv *pp_env, jobject pv_object, jbyteArray pv_tblName, jobjectArray pv_tableOptions, jlong pv_transID);
 
 

--- a/core/sqf/src/tm/tmtransaction.cpp
+++ b/core/sqf/src/tm/tmtransaction.cpp
@@ -136,7 +136,6 @@ short  TM_Transaction::register_region(long startid, int port, char *hostName, i
 
 short TM_Transaction::create_table(char* pa_tbldesc, int pv_tbldesc_len, char* pa_tblname, char** pa_keys, int pv_numsplits, int pv_keylen)
 {
-    short lv_error = FEOK;
     Tm_Req_Msg_Type lv_req;
     Tm_Rsp_Msg_Type lv_rsp;
 
@@ -174,12 +173,14 @@ short TM_Transaction::create_table(char* pa_tbldesc, int pv_tbldesc_len, char* p
         TMlibTrace(("TMLIB_TRACE : TM_Transaction::create_table returning error %d\n", iv_last_error), 1);
         return iv_last_error;
     }
-    return lv_error;
+    
+    iv_last_error = lv_rsp.iv_msg_hdr.miv_err.error;
+    
+    return iv_last_error;
 }
 
 short TM_Transaction::alter_table(char * pa_tblname, int pv_tblname_len,  char ** pv_tbloptions,  int pv_tbloptslen, int pv_tbloptscnt)
 {    
-    short lv_error = FEOK;
     Tm_Req_Msg_Type lv_req;
     Tm_Rsp_Msg_Type lv_rsp;
  
@@ -218,12 +219,12 @@ short TM_Transaction::alter_table(char * pa_tblname, int pv_tblname_len,  char *
         return lv_last_error;
     }
 
-    return lv_error;
+    iv_last_error = lv_rsp.iv_msg_hdr.miv_err.error;
+    return lv_last_error;
 }
 
 short TM_Transaction::reg_truncateonabort(char* pa_tblname, int pv_tblname_len)
 {
-    short lv_error = FEOK;
     Tm_Req_Msg_Type lv_req;
     Tm_Rsp_Msg_Type lv_rsp;
 
@@ -244,12 +245,12 @@ short TM_Transaction::reg_truncateonabort(char* pa_tblname, int pv_tblname_len)
         TMlibTrace(("TMLIB_TRACE : TM_Transaction::reg_truncateonabort returning error %d\n", iv_last_error), 1);
         return iv_last_error;
     }
-    return lv_error;
+    iv_last_error = lv_rsp.iv_msg_hdr.miv_err.error;
+    return iv_last_error;
 }
 
 short TM_Transaction::drop_table(char* pa_tblname, int pv_tblname_len)
 {
-    short lv_error = FEOK;
     Tm_Req_Msg_Type lv_req;
     Tm_Rsp_Msg_Type lv_rsp;
 
@@ -270,7 +271,8 @@ short TM_Transaction::drop_table(char* pa_tblname, int pv_tblname_len)
         TMlibTrace(("TMLIB_TRACE : TM_Transaction::drop_table returning error %d\n", iv_last_error), 1);
         return iv_last_error;
     }
-    return lv_error;
+    iv_last_error = lv_rsp.iv_msg_hdr.miv_err.error;
+    return iv_last_error;
 }
 
 // --------------------------------------------------------------------------


### PR DESCRIPTION
SQL calls create and drop requests to transaction manager. However, sometimes in error scenarios, the error codes never reach SQL. This results in sql assuming the operation is successful in failure conditions.
Fix is to propagate the error all the way back to RMInterface and raise exception.