### PR TITLE
[TRAFODION-2238] Compiler Internal Error: RelExpr with unknown arity …

### DIFF
--- a/core/sql/common/ExprNode.cpp
+++ b/core/sql/common/ExprNode.cpp
@@ -359,6 +359,8 @@ NABoolean OperatorType::match(OperatorTypeEnum wildcard) const
 	    case REL_HYBRID_HASH_SEMIJOIN:
 	    case REL_HYBRID_HASH_ANTI_SEMIJOIN:
 	    case REL_MERGE_UNION:
+            case REL_INTERSECT:
+            case REL_EXCEPT:
 	      return TRUE;
 	    default:
 	      return FALSE;
@@ -401,6 +403,8 @@ NABoolean OperatorType::match(OperatorTypeEnum wildcard) const
 	    case REL_HYBRID_HASH_SEMIJOIN:
 	    case REL_HYBRID_HASH_ANTI_SEMIJOIN:
 	    case REL_FULL_JOIN:
+            case REL_INTERSECT:
+            case REL_EXCEPT:
 	      return TRUE;
 	    default:
 	      return FALSE;
@@ -564,6 +568,7 @@ NABoolean OperatorType::match(OperatorTypeEnum wildcard) const
 	    case REL_HASH_ANTI_SEMIJOIN:
 	    case REL_HYBRID_HASH_ANTI_SEMIJOIN:
 	    case REL_ORDERED_HASH_ANTI_SEMIJOIN:
+            case REL_EXCEPT:
 	      return TRUE;
 	    default:
 	      return FALSE;

--- a/core/sql/optimizer/RelExpr.cpp
+++ b/core/sql/optimizer/RelExpr.cpp
@@ -347,6 +347,8 @@ Int32 RelExpr::getArity() const
     case REL_LEFT_TSJ:
     case REL_NESTED_JOIN:
     case REL_MERGE_JOIN:
+    case REL_INTERSECT:
+    case REL_EXCEPT:
       return 2;
 
     default:
@@ -3807,6 +3809,8 @@ NABoolean RelExpr::isAnyJoin() const
     case REL_FORCE_ORDERED_HASH_JOIN:
     case REL_FORCE_HYBRID_HASH_JOIN:
     case REL_FORCE_MERGE_JOIN:
+    case REL_INTERSECT:
+    case REL_EXCEPT:
       return TRUE;
 
     default:
@@ -5142,6 +5146,39 @@ NABoolean Join::duplicateMatch(const RelExpr & other) const
     return FALSE;
 
   return TRUE;
+}
+
+ 
+RelExpr * Intersect::copyTopNode(RelExpr *derivedNode, CollHeap* outHeap)
+{
+  RelExpr *result;
+
+  if (derivedNode == NULL)
+    {
+      result = new (outHeap) Intersect(NULL,
+                                        NULL
+                                        );
+    }
+  else
+    result = derivedNode;
+
+  return RelExpr::copyTopNode(result, outHeap);
+}
+
+RelExpr * Except::copyTopNode(RelExpr *derivedNode, CollHeap* outHeap)
+{
+  RelExpr *result;
+
+  if (derivedNode == NULL)
+    {
+      result = new (outHeap) Except(NULL,
+                                        NULL
+                                        );
+    }
+  else
+    result = derivedNode;
+
+  return RelExpr::copyTopNode(result, outHeap);
 }
 
 RelExpr * Join::copyTopNode(RelExpr *derivedNode, CollHeap* outHeap)

--- a/core/sql/optimizer/RelSet.h
+++ b/core/sql/optimizer/RelSet.h
@@ -78,6 +78,8 @@ public:
 
   const NAString getText() const;
 
+  virtual RelExpr * copyTopNode(RelExpr *derivedNode = NULL, CollHeap* outHeap = 0);
+
   // a virtual function for performing name binding within the query tree
   virtual RelExpr * bindNode(BindWA *bindWAPtr);
 };
@@ -101,6 +103,8 @@ public:
   virtual Int32 getArity() const;
 
   const NAString getText() const;
+
+  virtual RelExpr * copyTopNode(RelExpr *derivedNode = NULL, CollHeap* outHeap = 0);
 
   // a virtual function for performing name binding within the query tree
   virtual RelExpr * bindNode(BindWA *bindWAPtr);


### PR DESCRIPTION
…encountered with combination of WITH clause and Intersect

WITH will use copyTree() try to do a deep copy of the binded node. But before INTERSECT doesn't implement the CopyTopNode() method, so cannot be copied.
This fix the issue and let the Q14 from TPCDS compile success.