### PR TITLE
[TRAFODION-2272] Insure adequate hbase.client.scanner.timeout.period

### DIFF
--- a/core/sql/src/main/java/org/trafodion/sql/HBaseClient.java
+++ b/core/sql/src/main/java/org/trafodion/sql/HBaseClient.java
@@ -181,7 +181,7 @@ public class HBaseClient {
         if (logger.isDebugEnabled()) logger.debug("HBaseClient.init(" + connectParam1 + ", " + connectParam2
                          + ") called.");
         if (connection != null)
-           connection = ConnectionFactory.createConnection(config); 
+           connection = getConnection(); 
         table = new RMInterface(connection);
         return true;
     }

--- a/core/sql/src/main/java/org/trafodion/sql/HBaseClient.java
+++ b/core/sql/src/main/java/org/trafodion/sql/HBaseClient.java
@@ -159,6 +159,17 @@ public class HBaseClient {
 
     
     static public Connection getConnection() throws IOException {
+        // On some distributions, the hbase.client.scanner.timeout.period setting is
+        // too small, resulting in annoying SocketTimeoutExceptions during operations
+        // such as UPDATE STATISTICS on very large tables. On CDH 5.4.5 in particular
+        // we have seen this. Unfortunately Cloudera Manager does not allow us to 
+        // change this setting, and setting it manually in hbase-site.xml doesn't work
+        // because a later Cloudera Manager deploy would just overwrite it. So, we
+        // programmatically check the setting here and insure it is at least 1 hour.
+        long configuredTimeout = config.getLong("hbase.client.scanner.timeout.period",0);
+        if (configuredTimeout < 3600000 /* 1 hour */)
+          config.setLong("hbase.client.scanner.timeout.period",3600000);    
+ 
         if (connection == null) 
               connection = ConnectionFactory.createConnection(config);
         return connection;


### PR DESCRIPTION
UPDATE STATISTICS on large tables fails on some cluster installations because the hbase.client.scanner.timeout.period setting is too low. The symptom is that a sample scan fails with a SocketTimeoutException. This change adds code to insure the setting is at least 1 hour.

This is viewed as a short-term fix. The setting is hard-coded in the Trafodion HBase client code. Very soon there will be another change that will abstract this out into some sort of properties file mechanism that is easier to manipulate.

Too, as soon as we migrate to HBase 1.1-based distributions, the HBase heartbeat protocol should eliminate the need for this particular change.