### PR TITLE
sql regression test executor test022 fix, min largeint

### DIFF
--- a/core/sql/exp/exp_conv.cpp
+++ b/core/sql/exp/exp_conv.cpp
@@ -2091,8 +2091,11 @@ ex_expr::exp_return_type convAsciiToInt64(Int64 &target,
                           heap, diagsArea, flags);
   if (ert == ex_expr::EXPR_ERROR)
     return ert;
-
-  if (tempTgt > LLONG_MAX)
+  UInt64 maxLongPlus1 = LLONG_MAX ;
+  maxLongPlus1 ++; // min 64bit long integer is -9223372036854775808
+                   // max 64bit long integer is 9223372036854775807
+                   // so if negative value convert to non-negative value, should check with LLONG_MAX + 1
+  if ((tempTgt > LLONG_MAX && NOT negative) || (tempTgt > maxLongPlus1) )
     {
       ExRaiseDetailSqlError(heap, diagsArea, EXE_NUMERIC_OVERFLOW,
                             source, sourceLen, REC_BYTE_F_ASCII,

--- a/core/sql/exp/exp_conv.cpp
+++ b/core/sql/exp/exp_conv.cpp
@@ -2109,6 +2109,10 @@ ex_expr::exp_return_type convAsciiToInt64(Int64 &target,
       target = (Int64)tempTgt;
       return ex_expr::EXPR_OK;
     }
+  /* remove below code according to discussion in github
+   * https://github.com/apache/incubator-trafodion/pull/706
+   * with above validation, below checking is no longer needed
+   * comment out
   
   if (-(Int64)tempTgt < LLONG_MIN)
     {
@@ -2118,7 +2122,7 @@ ex_expr::exp_return_type convAsciiToInt64(Int64 &target,
                             REC_BIN64_SIGNED, flags);
       return ex_expr::EXPR_ERROR;
     }
-
+  */
   target = - (Int64)tempTgt;
 
   return ex_expr::EXPR_OK;

--- a/core/sql/regress/seabase/EXPECTED003
+++ b/core/sql/regress/seabase/EXPECTED003
@@ -1160,6 +1160,20 @@ A                     (EXPR)
 
 --- 2 row(s) selected.
 >>
+>>select cast('-9223372036854775808' as largeint) from (values(1)) x(a);
+
+(EXPR)
+----------
+
+-9223372036854775808
+
+--- 1 row(s) selected.
+>>select cast('-9223372036854775809' as largeint) from (values(1)) x(a);
+
+*** ERROR[8411] A numeric overflow occurred during an arithmetic computation or data conversion. Conversion of Source Type:CHAR(REC_BYTE_F_ASCII,20 BYTES,ISO88591) Source Value:-9223372036854775809 to Target Type:LARGEINT(REC_BIN64_SIGNED).
+
+--- 0 row(s) selected.
+>>
 >>select a+10 from t003t2 where a = 1 or a = -1;
 
 (EXPR)              
@@ -1503,6 +1517,20 @@ A                     (EXPR)
 18446744073709551615  18446744073709551615
 
 --- 2 row(s) selected.
+>>
+>>select cast('-9223372036854775808' as largeint) from (values(1)) x(a);
+
+(EXPR)
+----------
+
+-9223372036854775808
+
+--- 1 row(s) selected.
+>>select cast('-9223372036854775809' as largeint) from (values(1)) x(a);
+
+*** ERROR[8411] A numeric overflow occurred during an arithmetic computation or data conversion. Conversion of Source Type:CHAR(REC_BYTE_F_ASCII,20 BYTES,ISO88591) Source Value:-9223372036854775809 to Target Type:LARGEINT(REC_BIN64_SIGNED).
+
+--- 0 row(s) selected.
 >>
 >>select a+10 from t003t2 where a = 1 or a = -1;
 
@@ -1850,6 +1878,20 @@ A                      (EXPR)
  18446744073709551615   18446744073709551615
 
 --- 2 row(s) selected.
+>>
+>>select cast('-9223372036854775808' as largeint) from (values(1)) x(a);
+
+(EXPR)
+----------
+
+-9223372036854775808
+
+--- 1 row(s) selected.
+>>select cast('-9223372036854775809' as largeint) from (values(1)) x(a);
+
+*** ERROR[8411] A numeric overflow occurred during an arithmetic computation or data conversion. Conversion of Source Type:CHAR(REC_BYTE_F_ASCII,20 BYTES,ISO88591) Source Value:-9223372036854775809 to Target Type:LARGEINT(REC_BIN64_SIGNED).
+
+--- 0 row(s) selected.
 >>
 >>select a+10 from t003t2 where a = 1 or a = -1;
 

--- a/core/sql/regress/seabase/TEST003
+++ b/core/sql/regress/seabase/TEST003
@@ -221,6 +221,9 @@ select * from t003t2 where b = 18446744073709551615;
 
 select a, cast(cast(a as varchar(40)) as largeint unsigned) from t003t2;
 
+select cast('-9223372036854775808' as largeint) from (values(1)) x(a);
+select cast('-9223372036854775809' as largeint) from (values(1)) x(a);
+
 select a+10 from t003t2 where a = 1 or a = -1;
 
 select cast(100 as largeint unsigned) from (values(1)) x(a);


### PR DESCRIPTION
On Linux platform, min 64 bit int value is -9223372036854775808. So the validation seems wrong. Try to fix it.