### PR TITLE
[TRAFODION-2161] Fix issue with upgrade failure when Repository views…

### DIFF
--- a/core/sql/parser/StmtDDLAlterTableRename.h
+++ b/core/sql/parser/StmtDDLAlterTableRename.h
@@ -65,10 +65,12 @@ public:
 
   // constructor
   StmtDDLAlterTableRename(const NAString & newName,
-                          ComBoolean isCascade)
+                          ComBoolean isCascade,
+                          ComBoolean skipViewCheck)
   : StmtDDLAlterTable(DDL_ALTER_TABLE_RENAME),
     newName_(newName, PARSERHEAP()),
-    isCascade_(isCascade)
+    isCascade_(isCascade),
+    skipViewCheck_(skipViewCheck)
   { }
 
   // virtual destructor
@@ -80,6 +82,7 @@ public:
   // accessors
   inline const NAString & getNewName() const;
   inline ComBoolean isCascade() const;
+  inline ComBoolean skipViewCheck() const;
 
   inline const NAString getNewNameAsAnsiString() const;
 
@@ -91,6 +94,7 @@ private:
 
   NAString   newName_;
   ComBoolean isCascade_;
+  ComBoolean skipViewCheck_;
 
 }; // class StmtDDLAlterTableRename
 
@@ -116,6 +120,13 @@ ComBoolean
 StmtDDLAlterTableRename::isCascade() const
 {
   return isCascade_;
+}
+
+inline
+ComBoolean
+StmtDDLAlterTableRename::skipViewCheck() const
+{
+  return skipViewCheck_;
 }
 
 #endif // STMTDDLALTERTABLERENAME_H

--- a/core/sql/sqlcomp/CmpSeabaseDDL.h
+++ b/core/sql/sqlcomp/CmpSeabaseDDL.h
@@ -1338,6 +1338,8 @@ protected:
                   NABoolean inRecovery = FALSE);
   short alterRenameRepos(ExeCliInterface * cliInterface, NABoolean newToOld);
   short copyOldReposToNew(ExeCliInterface * cliInterface);
+  short dropAndLogReposViews(ExeCliInterface * cliInterface,
+                             NABoolean & someViewSaved /* out */);
 
 public:
 

--- a/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
@@ -9591,26 +9591,20 @@ char objectTypeString[20] = {0};
    str_sprintf(buf,"DROP %s %s %s CASCADE",
                volatileString,objectTypeString,objectName);
                
-// Save the current parserflags setting
-   ULng32 savedParserFlags = Get_SqlParser_Flags(0xFFFFFFFF);
+   // Turn on the internal query parser flag; note that when
+   // this object is destroyed, the flags will be reset to
+   // their original state
+   PushAndSetSqlParserFlags savedParserFlags(INTERNAL_QUERY_FROM_EXEUTIL);
    Lng32 cliRC = 0;
 
    try
-   {            
-      Set_SqlParser_Flags(INTERNAL_QUERY_FROM_EXEUTIL);
-               
+   {                      
       cliRC = cliInterface.executeImmediate(buf);
    }
    catch (...)
-   {
-      // Restore parser flags settings to what they originally were
-      Assign_SqlParser_Flags(savedParserFlags);
-      
+   {      
       throw;
    }
-   
-// Restore parser flags settings to what they originally were
-   Set_SqlParser_Flags(INTERNAL_QUERY_FROM_EXEUTIL);
    
    if (cliRC < 0 && cliRC != -CAT_OBJECT_DOES_NOT_EXIST_IN_TRAFODION)
       someObjectsCouldNotBeDropped = true;

--- a/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
@@ -4111,23 +4111,26 @@ void CmpSeabaseDDL::renameSeabaseTable(
       return;
     }
 
-  // cannot rename if views are using this table
-  Queue * usingViewsQueue = NULL;
-  cliRC = getUsingViews(&cliInterface, objUID, usingViewsQueue);
-  if (cliRC < 0)
+  if (!renameTableNode->skipViewCheck())
     {
-      processReturn();
+      // cannot rename if views are using this table
+      Queue * usingViewsQueue = NULL;
+      cliRC = getUsingViews(&cliInterface, objUID, usingViewsQueue);
+      if (cliRC < 0)
+        {
+          processReturn();
       
-      return;
-    }
+          return;
+        }
   
-  if (usingViewsQueue->numEntries() > 0)
-    {
-      *CmpCommon::diags() << DgSqlCode(-1427)
-                          << DgString0("Reason: Operation not allowed if dependent views exist. Drop the views and recreate them after rename.");
+      if (usingViewsQueue->numEntries() > 0)
+        {
+          *CmpCommon::diags() << DgSqlCode(-1427)
+                              << DgString0("Reason: Operation not allowed if dependent views exist. Drop the views and recreate them after rename.");
       
-      processReturn();
-      return;
+          processReturn();
+          return;
+        }
     }
 
   cliRC = updateObjectName(&cliInterface,


### PR DESCRIPTION
… exist

Before this change, "initialize trafodion, upgrade" would fail if a view existed that referenced a Repository table. With this change, "initialize trafodion, upgrade" will succeed. It will automatically drop any view on a Repository table that needs upgrading. The view text for the view definition is captured in the log file for that session. Also included are design notes on how to improve this to support automatic migration of such views in the future.

Also, while developing this change, a bug in parser flags handling was noticed in sqlcomp/CmpSeabaseDDLcommon.cpp. That bug has been fixed.