### PR TITLE
[TRAFODION-2218] Memory leak from JVM used for TMUDF compile time interaction

### DIFF
--- a/core/sql/langman/LmRoutineJavaObj.cpp
+++ b/core/sql/langman/LmRoutineJavaObj.cpp
@@ -192,6 +192,7 @@ LmResult LmRoutineJavaObj::invokeRoutineMethod(
           (*emitRowPtr_)(NULL,0,&qs);
         }
     }
+  jni->DeleteLocalRef(jniResult);
 
   if (invocationInfoLenOut)
     *invocationInfoLenOut = static_cast<Int32>(iiLen_);

--- a/core/sql/src/main/java/org/trafodion/sql/udr/LmUDRObjMethodInvoke.java
+++ b/core/sql/src/main/java/org/trafodion/sql/udr/LmUDRObjMethodInvoke.java
@@ -68,7 +68,7 @@ public class LmUDRObjMethodInvoke
         return result;
     }
 
-    public static class ReturnInfo
+    public class ReturnInfo
     {
         // return status:
         // <0: Internal error, check for Java exception

--- a/core/sql/src/main/java/org/trafodion/sql/udr/LmUDRObjMethodInvoke.java
+++ b/core/sql/src/main/java/org/trafodion/sql/udr/LmUDRObjMethodInvoke.java
@@ -68,7 +68,7 @@ public class LmUDRObjMethodInvoke
         return result;
     }
 
-    public class ReturnInfo
+    public static class ReturnInfo
     {
         // return status:
         // <0: Internal error, check for Java exception


### PR DESCRIPTION
DeleteLocalRef added. ReturnInfo is no longer static. Please see JIRA for an explanation.