### PR TITLE
[TRAFODION-2118] dynamic add coprocessor using Hbase api

### DIFF
--- a/core/sqf/sqenvcom.sh
+++ b/core/sqf/sqenvcom.sh
@@ -862,15 +862,9 @@ if [[ -n "$HBASE_CNF_DIR"  ]]; then SQ_CLASSPATH="$SQ_CLASSPATH:$HBASE_CNF_DIR";
 if [[ -n "$HIVE_CNF_DIR"   ]]; then SQ_CLASSPATH="$SQ_CLASSPATH:$HIVE_CNF_DIR";   fi
 if [[ -n "$SQ_CLASSPATH"   ]]; then SQ_CLASSPATH="$SQ_CLASSPATH:";   fi
 
-# set Trx in classpath only incase of workstation env.
-# In case of cluster, correct version of trx is already installed by
-# installer and hbase classpath already contains the correct trx jar.
-# In future, installer can put additional hints in bashrc to cleanup
-# and fine tune these adjustments for many other jars.
-if [[ -e $MY_SQROOT/sql/scripts/sw_env.sh ]]; then
-        SQ_CLASSPATH=${SQ_CLASSPATH}:${HBASE_TRXDIR}/${HBASE_TRX_JAR}
-fi
-
+# Trx will put into HDFS hbase classpath will never contains trx jar.
+# this will work for trafodion process.
+SQ_CLASSPATH=${SQ_CLASSPATH}:${HBASE_TRXDIR}/${HBASE_TRX_JAR}
 
 SQ_CLASSPATH=${SQ_CLASSPATH}:\
 $MY_SQROOT/export/lib/${DTM_COMMON_JAR}:\

--- a/core/sqf/sql/scripts/install_local_hadoop
+++ b/core/sqf/sql/scripts/install_local_hadoop
@@ -1242,6 +1242,7 @@ EOF
   bin/hdfs dfs -mkdir /user/trafodion/bulkload       >>${MY_LOG_FILE} 2>&1
   bin/hdfs dfs -mkdir /user/hive/warehouse           >>${MY_LOG_FILE} 2>&1
   bin/hdfs dfs -mkdir /hive                          >>${MY_LOG_FILE} 2>&1
+  bin/hdfs dfs -mkdir -p /hbase/lib                  >>${MY_LOG_FILE} 2>&1
   bin/hdfs dfs -chmod g+w /tmp                       >>${MY_LOG_FILE} 2>&1
   bin/hdfs dfs -chmod g+w /user/hive/warehouse       >>${MY_LOG_FILE} 2>&1
   bin/hdfs dfs -chmod g+w /bulkload                  >>${MY_LOG_FILE} 2>&1
@@ -1522,6 +1523,8 @@ echo "$MY_LOCAL_SW_DIST/${HBASE_TAR}"
      make 2>&1 | tee -a ${MY_LOG_FILE}
   fi
 
+  swhadoop fs -put  ${MY_SQROOT}/export/lib/${HBASE_TRX_JAR} /hbase/lib/hbase-trx.jar
+
   cd $MY_SW_ROOT
 
   # Setup HBase TRX JAR and utility JAR in HBase' CLASSPATH
@@ -1620,14 +1623,6 @@ echo "$MY_LOCAL_SW_DIST/${HBASE_TAR}"
      <value>org.apache.hadoop.hbase.regionserver.transactional.TransactionalRegion</value>
    </property>
    ${MASTER_VISBILITY_COPROC}
-   <property>
-    <name>hbase.coprocessor.region.classes</name>
-      <value>
-           org.apache.hadoop.hbase.coprocessor.transactional.TrxRegionObserver,
-           org.apache.hadoop.hbase.coprocessor.transactional.TrxRegionEndpoint,
-           org.apache.hadoop.hbase.coprocessor.AggregateImplementation
-      </value>
-   </property>
 </configuration>
 EOF
 

--- a/core/sqf/sql/scripts/traf_coprocessor.properties
+++ b/core/sqf/sql/scripts/traf_coprocessor.properties
@@ -21,6 +21,8 @@
 # @@@ END COPYRIGHT @@@
 #
 
-coprocessors=org.apache.hadoop.hbase.coprocessor.transactional.TrxRegionObserver,org.apache.hadoop.hbase.coprocessor.AggregateImplementation
-MVCC=org.apache.hadoop.hbase.coprocessor.transactional.TrxRegionEndpoint
-SSCC=org.apache.hadoop.hbase.coprocessor.transactional.SsccRegionEndpoint
+coprocessors=org.trafodion.coprocessor.TrxRegionObserver
+build_in_coprocessors=org.apache.hadoop.hbase.coprocessor.AggregateImplementation
+MVCC=org.trafodion.coprocessor.TrxRegionEndpoint
+SSCC=org.trafodion.coprocessor.SsccRegionEndpoint
+HBASE_TRX_JAR_NAME=hbase-trx

--- a/core/sqf/src/seatrans/.gitignore
+++ b/core/sqf/src/seatrans/.gitignore
@@ -5,13 +5,12 @@ tm/hbasetmlib2/testrun
 hbase-trx/src/main/java/org/apache/hadoop/hbase/client/PatchClientScanner.java
 hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/SsccTransactionalScanner.java
 hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/TransactionalScanner.java
-hbase-trx/src/main/java/org/apache/hadoop/hbase/coprocessor/transactional/SsccRegionEndpoint.java
-hbase-trx/src/main/java/org/apache/hadoop/hbase/coprocessor/transactional/TrxRegionEndpoint.java
-hbase-trx/src/main/java/org/apache/hadoop/hbase/coprocessor/transactional/TrxRegionObserver.java
 hbase-trx/src/main/java/org/apache/hadoop/hbase/regionserver/transactional/CleanOldTransactionsChore.java
 hbase-trx/src/main/java/org/apache/hadoop/hbase/regionserver/transactional/KeyValueListScanner.java
 hbase-trx/src/main/java/org/apache/hadoop/hbase/regionserver/transactional/MemoryUsageChore.java
 hbase-trx/src/main/java/org/apache/hadoop/hbase/regionserver/transactional/TrxTransactionState.java
 hbase-trx/src/main/java/org/apache/hadoop/hbase/client/ClientScanner98.java
 hbase-trx/src/main/java/org/apache/hadoop/hbase/client/TrafParallelClientScanner.java
-
+hbase-trx/src/main/java/org/apache/trafodion/coprocessor/SsccRegionEndpoint.java
+hbase-trx/src/main/java/org/apache/trafodion/coprocessor/TrxRegionEndpoint.java
+hbase-trx/src/main/java/org/apache/trafodion/coprocessor/TrxRegionObserver.java

--- a/core/sqf/src/seatrans/.gitignore
+++ b/core/sqf/src/seatrans/.gitignore
@@ -12,5 +12,5 @@ hbase-trx/src/main/java/org/apache/hadoop/hbase/regionserver/transactional/TrxTr
 hbase-trx/src/main/java/org/apache/hadoop/hbase/client/ClientScanner98.java
 hbase-trx/src/main/java/org/apache/hadoop/hbase/client/TrafParallelClientScanner.java
 hbase-trx/src/main/java/org/apache/trafodion/coprocessor/SsccRegionEndpoint.java
-hbase-trx/src/main/java/org/apache/trafodion/coprocessor/TrxRegionEndpoint.java
-hbase-trx/src/main/java/org/apache/trafodion/coprocessor/TrxRegionObserver.java
+hbase-trx/src/main/java/org/trafodion/coprocessor/TrxRegionEndpoint.java
+hbase-trx/src/main/java/org/trafodion/coprocessor/TrxRegionObserver.java

--- a/core/sqf/src/seatrans/.gitignore
+++ b/core/sqf/src/seatrans/.gitignore
@@ -11,6 +11,6 @@ hbase-trx/src/main/java/org/apache/hadoop/hbase/regionserver/transactional/Memor
 hbase-trx/src/main/java/org/apache/hadoop/hbase/regionserver/transactional/TrxTransactionState.java
 hbase-trx/src/main/java/org/apache/hadoop/hbase/client/ClientScanner98.java
 hbase-trx/src/main/java/org/apache/hadoop/hbase/client/TrafParallelClientScanner.java
-hbase-trx/src/main/java/org/apache/trafodion/coprocessor/SsccRegionEndpoint.java
+hbase-trx/src/main/java/org/trafodion/coprocessor/SsccRegionEndpoint.java
 hbase-trx/src/main/java/org/trafodion/coprocessor/TrxRegionEndpoint.java
 hbase-trx/src/main/java/org/trafodion/coprocessor/TrxRegionObserver.java

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/coprocessor/transactional/SplitBalanceHelper.java
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/coprocessor/transactional/SplitBalanceHelper.java
@@ -44,6 +44,8 @@ import org.apache.hadoop.hbase.zookeeper.ZKUtil;
 import org.apache.hadoop.hbase.zookeeper.ZooKeeperWatcher;
 import org.apache.zookeeper.KeeperException;
 
+import org.trafodion.coprocessor.TrxRegionObserver;
+
 public class SplitBalanceHelper {
     private static final Log LOG = LogFactory.getLog(SplitBalanceHelper.class);
 
@@ -284,7 +286,7 @@ public class SplitBalanceHelper {
     	  }
     }
 
-    protected void pendingWait(Set<TrxTransactionState> commitPendingTransactions, int pendingDelayLen) throws IOException {
+    public void pendingWait(Set<TrxTransactionState> commitPendingTransactions, int pendingDelayLen) throws IOException {
         int count = 1;
         while (!pendingListClear(commitPendingTransactions)) {
             try {
@@ -315,7 +317,7 @@ public class SplitBalanceHelper {
     }
     */
 
-    protected void pendingAndScannersWait(Set<TrxTransactionState> commitPendingTransactions,
+    public void pendingAndScannersWait(Set<TrxTransactionState> commitPendingTransactions,
             ConcurrentHashMap<Long, TransactionalRegionScannerHolder> scanners,
             ConcurrentHashMap<String, TrxTransactionState> transactionsById, int pendingDelayLen) throws IOException {
         int count = 1;
@@ -331,7 +333,7 @@ public class SplitBalanceHelper {
         }
     }
 
-    protected void activeWait(ConcurrentHashMap<String, TrxTransactionState> transactionsById, int activeDelayLen,
+    public void activeWait(ConcurrentHashMap<String, TrxTransactionState> transactionsById, int activeDelayLen,
             int splitDelayLimit) throws IOException {
         int counter = 0;
         int minutes = 0;

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/regionserver/transactional/CleanOldTransactionsChore.java.tmpl
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/regionserver/transactional/CleanOldTransactionsChore.java.tmpl
@@ -34,7 +34,7 @@ import org.apache.hadoop.hbase.Chore;
 #endif
 import org.apache.hadoop.hbase.Stoppable;
 
-import org.apache.hadoop.hbase.coprocessor.transactional.TrxRegionEndpoint;
+import org.trafodion.coprocessor.TrxRegionEndpoint;
 
 /**
  * Cleans up committed transactions when they are no longer needed to verify

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/regionserver/transactional/MemoryUsageChore.java.tmpl
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/regionserver/transactional/MemoryUsageChore.java.tmpl
@@ -35,7 +35,7 @@ import org.apache.hadoop.hbase.Chore;
 #endif
 import org.apache.hadoop.hbase.Stoppable;
 
-import org.apache.hadoop.hbase.coprocessor.transactional.TrxRegionEndpoint;
+import org.trafodion.coprocessor.TrxRegionEndpoint;
 
 /**
  * Manages the MemoryMXBean to determine a regionserver's memory usage.

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/trafodion/coprocessor/SsccRegionEndpoint.java.tmpl
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/trafodion/coprocessor/SsccRegionEndpoint.java.tmpl
@@ -21,7 +21,7 @@
 * @@@ END COPYRIGHT @@@
 **/
 
-package org.apache.hadoop.hbase.coprocessor.transactional;
+package org.trafodion.coprocessor;
 
 import java.io.IOException;
 import java.lang.Thread.UncaughtExceptionHandler;
@@ -145,6 +145,8 @@ import org.apache.hadoop.hbase.wal.WAL;
 import org.apache.hadoop.hbase.zookeeper.ZKUtil;
 import org.apache.hadoop.hbase.zookeeper.ZooKeeperWatcher;
 import org.apache.zookeeper.KeeperException;
+
+import org.trafodion.coprocessor.*;
 
 import com.google.protobuf.ByteString;
 import com.google.protobuf.Message;

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/trafodion/coprocessor/TrxRegionEndpoint.java.tmpl
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/trafodion/coprocessor/TrxRegionEndpoint.java.tmpl
@@ -21,7 +21,7 @@
 * @@@ END COPYRIGHT @@@
 **/
 
-package org.apache.hadoop.hbase.coprocessor.transactional;
+package org.trafodion.coprocessor;
 
 import java.io.IOException;
 
@@ -34,6 +34,8 @@ import org.apache.hadoop.hbase.coprocessor.ColumnInterpreter;
 import org.apache.hadoop.hbase.coprocessor.CoprocessorException;
 import org.apache.hadoop.hbase.coprocessor.CoprocessorService;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+
+import org.trafodion.coprocessor.*;
 
 import java.io.*;
 import java.io.IOException;
@@ -178,7 +180,6 @@ import org.apache.hadoop.hbase.protobuf.ProtobufUtil;
 import org.apache.hadoop.hbase.protobuf.ResponseConverter;
 import org.apache.hadoop.hbase.protobuf.generated.ClientProtos.MutationProto;
 import org.apache.hadoop.hbase.protobuf.generated.ClientProtos.MutationProto.MutationType;
-import org.apache.hadoop.hbase.coprocessor.transactional.TrxRegionObserver;
 import org.apache.hadoop.hbase.coprocessor.transactional.generated.TrxRegionProtos;
 import org.apache.hadoop.hbase.coprocessor.transactional.generated.TrxRegionProtos.AbortTransactionRequest;
 import org.apache.hadoop.hbase.coprocessor.transactional.generated.TrxRegionProtos.AbortTransactionResponse;

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/trafodion/coprocessor/TrxRegionObserver.java.tmpl
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/trafodion/coprocessor/TrxRegionObserver.java.tmpl
@@ -21,7 +21,7 @@
 * @@@ END COPYRIGHT @@@
 **/
 
-package org.apache.hadoop.hbase.coprocessor.transactional;
+package org.trafodion.coprocessor;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -55,6 +55,7 @@ import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.coprocessor.BaseRegionObserver;
 import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.coprocessor.transactional.SplitBalanceHelper;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.RegionServerServices;
 import org.apache.hadoop.hbase.regionserver.ScanType;
@@ -91,6 +92,8 @@ import org.apache.hadoop.hbase.regionserver.ScannerContext;
 #ifdef HDP2.3 APACHE1.1 CDH5.7 APACHE1.2
 import org.apache.hadoop.hbase.regionserver.Region;
 #endif
+
+import org.trafodion.coprocessor.*;
 
 public class TrxRegionObserver extends BaseRegionObserver {
 

--- a/core/sql/src/main/java/org/trafodion/sql/CoprocessorUtils.java
+++ b/core/sql/src/main/java/org/trafodion/sql/CoprocessorUtils.java
@@ -28,15 +28,24 @@ import java.util.List;
 import org.apache.commons.configuration.Configuration;
 import org.apache.commons.configuration.ConfigurationException;
 import org.apache.commons.configuration.PropertiesConfiguration;
+import org.apache.commons.lang.StringUtils;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.FileUtil;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.Coprocessor;
+import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.log4j.Logger;
 
 public class CoprocessorUtils {
     private static Logger logger = Logger.getLogger(CoprocessorUtils.class.getName());
     private static List<String> coprocessors = new ArrayList<String>();
+    private static List<String> buildInCoprocessors = new ArrayList<String>();
     private static String MVCC = null;
     private static String SSCC = null;
-
+    private static Path hdfsPath = null;
+    private static String HBASE_TRX_JAR_NAME = null;
     static {
         init();
     }
@@ -55,29 +64,63 @@ public class CoprocessorUtils {
             for (String coprocessor : config.getStringArray("coprocessors")) {
                 coprocessors.add(coprocessor);
             }
+            for (String coprocessor : config.getStringArray("build_in_coprocessors")) {
+            	buildInCoprocessors.add(coprocessor);
+            }
             MVCC = config.getString("MVCC");
             SSCC = config.getString("SSCC");
+            HBASE_TRX_JAR_NAME= config.getString("HBASE_TRX_JAR_NAME");
         }
+        org.apache.hadoop.conf.Configuration conf = HBaseConfiguration.create();
+        String dynamicDir = conf.get("hbase.dynamic.jars.dir");
+        Path hPath = new Path(dynamicDir);
+
+        try {
+            FileSystem fs = FileSystem.get(conf);
+            FileStatus[] status = fs.listStatus(hPath);
+            Path[] listedPaths = FileUtil.stat2Paths(status);
+
+            for (Path p : listedPaths) {
+                if (p.getName().contains(HBASE_TRX_JAR_NAME)) {
+                    hdfsPath = p;
+                    break;
+                }
+            }
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+        if (hdfsPath == null) {
+            throw new RuntimeException("can't find hbase-trx*.jar in HDFS, pls make sure trafodion installation is correct!");
+        }
+
     }
 
     //boolean as return ,to make sure whether changes take place in HTableDescriptor
     public static boolean addCoprocessor(String currentAllClassName, HTableDescriptor desc, boolean isMVCC) throws IOException {
-        boolean retVal = false; 
-        if (coprocessors == null) {
+        boolean retVal = false;
+        if (coprocessors.size()==0 && buildInCoprocessors.size()==0 && StringUtils.isBlank(MVCC) && StringUtils.isBlank(SSCC)) {
             return retVal;
         }
-        for (String coprocess : coprocessors) {
+
+        for (String coprocess : buildInCoprocessors) {
             if ((currentAllClassName == null || !currentAllClassName.contains(coprocess)) && !desc.hasCoprocessor(coprocess)) {
                 desc.addCoprocessor(coprocess);
                 retVal = true;
             }
         }
+
+        for (String coprocess : coprocessors) {
+            if ((currentAllClassName == null || !currentAllClassName.contains(coprocess)) && !desc.hasCoprocessor(coprocess)) {
+                desc.addCoprocessor(coprocess, hdfsPath, Coprocessor.PRIORITY_USER, null);
+                retVal = true;
+            }
+        }
         
         if (isMVCC && (currentAllClassName == null || !currentAllClassName.contains(MVCC)) && !desc.hasCoprocessor(MVCC)) {
-            desc.addCoprocessor(MVCC);
+            desc.addCoprocessor(MVCC, hdfsPath, Coprocessor.PRIORITY_USER, null);
             retVal = true;
         } else if (!isMVCC && (currentAllClassName == null || !currentAllClassName.contains(SSCC)) && !desc.hasCoprocessor(SSCC)) {
-            desc.addCoprocessor(SSCC);
+            desc.addCoprocessor(SSCC, hdfsPath, Coprocessor.PRIORITY_USER, null);
             retVal = true;
         }
 
@@ -102,3 +145,4 @@ public class CoprocessorUtils {
         System.out.println("================CoprocessorUtils.main======================");
     }
 }
+

--- a/core/sql/src/main/java/org/trafodion/sql/HBaseClient.java
+++ b/core/sql/src/main/java/org/trafodion/sql/HBaseClient.java
@@ -965,12 +965,10 @@ public class HBaseClient {
           if (added) {
               if (logger.isDebugEnabled())
                   logger.debug("  ==> add coprocessor for table : " + tblName);
-              synchronized (admin) {
                   TableName table = TableName.valueOf(tblName);
                   admin.disableTable(table);
                   admin.modifyTable(table, tblDesc);
                   admin.enableTable(table);
-              }
           }
 
           if (logger.isDebugEnabled()) logger.debug("  ==> Created new object.");

--- a/install/installer/traf_apache_mods
+++ b/install/installer/traf_apache_mods
@@ -73,16 +73,16 @@ if [ $node_count -ne 1 ]; then
     $PDSH_HADOOP_NODES sudo rm -rf  $HBASE_HOME/lib/hbase-trx* 2>/dev/null
     $TRAF_PDSH mkdir -p $LOCAL_WORKDIR 2>/dev/null
     $PDSH_HADOOP_NODES mkdir -p $LOCAL_WORKDIR 2>/dev/null
-    cp $UNTAR_DIR/export/lib/$hbase_trx_jar $LOCAL_WORKDIR
+#    cp $UNTAR_DIR/export/lib/$hbase_trx_jar $LOCAL_WORKDIR
     cp $UNTAR_DIR/export/lib/$traf_util_jar $LOCAL_WORKDIR
-    $PDCP_HADOOP_NODES $LOCAL_WORKDIR/$hbase_trx_jar $LOCAL_WORKDIR
+#    $PDCP_HADOOP_NODES $LOCAL_WORKDIR/$hbase_trx_jar $LOCAL_WORKDIR
     $PDCP_HADOOP_NODES $LOCAL_WORKDIR/$traf_util_jar $LOCAL_WORKDIR
     $PDSH_HADOOP_NODES sudo cp $LOCAL_WORKDIR/$traf_util_jar $HBASE_HOME/lib
-    $PDSH_HADOOP_NODES sudo cp $LOCAL_WORKDIR/$hbase_trx_jar $HBASE_HOME/lib
-    $PDSH_HADOOP_NODES sudo chmod 644 $HBASE_HOME/lib/$hbase_trx_jar
+#    $PDSH_HADOOP_NODES sudo cp $LOCAL_WORKDIR/$hbase_trx_jar $HBASE_HOME/lib
+#    $PDSH_HADOOP_NODES sudo chmod 644 $HBASE_HOME/lib/$hbase_trx_jar
     $PDSH_HADOOP_NODES sudo chmod 644 $HBASE_HOME/lib/$traf_util_jar
 
-    $PDSH_HADOOP_NODES rm $LOCAL_WORKDIR/$hbase_trx_jar 2>/dev/null
+#    $PDSH_HADOOP_NODES rm $LOCAL_WORKDIR/$hbase_trx_jar 2>/dev/null
     $PDSH_HADOOP_NODES rm $LOCAL_WORKDIR/$traf_util_jar 2>/dev/null
 else
     for node in $HBASE_NODES
@@ -90,30 +90,30 @@ else
     ssh -q -n $node sudo rm -rf $HBASE_HOME/lib/hbase-trx* 2>/dev/null
     ssh -q -n $node sudo mkdir -p $TRAF_WORKDIR 2>/dev/null
     ssh -q -n $node sudo chmod 777 $TRAF_WORKDIR
-    scp -q $UNTAR_DIR/export/lib/$hbase_trx_jar $(whoami)@$node:$TRAF_WORKDIR
+#    scp -q $UNTAR_DIR/export/lib/$hbase_trx_jar $(whoami)@$node:$TRAF_WORKDIR
     scp -q $UNTAR_DIR/export/lib/$traf_util_jar $(whoami)@$node:$TRAF_WORKDIR
-    ssh -q -n $node sudo cp $TRAF_WORKDIR/$hbase_trx_jar $HBASE_HOME/lib
+#    ssh -q -n $node sudo cp $TRAF_WORKDIR/$hbase_trx_jar $HBASE_HOME/lib
     ssh -q -n $node sudo cp $TRAF_WORKDIR/$traf_util_jar $HBASE_HOME/lib
-    ssh -q -n $node sudo chmod 644 $HBASE_HOME/lib/$hbase_trx_jar
+#    ssh -q -n $node sudo chmod 644 $HBASE_HOME/lib/$hbase_trx_jar
     ssh -q -n $node sudo chmod 644 $HBASE_HOME/lib/$traf_util_jar
     done
 fi
 
 #=======================================
 #Check that HBase-trx copied to all nodes
-echo "Check that HBase-trx copied to all nodes"
-for node in $HBASE_NODES
-do
-   copiedOver=$(ssh -q -n $node sudo ls $HBASE_HOME/lib/hbase-trx* | wc -l)
-   if [[ $copiedOver -ne "1" ]]; then
-      echo "***ERROR: $hbase_trx_jar was not copied on $node"
-      echo "***ERROR: Please investigate why this happened"
-      echo "***ERROR: Trafodion can not start without this. EXITING..."
-      exit -1
-   fi
-done
+#echo "Check that HBase-trx copied to all nodes"
+#for node in $HBASE_NODES
+#do
+#   copiedOver=$(ssh -q -n $node sudo ls $HBASE_HOME/lib/hbase-trx* | wc -l)
+#   if [[ $copiedOver -ne "1" ]]; then
+#      echo "***ERROR: $hbase_trx_jar was not copied on $node"
+#      echo "***ERROR: Please investigate why this happened"
+#      echo "***ERROR: Trafodion can not start without this. EXITING..."
+#      exit -1
+#   fi
+#done
 
-echo "***INFO: $hbase_trx_jar copied correctly! Huzzah."
+#echo "***INFO: $hbase_trx_jar copied correctly! Huzzah."
 
 
 
@@ -169,6 +169,15 @@ if [ $? != 0 ]; then
 fi
 ssh -q -n $HDFS_NODE 'sudo su' "$HDFS_USER" '--command "' "$HADOOP_PREFIX"'/bin/hdfs dfs -chown -R' "$TRAF_USER"':trafodion /trafodion_backups"'
 
+#create /hbase/lib to put hbase-trx.jar
+ssh -q -n $HDFS_NODE 'sudo su' "$HDFS_USER" '--command "' "$HADOOP_BIN_PATH"'/hadoop fs -mkdir -p /hbase/lib"'
+if [ $? != 0 ]; then
+   echo "***ERROR: '$HADOOP_BIN_PATH/hadoop fs -mkdir -p /hbase/lib' command failed"
+   exit -1
+fi
+ssh -q -n $HDFS_NODE 'sudo su' "$HDFS_USER" '--command "'"$HADOOP_BIN_PATH"'/hadoop fs -chown -R '"$TRAF_USER"':trafodion /hbase/lib"'
+#put hbase-trx.jar into /hbase/lib
+ssh -q -n $HDFS_NODE 'sudo su' "$HDFS_USER" '--command "'"$HADOOP_BIN_PATH"'/hadoop fs -put '"$UNTAR_DIR"'/export/lib/'"$hbase_trx_jar"' /hbase/lib/hbase-trx-apache.jar"'
 
 ssh -q -n $HDFS_NODE 'rm -rf $HOME/traf_temp_output'
 #=====================================

--- a/install/installer/traf_cloudera_mods
+++ b/install/installer/traf_cloudera_mods
@@ -81,7 +81,7 @@ if [ ! -f $UNTAR_DIR/export/lib/$hbase_trx_jar ]; then
 fi
 
 # if more than one node then copy to all nodes
-echo "***INFO: copying $hbase_trx_jar to all nodes"
+echo "***INFO: copying $traf_util_jar to all nodes"
 if [ $node_count -ne 1 ]; then
     
     $PDSH_HADOOP_NODES sudo rm -rf $HADOOP_PATH/hbase-trx* 2>/dev/null
@@ -91,15 +91,15 @@ if [ $node_count -ne 1 ]; then
     $PDSH_HADOOP_NODES sudo rm -rf /usr/share/cmf/lib/plugins/trafodion* 2>/dev/null
     $TRAF_PDSH mkdir -p $LOCAL_WORKDIR 2>/dev/null
     $PDSH_HADOOP_NODES mkdir -p $LOCAL_WORKDIR 2>/dev/null
-    cp $UNTAR_DIR/export/lib/$hbase_trx_jar $LOCAL_WORKDIR
+#    cp $UNTAR_DIR/export/lib/$hbase_trx_jar $LOCAL_WORKDIR
     cp $UNTAR_DIR/export/lib/$traf_util_jar $LOCAL_WORKDIR
-    $PDCP_HADOOP_NODES $LOCAL_WORKDIR/$hbase_trx_jar $LOCAL_WORKDIR
+#    $PDCP_HADOOP_NODES $LOCAL_WORKDIR/$hbase_trx_jar $LOCAL_WORKDIR
     $PDCP_HADOOP_NODES $LOCAL_WORKDIR/$traf_util_jar $LOCAL_WORKDIR
-    $PDSH_HADOOP_NODES sudo cp $LOCAL_WORKDIR/$hbase_trx_jar $HADOOP_PATH
+#    $PDSH_HADOOP_NODES sudo cp $LOCAL_WORKDIR/$hbase_trx_jar $HADOOP_PATH
     $PDSH_HADOOP_NODES sudo cp $LOCAL_WORKDIR/$traf_util_jar $HADOOP_PATH
-    $PDSH_HADOOP_NODES sudo chmod 644 $HADOOP_PATH/$hbase_trx_jar
+#    $PDSH_HADOOP_NODES sudo chmod 644 $HADOOP_PATH/$hbase_trx_jar
     $PDSH_HADOOP_NODES sudo chmod 644 $HADOOP_PATH/$traf_util_jar
-    $PDSH_HADOOP_NODES rm $LOCAL_WORKDIR/$hbase_trx_jar 2>/dev/null
+#    $PDSH_HADOOP_NODES rm $LOCAL_WORKDIR/$hbase_trx_jar 2>/dev/null
     $PDSH_HADOOP_NODES rm $LOCAL_WORKDIR/$traf_util_jar 2>/dev/null
 else
     for node in $HBASE_NODES
@@ -111,11 +111,11 @@ else
     ssh -q -n $node sudo rm -rf $HADOOP_PATH/hbase-trx* 2>/dev/null
     ssh -q -n $node sudo mkdir -p $TRAF_WORKDIR 2>/dev/null
     ssh -q -n $node sudo chmod 777 $TRAF_WORKDIR
-    scp -q $UNTAR_DIR/export/lib/$hbase_trx_jar $(whoami)@$node:$TRAF_WORKDIR
+#    scp -q $UNTAR_DIR/export/lib/$hbase_trx_jar $(whoami)@$node:$TRAF_WORKDIR
     scp -q $UNTAR_DIR/export/lib/$traf_util_jar $(whoami)@$node:$TRAF_WORKDIR
-    ssh -q -n $node sudo cp $TRAF_WORKDIR/$hbase_trx_jar $HADOOP_PATH
+#    ssh -q -n $node sudo cp $TRAF_WORKDIR/$hbase_trx_jar $HADOOP_PATH
     ssh -q -n $node sudo cp $TRAF_WORKDIR/$traf_util_jar $HADOOP_PATH
-    ssh -q -n $node sudo chmod 644 $HADOOP_PATH/$hbase_trx_jar
+#    ssh -q -n $node sudo chmod 644 $HADOOP_PATH/$hbase_trx_jar
     ssh -q -n $node sudo chmod 644 $HADOOP_PATH/$traf_util_jar
     done
 fi
@@ -123,18 +123,18 @@ fi
 #====================================
 #Make sure hbase-trx*jar got copied
 
-for node in $HBASE_NODES
-do
-   copiedOver=$(ssh -q -n $node sudo ls $HADOOP_PATH/hbase-trx* | wc -l)
-   if [[ $copiedOver -ne "1" ]]; then
-      echo "***ERROR: $hbase_trx_jar was not copied on $node"
-      echo "***ERROR: Please investigate why this happened"
-      echo "***ERROR: Trafodion can not start without this. EXITING..."
-      exit -1
-   fi
-done
+#for node in $HBASE_NODES
+#do
+#   copiedOver=$(ssh -q -n $node sudo ls $HADOOP_PATH/hbase-trx* | wc -l)
+#   if [[ $copiedOver -ne "1" ]]; then
+#      echo "***ERROR: $hbase_trx_jar was not copied on $node"
+#      echo "***ERROR: Please investigate why this happened"
+#      echo "***ERROR: Trafodion can not start without this. EXITING..."
+#      exit -1
+#   fi
+#done
 
-echo "***INFO: $hbase_trx_jar copied correctly! Huzzah."
+#echo "***INFO: $hbase_trx_jar copied correctly! Huzzah."
 
 
 
@@ -197,6 +197,18 @@ fi
 ssh -q -n $HDFS_NODE 'sudo su' "$HDFS_USER" '--command "'"$HADOOP_BIN_PATH"'/hadoop fs -chown -R '"$TRAF_USER"':trafodion /trafodion_backups"'
 
 ssh -q -n $HDFS_NODE 'sudo su' "$HDFS_USER" '--command "' "$HADOOP_BIN_PATH"'/hadoop fs -chmod 777 /trafodion_backups"'
+
+#create /hbase/lib to put hbase-trx.jar
+ssh -q -n $HDFS_NODE 'sudo su' "$HDFS_USER" '--command "' "$HADOOP_BIN_PATH"'/hadoop fs -mkdir -p /hbase/lib"'
+if [ $? != 0 ]; then
+   echo "***ERROR: '$HADOOP_BIN_PATH/hadoop fs -mkdir -p /hbase/lib' command failed"
+   exit -1
+fi
+ssh -q -n $HDFS_NODE 'sudo su' "$HDFS_USER" '--command "'"$HADOOP_BIN_PATH"'/hadoop fs -chown -R '"$TRAF_USER"':trafodion /hbase/lib"'
+#put hbase-trx.jar into /hbase/lib
+ssh -q -n $HDFS_NODE 'sudo su' "$HDFS_USER" '--command "'"$HADOOP_BIN_PATH"'/hadoop fs -put '"$UNTAR_DIR"'/export/lib/'"$hbase_trx_jar"' /hbase/lib/hbase-trx-cdh.jar"'
+
+
 #=====================================
 # Modify hadoop settings as needed by Trafodion
 

--- a/install/installer/traf_hortonworks_mods
+++ b/install/installer/traf_hortonworks_mods
@@ -132,18 +132,18 @@ fi
 #=======================================
 #Check that HBase-trx copied to all nodes
 
-for node in $HBASE_NODES
-do
-   copiedOver=$(ssh -q -n $node sudo ls $HADOOP_PATH/hbase-trx* | wc -l)
-   if [[ $copiedOver -ne "1" ]]; then
-      echo "***ERROR: $hbase_trx_jar was not copied on $node"
-      echo "***ERROR: Please investigate why this happened"
-      echo "***ERROR: Trafodion can not start without this. EXITING..."
-      exit -1
-   fi
-done
+#for node in $HBASE_NODES
+#do
+#   copiedOver=$(ssh -q -n $node sudo ls $HADOOP_PATH/hbase-trx* | wc -l)
+#   if [[ $copiedOver -ne "1" ]]; then
+#      echo "***ERROR: $hbase_trx_jar was not copied on $node"
+#      echo "***ERROR: Please investigate why this happened"
+#      echo "***ERROR: Trafodion can not start without this. EXITING..."
+#      exit -1
+#   fi
+#done
 
-echo "***INFO: $hbase_trx_jar copied correctly! Huzzah."
+#echo "***INFO: $hbase_trx_jar copied correctly! Huzzah."
 
 
 

--- a/install/installer/traf_hortonworks_mods
+++ b/install/installer/traf_hortonworks_mods
@@ -99,16 +99,16 @@ if [ $node_count -ne 1 ]; then
     $PDSH_HADOOP_NODES sudo rm -rf /usr/share/cmf/lib/plugins/trafodion* 2>/dev/null
     $TRAF_PDSH mkdir -p $LOCAL_WORKDIR 2>/dev/null
     $PDSH_HADOOP_NODES mkdir -p $LOCAL_WORKDIR 2>/dev/null
-    cp $UNTAR_DIR/export/lib/$hbase_trx_jar $LOCAL_WORKDIR
+#    cp $UNTAR_DIR/export/lib/$hbase_trx_jar $LOCAL_WORKDIR
     cp $UNTAR_DIR/export/lib/$traf_util_jar $LOCAL_WORKDIR
-    $PDCP_HADOOP_NODES $LOCAL_WORKDIR/$hbase_trx_jar $LOCAL_WORKDIR
+#    $PDCP_HADOOP_NODES $LOCAL_WORKDIR/$hbase_trx_jar $LOCAL_WORKDIR
     $PDCP_HADOOP_NODES $LOCAL_WORKDIR/$traf_util_jar $LOCAL_WORKDIR
     $PDSH_HADOOP_NODES sudo cp $LOCAL_WORKDIR/$traf_util_jar $HADOOP_PATH
-    $PDSH_HADOOP_NODES sudo cp $LOCAL_WORKDIR/$hbase_trx_jar $HADOOP_PATH
-    $PDSH_HADOOP_NODES sudo chmod 644 $HADOOP_PATH/$hbase_trx_jar
+#    $PDSH_HADOOP_NODES sudo cp $LOCAL_WORKDIR/$hbase_trx_jar $HADOOP_PATH
+#    $PDSH_HADOOP_NODES sudo chmod 644 $HADOOP_PATH/$hbase_trx_jar
     $PDSH_HADOOP_NODES sudo chmod 644 $HADOOP_PATH/$traf_util_jar
 
-    $PDSH_HADOOP_NODES rm $LOCAL_WORKDIR/$hbase_trx_jar 2>/dev/null
+#    $PDSH_HADOOP_NODES rm $LOCAL_WORKDIR/$hbase_trx_jar 2>/dev/null
     $PDSH_HADOOP_NODES rm $LOCAL_WORKDIR/$traf_util_jar 2>/dev/null
 else
     for node in $HBASE_NODES
@@ -120,11 +120,11 @@ else
     ssh -q -n $node sudo rm -rf /usr/share/cmf/lib/plugins/trafodion* 2>/dev/null
     ssh -q -n $node sudo mkdir -p $TRAF_WORKDIR 2>/dev/null
     ssh -q -n $node sudo chmod 777 $TRAF_WORKDIR
-    scp -q $UNTAR_DIR/export/lib/$hbase_trx_jar $(whoami)@$node:$TRAF_WORKDIR
+#    scp -q $UNTAR_DIR/export/lib/$hbase_trx_jar $(whoami)@$node:$TRAF_WORKDIR
     scp -q $UNTAR_DIR/export/lib/$traf_util_jar $(whoami)@$node:$TRAF_WORKDIR
-    ssh -q -n $node sudo cp $TRAF_WORKDIR/$hbase_trx_jar $HADOOP_PATH
+#    ssh -q -n $node sudo cp $TRAF_WORKDIR/$hbase_trx_jar $HADOOP_PATH
     ssh -q -n $node sudo cp $TRAF_WORKDIR/$traf_util_jar $HADOOP_PATH
-    ssh -q -n $node sudo chmod 644 $HADOOP_PATH/$hbase_trx_jar
+#    ssh -q -n $node sudo chmod 644 $HADOOP_PATH/$hbase_trx_jar
     ssh -q -n $node sudo chmod 644 $HADOOP_PATH/$traf_util_jar
     done
 fi
@@ -200,6 +200,15 @@ if [ $? != 0 ]; then
 fi
 ssh -q -n $HDFS_NODE 'sudo su' "$HDFS_USER" '--command "hadoop fs -chown -R' "$TRAF_USER"':trafodion /trafodion_backups"'
 
+#create /hbase/lib to put hbase-trx.jar
+ssh -q -n $HDFS_NODE 'sudo su' "$HDFS_USER" '--command "hadoop fs -mkdir -p /hbase/lib"'
+if [ $? != 0 ]; then
+   echo "***ERROR: 'hadoop fs -mkdir -p /hbase/lib' command failed"
+   exit -1
+fi
+ssh -q -n $HDFS_NODE 'sudo su' "$HDFS_USER" '--command "hadoop fs -chown -R '"$TRAF_USER"':trafodion /hbase/lib"'
+#put hbase-trx.jar into /hbase/lib
+ssh -q -n $HDFS_NODE 'sudo su' "$HDFS_USER" '--command "hadoop fs -put '"$UNTAR_DIR"'/export/lib/'"$hbase_trx_jar"' /hbase/lib/hbase-trx-hdp.jar"'
 
 ssh -q -n $HDFS_NODE 'rm -rf $HOME/traf_temp_output'
 #=====================================


### PR DESCRIPTION
1. mv coprocessor from org.apache.hbase.coprocessor.transactional to org.apache.trafodion.coprocessor, beacuse org.apache.hbase.coprocessor is build-in namespace and the coprocessors under this namespace will be block.
2. hbase-trx-*.jar will never put under $HBASE_HOME/lib , but put into HDFS which is under /hbase/lib. this will help to dynamic add coprocessor.
3. no need to change hbase-site.xml to add hbase.coprocessor.region.classes in the future
4. change related install scripts.
