### PR TITLE
[TRAFODION-2202] in mode_special_4, sequence function is broken

### DIFF
--- a/core/sql/cli/Cli.cpp
+++ b/core/sql/cli/Cli.cpp
@@ -11599,7 +11599,7 @@ static Lng32 SeqGenCliInterfaceUpdAndValidate(
   if (! cliInterfaceArr[SEQ_PROCESS_QRY_IDX])
     {
       cliRC = SeqGenCliInterfacePrepQry(
-                                        "select  case when cast(? as largeint not null) = 1 then t.startVal else t.nextVal end, t.redefTS from (update %s.\"%s\".%s set next_value = (case when cast(? as largeint not null) = 1 then start_value + cast(? as largeint not null) else (case when next_value + cast(? as largeint not null) > max_value then max_value+1 else next_value + cast(? as largeint not null) end) end), num_calls = num_calls + 1 where seq_uid = %Ld return old.start_value, old.next_value, old.redef_ts) t(startVal, nextVal, redefTS);",
+                                        "select  case when cast(? as largeint not null) = 1 then t.startVal else t.nextValue end, t.redefTS from (update %s.\"%s\".%s set next_value = (case when cast(? as largeint not null) = 1 then start_value + cast(? as largeint not null) else (case when next_value + cast(? as largeint not null) > max_value then max_value+1 else next_value + cast(? as largeint not null) end) end), num_calls = num_calls + 1 where seq_uid = %Ld return old.start_value, old.next_value, old.redef_ts) t(startVal, nextValue, redefTS);",
                                         SEQ_PROCESS_QRY_IDX,
                                         "SEQ_PROCESS_QRY_IDX",
                                         cliInterfaceArr, sga, myDiags, currContext, diags, exHeap);


### PR DESCRIPTION
when CQD mode_special_4 is 'on', the binder try to support Oracle sequence syntax as 'indentifier.nextval'.
Binder will regard the identifier as a sequence object which object_type is 'SG'.
However, the sequence execution code will try to get the current value via such a query in SeqGenCliInterfaceUpdAndValidate():
     _**"select  case when cast(? as largeint not null) = 1 then t.startVal else t.nextVal end, t.redefTS from 
    (update %s.\"%s\".%s set next_value = (case when cast(? as largeint not null) = 1 then start_value + 
   cast(? as largeint not null) else (case when next_value + cast(? as largeint not null) > max_value then max_value+1 else next_value + cast(? as largeint not null) end) end), num_calls = num_calls + 1 where seq_uid = %Ld return old.start_value, old.next_value, old.redef_ts) t(startVal, nextVal, redefTS);",**_

so the t.nextval will be handled special, try to find SG object for object 'T', which cannot find, so trigger issues.

This change is very simple, to change the nextval into some other string: 'nextvalue', so the binder will NOT try to treat it as a Oracle syntax.

So when mode_special_4 is 'ON', one can still use the normal sequence function.