### PR TITLE
[TRAFODION-2261] Mxosrvr or java core with starting from Java_org_tra…

### DIFF
--- a/core/conn/jdbc_type2/native/SQLMXDriver.cpp
+++ b/core/conn/jdbc_type2/native/SQLMXDriver.cpp
@@ -88,19 +88,6 @@ JNIEXPORT void JNICALL Java_org_trafodion_jdbc_t2_T2Driver_SQLMXInitialize(JNIEn
 	const char					*nModuleCaching;
 	const char					*nCompiledModuleLocation;
         
-        sqInit();
-
-        int myNid;
-        pid_t myPid;
-        MS_Mon_Process_Info_Type  proc_info;
-        msg_mon_get_process_info_detail(NULL, &proc_info);
-        myNid = proc_info.nid;
-        myPid = proc_info.pid;
-
-        char logNameSuffix[32];
-        sprintf( logNameSuffix, "_%d_%d.log", myNid, myPid );
-        CommonLogger::instance().initLog4cxx("log4cxx.trafodion.masterexe.config", logNameSuffix);
-
 	if (!driverVersionChecked)
 	{
 		printf("JDBC Library Version Error - Jar: Unknown Jni: %s\n",

--- a/core/sqf/commonLogger/CommonLogger.cpp
+++ b/core/sqf/commonLogger/CommonLogger.cpp
@@ -41,6 +41,9 @@
 using namespace log4cxx;
 using namespace log4cxx::helpers;
 
+bool gv_commonLoggerInitialized = false;
+
+
 // **************************************************************************
 // Reads configuration file, creates an appender, layout, and categories.
 // Attaches layout to the appender and appender to categories.
@@ -100,7 +103,7 @@ bool CommonLogger::initLog4cxx(const char* configFileName, const char* fileSuffi
     }
 
     log4cxx::PropertyConfigurator::configure(configPath.data());
-
+    gv_commonLoggerInitialized = true;
     return true;
 
   }

--- a/core/sqf/commonLogger/CommonLogger.h
+++ b/core/sqf/commonLogger/CommonLogger.h
@@ -32,6 +32,8 @@
 #include <log4cxx/appender.h>
 #include <log4cxx/helpers/exception.h>
 
+extern bool gv_commonLoggerInitialized;
+
 using namespace log4cxx;
 using namespace log4cxx::helpers;
 

--- a/core/sql/cli/CliExtern.cpp
+++ b/core/sql/cli/CliExtern.cpp
@@ -89,7 +89,7 @@ CLISemaphore globalSemaphore ;
 #include "SqlStats.h"
 #include "ComExeTrace.h"
 #include "Context.h"
-
+#include "CommonLogger.h"
 
 #ifndef CLI_PRIV_SRL
 #pragma warning (disable : 4273)   //warning elimination
@@ -892,6 +892,19 @@ short sqInit()
     try
     {
       short retcode = my_mpi_setup(&largc, &largv);
+      int myNid;
+      pid_t myPid;
+      MS_Mon_Process_Info_Type  proc_info;
+
+      if (! gv_commonLoggerInitialized) {
+         retcode = msg_mon_get_process_info_detail(NULL, &proc_info);
+         ex_assert(retcode == 0, "Error while calling msg_non_get_process in sqInit()");   
+         myNid = proc_info.nid;
+         myPid = proc_info.pid;
+         char logNameSuffix[32];
+         sprintf( logNameSuffix, "_%d_%d.log", myNid, myPid );
+         CommonLogger::instance().initLog4cxx("log4cxx.trafodion.masterexe.config", logNameSuffix);
+      }
     }
     catch (...)
     {

--- a/core/sql/cli/ExSqlComp.cpp
+++ b/core/sql/cli/ExSqlComp.cpp
@@ -1040,7 +1040,7 @@ ExSqlComp::~ExSqlComp()
 
   delete sqlcompMessage_;
 
-  delete sc_;
+  NADELETE(sc_, IpcServerClass, h_);
   NADELETEBASIC(nodeName_, h_);
   nodeName_ = NULL;
 

--- a/core/sql/common/Ipc.h
+++ b/core/sql/common/Ipc.h
@@ -2975,6 +2975,7 @@ public:
 		 IPC_ALLOC_DONT_CARE,
                  short version = COM_VERS_MXV,
                  char *nodeName = NULL);
+  ~IpcServerClass();
 
   inline IpcEnvironment *getEnv() const           { return environment_; }
 
@@ -3000,7 +3001,6 @@ public:
   char *getProcessName(const char *nodeName, short nodeNameLen, short cpuNum, char *processName);
   NABoolean parallelOpens() { return parallelOpens_; }
   NowaitedEspServer nowaitedEspServer_;
-
 private:
 
   // server type

--- a/core/sql/executor/ex_frag_rt.cpp
+++ b/core/sql/executor/ex_frag_rt.cpp
@@ -2824,34 +2824,10 @@ ExEspManager::ExEspManager(IpcEnvironment *env, CliGlobals *cliGlobals)
 ExEspManager::~ExEspManager()
 {
   if (espServerClass_)
-    NADELETEBASIC(espServerClass_, env_->getHeap());
-
+    NADELETE(espServerClass_, IpcServerClass, env_->getHeap());
+  
   if (espCache_)
-    {
-      // delete/kill all esps in cache
-      ExEspCacheKey *key = NULL;
-      NAList<ExEspDbEntry *> *espList = NULL;
-      NAHashDictionaryIterator<ExEspCacheKey, NAList<ExEspDbEntry *> > iter(*espCache_);
-      for (CollIndex i = 0; i < iter.entries(); i++)
-        {
-          iter.getNext(key, espList);
-          for (CollIndex j = FIRST_COLL_INDEX; j < espList->getUsedLength(); j++)
-            {
-              if (espList->getUsage(j) == UNUSED_COLL_ENTRY)
-                continue;
-
-              ExEspDbEntry *entry = espList->usedEntry(j);
-              if (entry && 
-                  entry->getIpcServer())
-                entry->getIpcServer()->logEspRelease(__FILE__, __LINE__);
-              delete entry;
-            }
-        }
-
-      // delete all cache key and bucket objects
-      espCache_->clear(TRUE);
-      NADELETEBASIC(espCache_, env_->getHeap());
-    }
+    NADELETE(espCache_, NAHashDictionary, env_->getHeap());
 
   if (traceRef_)
     {

--- a/core/sql/qmscommon/QRLogger.cpp
+++ b/core/sql/qmscommon/QRLogger.cpp
@@ -217,6 +217,12 @@ NABoolean QRLogger::initLog4cxx(const char* configFileName)
     return TRUE;
   }
 
+/* This code is kept around for the old QMS kind of logging
+   This can be deleted. But keeeping it around if we need
+   to do use the catgory later */
+
+/*
+
   logFileName += "sql_events";
   logFileName += logFileSuffix;
   
@@ -257,7 +263,7 @@ NABoolean QRLogger::initLog4cxx(const char* configFileName)
   introduceSelf();
 
   // initialize sub categories here - they were removed since they are not currently being used
-
+*/
   return FALSE;
 }
 

--- a/core/sql/sqlmxevents/logmxevent_traf.cpp
+++ b/core/sql/sqlmxevents/logmxevent_traf.cpp
@@ -72,7 +72,7 @@ void SQLMXLoggingArea::init()
     else
     {
       sprintf(buffer, "SQLMXLoggingArea::init() pthread_mutex_init() rc=%d", rc);
-      logSQLMXDebugEvent(buffer, (short)rc,__LINE__);
+      abort();
     }
   }
 }
@@ -83,11 +83,11 @@ bool SQLMXLoggingArea::lockMutex()
   int rc = 0;
   if (loggingMutexInitialized_)
   {
-    rc = pthread_mutex_trylock(&loggingMutex_);
+    rc = pthread_mutex_lock(&loggingMutex_);
     if (rc)
     {
       sprintf(buffer, "SQLMXLoggingArea::lockMutex() pthread_mutex_trylock() rc=%d", rc);
-      logSQLMXDebugEvent(buffer, (short)rc, false);
+      abort();
     }
   }
   return rc ? false : true;
@@ -102,7 +102,7 @@ void SQLMXLoggingArea::unlockMutex()
   if (rc)
   {
     sprintf(buffer, "SQLMXLoggingArea::unlockMutex() pthread_mutex_unlock() rc=%d", rc);
-    logSQLMXDebugEvent(buffer, (short)rc, false);
+    abort();
   }
 }
 


### PR DESCRIPTION
…fodion_jdbc_t2_SQLMXConnection_close

[TRAFODION-2262] Mxosrvr or Java core with the stack trace pointing to log4Cxx functions

IpcServerClass was not getting destructed correctly. When the CLI context is deleted, the ESP
server class object an IpcServerClass instance that manages the ESP server started
in the CLI context are also destroyed.  Fixed the IpcServerClass and IpcServer destructors
so that there is no memory corruption.

Log4Cxx infrastructure in SQL was recursively attempting to log the messages when there is an
issue with it. This was causing stack corruption.

Also added a code to initialize the log4cxx infrastructure if it is not done already upon
the first CLI call.