### PR TITLE
TRAFODION [2171] 'get users' returned invalid character error when trying to ...

### DIFF
--- a/core/sql/executor/ExExeUtilGet.cpp
+++ b/core/sql/executor/ExExeUtilGet.cpp
@@ -417,7 +417,7 @@ static const QueryString getTrafUsers[] =
 {
   {" select distinct auth_db_name "},
   {"   from %s.\"%s\".%s "},
-  {"  where auth_type = '%s' "},
+  {"  where auth_type = 'U' "},
   {" order by 1 "},
   {"  ; "}
 };
@@ -1835,13 +1835,9 @@ short ExExeUtilGetMetadataInfoTcb::work()
                   qs = getTrafUsers;
                   sizeOfqs = sizeof(getTrafUsers);
 
-                  char type[2];
-                  type[0] = 'U';
-                  type[1] = 0;
                   param_[0] = cat;
                   param_[1] = sch;
                   param_[2] = auths;
-                  param_[3] = (char *)&type;
 		}
                 break;
               case ComTdbExeUtilGetMetadataInfo::PROCEDURES_IN_SCHEMA_:


### PR DESCRIPTION
'get users' returned invalid character error on centos7.1 and centos7.2,
running the traf_authentication_setup script that enables security.
The problem occurred while referencing a pointer to a local variable that has 
gone out of scope.  Fixed 'get users' to work the same as 'get roles'.