### PR TITLE
[TRAFODION-2255] Fix off-by-one error in incremental update stats

### DIFF
--- a/core/sql/ustat/hs_globals.cpp
+++ b/core/sql/ustat/hs_globals.cpp
@@ -6026,7 +6026,7 @@ void genSQLTimestampConstant(struct tm * bdt, NAString& timestamp)
   timestamp += "-";
 
   // tm_mon is in  [0, 11]
-  if ( bdt->tm_mon <= 9 ) timestamp += "0";
+  if ( bdt->tm_mon < 9 ) timestamp += "0"; // < rather than <= since we add one in the next line
   str_itoa(bdt->tm_mon+1, buf); timestamp += buf;
 
   timestamp += "-";


### PR DESCRIPTION
This change fixes a problem that caused regression test compGeneral/TEST023 to fail. It turns out to be an example of both an off-by-one bug and a time-bomb bug. The bug only appears in October. If I had been fortunate enough to have added this test last October or before we would have seen this bug a year ago.