### PR TITLE
[TRAFODION-2170] create table failure when pk length is too long

### DIFF
--- a/core/sqf/src/tm/tmddlrequests.cpp
+++ b/core/sqf/src/tm/tmddlrequests.cpp
@@ -24,6 +24,7 @@
 #include "dtm/tm.h"
 #include <string.h>
 #include <iostream>
+#include <stdlib.h>
 
 using namespace std;
 
@@ -39,13 +40,24 @@ JNIEXPORT void JNICALL Java_org_apache_hadoop_hbase_client_transactional_RMInter
    char la_tbldesc[TM_MAX_DDLREQUEST_STRING];
    char la_tblname[TM_MAX_DDLREQUEST_STRING];
    char* str_key;
-   str_key = new char[TM_MAX_DDLREQUEST_STRING];
+   if(pv_keyLength <= 0) 
+   {
+     cout << "createTableReq bad input pv_keyLength, abort" << endl;
+     abort();
+   }
+   str_key = new char[pv_keyLength];
    char** la_keys;
-   la_keys = new char *[TM_MAX_DDLREQUEST_STRING];
+   if(pv_numSplits < 0)
+   {
+     cout << "createTableReq bad input pv_numSplits, abort" << endl;
+     abort();
+   }
+   la_keys = new char *[pv_numSplits];
 
    int lv_tblname_len = pp_env->GetArrayLength(pv_tblname);
+   
    if(lv_tblname_len > TM_MAX_DDLREQUEST_STRING) {
-      cout << "Table name length is larger than max allowed" << endl;
+      cout << "Table name length is larger than max allowed [" << TM_MAX_DDLREQUEST_STRING << "]" << endl;
    }
    else {
       int lv_tbldesc_length = pp_env->GetArrayLength(pv_tableDescriptor);

--- a/core/sql/regress/compGeneral/EXPECTED005
+++ b/core/sql/regress/compGeneral/EXPECTED005
@@ -1121,6 +1121,17 @@ C1 C2
 
 --- SQL operation complete.
 >>
+>>create table test2170 (
++>c1 varchar(255) CHARACTER SET UTF8 not null,
++>c2 varchar(256) CHARACTER SET UTF8 not null,
++>c3 varchar(256) CHARACTER SET UTF8 not null,
++>c4 int not null ,
++>c5 int,
++>primary key(c1,c2,c3,c4))
++>salt using 4 partitions ;
+
+--- SQL operation complete.
+>>
 >>?section cleanup
 >>
 >>-- Clean up test
@@ -1157,6 +1168,9 @@ C1 C2
 
 --- SQL operation complete.
 >>drop table witht2;
+
+--- SQL operation complete.
+>>drop table test2170;
 
 --- SQL operation complete.
 >>exit;

--- a/core/sql/regress/compGeneral/TEST005
+++ b/core/sql/regress/compGeneral/TEST005
@@ -507,6 +507,15 @@ with recursive w1 as (select c1, c2 from witht1 union all select origin.c1 , ori
 with w1 as (select * from witht1), w1 as (select * from witht2) select * from w1;
 cqd mode_special_4 reset;
 
+create table test2170 (
+c1 varchar(255) CHARACTER SET UTF8 not null, 
+c2 varchar(256) CHARACTER SET UTF8 not null, 
+c3 varchar(256) CHARACTER SET UTF8 not null, 
+c4 int not null , 
+c5 int, 
+primary key(c1,c2,c3,c4))
+salt using 4 partitions ;
+
 ?section cleanup
 
 -- Clean up test
@@ -523,3 +532,4 @@ drop table t005_hx;
 drop table t005_fx;
 drop table witht1;
 drop table witht2;
+drop table test2170;


### PR DESCRIPTION
If the length of the primary key greater than 2048, Trafodion will have memory overrun issue and core dump.

The changed method will alloc a 2048 buffer and do java memory copy later into this buffer, which cause memory overrun.

This is rare, but still need to be fixed.