### PR TITLE
[TRAFODION-2200] Add Javadoc and Doxygen for UDRs to document build

### DIFF
--- a/core/sqf/sql/scripts/build_apidocs.sh
+++ b/core/sqf/sql/scripts/build_apidocs.sh
@@ -105,8 +105,10 @@ do
   esac
 
   if [[ -n "$TGT_DIR" ]]; then
-    echo "Moving $d apidocs to ${TGT_DIR}${TGT_SUBDIR}"
+    echo "Moving $d apidocs from $APIDOC_DIR to ${TGT_DIR}${TGT_SUBDIR}"
+    echo "Current working dir is $PWD"
     if [[ ! -d ${TGT_DIR}${TGT_SUBDIR} ]]; then
+      echo "Making target directory ${TGT_DIR}${TGT_SUBDIR}"
       mkdir -p ${TGT_DIR}${TGT_SUBDIR}
     fi
     mv -f $APIDOC_DIR ${TGT_DIR}${TGT_SUBDIR}

--- a/core/sqf/sql/scripts/build_apidocs.sh
+++ b/core/sqf/sql/scripts/build_apidocs.sh
@@ -87,7 +87,9 @@ do
          cd $MY_SQROOT ; make genverhdr
          cd $MY_SQROOT/src/seatrans/hbase-trx
          make clean
-         make
+         # make sure the set -pipefail command in the make file is
+         # supported by using bash as the shell
+         make SHELL=/bin/bash
 
          echo "Now make the actual Javadoc"
          cd $MY_SQROOT/../sql

--- a/core/sqf/sql/scripts/build_apidocs.sh
+++ b/core/sqf/sql/scripts/build_apidocs.sh
@@ -1,4 +1,24 @@
 #!/bin/bash
+# @@@ START COPYRIGHT @@@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# @@@ END COPYRIGHT @@@
 
 #
 # script to build Javadoc and Doxygen sites

--- a/core/sqf/sql/scripts/build_apidocs.sh
+++ b/core/sqf/sql/scripts/build_apidocs.sh
@@ -83,15 +83,6 @@ do
     sql_javadoc)
 
          echo "Building Javadocs for SQL project"
-         echo "Building required HBase-trx jar"
-         cd $MY_SQROOT ; make genverhdr
-         cd $MY_SQROOT/src/seatrans/hbase-trx
-         make clean
-         # make sure the set -pipefail command in the make file is
-         # supported by using bash as the shell
-         make SHELL=/bin/bash
-
-         echo "Now make the actual Javadoc"
          cd $MY_SQROOT/../sql
          mvn javadoc:javadoc
          APIDOC_DIR=target/site/apidocs

--- a/core/sqf/sql/scripts/build_apidocs.sh
+++ b/core/sqf/sql/scripts/build_apidocs.sh
@@ -1,0 +1,94 @@
+#!/bin/bash
+
+#
+# script to build Javadoc and Doxygen sites
+#
+# Currently this is invoked from the mvn site goals of
+# those documents that have associated apidocs
+#
+
+WHICH_DOC=
+TGT_DIR=
+TGT_SUBDIR=
+
+while [[ $# > 0 ]]
+  do
+    case "$1" in
+      -h )
+            echo ""
+            echo "Usage: $0 [-h] [-o dir] [project ...]"
+            echo ""
+            echo "-o specifies the output/target directory, default is ."
+            echo "projects are sql_javadoc or udr_doxygen for now, default is all"
+            exit 1
+            ;;
+
+      -o )
+            shift
+            if [[ $# > 0 ]]; then
+              TGT_DIR=$1
+            else
+              echo "expected directory after -o flag"
+              exit 98
+            fi
+            ;;
+
+      ** )
+            WHICH_DOC="${WHICH_DOC} $1"
+            ;;
+
+    esac
+    shift
+  done
+
+# set default parameters, if needed
+if [[ -z "$TGT_DIR" ]]; then
+  TGT_DIR=.
+fi
+
+if [[ -z "$WHICH_DOC" ]]; then
+  WHICH_DOC="sql_javadoc udr_doxygen"
+fi
+
+# create output dir and get the absolute path name
+mkdir -p $TGT_DIR
+cd $TGT_DIR
+TGT_DIR=$PWD
+
+for d in $WHICH_DOC
+do
+  APIDOC_DIR=
+
+  case $d in
+    sql_javadoc)
+
+         echo "Building Javadocs for SQL project"
+         cd $MY_SQROOT/../sql
+         mvn javadoc:javadoc
+         APIDOC_DIR=target/site/apidocs
+         TGT_SUBDIR="/tmudr_javadoc"
+    ;;
+
+    udr_doxygen)
+
+         echo "Building Doxygen for TMUDF C++ interface"
+         cd $MY_SQROOT/../sql/sqludr
+         doxygen doxygen_tmudr*.config
+         APIDOC_DIR=tmudr_2.0.1/html
+         TGT_SUBDIR="/tmudr_doxygen"
+    ;;
+
+    *)
+    echo "Unrecognized apidoc to build: $d"
+    exit 99
+    ;;
+  esac
+
+  if [[ -n "$TGT_DIR" ]]; then
+    echo "Moving $d apidocs to ${TGT_DIR}${TGT_SUBDIR}"
+    if [[ ! -d ${TGT_DIR}${TGT_SUBDIR} ]]; then
+      mkdir -p ${TGT_DIR}${TGT_SUBDIR}
+    fi
+    mv -f $APIDOC_DIR ${TGT_DIR}${TGT_SUBDIR}
+  fi
+done

--- a/core/sqf/sql/scripts/build_apidocs.sh
+++ b/core/sqf/sql/scripts/build_apidocs.sh
@@ -83,6 +83,13 @@ do
     sql_javadoc)
 
          echo "Building Javadocs for SQL project"
+         echo "Building required HBase-trx jar"
+         cd $MY_SQROOT ; make genverhdr
+         cd $MY_SQROOT/src/seatrans/hbase-trx
+         make clean
+         make
+
+         echo "Now make the actual Javadoc"
          cd $MY_SQROOT/../sql
          mvn javadoc:javadoc
          APIDOC_DIR=target/site/apidocs
@@ -93,8 +100,9 @@ do
 
          echo "Building Doxygen for TMUDF C++ interface"
          cd $MY_SQROOT/../sql/sqludr
-         doxygen doxygen_tmudr*.config
          APIDOC_DIR=tmudr_2.0.1/html
+         rm -rf $APIDOC_DIR
+         doxygen doxygen_tmudr*.config
          TGT_SUBDIR="/tmudr_doxygen"
     ;;
 
@@ -106,10 +114,10 @@ do
 
   if [[ -n "$TGT_DIR" ]]; then
     echo "Moving $d apidocs from $APIDOC_DIR to ${TGT_DIR}${TGT_SUBDIR}"
-    echo "Current working dir is $PWD"
     if [[ ! -d ${TGT_DIR}${TGT_SUBDIR} ]]; then
-      echo "Making target directory ${TGT_DIR}${TGT_SUBDIR}"
       mkdir -p ${TGT_DIR}${TGT_SUBDIR}
+    else
+      rm -rf ${TGT_DIR}${TGT_SUBDIR}
     fi
     mv -f $APIDOC_DIR ${TGT_DIR}${TGT_SUBDIR}
   fi

--- a/core/sql/sqludr/doxygen_tmudr.1.6.config
+++ b/core/sql/sqludr/doxygen_tmudr.1.6.config
@@ -31,14 +31,19 @@ PROJECT_NAME           = tmudr
 # This could be handy for archiving the generated documentation or
 # if some version control system is used.
 
-PROJECT_NUMBER         = 1.3.0
+# NOTE: Also change this in file $MY_SQROOT/sql/scripts/build_apidocs.sh
+# This is the main version number of the TMUDF interface, it does not
+# need to change with every Trafodion release, only when the API changes
+# in a significant way.
+
+PROJECT_NUMBER         = 2.0.1
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute)
 # base path where the generated documentation will be put.
 # If a relative path is entered, it will be relative to the location
 # where doxygen was started. If left blank the current directory will be used.
 
-OUTPUT_DIRECTORY       = tmudr_1.3.0
+OUTPUT_DIRECTORY       = tmudr_2.0.1
 
 # If the CREATE_SUBDIRS tag is set to YES, then doxygen will create
 # 4096 sub-directories (in 2 levels) under the output directory of each output

--- a/docs/spj_guide/pom.xml
+++ b/docs/spj_guide/pom.xml
@@ -264,6 +264,30 @@
           </execution>
         </executions>
       </plugin>
+      <!-- Build Doxygen site for Trafodion TMUDF C++ interface -->
+      <plugin>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>exec-maven-plugin</artifactId>
+        <version>1.1.1</version>
+        <executions>
+          <execution>
+            <id>build-javadoc</id>
+            <phase>site</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+          </execution>
+        </executions>
+        <configuration>
+          <executable>${env.MY_SQROOT}/sql/scripts/build_apidocs.sh</executable>
+          <arguments>
+            <argument>-o</argument>
+            <argument>${basedir}/target/site/apidocs</argument>
+            <argument>sql_javadoc</argument>
+            <argument>udr_doxygen</argument>
+          </arguments>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 

--- a/docs/spj_guide/pom.xml
+++ b/docs/spj_guide/pom.xml
@@ -264,30 +264,6 @@
           </execution>
         </executions>
       </plugin>
-      <!-- Build Doxygen site for Trafodion TMUDF C++ interface -->
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>exec-maven-plugin</artifactId>
-        <version>1.1.1</version>
-        <executions>
-          <execution>
-            <id>build-javadoc</id>
-            <phase>site</phase>
-            <goals>
-              <goal>exec</goal>
-            </goals>
-          </execution>
-        </executions>
-        <configuration>
-          <executable>${env.MY_SQROOT}/sql/scripts/build_apidocs.sh</executable>
-          <arguments>
-            <argument>-o</argument>
-            <argument>${basedir}/target/site/apidocs</argument>
-            <argument>sql_javadoc</argument>
-            <argument>udr_doxygen</argument>
-          </arguments>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
 


### PR DESCRIPTION
Adding a new apidocs directory to the Trafodion web site. 
This PR is just for the script to generate the content. Instructions
for generating apidocs for a particular release can be found [here](https://cwiki.apache.org/confluence/display/TRAFODION/Merge+Changes#MergeChanges-PublishWebSiteUpdates).
