### PR TITLE
jira TRAFODION-2181 Enable incompatible operations in sql queries

### DIFF
--- a/core/sql/sqlcomp/nadefaults.cpp
+++ b/core/sql/sqlcomp/nadefaults.cpp
@@ -368,19 +368,19 @@ SDDkwd__(ALLOW_DP2_ROW_SAMPLING,               "SYSTEM"),
  // assignment, like string to int. The assignment will be done by
  // implicitely CASTing one operand to another as long as CAST between
  // the two is supported. See binder for details.
-  DDkwd__(ALLOW_INCOMPATIBLE_ASSIGNMENT,	"OFF"),
+  DDkwd__(ALLOW_INCOMPATIBLE_ASSIGNMENT,	"ON"),
 
  // this default, if set to ON, will allow certain incompatible
  // comparisons, like string to int. The comparison will be done by
  // implicitely CASTing one operand to another as long as CAST between
  // the two is supported. See binder for details.
-  DDkwd__(ALLOW_INCOMPATIBLE_COMPARISON,	"OFF"),
+  DDkwd__(ALLOW_INCOMPATIBLE_COMPARISON,	"ON"),
 
  // this default, if set to ON, will allow certain incompatible
  // comparisons. This includes incompatible comparisons, assignments,
  // conversions, UNION, arith, string and case stmts.
  // See binder(BindItemExpr.cpp, SynthType.cpp) for details.
-  DDkwd__(ALLOW_INCOMPATIBLE_OPERATIONS,	"OFF"),
+  DDkwd__(ALLOW_INCOMPATIBLE_OPERATIONS,	"ON"),
 
   // if set to 2, the replicateNonKeyVEGPred() mdamkey method
   // will try to use inputs to filter out VEG elements that are not


### PR DESCRIPTION
Incompatible operations are defined as opers between datatypes
that belong to different categories.
For ex, comparison of numeric to string. In these cases, one side
need to be converted to the other before doing the comparison.

This checkin enables following incompatible operations:
  -- assignment between incompatible datatypes
  -- conversion between incompatible datatypes
  -- comparison between incompatible datatypes
  -- arith between incompatible datatypes
  -- string operation on incompatible datatypes

The infrastructure changes to support was added as part of
a previous jira. Dev regressions have since then been running with
incomp opers enabled.

These operations are on by default now and some operations that
previously failed will no longer fail.

Changes are been tested as much as possible and any issues that
show up during runs will be fixed as a regular bug fix.