### PR TITLE
automatic creation of schemas

### DIFF
--- a/core/sql/regress/seabase/EXPECTED032
+++ b/core/sql/regress/seabase/EXPECTED032
@@ -15,7 +15,7 @@
 >>invoke t032t1;
 
 -- Definition of Trafodion table TRAFODION.SCH.T032T1
--- Definition current  Wed Aug 24 20:59:45 2016
+-- Definition current  Sun Sep 11 15:22:27 2016
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -140,7 +140,7 @@ B
 (EXPR)                        
 ------------------------------
 
-RANDOMVAL=1935127796          
+RANDOMVAL=262036305           
 
 --- 1 row(s) selected.
 >>select random() from (values(1)) x(a);
@@ -293,5 +293,44 @@ A
      1
 
 --- 1 row(s) selected.
+>>
+>>
+>>-- auto create schema
+>>
+>>-- should fail, schema doesnt exist
+>>create table t032sch.t032t2 (a int);
+
+*** ERROR[1003] Schema TRAFODION.T032SCH does not exist.
+
+--- SQL operation failed with errors.
+>>
+>>-- should succeed, schema will be automatically created
+>>cqd traf_auto_create_schema 'ON';
+
+--- SQL operation complete.
+>>create table t032sch.t032t2 (a int);
+
+--- SQL operation complete.
+>>set schema t032sch;
+
+--- SQL operation complete.
+>>invoke t032t2;
+
+-- Definition of Trafodion table TRAFODION.T032SCH.T032T2
+-- Definition current  Sun Sep 11 15:22:36 2016
+
+  (
+    SYSKEY                           LARGEINT NO DEFAULT NOT NULL NOT DROPPABLE
+  , A                                INT DEFAULT NULL
+  )
+
+--- SQL operation complete.
+>>insert into t032t2 values (1);
+
+--- 1 row(s) inserted.
+>>
+>>drop schema t032sch cascade;
+
+--- SQL operation complete.
 >>
 >>log;

--- a/core/sql/regress/seabase/TEST032
+++ b/core/sql/regress/seabase/TEST032
@@ -87,5 +87,20 @@ select * from (values(1)) x(a) where current_timestamp(0) = current_timestamp(6)
 
 select cast(1e0 as interval year) from dual;
 
+
+-- auto create schema
+
+-- should fail, schema doesnt exist
+create table t032sch.t032t2 (a int);
+
+-- should succeed, schema will be automatically created
+cqd traf_auto_create_schema 'ON';
+create table t032sch.t032t2 (a int);
+set schema t032sch;
+invoke t032t2;
+insert into t032t2 values (1);
+
+drop schema t032sch cascade;
+
 log;
 

--- a/core/sql/sqlcomp/DefaultConstants.h
+++ b/core/sql/sqlcomp/DefaultConstants.h
@@ -3854,6 +3854,10 @@ enum DefaultConstants
   // allow ORDER BY in subqueries.
   ALLOW_ORDER_BY_IN_SUBQUERIES,
 
+  // if the schema specified in a create stmt doesn't exist, automatically
+  // create it.
+  TRAF_AUTO_CREATE_SCHEMA,
+
   // This enum constant must be the LAST one in the list; it's a count,
   // not an Attribute (it's not IN DefaultDefaults; it's the SIZE of it)!
   __NUM_DEFAULT_ATTRIBUTES

--- a/core/sql/sqlcomp/nadefaults.cpp
+++ b/core/sql/sqlcomp/nadefaults.cpp
@@ -3303,6 +3303,8 @@ XDDkwd__(SUBQUERY_UNNESTING,			"ON"),
 
   DDkwd__(TRAF_ALTER_COL_ATTRS,                 "ON"),   
 
+  DDkwd__(TRAF_AUTO_CREATE_SCHEMA,                 "OFF"),   
+
   DDkwd__(TRAF_BLOB_AS_VARCHAR,                 "ON"), //set to OFF to enable Lobs support  
 
   DDkwd__(TRAF_BOOLEAN_IO,                        "OFF"),


### PR DESCRIPTION
couple changes:
1) if dev regressions are being run and regr schema ("trafodion.sch")
  doesn't exist, then it is automatically created as part
  of the first 'create' stmt. This schema is also updated
  as the default schema in DEFAULTS metadata table.
2) if cqd traf_auto_create_schema is set and the schema specified
  in a 'create' stmt doesn't exist, then it is automatically
  created. This helps with migrating scripts from other vendors
  if schema is specified as part of create table stmt.

