### PR TITLE
jira TRAFODION-2184 Fix to order by on renamed expressions

### DIFF
--- a/core/sql/optimizer/BindRelExpr.cpp
+++ b/core/sql/optimizer/BindRelExpr.cpp
@@ -3856,9 +3856,17 @@ RelRoot * RelRoot::transformOrderByWithExpr(BindWA *bindWA)
           NABoolean found = FALSE;
           Lng32 selListIndex = 0;
           ItemExpr * selItem = NULL;
+          ItemExpr * renameColEntry = NULL;
           while ((NOT found) && (selListIndex < selListCount))
             {
               selItem = origSelectList[selListIndex];
+              
+              if (selItem->getOperatorType() == ITM_RENAME_COL)
+                {
+                  renameColEntry = selItem;
+                  selItem = selItem->child(0);
+                }
+              
               found = currOrderByItemExpr->duplicateMatch(*selItem);
               if (NOT found)
                 selListIndex++;

--- a/core/sql/regress/hive/DIFF003.KNOWN
+++ b/core/sql/regress/hive/DIFF003.KNOWN
@@ -1,0 +1,10 @@
+192,195d191
+< *** WARNING[8597] Statement was automatically retried 1 time(s). Delay before each retry was 0 seconds. See next entry for the error that caused this retry.
+< 
+< *** WARNING[8436] Mismatch detected between compiletime and runtime hive table definitions. DataModMismatchDetails: removed
+< 
+216a213,216
+> *** WARNING[8597] Statement was automatically retried 1 time(s). Delay before each retry was 0 seconds. See next entry for the error that caused this retry.
+> 
+> *** WARNING[8436] Mismatch detected between compiletime and runtime hive table definitions. DataModMismatchDetails: removed
+> 

--- a/core/sql/regress/seabase/EXPECTED032
+++ b/core/sql/regress/seabase/EXPECTED032
@@ -15,7 +15,7 @@
 >>invoke t032t1;
 
 -- Definition of Trafodion table TRAFODION.SCH.T032T1
--- Definition current  Wed Sep 14 14:50:10 2016
+-- Definition current  Wed Sep 21 02:57:14 2016
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -140,7 +140,7 @@ B
 (EXPR)                        
 ------------------------------
 
-RANDOMVAL=1244080372          
+RANDOMVAL=323996797           
 
 --- 1 row(s) selected.
 >>select random() from (values(1)) x(a);
@@ -205,6 +205,33 @@ AA
                    3
 
 --- 2 row(s) selected.
+>>select a+1 aa from t032t1 order by a+1;
+
+AA                  
+--------------------
+
+                   2
+                   3
+
+--- 2 row(s) selected.
+>>select a+1 aa from t032t1 order by aa;
+
+AA                  
+--------------------
+
+                   2
+                   3
+
+--- 2 row(s) selected.
+>>select a+1 aa from t032t1 order by 1;
+
+AA                  
+--------------------
+
+                   2
+                   3
+
+--- 2 row(s) selected.
 >>select * from (select b from t032t1 order by b desc) x(z);
 
 Z   
@@ -233,6 +260,14 @@ Z
 >>select count(*) from t032t1 order by count(*) desc;
 
 (EXPR)              
+--------------------
+
+                   2
+
+--- 1 row(s) selected.
+>>select count(*) cc from t032t1 order by count(*) desc;
+
+CC                  
 --------------------
 
                    2
@@ -361,7 +396,7 @@ A
 >>invoke t032t2;
 
 -- Definition of Trafodion table TRAFODION.T032SCH.T032T2
--- Definition current  Wed Sep 14 14:50:21 2016
+-- Definition current  Wed Sep 21 02:57:30 2016
 
   (
     SYSKEY                           LARGEINT NO DEFAULT NOT NULL NOT DROPPABLE

--- a/core/sql/regress/seabase/TEST032
+++ b/core/sql/regress/seabase/TEST032
@@ -70,10 +70,14 @@ select cast('a' as int) from dual;
 select a aa from t032t1 group by aa;
 select a+1 from t032t1 group by a+1;
 select a+1 from t032t1 order by a+1;
+select a+1 aa from t032t1 order by a+1;
+select a+1 aa from t032t1 order by aa;
+select a+1 aa from t032t1 order by 1;
 select * from (select b from t032t1 order by b desc) x(z);
 select * from (select [first 1] a from t032t1) x(z);
 select count(*) from t032t1 order by count(*);
 select count(*) from t032t1 order by count(*) desc;
+select count(*) cc from t032t1 order by count(*) desc;
 select count(distinct a) from t032t1 order by count(distinct a);
 
 -- error cases


### PR DESCRIPTION
code fix so renamed expressions with order by as shown below work:

  select count(*) aa from t order by count(*);
or:
  select a+1 aa from t order by a+1;
