### PR TITLE
[TRAFODION-2194] Fix update stats core on tinyint unsigned column

### DIFF
--- a/core/sql/exp/exp_conv.cpp
+++ b/core/sql/exp/exp_conv.cpp
@@ -5146,7 +5146,7 @@ convDoIt(char * source,
                              diagsArea,
                              tempFlags) == ex_expr::EXPR_OK)
             {
-              *(unsigned short *)target = *(unsigned short *)source;
+              *(UInt8 *)target = *(UInt8 *)source;
             }
           else
             {


### PR DESCRIPTION
The core was caused by a buffer overrun. With this change the buffer overrun is fixed.