### PR TITLE
[TRAFODION-2161] Support migration of user views on Repository upgrade

### DIFF
--- a/core/sql/common/ComSmallDefs.h
+++ b/core/sql/common/ComSmallDefs.h
@@ -647,7 +647,8 @@ enum ComTextType {COM_VIEW_TEXT = 0,
                   COM_HBASE_COL_FAMILY_TEXT = 5,
                   COM_HBASE_SPLIT_TEXT = 6,
                   COM_STORED_DESC_TEXT = 7,
-                  COM_VIEW_REF_COLS_TEXT = 8
+                  COM_VIEW_REF_COLS_TEXT = 8,
+                  COM_BAD_VIEW_TEXT = 9  // bad view text saved on metadata upgrade
 };
 
 enum ComColumnDirection { COM_UNKNOWN_DIRECTION

--- a/core/sql/parser/StmtDDLAlterTableRename.h
+++ b/core/sql/parser/StmtDDLAlterTableRename.h
@@ -65,10 +65,12 @@ public:
 
   // constructor
   StmtDDLAlterTableRename(const NAString & newName,
-                          ComBoolean isCascade)
+                          ComBoolean isCascade,
+                          ComBoolean skipViewCheck)
   : StmtDDLAlterTable(DDL_ALTER_TABLE_RENAME),
     newName_(newName, PARSERHEAP()),
-    isCascade_(isCascade)
+    isCascade_(isCascade),
+    skipViewCheck_(skipViewCheck)
   { }
 
   // virtual destructor
@@ -80,6 +82,7 @@ public:
   // accessors
   inline const NAString & getNewName() const;
   inline ComBoolean isCascade() const;
+  inline ComBoolean skipViewCheck() const;
 
   inline const NAString getNewNameAsAnsiString() const;
 
@@ -91,6 +94,7 @@ private:
 
   NAString   newName_;
   ComBoolean isCascade_;
+  ComBoolean skipViewCheck_;
 
 }; // class StmtDDLAlterTableRename
 
@@ -116,6 +120,13 @@ ComBoolean
 StmtDDLAlterTableRename::isCascade() const
 {
   return isCascade_;
+}
+
+inline
+ComBoolean
+StmtDDLAlterTableRename::skipViewCheck() const
+{
+  return skipViewCheck_;
 }
 
 #endif // STMTDDLALTERTABLERENAME_H

--- a/core/sql/sqlcomp/CmpSeabaseDDL.h
+++ b/core/sql/sqlcomp/CmpSeabaseDDL.h
@@ -1118,7 +1118,8 @@ protected:
   short recreateUsingViews(ExeCliInterface *cliInterface,
                            NAList<NAString> &viewNameList,
                            NAList<NAString> &viewDefnList,
-                           NABoolean ddlXns);
+                           NABoolean ddlXns,
+                           Lng32 * firstBadOne = NULL);
 
   void alterSeabaseTableAlterIdentityColumn(
        StmtDDLAlterTableAlterColumnSetSGOption * alterIdentityColNode,
@@ -1338,6 +1339,8 @@ protected:
                   NABoolean inRecovery = FALSE);
   short alterRenameRepos(ExeCliInterface * cliInterface, NABoolean newToOld);
   short copyOldReposToNew(ExeCliInterface * cliInterface);
+  short migrateReposViews(ExeCliInterface * cliInterface,
+                          NABoolean & someViewSaved /* out */);
 
 public:
 

--- a/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
@@ -9591,26 +9591,20 @@ char objectTypeString[20] = {0};
    str_sprintf(buf,"DROP %s %s %s CASCADE",
                volatileString,objectTypeString,objectName);
                
-// Save the current parserflags setting
-   ULng32 savedParserFlags = Get_SqlParser_Flags(0xFFFFFFFF);
+   // Turn on the internal query parser flag; note that when
+   // this object is destroyed, the flags will be reset to
+   // their original state
+   PushAndSetSqlParserFlags savedParserFlags(INTERNAL_QUERY_FROM_EXEUTIL);
    Lng32 cliRC = 0;
 
    try
-   {            
-      Set_SqlParser_Flags(INTERNAL_QUERY_FROM_EXEUTIL);
-               
+   {                      
       cliRC = cliInterface.executeImmediate(buf);
    }
    catch (...)
-   {
-      // Restore parser flags settings to what they originally were
-      Assign_SqlParser_Flags(savedParserFlags);
-      
+   {      
       throw;
    }
-   
-// Restore parser flags settings to what they originally were
-   Set_SqlParser_Flags(INTERNAL_QUERY_FROM_EXEUTIL);
    
    if (cliRC < 0 && cliRC != -CAT_OBJECT_DOES_NOT_EXIST_IN_TRAFODION)
       someObjectsCouldNotBeDropped = true;

--- a/core/sql/sqlcomp/CmpSeabaseDDLrepos.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLrepos.cpp
@@ -371,7 +371,7 @@ short CmpSeabaseDDL::migrateReposViews(ExeCliInterface * cliInterface,
     {
       const MDUpgradeInfo &rti = allReposUpgradeInfo[i];
 
-      if ((! rti.newName) || (! rti.oldName) || (NOT rti.upgradeNeeded))
+      if ((! rti.oldName) || (NOT rti.upgradeNeeded))
         continue;
 
       Int64 tableUID = getObjectUID(cliInterface,

--- a/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
@@ -6142,12 +6142,19 @@ short CmpSeabaseDDL::recreateUsingViews(ExeCliInterface *cliInterface,
     {
       cliRC = cliInterface->executeImmediate(viewDefnList[i]);
       if (cliRC < 0)
-        {
-          cliInterface->retrieveSQLDiagnostics(CmpCommon::diags());
-          
+        {         
           cliRC = -1;
           if (firstBadOne)
-            *firstBadOne = i;  // tell caller which one was bad
+            {
+              // tell caller which one was bad; caller does *not* want
+              // diagnostics
+              *firstBadOne = i;
+            }
+          else
+            {
+              cliInterface->retrieveSQLDiagnostics(CmpCommon::diags());
+            }
+
           goto label_return;
         }
     }


### PR DESCRIPTION
Today, users can create views that reference Repository tables. However, when they do so, "initialize trafodion, upgrade" fails because under the covers it does ALTER TABLE RENAME on old Repository tables and the latter does not support views.

This change adds support for such views to "initialize trafodion, upgrade".

The design is as follows:

1. An internal-only option, "SKIP VIEW CHECK", has been added to ALTER TABLE RENAME. This causes any views on the object being renamed to be ignored; that is, they remain in the metadata, referring to the object by its old name. Note that if we abort the upgrade, we'll rename the old repository tables back to their original names (again using "SKIP VIEW CHECK"), so the views are then in their original state.

2. When we determine that upgrade has progressed far enough that we will not turn back, we drop the views but replay their view text to create new views of the same name. If this succeeds, the view has been successfully migrated. But it might not succeed, for example if it depends on a column in the old repository table that has been dropped. In this case, we save the view text in the metadata TEXT table, with TEXT_TYPE = 9 and report that fact to the user. This gives the user a way to take that view text and modify it at their leisure after the upgrade has completed.

While making these changes, I also noticed and fixed a bug in CmpSeabaseDDL::dropOneTableorView where the SQL parser flags global was not being handled correctly.