### PR TITLE
[TRAFODION-2262] Mxosrvr or java core with the stack trace pointing t…

### DIFF
--- a/core/sql/cli/CliExtern.cpp
+++ b/core/sql/cli/CliExtern.cpp
@@ -89,7 +89,7 @@ CLISemaphore globalSemaphore ;
 #include "SqlStats.h"
 #include "ComExeTrace.h"
 #include "Context.h"
-#include "CommonLogger.h"
+#include "QRLogger.h"
 
 #ifndef CLI_PRIV_SRL
 #pragma warning (disable : 4273)   //warning elimination
@@ -892,19 +892,7 @@ short sqInit()
     try
     {
       short retcode = my_mpi_setup(&largc, &largv);
-      int myNid;
-      pid_t myPid;
-      MS_Mon_Process_Info_Type  proc_info;
-
-      if (! gv_commonLoggerInitialized) {
-         retcode = msg_mon_get_process_info_detail(NULL, &proc_info);
-         ex_assert(retcode == 0, "Error while calling msg_non_get_process in sqInit()");   
-         myNid = proc_info.nid;
-         myPid = proc_info.pid;
-         char logNameSuffix[32];
-         sprintf( logNameSuffix, "_%d_%d.log", myNid, myPid );
-         CommonLogger::instance().initLog4cxx("log4cxx.trafodion.masterexe.config", logNameSuffix);
-      }
+      QRLogger::instance().initLog4cxx("log4cxx.trafodion.masterexe.config");
     }
     catch (...)
     {

--- a/core/sql/qmscommon/QRLogger.cpp
+++ b/core/sql/qmscommon/QRLogger.cpp
@@ -38,6 +38,8 @@
 #include "seabed/ms.h"
 #include "seabed/fserr.h"
 
+BOOL gv_QRLoggerInitialized_ = FALSE;
+
 using namespace log4cxx;
 using namespace log4cxx::helpers;
 
@@ -186,6 +188,9 @@ NABoolean QRLogger::initLog4cxx(const char* configFileName)
 {
   NAString logFileName;
 
+  if (gv_QRLoggerInitialized_)
+     return TRUE;
+ 
   // get the log directory
   logFileName = "";
 
@@ -214,6 +219,7 @@ NABoolean QRLogger::initLog4cxx(const char* configFileName)
   if (CommonLogger::initLog4cxx(configFileName, logFileSuffix))
   {
     introduceSelf();
+    gv_QRLoggerInitialized_ = TRUE;
     return TRUE;
   }
 

--- a/core/sql/runtimestats/ssmpipc.cpp
+++ b/core/sql/runtimestats/ssmpipc.cpp
@@ -158,8 +158,6 @@ void ExSsmpManager::cleanupDeletedSsmpServers()
   IpcServer *ssmp;
   while (deletedSsmps_->getFirst(ssmp))
     {
-      IpcConnection *conn = ssmp->getControlConnection();
-      NADELETE(conn, IpcConnection, conn->collHeap());
       ssmpServerClass_->freeServerProcess(ssmp);
     }
 }
@@ -462,7 +460,6 @@ void SsmpGlobals::cleanupDeletedSscpServers()
         }
       else
         {
-          NADELETE(conn, IpcConnection, conn->collHeap());
           sscpServerClass_->freeServerProcess(sscp);
         }
     }

--- a/core/sql/sqlmxevents/logmxevent_traf.cpp
+++ b/core/sql/sqlmxevents/logmxevent_traf.cpp
@@ -86,7 +86,7 @@ bool SQLMXLoggingArea::lockMutex()
     rc = pthread_mutex_lock(&loggingMutex_);
     if (rc)
     {
-      sprintf(buffer, "SQLMXLoggingArea::lockMutex() pthread_mutex_trylock() rc=%d", rc);
+      sprintf(buffer, "SQLMXLoggingArea::lockMutex() pthread_mutex_lock() rc=%d", rc);
       abort();
     }
   }


### PR DESCRIPTION
…o log4Cxx functions

The Logger repository needs to be initialized. The method QRLogger::initLog4cxx
initialized the commonLogger infrastructure also.

PR #745 merged to fix this issue exposed a problem in SSMP. This
caused SSMP to dump core when a node is brought down.
SSMP should have create the connection to SSCP on that node.