### PR TITLE
[TRAFODION-2219] charsets regression failures and retrieved columns

### DIFF
--- a/core/sql/generator/GenExplain.cpp
+++ b/core/sql/generator/GenExplain.cpp
@@ -570,8 +570,7 @@ FileScan::addSpecificExplainInfo(ExplainTupleMaster *explainTuple,
   // now get columns_retrieved
   description += "columns_retrieved: ";
   char buf[27];
-  //sprintf(buf, "%d ", retrievedCols().entries());
-  sprintf(buf, "%d ", getIndexDesc()->getIndexColumns().entries());
+  sprintf(buf, "%d ", retrievedCols().entries());
   description += buf;
 
   // now get the probe counters

--- a/core/sql/generator/GenRelScan.cpp
+++ b/core/sql/generator/GenRelScan.cpp
@@ -758,6 +758,8 @@ short FileScan::codeGenForHive(Generator * generator)
     
   }
 
+  setRetrievedCols(neededHdfsVals);
+
   ex_expr *executor_expr = 0;
   ex_expr *proj_expr = 0;
   ex_expr *convert_expr = 0;

--- a/core/sql/optimizer/RelScan.h
+++ b/core/sql/optimizer/RelScan.h
@@ -1023,6 +1023,11 @@ public:
 
   Int32 getComputedNumOfActivePartiions()  const { return computedNumOfActivePartitions_; }
 
+protected:
+
+  void setRetrievedCols(const ValueIdSet &retrievedCols)
+                                           { retrievedCols_ = retrievedCols; }
+
 private:
 
 

--- a/core/sql/regress/charsets/EXPECTED310
+++ b/core/sql/regress/charsets/EXPECTED310
@@ -101,7 +101,7 @@ u1u1
 *** ERROR[8822] The statement was not prepared.
 
 >>--
->>select * from cs310t2, cs310t1 order by 1;
+>>select * from cs310t2, cs310t1 order by 1,2;
 
 U1                A1      
 ----------------  --------
@@ -406,7 +406,7 @@ u1u1
 >>--
 >>-- Tests for basic SQL functions
 >>--
->>select * from cs310t3, cs310t4 order by 1;
+>>select * from cs310t3, cs310t4 order by 1,2;
 
 A1        U1              
 --------  ----------------

--- a/core/sql/regress/charsets/EXPECTED311
+++ b/core/sql/regress/charsets/EXPECTED311
@@ -101,7 +101,7 @@ u1u1
 *** ERROR[8822] The statement was not prepared.
 
 >>--
->>select * from cs311t2, cs311t1 order by 1;
+>>select * from cs311t2, cs311t1 order by 1,2;
 
 U1                A1      
 ----------------  --------
@@ -406,7 +406,7 @@ u1u1
 >>--
 >>-- Tests for basic SQL functions
 >>--
->>select * from cs311t3, cs311t4 order by 1;
+>>select * from cs311t3, cs311t4 order by 1,2;
 
 A1        U1              
 --------  ----------------

--- a/core/sql/regress/charsets/TEST310
+++ b/core/sql/regress/charsets/TEST310
@@ -73,7 +73,7 @@ select ascii( _ucs2'a') from cs310t1 order by 1;
 select ascii(u1) from cs310t2 order by 1;
 select ascii( TRANSLATE(_iso88591'abcdefghijklmnop' using Iso88591ToUCS2) ) from cs310t2 order by 1;
 --
-select * from cs310t2, cs310t1 order by 1;
+select * from cs310t2, cs310t1 order by 1,2;
 select * from cs310t2, cs310t1 where 'a' = CHAR(ASCII('a1a1')) order by 1,2; -- SEE NOTE ABOVE
 select * from cs310t2, cs310t1 where 'u' = CHAR(ASCII('u1u1'),UCS2) order by 1,2; -- SEE NOTE ABOVE
 select * from cs310t2, cs310t1 where 'u' = lower(CHAR(ASCII(upper(a1)))) order by 1,2; -- SEE NOTE ABOVE
@@ -117,7 +117,7 @@ select * from cs310t3 union all (select * from cs310t4) order by 1;
 --
 -- Tests for basic SQL functions
 --
-select * from cs310t3, cs310t4 order by 1;
+select * from cs310t3, cs310t4 order by 1,2;
 select * from cs310t3, cs310t4 where a1 = case when a1 > 'a1a' then u1 else 'a100' end order by 1,2;
 select * from cs310t3, cs310t4 where a1 = case when a1 > 'a1a' then 'a1a1' else 'a100' end order by 1,2;
 select * from cs310t3, cs310t4 where a1 = coalesce(cast(NULL as varchar(8) character set ISO88591), u1, a1) order by 1,2;

--- a/core/sql/regress/charsets/TEST311
+++ b/core/sql/regress/charsets/TEST311
@@ -74,7 +74,7 @@ select ascii( _ucs2'a') from cs311t1 order by 1;
 select ascii(u1) from cs311t2 order by 1;
 select ascii( TRANSLATE(_iso88591'abcdefghijklmnop' using Iso88591ToUCS2) ) from cs311t2 order by 1;
 --
-select * from cs311t2, cs311t1 order by 1;
+select * from cs311t2, cs311t1 order by 1,2;
 select * from cs311t2, cs311t1 where 'a' = CHAR(ASCII('a1a1')) order by 1,2; -- SEE NOTE ABOVE
 select * from cs311t2, cs311t1 where 'u' = CHAR(ASCII('u1u1'),UCS2) order by 1,2; -- SEE NOTE ABOVE
 select * from cs311t2, cs311t1 where 'u' = lower(CHAR(ASCII(upper(a1)))) order by 1,2; -- SEE NOTE ABOVE
@@ -118,7 +118,7 @@ select * from cs311t3 union all (select * from cs311t4) order by 1;
 --
 -- Tests for basic SQL functions
 --
-select * from cs311t3, cs311t4 order by 1;
+select * from cs311t3, cs311t4 order by 1,2;
 select * from cs311t3, cs311t4 where a1 = case when a1 > 'a1a' then u1 else 'a100' end order by 1,2;
 select * from cs311t3, cs311t4 where a1 = case when a1 > 'a1a' then 'a1a1' else 'a100' end order by 1,2;
 select * from cs311t3, cs311t4 where a1 = coalesce(cast(NULL as varchar(8) character set ISO88591), u1, a1) order by 1,2;


### PR DESCRIPTION
Fixed a problem with occasional failures of regressions, due to
non-deterministic order of results.

Also changed the way we show the number of "retrieved columns" for
Hive and ORC scans. The EXPLAIN now only shows the number of
actually needed columns, not all of them.