### PR TITLE
[TRAFODION-2251] Fix upd stats issues with long char/varchar columns

### DIFF
--- a/core/sql/executor/ExExeUtilLoad.cpp
+++ b/core/sql/executor/ExExeUtilLoad.cpp
@@ -132,7 +132,8 @@ short ExExeUtilCreateTableAsTcb::work()
 	  {
 	    NABoolean xnAlreadyStarted = ta->xnInProgress();
 
-	    if (xnAlreadyStarted)
+	    // allow a user transaction if NO LOAD was specified
+	    if (xnAlreadyStarted && !ctaTdb().noLoad())
               {
                 *getDiagsArea() << DgSqlCode(-20123)
                                 << DgString0("This DDL operation");

--- a/core/sql/ustat/hs_cli.cpp
+++ b/core/sql/ustat/hs_cli.cpp
@@ -504,6 +504,8 @@ Lng32 HSSample::create(NAString& tblName, NABoolean unpartitioned, NABoolean isP
     NAString tempTabName = tblName;
     NAString userTabName = objDef->getObjectFullName();
 
+    HSGlobalsClass *hs_globals = GetHSContext();
+
     // If the table is a native one, convert the fully qualified user table name NT
     // to a fully qualified external table name ET. The sample table will be created
     // like ET.
@@ -542,21 +544,37 @@ Lng32 HSSample::create(NAString& tblName, NABoolean unpartitioned, NABoolean isP
 
         ddl  = "CREATE TABLE ";
         ddl += tempTabName;
-        ddl += " LIKE ";
-
-        // is this an MV LOG table?
-        if (objDef->getNameSpace() == COM_IUD_LOG_TABLE_NAME)
-        {
-          ddl += "TABLE (IUD_LOG_TABLE ";
-          ddl += userTabName;
-          ddl += ") ";
-        }
+        if (hs_globals->hasOversizedColumns)
+          {
+            // Use CREATE TABLE AS SELECT when we have to modify the column lengths
+            // (this happens for tables having very long chars/varchars). One 
+            // peculiarity: We have to use the native version of the name
+            // (e.g. HIVE.whatever.whatever for Hive tables) instead of the external
+            // table name (e.g. TRAFODION._HV_whatever.whatever) in the SELECT.
+            ddl += " NO LOAD AS SELECT ";
+            addTruncatedSelectList(ddl);
+            ddl += " FROM ";
+            ddl += objDef->getObjectFullName().data();  // e.g. HIVE.whatever.whatever
+            // ddl += tableOptions;  unfortunately not supported with CREATE TABLE AS SELECT
+          }
         else
-        {
-          ddl += userTabName;
-        }
+          {
+            ddl += " LIKE ";
 
-        ddl += tableOptions;
+            // is this an MV LOG table?
+            if (objDef->getNameSpace() == COM_IUD_LOG_TABLE_NAME)
+              {
+                ddl += "TABLE (IUD_LOG_TABLE ";
+                ddl += userTabName;
+                ddl += ") ";
+              }
+            else
+              {
+                ddl += userTabName;
+              }
+
+            ddl += tableOptions;    
+          }
         tableType = ANSI_TABLE;
         sampleName = new(STMTHEAP) ComObjectName(tempTabName,
                                                  COM_UNKNOWN_NAME,
@@ -648,7 +666,6 @@ Lng32 HSSample::create(NAString& tblName, NABoolean unpartitioned, NABoolean isP
         HSHandleError(retcode);
       }
 
-    HSGlobalsClass *hs_globals = GetHSContext();
     if (hs_globals && hs_globals->diagsArea.getNumber(DgSqlCode::ERROR_))
       hs_globals->diagsArea.deleteError(0);
 
@@ -5408,6 +5425,64 @@ NAString HSSample::getTempTablePartitionInfo(NABoolean unpartitionedSample,
     LM->Log(LM->msg);
 
     return tableOptions;
+  }
+
+
+//
+// METHOD:  addTruncatedSelectList()
+//
+// PURPOSE: Generates a SELECT list consisting of 
+//          column references or a SUBSTRING
+//          on column references which truncates the
+//          column to the maximum length allowed in
+//          UPDATE STATISTICS.
+//
+// INPUT:   'qry' - the SQL query string to append the 
+//          select list to.
+//
+void HSSample::addTruncatedSelectList(NAString & qry)
+  {
+    for (Lng32 i = 0; i < objDef->getNumCols(); i++)
+      {
+        if (i)
+          qry += ", ";
+
+        addTruncatedColumnReference(qry,objDef->getColInfo(i));
+      }
+  }
+
+
+//
+// METHOD:  addTruncatedColumnReference()
+//
+// PURPOSE: Generates a column reference or a SUBSTRING
+//          on a column reference which truncates the
+//          column to the maximum length allowed in
+//          UPDATE STATISTICS.
+//
+// INPUT:   'qry' - the SQL query string to append the 
+//          reference to.
+//          'colInfo' - struct containing datatype info
+//          about the column.
+//
+void HSSample::addTruncatedColumnReference(NAString & qry,HSColumnStruct & colInfo)
+  {
+    Lng32 maxLengthInBytes = MAX_SUPPORTED_CHAR_LENGTH;
+    bool isOverSized = DFS2REC::isAnyCharacter(colInfo.datatype) &&
+                           (colInfo.length > maxLengthInBytes);
+    if (isOverSized)
+      {
+        qry += "SUBSTRING(";
+        qry += colInfo.colname->data();
+        qry += " FOR ";
+        
+        char temp[20];  // big enough for "nnnnnn) AS "
+        sprintf(temp,"%d) AS ", maxLengthInBytes / CharInfo::maxBytesPerChar(colInfo.charset));
+        qry += temp;
+        qry += colInfo.colname->data();
+      }
+    else
+      qry += colInfo.colname->data();
   }
 
 

--- a/core/sql/ustat/hs_cli.cpp
+++ b/core/sql/ustat/hs_cli.cpp
@@ -5473,16 +5473,16 @@ void HSSample::addTruncatedColumnReference(NAString & qry,HSColumnStruct & colIn
     if (isOverSized)
       {
         qry += "SUBSTRING(";
-        qry += colInfo.colname->data();
+        qry += colInfo.externalColumnName->data();
         qry += " FOR ";
         
         char temp[20];  // big enough for "nnnnnn) AS "
         sprintf(temp,"%d) AS ", maxLengthInBytes / CharInfo::maxBytesPerChar(colInfo.charset));
         qry += temp;
-        qry += colInfo.colname->data();
+        qry += colInfo.externalColumnName->data();
       }
     else
-      qry += colInfo.colname->data();
+      qry += colInfo.externalColumnName->data();
   }
 
 

--- a/core/sql/ustat/hs_cli.h
+++ b/core/sql/ustat/hs_cli.h
@@ -57,6 +57,7 @@ class HSDataBuffer;
 class HSTableDef;
 struct HSColDesc;
 struct HSColGroupStruct;
+struct HSColumnStruct;
 class ISFixedChar;
 class ISVarChar;
 class MCWrapper;
@@ -192,6 +193,9 @@ class HSSample
     Lng32 drop() { return dropSample(sampleTable, objDef); }
 
     NABoolean isIUS() { return isIUS_; }
+
+    void addTruncatedSelectList(NAString & qry);
+    static void addTruncatedColumnReference(NAString & qry, HSColumnStruct & colInfo);
 
   private:
     // Member function

--- a/core/sql/ustat/hs_globals.cpp
+++ b/core/sql/ustat/hs_globals.cpp
@@ -2841,6 +2841,7 @@ HSGlobalsClass::HSGlobalsClass(ComDiagsArea &diags)
   : catSch(new(STMTHEAP) NAString(STMTHEAP)),
     isHbaseTable(FALSE),
     isHiveTable(FALSE),
+    hasOversizedColumns(FALSE),
     user_table(new(STMTHEAP) NAString(STMTHEAP)),
     numPartitions(0),
     hstogram_table(new(STMTHEAP) NAString(STMTHEAP)),
@@ -4001,7 +4002,18 @@ Lng32 HSSample::make(NABoolean rowCountIsEstimate, // input
 
     dml  = insertType;
     dml += sampleTable;
-    dml += " SELECT * FROM ";
+    dml += " SELECT ";
+    if (hs_globals->hasOversizedColumns)
+      {
+        // The source table has an oversized column. We have to generate
+        // SUBSTRING calls on such columns to fit them into the sample
+        // table.
+        addTruncatedSelectList(dml);
+      }      
+    else
+      dml += "*";
+
+    dml += " FROM ";
 
     NAString hiveSrc = CmpCommon::getDefaultString(USE_HIVE_SOURCE);
     if (! hiveSrc.isNull())
@@ -4874,9 +4886,12 @@ static void mapInternalSortTypes(HSColGroupStruct *groupList, NABoolean forHive 
       default:
         group->ISdatatype = col.datatype;
         group->ISlength = col.length;
+        if (group->ISlength > MAX_SUPPORTED_CHAR_LENGTH)
+          group->ISlength = MAX_SUPPORTED_CHAR_LENGTH;
         group->ISprecision = col.precision;
         group->ISscale = col.scale;
-        group->ISSelectExpn.append(columnName);
+        // the method below handles adding SUBSTRING for over-size char/varchars
+        HSSample::addTruncatedColumnReference(group->ISSelectExpn,col);
         break;
      } // switch
      group = group->next;

--- a/core/sql/ustat/hs_globals.cpp
+++ b/core/sql/ustat/hs_globals.cpp
@@ -1643,6 +1643,7 @@ void HSColGroupStruct::freeISMemory(NABoolean freeStrData, NABoolean freeMCData)
 HSColumnStruct::HSColumnStruct(const HSColumnStruct &src, NAMemory *h)
   {
     colname         = new (h) NAString(src.colname->data(), h);
+    externalColumnName = new (h) NAString(src.externalColumnName->data(), h);
     colnum          = src.colnum;
     position        = src.position;
     datatype        = src.datatype;
@@ -1663,6 +1664,11 @@ HSColumnStruct::~HSColumnStruct()
         delete colname;
         colname = NULL;
       }
+    if (externalColumnName != NULL)
+      {
+        delete externalColumnName;
+        externalColumnName = NULL;
+      }
   }
 
 // Assignment operator
@@ -1677,6 +1683,7 @@ HSColumnStruct& HSColumnStruct::operator=(const HSColumnStruct& rhs)
     // already deleted; colname is on the STMTHEAP and will be destructed at the
     // end of the statement. [SOL 10-070822-6995]
     colname         = new (STMTHEAP) NAString(rhs.colname->data(), STMTHEAP);
+    externalColumnName = new (STMTHEAP) NAString(rhs.externalColumnName->data(), STMTHEAP);
     colnum          = rhs.colnum;
     position        = rhs.position;
     datatype        = rhs.datatype;
@@ -4601,6 +4608,8 @@ static void mapInternalSortTypes(HSColGroupStruct *groupList, NABoolean forHive 
        columnName=group->colNames->data();
      else
        columnName=dblQuote+group->colNames->data()+dblQuote;
+
+     *(col.externalColumnName) = columnName;
 
      switch (col.datatype)
      {

--- a/core/sql/ustat/hs_globals.h
+++ b/core/sql/ustat/hs_globals.h
@@ -1011,6 +1011,7 @@ class MCWrapper
 struct HSColumnStruct : public NABasicObject
   {
     NAString         *colname;        /* column name              */
+    NAString         *externalColumnName;  /* column name to use in SQL (e.g. with delimiters) */
     Lng32              colnum;         /* column position in table */
     Lng32              position;       /* position in grouplist    */
     Lng32              datatype;
@@ -1026,6 +1027,7 @@ struct HSColumnStruct : public NABasicObject
 
     HSColumnStruct()
       : colname(new(STMTHEAP) NAString(STMTHEAP)),
+        externalColumnName(new(STMTHEAP) NAString(STMTHEAP)),
         colnum(-1), position(0), datatype(-1), nullflag(-1),
         charset(CharInfo::UnknownCharSet),
         length(-1), precision(-1), scale(-1),

--- a/core/sql/ustat/hs_globals.h
+++ b/core/sql/ustat/hs_globals.h
@@ -84,6 +84,16 @@ Lng32 setBufferValue(T& value,
                       HSDataBuffer &boundary);
 
 
+
+// This is the max supported length of character strings in UPDATE STATISTICS.
+// We will process longer columns, but we truncate their values to this length
+// during the processing. As a result, we may underestimate UEC, if, for 
+// example, the first 32767 bytes are identical but some difference occurs
+// afterwards. If we someday wish to support longer lengths, at the very least
+// the ISVarChar class needs to change to use a longer length field for varchar
+// values.
+enum { MAX_SUPPORTED_CHAR_LENGTH = 32767 };
+
 // An instance of ISFixedChar represents a value of a fixed-length character
 // string (either single or double-byte) retrieved into memory for use by
 // internal sort. A pointer to the actual string is maintained, and definitions
@@ -1583,6 +1593,8 @@ public:
     NAString      *user_table;                     /* object name             */
     NABoolean     isHbaseTable;                    /* ustat on HBase table    */
     NABoolean     isHiveTable;                     /* ustat on Hive table     */
+    NABoolean     hasOversizedColumns;             /* set to TRUE for tables  */
+                                                   /* having gigantic columns */
     ComAnsiNameSpace nameSpace;                    /* object namespace    ++MV*/
     Int64          numPartitions;                  /* # of partns in object   */
     NAString      *hstogram_table;                 /* HISTOGRM table          */

--- a/core/sql/ustat/hs_la.cpp
+++ b/core/sql/ustat/hs_la.cpp
@@ -291,6 +291,7 @@ Lng32 HSSqTableDef::DescribeColumnNames()
         HSHandleError(retcode_);
         colName[len] = '\0';
         *colInfo_[i].colname = &*colName;
+        *colInfo_[i].externalColumnName = ToAnsiIdentifier(*colInfo_[i].colname);
                                                   /*== GET COLUMN DATATYPE ==*/
         retcode_ = SQL_EXEC_GetDescItem(outputDesc, entry,
                                         SQLDESC_TYPE_FS,
@@ -1010,6 +1011,7 @@ Lng32 HSHiveTableDef::DescribeColumnNames()
     {
       *(colInfo_[i].colname) = hiveColDesc->name_;
       colInfo_[i].colname->toUpper();
+      *colInfo_[i].externalColumnName = ToAnsiIdentifier(*colInfo_[i].colname);
 
       NAType* natype = getSQColTypeForHive(hiveColDesc->type_, STMTHEAP);
       colInfo_[i].datatype = natype->getFSDatatype();
@@ -1238,6 +1240,7 @@ Lng32 HSHbaseTableDef::DescribeColumnNames()
     {
       colInfo_[i].colnum = i;  // position of col in table
       *(colInfo_[i].colname) = colArr[i]->getColName();
+      *colInfo_[i].externalColumnName = ToAnsiIdentifier(*colInfo_[i].colname);
       natype = colArr[i]->getType();
       colInfo_[i].datatype = natype->getFSDatatype();
       colInfo_[i].nullflag = natype->supportsSQLnullLogical();

--- a/core/sql/ustat/hs_log.h
+++ b/core/sql/ustat/hs_log.h
@@ -150,12 +150,14 @@ void HSFuncLogError(Lng32 error, char *filename, Lng32 lineno);
 //    [6008] missing single-column histograms
 //    [6007] missing multi-column histograms
 //    [4030] non-standard DATETIME format
+//    [2053] Optimizer pass two assertion failure (optimizer still attempts to produce a plan)
 //    [4]    internal Warning
 #define HSFilterWarning(retcode) \
         { \
           if ((retcode == 6008) || \
               (retcode == 6007) || \
               (retcode == 4030) || \
+              (retcode == 2053) || \
               (retcode == HS_WARNING)) \
             retcode = 0; \
         }

--- a/core/sql/ustat/hs_parser.cpp
+++ b/core/sql/ustat/hs_parser.cpp
@@ -520,6 +520,13 @@ HSColGroupStruct* AddSingleColumn(const Lng32 colNumber, HSColGroupStruct*& grou
     HSColGroupStruct *newGroup = new(STMTHEAP) HSColGroupStruct;
     HSColumnStruct   newColumn = HSColumnStruct(hs_globals->objDef->getColInfo(colNumber));
 
+    bool isOverSized = DFS2REC::isAnyCharacter(newColumn.datatype) &&
+              (newColumn.length > MAX_SUPPORTED_CHAR_LENGTH);
+    if (isOverSized)
+      {
+        hs_globals->hasOversizedColumns = TRUE;
+      }
+
     newColumn.colnum  = colNumber;
     newGroup->colSet.insert((const HSColumnStruct) newColumn);
     newGroup->colCount = 1;

--- a/core/sql/ustat/hs_update.cpp
+++ b/core/sql/ustat/hs_update.cpp
@@ -308,6 +308,12 @@ Lng32 UpdateStats(char *input, NABoolean requestedByCompiler)
     retcode = HSFuncExecQuery("CONTROL QUERY DEFAULT TRAF_LARGEINT_UNSIGNED_IO 'ON'");
     HSExitIfError(retcode);
 
+    // Set the following CQD to allow "_SALT_", "_DIV_" and similar system columns
+    // in a sample table when the table is created using CREATE TABLE AS SELECT
+    retcode = HSFuncExecQuery("CONTROL QUERY DEFAULT TRAF_ALLOW_RESERVED_COLNAMES 'ON'");
+    HSExitIfError(retcode);
+
+
     LM->StopTimer();
 
     LM->StartTimer("Parse statement");


### PR DESCRIPTION
The following issues in UPDATE STATISTICS concerning long char/varchar columns have been fixed:

1. Creating a sample table would fail if the source table was a Hive table with columns longer than the Trafodion maximum (200000 bytes).
2. UPDATE STATISTICS might fail because the Optimizer raised a 2053 warning during pass 2 optimization.  This warning happens on some queries on Hive tables having columns of over 1 million bytes in length. Now UPDATE STATISTICS will ignore the warning and continue. (The Optimizer does generate a plan in spite of the warning.)
3. UPDATE STATISTICS might abend resulting in a core file when sorting varchars of longer than 32767 bytes.

Design notes:

The 32767 limitation is due to the ISVarChar class using a 2-byte length field. I chose to not increase this to 4 bytes as that would reduce the amount of memory available for existing UPDATE STATISTICS scenarios. Instead, I chose to truncate longer values to fit within 32767 bytes using the SQL SUBSTRING function. The result is that UEC might be underestimated for such columns, for example if the first 32767 bytes of two values are equal and the values differ at the 32768th or later byte. We can lift this limitation either by accepting the loss of memory to a longer length field, or by adding another class, ISLongVarChar say, for these long values. That work is left for the future, when needed.

The logic to create the sample table used to use CREATE TABLE LIKE. This doesn't work for Hive source tables having char/varchar columns of longer than 200000 bytes, as Trafodion imposes a 200000 byte limit on its own columns. Instead, we use CREATE TABLE AS SELECT, and use SUBSTRING to limit the size of the long char/varchar columns. (We also use SUBSTRING on the subsequent UPSERT used to populate the table.)

CREATE TABLE AS SELECT did not support running in a user transaction, but UPDATE STATISTICS needs to do so. Fortunately, we only use the NO LOAD flavor of CREATE TABLE AS SELECT, so there is no non-transactional load step. Therefore, the ExExeUtilLoad tcb has been changed to support running in a user transaction if NO LOAD has been specified.
