### PR TITLE
jira TRAFODION-1755 mxosrvr crashes during explain using EXPLAIN_STMT…

### DIFF
--- a/core/sql/executor/ExExeUtilCli.cpp
+++ b/core/sql/executor/ExExeUtilCli.cpp
@@ -626,9 +626,10 @@ Lng32 ExeCliInterface::setupExplainData(SQLMODULE_ID * module,
   // get explain fragment.
   explainDataLen_ = 50000; // start with 50K bytes
   Int32 retExplainLen = 0;
-  explainData_ = new(getHeap()) char[explainDataLen_];
+  explainData_ = new(getHeap()) char[explainDataLen_+1];
   retcode = SQL_EXEC_GetExplainData(stmt,
-                                    explainData_, explainDataLen_, &retExplainLen
+                                    explainData_, explainDataLen_+1, 
+                                    &retExplainLen
                                     );
   if (retcode == -CLI_GENCODE_BUFFER_TOO_SMALL)
     {
@@ -638,7 +639,8 @@ Lng32 ExeCliInterface::setupExplainData(SQLMODULE_ID * module,
       explainData_ = new(getHeap()) char[explainDataLen_ + 1];
 
       retcode = SQL_EXEC_GetExplainData(stmt,
-                                        explainData_, explainDataLen_, &retExplainLen
+                                        explainData_, explainDataLen_+1, 
+                                        &retExplainLen
                                         );
     }
   

--- a/core/sql/executor/ExExplain.cpp
+++ b/core/sql/executor/ExExplain.cpp
@@ -1651,9 +1651,10 @@ short ExExplainTcb::getExplainData(
   // data stored is explain repos header followed by actual explain tdb data.
   Int32 storedExplLen = sizeof(ExplainReposInfo) + fragLen;
   Lng32 encodedFragLen = str_encoded_len(storedExplLen);
-  *ret_explain_len = encodedFragLen  + 1 /*null terminator*/;
+  *ret_explain_len = encodedFragLen;
   
-  if ((! explain_ptr) || (explain_buf_len < *ret_explain_len))
+  if ((! explain_ptr) || 
+      (explain_buf_len < (*ret_explain_len + 1/*null terminator*/)))
     {
       cliRC = -CLI_GENCODE_BUFFER_TOO_SMALL;
 
@@ -1671,6 +1672,8 @@ short ExExplainTcb::getExplainData(
 
   // encode it before returning
   str_encode(explain_ptr, encodedFragLen, storedExplData, storedExplLen);
+
+  // null terminate explain fragment
   explain_ptr[encodedFragLen] = 0;
 
   NADELETEBASIC(storedExplData, heap);
@@ -1738,9 +1741,9 @@ short ExExplainTcb::getExplainFromRepos(char * qid, Lng32 qidLen)
   if (vi->get(0, ptr, len))
     goto label_error2;
   
-  explainFragLen_ = str_decoded_len(len-1); // remove trailing null terminator
+  explainFragLen_ = str_decoded_len(len); // remove trailing null terminator
   explainFrag_ = new(getHeap()) char[explainFragLen_];
-  if (str_decode(explainFrag_, explainFragLen_, ptr, len-1) < 0)
+  if (str_decode(explainFrag_, explainFragLen_, ptr, len) < 0)
     {
       diagsArea = pEntryDown->getAtp()->getDiagsArea();
       ExRaiseSqlError(getGlobals()->getDefaultHeap(), 

--- a/core/sql/sqlci/SqlCmd.cpp
+++ b/core/sql/sqlci/SqlCmd.cpp
@@ -715,7 +715,8 @@ short SqlCmd::updateRepos(SqlciEnv * sqlci_env, SQLSTMT_ID * stmt, char * queryI
   Int32 retExplainLen = 0;
   char * explainData = new char[explainDataLen + 1];
   retcode = SQL_EXEC_GetExplainData(stmt,
-                                    explainData, explainDataLen, &retExplainLen
+                                    explainData, explainDataLen+1, 
+                                    &retExplainLen
                                     );
   if (retcode == -CLI_GENCODE_BUFFER_TOO_SMALL)
     {
@@ -726,7 +727,8 @@ short SqlCmd::updateRepos(SqlciEnv * sqlci_env, SQLSTMT_ID * stmt, char * queryI
 
       SqlCmd::clearCLIDiagnostics();
       retcode = SQL_EXEC_GetExplainData(stmt,
-                                        explainData, explainDataLen, &retExplainLen
+                                        explainData, explainDataLen+1, 
+                                        &retExplainLen
                                         );
     }
   


### PR DESCRIPTION
… syntax

mxosrvr crashes when using the explain_stmt option
select * from table(explain(null, 'EXPLAIN_STMT=<stmt>'));