### PR TITLE
[TRAFODION-2187] Fix DROP SCHEMA CASCADE when sample tables are present

### DIFF
--- a/core/sql/common/ComSmallDefs.h
+++ b/core/sql/common/ComSmallDefs.h
@@ -129,6 +129,7 @@ typedef NABoolean               ComBoolean;
 #define SEABASE_OLD_PRIVMGR_SCHEMA         "PRIVMGR_MD"
 #define SEABASE_PRIVMGR_SCHEMA         "_PRIVMGR_MD_"
 #define SEABASE_UDF_SCHEMA             "_UDF_"
+#define TRAF_SAMPLE_PREFIX             "TRAF_SAMPLE_"  // prefix for a sample table used by update stats
 #define LOB_MD_PREFIX                  "LOBMD_"
 #define LOB_DESC_CHUNK_PREFIX          "LOBDescChunks_"
 #define LOB_DESC_HANDLE_PREFIX         "LOBDescHandle_"

--- a/core/sql/sqlcomp/CmpSeabaseDDL.h
+++ b/core/sql/sqlcomp/CmpSeabaseDDL.h
@@ -160,6 +160,7 @@ class CmpSeabaseDDL
   static NABoolean isHbase(const NAString &catName);
 
   static bool isHistogramTable(const NAString &tabName);
+  static bool isSampleTable(const NAString &tabName);
   static NABoolean isLOBDependentNameMatch(const NAString &name);
   static NABoolean isSeabaseMD(const NAString &catName,
 			       const NAString &schName,

--- a/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
@@ -958,6 +958,14 @@ bool CmpSeabaseDDL::isHistogramTable(const NAString &name)
 
 }
 
+bool CmpSeabaseDDL::isSampleTable(const NAString &name)
+{
+  if (name(0,min((sizeof(TRAF_SAMPLE_PREFIX)-1), name.length())) == TRAF_SAMPLE_PREFIX)
+    return true;
+
+  return false;
+}
+
 NABoolean CmpSeabaseDDL::isLOBDependentNameMatch(const NAString &name)
 {
   if ((name(0,min((sizeof(LOB_MD_PREFIX)-1), name.length())) == LOB_MD_PREFIX) ||

--- a/core/sql/sqlcomp/CmpSeabaseDDLschema.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLschema.cpp
@@ -684,10 +684,14 @@ void CmpSeabaseDDL::dropSeabaseSchema(StmtDDLDropSchema * dropSchemaNode)
        // drop user objects first
        if (objType == COM_BASE_TABLE_OBJECT_LIT) 
 	 {
-	   // histogram tables have already been dropped
-	   // Avoid any tables that match LOB dependent tablenames.
-	   // (there is no special type for these tables) 
-	   if (!isHistogramTable(objName) && !isLOBDependentNameMatch(objName))
+	   // Histogram tables are dropped later. Sample tables
+	   // are dropped when their corresponding tables are dropped
+	   // so we don't need to drop them directly. Also,
+	   // avoid any tables that match LOB dependent tablenames
+	   // (there is no special type for these tables).
+	   if (!isHistogramTable(objName) &&
+               !isSampleTable(objName) &&
+               !isLOBDependentNameMatch(objName))
 	     {
 	       dirtiedMetadata = TRUE;
 	       if (dropOneTable(cliInterface,(char*)catName.data(), 

--- a/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
@@ -3670,7 +3670,7 @@ short CmpSeabaseDDL::dropSeabaseTable2(
       if (objectNamePart != "SB_HISTOGRAMS" && 
           objectNamePart != "SB_HISTOGRAM_INTERVALS" &&
           objectNamePart != "SB_PERSISTENT_SAMPLES" &&
-          strncmp(objectNamePart.data(),"TRAF_SAMPLE_",sizeof("TRAF_SAMPLE_")) != 0)
+          strncmp(objectNamePart.data(),TRAF_SAMPLE_PREFIX,sizeof(TRAF_SAMPLE_PREFIX)) != 0)
           
       {
         if (dropSeabaseStats(cliInterface,

--- a/core/sql/ustat/hs_globals.cpp
+++ b/core/sql/ustat/hs_globals.cpp
@@ -3856,7 +3856,7 @@ void HSSample::makeTableName(NABoolean isPersSample)
 
         convertInt64ToAscii(objDef->getObjectUID(), objectIDStr);
         sprintf(timestampStr, "_%u_%u", (UInt32)tv.tv_sec, (UInt32)tv.tv_usec);
-        sampleTable += "TRAF_SAMPLE_";
+        sampleTable += TRAF_SAMPLE_PREFIX;  // "TRAF_SAMPLE_"
         sampleTable += objectIDStr;
         sampleTable += timestampStr;
 


### PR DESCRIPTION
The problem was that when a sample table existed, the DROP SCHEMA code would try dropping it but it had already been dropped when its associated user table was dropped.

The fix is to skip over sample tables when dropping user tables, as the sample tables are dropped automatically when their associated user tables are dropped via DROP TABLE.