### PR TITLE
[TRAFODION-2220] Change handling of manual persistent sample tables

### DIFF
--- a/core/sql/bin/SqlciErrors.txt
+++ b/core/sql/bin/SqlciErrors.txt
@@ -1894,6 +1894,7 @@ drop the default context
 9248 ZZZZZ 99999 BEGINNER MAJOR DBADMIN UPDATE STATISTICS failed due to a memory allocation failure.
 9249 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Incremental UPDATE STATISTICS is disabled.
 9250 ZZZZZ 99999 BEGINNER MINOR LOGONLY Incremental UPDATE STATISTICS: non-NULL values added to previously all-NULL histogram for column $0~string0. A regular UPDATE STATISTICS is performed instead.
+9251 ZZZZZ 99999 BEGINNER MAJOR DBADMIN A persistent sample table already exists. Use UPDATE STATISTICS ... REMOVE SAMPLE to drop it first if desired.
 9259 ZZZZZ 99999 UUUUUUUU UUUUU UUUUUUU Last UPDATE STATISTICS error.
 10000 ZZZZZ 99999 UUUUUUUU UUUUU UUUUUUU Sort Error: First Sort error
 10001 ZZZZZ 99999 ADVANCED MAJOR DIALOUT Sort Error : No error text defined. Unexpected error. $0~String0

--- a/core/sql/regress/compGeneral/EXPECTED023
+++ b/core/sql/regress/compGeneral/EXPECTED023
@@ -95,7 +95,7 @@ STESTC
 STEST_EMPTY
 
 --- SQL operation complete.
->>  -- should be just stest, stest_empty, stestc; no sb_* tables yet
+>>  -- should be just stest, stest_empty, stestc, and the sb_* tables
 >>
 >>?section ustat1p
 >>
@@ -119,7 +119,7 @@ STEST_EMPTY
 OBJECT_NAME                                                                                                                                                                                                                                                       SAMPLE_NAME                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           REASON  LAST_WHERE_PREDICATE
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  ------  --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-STEST                                                                                                                                                                                                                                                             TRAFODION.COMPGENERAL_TEST023.TRAF_SAMPLE_6_1456279355_95736                                                                                                                                                                                                                                                                                                                                                                                                                                                          M                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+STEST                                                                                                                                                                                                                                                             TRAFODION.COMPGENERAL_TEST023.TRAF_SAMPLE_42_1473872687_899942                                                                                                                                                                                                                                                                                                                                                                                                                                                        M                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
 
 --- 1 row(s) selected.
 >>-- should see one row
@@ -135,12 +135,15 @@ SB_PERSISTENT_SAMPLES
 STEST
 STESTC
 STEST_EMPTY
-TRAF_SAMPLE_6_1456279355_95736
+TRAF_SAMPLE_42_1473872687_899942
 
 --- SQL operation complete.
->> -- should be stest, stest_empty, stestc, sb_persistent_samples + a sample table
+>> -- should be stest, stest_empty, stestc, sb_* tables + a sample table
 >>
 >>-- create another one, showing its replacement
+>>update statistics for table stest remove sample;
+
+--- SQL operation complete.
 >>update statistics for table stest create sample random 10 percent;
 
 --- SQL operation complete.
@@ -156,17 +159,17 @@ SB_PERSISTENT_SAMPLES
 STEST
 STESTC
 STEST_EMPTY
-TRAF_SAMPLE_5_1456279391_83165
+TRAF_SAMPLE_51_1473872720_555851
 
 --- SQL operation complete.
->> -- should be stest, stest_empty, stestc, sb_persistent_samples + a different sample table
+>> -- should be stest, stest_empty, stestc, sb_* tables + a different sample table
 >>
 >>execute s1 using 'STEST';
 
 OBJECT_NAME                                                                                                                                                                                                                                                       SAMPLE_NAME                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           REASON  LAST_WHERE_PREDICATE
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  ------  --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-STEST                                                                                                                                                                                                                                                             TRAFODION.COMPGENERAL_TEST023.TRAF_SAMPLE_5_1456279391_83165                                                                                                                                                                                                                                                                                                                                                                                                                                                          M                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+STEST                                                                                                                                                                                                                                                             TRAFODION.COMPGENERAL_TEST023.TRAF_SAMPLE_51_1473872720_555851                                                                                                                                                                                                                                                                                                                                                                                                                                                        M                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
 
 --- 1 row(s) selected.
 >>-- should see one row
@@ -189,7 +192,7 @@ STESTC
 STEST_EMPTY
 
 --- SQL operation complete.
->> -- should be stest, stest_empty, stestc, sb_persistent_samples only
+>> -- should be stest, stest_empty, stestc, sb_* tables only
 >>
 >>execute s1 using 'STEST';
 
@@ -213,22 +216,25 @@ SB_PERSISTENT_SAMPLES
 STEST
 STESTC
 STEST_EMPTY
-TRAF_SAMPLE_72_1456279415_388472
+TRAF_SAMPLE_81_1473872746_376381
 
 --- SQL operation complete.
->> -- should be stest, stest_empty, stestc, sb_persistent_samples, sb_hist* + another sample table
+>> -- should be stest, stest_empty, stestc, sb_* tables + another sample table
 >>
 >>execute s1 using 'STEST';
 
 OBJECT_NAME                                                                                                                                                                                                                                                       SAMPLE_NAME                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           REASON  LAST_WHERE_PREDICATE
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  ------  --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-STEST                                                                                                                                                                                                                                                             TRAFODION.COMPGENERAL_TEST023.TRAF_SAMPLE_72_1456279415_388472                                                                                                                                                                                                                                                                                                                                                                                                                                                        I                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+STEST                                                                                                                                                                                                                                                             TRAFODION.COMPGENERAL_TEST023.TRAF_SAMPLE_81_1473872746_376381                                                                                                                                                                                                                                                                                                                                                                                                                                                        I                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
 
 --- 1 row(s) selected.
 >>-- should see one row
 >>
 >>-- do it again showing its replacement
+>>update statistics for table stest remove sample;
+
+--- SQL operation complete.
 >>update statistics for table stest on every column sample random 10 percent persistent;
 
 --- SQL operation complete.
@@ -244,17 +250,17 @@ SB_PERSISTENT_SAMPLES
 STEST
 STESTC
 STEST_EMPTY
-TRAF_SAMPLE_88_1456279440_120688
+TRAF_SAMPLE_53_1473872773_525053
 
 --- SQL operation complete.
->> -- should be stest, stest_empty, stestc, sb_persistent_samples, sb_hist* + another sample table
+>> -- should be stest, stest_empty, stestc, sb_* tables + another sample table
 >>
 >>execute s1 using 'STEST';
 
 OBJECT_NAME                                                                                                                                                                                                                                                       SAMPLE_NAME                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           REASON  LAST_WHERE_PREDICATE
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  ------  --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-STEST                                                                                                                                                                                                                                                             TRAFODION.COMPGENERAL_TEST023.TRAF_SAMPLE_88_1456279440_120688                                                                                                                                                                                                                                                                                                                                                                                                                                                        I                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
+STEST                                                                                                                                                                                                                                                             TRAFODION.COMPGENERAL_TEST023.TRAF_SAMPLE_53_1473872773_525053                                                                                                                                                                                                                                                                                                                                                                                                                                                        I                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           
 
 --- 1 row(s) selected.
 >>-- should see one row
@@ -311,7 +317,7 @@ STEST                                                                           
 OBJECT_NAME                                                                                                                                                                                                                                                       SAMPLE_NAME                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           REASON  LAST_WHERE_PREDICATE
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  ------  --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-STEST                                                                                                                                                                                                                                                             TRAFODION.COMPGENERAL_TEST023.TRAF_SAMPLE_88_1456279440_120688                                                                                                                                                                                                                                                                                                                                                                                                                                                        I        c1 >= 100000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       
+STEST                                                                                                                                                                                                                                                             TRAFODION.COMPGENERAL_TEST023.TRAF_SAMPLE_53_1473872773_525053                                                                                                                                                                                                                                                                                                                                                                                                                                                        I        c1 >= 100000                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       
 
 --- 1 row(s) selected.
 >>
@@ -368,8 +374,8 @@ SB_PERSISTENT_SAMPLES
 STEST
 STESTC
 STEST_EMPTY
-TRAF_SAMPLE_85_1456279493_417385
-TRAF_SAMPLE_88_1456279440_120688
+TRAF_SAMPLE_34_1473872821_557534
+TRAF_SAMPLE_53_1473872773_525053
 
 --- SQL operation complete.
 >>
@@ -378,7 +384,7 @@ TRAF_SAMPLE_88_1456279440_120688
 OBJECT_NAME                                                                                                                                                                                                                                                       SAMPLE_NAME                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                           REASON  LAST_WHERE_PREDICATE
 ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------  ------  --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
 
-STESTC                                                                                                                                                                                                                                                            TRAFODION.COMPGENERAL_TEST023.TRAF_SAMPLE_85_1456279493_417385                                                                                                                                                                                                                                                                                                                                                                                                                                                        I        c1 >= 'naaaa'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      
+STESTC                                                                                                                                                                                                                                                            TRAFODION.COMPGENERAL_TEST023.TRAF_SAMPLE_34_1473872821_557534                                                                                                                                                                                                                                                                                                                                                                                                                                                        I        c1 >= 'naaaa'                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                      
 
 --- 1 row(s) selected.
 >>
@@ -403,8 +409,8 @@ SB_PERSISTENT_SAMPLES
 STEST
 STESTC
 STEST_EMPTY
-TRAF_SAMPLE_85_1456279493_417385
-TRAF_SAMPLE_88_1456279440_120688
+TRAF_SAMPLE_34_1473872821_557534
+TRAF_SAMPLE_53_1473872773_525053
 
 --- SQL operation complete.
 >> -- should be the same as previous "get tables"
@@ -429,8 +435,8 @@ SB_PERSISTENT_SAMPLES
 STEST
 STESTC
 STEST_EMPTY
-TRAF_SAMPLE_85_1456279493_417385
-TRAF_SAMPLE_88_1456279440_120688
+TRAF_SAMPLE_34_1473872821_557534
+TRAF_SAMPLE_53_1473872773_525053
 
 --- SQL operation complete.
 >> -- should be the same as previous "get tables"
@@ -458,8 +464,8 @@ SB_PERSISTENT_SAMPLES
 STEST
 STESTC
 STEST_EMPTY
-TRAF_SAMPLE_85_1456279493_417385
-TRAF_SAMPLE_88_1456279440_120688
+TRAF_SAMPLE_34_1473872821_557534
+TRAF_SAMPLE_53_1473872773_525053
 
 --- SQL operation complete.
 >> -- should be the same as previous "get tables"
@@ -471,7 +477,7 @@ TRAF_SAMPLE_88_1456279440_120688
 
 *** ERROR[15001] A syntax error occurred at or before: 
 SELECT "C1", "C2", "C3", "_SALT_" FROM TRAFODION.COMPGENERAL_TEST023.TRAF_SAMPL
-E_88_1456279440_120688 WHERE  1 FOR READ UNCOMMITTED ACCESS;
+E_53_1473872773_525053 WHERE  1 FOR READ UNCOMMITTED ACCESS;
                                         ^ (120 characters from start of SQL statement)
 
 *** ERROR[8822] The statement was not prepared.
@@ -480,7 +486,7 @@ E_88_1456279440_120688 WHERE  1 FOR READ UNCOMMITTED ACCESS;
 
 *** ERROR[15001] A syntax error occurred at or before: 
 SELECT "C1", "C2", "C3", "_SALT_" FROM TRAFODION.COMPGENERAL_TEST023.TRAF_SAMPL
-E_88_1456279440_120688 WHERE  1 FOR READ UNCOMMITTED ACCESS;
+E_53_1473872773_525053 WHERE  1 FOR READ UNCOMMITTED ACCESS;
                                         ^ (120 characters from start of SQL statement)
 
 *** ERROR[8822] The statement was not prepared.
@@ -498,16 +504,35 @@ SB_PERSISTENT_SAMPLES
 STEST
 STESTC
 STEST_EMPTY
-TRAF_SAMPLE_85_1456279493_417385
-TRAF_SAMPLE_88_1456279440_120688
+TRAF_SAMPLE_34_1473872821_557534
+TRAF_SAMPLE_53_1473872773_525053
 
 --- SQL operation complete.
 >> -- should be the same as previous "get tables"
 >>
 >>-- attempt to do incremental when no persistent sample exists
->>update statistics for table stest_empty on existing columns incremental where c1 >= 100000;
+>>update statistics for table stestc remove sample;
 
 --- SQL operation complete.
+>>update statistics for table stestc on existing columns incremental where c1 >= 'naaaa';
+
+*** ERROR[9221] Incremental UPDATE STATISTICS cannot be performed due to the absence of the IUS persistent sample table for TRAFODION.COMPGENERAL_TEST023.STESTC.  Use a regular UPDATE STATISTICS command with the sample clause and PERSISTENT first to create such a persistent sample table.
+
+--- SQL operation failed with errors.
+>>
+>>-- attempt to create a persistent sample when one already exists, syntax 1
+>>update statistics for table stest on every column sample random 10 percent persistent;
+
+*** ERROR[9251] A persistent sample table already exists. Use UPDATE STATISTICS ... REMOVE SAMPLE to drop it first if desired.
+
+--- SQL operation failed with errors.
+>>
+>>-- attempt to create a persistent sample when one already exists, syntax 2
+>>update statistics for table stest create sample random 20 percent;
+
+*** ERROR[9251] A persistent sample table already exists. Use UPDATE STATISTICS ... REMOVE SAMPLE to drop it first if desired.
+
+--- SQL operation failed with errors.
 >>
 >>get tables;
 
@@ -520,11 +545,10 @@ SB_PERSISTENT_SAMPLES
 STEST
 STESTC
 STEST_EMPTY
-TRAF_SAMPLE_85_1456279493_417385
-TRAF_SAMPLE_88_1456279440_120688
+TRAF_SAMPLE_53_1473872773_525053
 
 --- SQL operation complete.
->> -- should be the same as previous "get tables"
+>> -- should be the same as previous "get tables" except only one sample table
 >>
 >>
 >>?section clnup

--- a/core/sql/regress/compGeneral/TEST023
+++ b/core/sql/regress/compGeneral/TEST023
@@ -92,7 +92,7 @@ transpose 'a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j' as x5;
 
 create table stest_empty like stest with partitions;
 
-get tables;  -- should be just stest, stest_empty, stestc; no sb_* tables yet
+get tables;  -- should be just stest, stest_empty, stestc, and the sb_* tables
 
 ?section ustat1p
 
@@ -110,12 +110,13 @@ select object_name,sample_name,reason,last_where_predicate
 execute s1 using 'STEST';
 -- should see one row
 
-get tables; -- should be stest, stest_empty, stestc, sb_persistent_samples + a sample table
+get tables; -- should be stest, stest_empty, stestc, sb_* tables + a sample table
 
 -- create another one, showing its replacement
+update statistics for table stest remove sample;
 update statistics for table stest create sample random 10 percent;
 
-get tables; -- should be stest, stest_empty, stestc, sb_persistent_samples + a different sample table
+get tables; -- should be stest, stest_empty, stestc, sb_* tables + a different sample table
 
 execute s1 using 'STEST';
 -- should see one row
@@ -123,7 +124,7 @@ execute s1 using 'STEST';
 -- remove a persistent sample table
 update statistics for table stest remove sample;
 
-get tables; -- should be stest, stest_empty, stestc, sb_persistent_samples only
+get tables; -- should be stest, stest_empty, stestc, sb_* tables only
 
 execute s1 using 'STEST';
 -- should see zero rows
@@ -132,15 +133,16 @@ execute s1 using 'STEST';
 
 update statistics for table stest on every column sample random 10 percent persistent;
 
-get tables; -- should be stest, stest_empty, stestc, sb_persistent_samples, sb_hist* + another sample table
+get tables; -- should be stest, stest_empty, stestc, sb_* tables + another sample table
 
 execute s1 using 'STEST';
 -- should see one row
 
 -- do it again showing its replacement
+update statistics for table stest remove sample;
 update statistics for table stest on every column sample random 10 percent persistent;
 
-get tables; -- should be stest, stest_empty, stestc, sb_persistent_samples, sb_hist* + another sample table
+get tables; -- should be stest, stest_empty, stestc, sb_* tables + another sample table
 
 execute s1 using 'STEST';
 -- should see one row
@@ -255,9 +257,16 @@ update statistics for table stest on existing columns incremental where 1;
 get tables; -- should be the same as previous "get tables"
 
 -- attempt to do incremental when no persistent sample exists
-update statistics for table stest_empty on existing columns incremental where c1 >= 100000;
+update statistics for table stestc remove sample;
+update statistics for table stestc on existing columns incremental where c1 >= 'naaaa';
 
-get tables; -- should be the same as previous "get tables"
+-- attempt to create a persistent sample when one already exists, syntax 1
+update statistics for table stest on every column sample random 10 percent persistent;
+
+-- attempt to create a persistent sample when one already exists, syntax 2
+update statistics for table stest create sample random 20 percent;
+
+get tables; -- should be the same as previous "get tables" except only one sample table
 
 
 ?section clnup

--- a/core/sql/ustat/hs_const.h
+++ b/core/sql/ustat/hs_const.h
@@ -175,6 +175,7 @@ enum USTAT_ERROR_CODES {UERR_SYNTAX_ERROR                    = 15001,
                         UERR_FASTSTATS_MEM_ALLOCATION_ERROR  = 9248,
                         UERR_IUS_IS_DISABLED                 = 9249,
                         UERR_WARNING_IUS_NO_LONGER_ALL_NULL  = 9250,
+                        UERR_DROP_PERSISTANT_SAMPLE_FIRST    = 9251,
                         UERR_NO_ERROR                        = 9259,
                         UERR_LAST_ERROR                      = 9259
                        };


### PR DESCRIPTION
Changed the handling of persistent sample tables (that is, those created by UPDATE STATISTICS ... CREATE SAMPLE) to be the same as those created using the PERSISTENT keyword (that is, those created by UPDATE STATISTICS ... SAMPLE RANDOM PERSISTENT). This is a simpler model; now these tables are used interchangeably.

As before, we still limit a table to having at most one persistent sample table.

Contrary to before, the behavior when creating a persistent sample table (via either syntax) when one already exists has been changed. Before we would silently drop the earlier table; now the UPDATE STATISTICS statement will fail with error 9251. This is better behavior, because it prevents a user from accidentally destroying an existing persistent sample. The user has to explicitly remove it instead.

So, in the test script for this JIRA, the last UPDATE STATISTICS command will now fail with error 9251 (rather than the mysterious error 8102).