### PR TITLE
[TRAFODION-2104]odb crashed when extract single table using xml forma…

### DIFF
--- a/core/conn/odb/src/odb.c
+++ b/core/conn/odb/src/odb.c
@@ -9889,7 +9889,9 @@ static void Oextract(int eid)
             if ( etab[eid].fho ) {
                 (*hdfswrite)(hfs, etab[eid].fho, (void *)xbuff, xbuffl);
             } else {
-                (void)fwrite ( xbuff, 1, xbuffl, etab[eid].fo );
+                if ( etab[eid].fo == stdout ) {
+                    (void)fwrite ( xbuff, 1, xbuffl, etab[eid].fo );
+                }
             }
 #else
             (void)fwrite ( xbuff, 1, xbuffl, etab[eid].fo );

--- a/core/conn/odb/src/odb.c
+++ b/core/conn/odb/src/odb.c
@@ -9889,7 +9889,7 @@ static void Oextract(int eid)
             if ( etab[eid].fho ) {
                 (*hdfswrite)(hfs, etab[eid].fho, (void *)xbuff, xbuffl);
             } else {
-                if ( etab[eid].fo == stdout ) {
+                if ( etab[eid].fo ) {
                     (void)fwrite ( xbuff, 1, xbuffl, etab[eid].fo );
                 }
             }


### PR DESCRIPTION
…t in linux

reason: in function Oextract file handler etab[eid].fo is null and then fwite it, so odb return a Segmentation fault in the end.
solution: judge file handler first, only if it is stdout, do fwrite operation.