### PR TITLE
Fix for recovery IOException

### DIFF
--- a/core/sqf/src/seatrans/tm/hbasetmlib2/src/main/java/org/trafodion/dtm/HBaseTxClient.java
+++ b/core/sqf/src/seatrans/tm/hbasetmlib2/src/main/java/org/trafodion/dtm/HBaseTxClient.java
@@ -962,12 +962,6 @@ public class HBaseTxClient {
                  } catch (DeserializationException de) {
                     throw new IOException(de);
                  }
-                 ByteArrayInputStream lv_bis = new ByteArrayInputStream(regionInfo);
-                 DataInputStream lv_dis = new DataInputStream(lv_bis);
-                 regionInfoLoc.readFields(lv_dis);
-                 
-                 //HBase98 TODO: need to set the value of startcode correctly
-                 //HBase98 TODO: Not in CDH 5.1:  ServerName lv_servername = ServerName.valueOf(hostname, port, 0);
 
                  String lv_hostname_port_string = hostname + ":" + port;
                  String lv_servername_string = ServerName.getServerName(lv_hostname_port_string, 0);


### PR DESCRIPTION
2016-08-21 22:05:02,531 ERROR dtm.HBaseTxClient: Caught recovery thread exception for tmid: 0 retries: 0
java.io.IOException: Non-migratable/unknown version=1
        at org.apache.hadoop.hbase.HRegionInfo.readFields(HRegionInfo.java:895)
        at org.trafodion.dtm.HBaseTxClient$RecoveryThread.addRegionToTS(HBaseTxClient.java:967)
        at org.trafodion.dtm.HBaseTxClient$RecoveryThread.run(HBaseTxClient.java:1094)