### PR TITLE
[TRAFODION-2277] Remove obsolete entry-sequenced code from compiler

### DIFF
--- a/core/sql/bin/SqlciErrors.txt
+++ b/core/sql/bin/SqlciErrors.txt
@@ -1040,7 +1040,7 @@ $1~String1 --------------------------------
 3407 42000 99999 BEGINNER MAJOR DBADMIN Duplicate TABLE SIZE clauses were specified.
 3408 ZZZZZ 99999 BEGINNER MAJOR DBADMIN --- unused in this stream  ---
 3409 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Declaring a cursor on an embedded INSERT statement is not yet supported.
-3410 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Users cannot specify a value for SYSKEY column on an entry-sequenced table $1~TableName.
+3410 ZZZZZ 99999 BEGINNER MAJOR DBADMIN -- unused --
 3411 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Expressions are not allowed as IDENTITY column values. Specify DEFAULT or supply a valid numeric value.
 3412 ZZZZZ 99999 BEGINNER MAJOR DBADMIN IDENTITY column $0~ColumnName must be the primary key or must have a unique index on it.
 3413 ZZZZZ 99999 BEGINNER MAJOR DBADMIN The NOT NULL constraint on IDENTITY column $0~ColumnName must be NOT DROPPABLE.
@@ -1084,7 +1084,7 @@ $1~String1 --------------------------------
 4015 42000 99999 BEGINNER MAJOR DBADMIN Aggregate functions are placed incorrectly: $0~string0.
 4016 42000 99999 BEGINNER MAJOR DBADMIN The number of derived columns ($0~int0) must equal the degree of the derived table ($1~int1).
 4017 42000 99999 BEGINNER MAJOR DBADMIN Derived column name $0~ColumnName was specified more than once.
-4018 42000 99999 BEGINNER MAJOR DBADMIN Rows cannot be deleted from an entry-sequenced table.
+4018 42000 99999 BEGINNER MAJOR DBADMIN -- unused --
 4019 42000 99999 BEGINNER MAJOR DBADMIN The select list of a subquery in a select list must be scalar (degree of one).
 4020 42000 99999 BEGINNER MAJOR DBADMIN Arithmetic operations on row value constructors are not allowed.
 4021 42000 99999 BEGINNER MAJOR DBADMIN The select list contains a nongrouping non-aggregated column, $0~ColumnName.

--- a/core/sql/executor/dfs2fe.h
+++ b/core/sql/executor/dfs2fe.h
@@ -59,9 +59,7 @@ enum ExeDfs2feEnum
                                            // THE SUPPLIED RECORD IS TOO LONG.
                                            // ALSO RETURNED BY THE DISCPROCESS WHEN
                                            // IT ENCOUNTERS A BAD FIELD IN A STORED
-                                           // RECORD, OR IF AN ENTRY-SEQUENCED
-                                           // RECORD UPDATE IS ATTEMPTED WHICH
-                                           // CHANGES THE LENGTH OF A VARCHAR FIELD.
+                                           // RECORD.
                                            //------------------------------
    , FEBADRECDESC            = dfs2fe_base +  1032        // THE RECORD DESCRIPTION IS
                                            // INCONSISTENT.

--- a/core/sql/optimizer/ImplRule.cpp
+++ b/core/sql/optimizer/ImplRule.cpp
@@ -2569,8 +2569,6 @@ RelExpr * HiveInsertRule::nextSubstitute(RelExpr * before,
                    CIdesc);
 
       // insert is always a row-at-a-time operator
-      // This will for now disable inserts into partitioned, entry-sequenced
-      // tables.
       //CMPASSERT(skey->isUnique());
     }
 
@@ -2663,8 +2661,6 @@ RelExpr * HbaseInsertRule::nextSubstitute(RelExpr * before,
                    CIdesc);
 
       // insert is always a row-at-a-time operator
-      // This will for now disable inserts into partitioned, entry-sequenced
-      // tables.
       //CMPASSERT(skey->isUnique());
     }
 

--- a/core/sql/optimizer/Inlining.cpp
+++ b/core/sql/optimizer/Inlining.cpp
@@ -1325,25 +1325,6 @@ void GenericUpdate::fixTentativeRETDesc(BindWA *bindWA, CollHeap *heap)
         BiArith(ITM_PLUS, incrementExpr, new (heap)
 	  JulianTimestamp(new (heap) InternalTimestamp));
 
-      // If this is an entry sequenced table, than the SYSKEY is an INT 
-      // instead of a LARGEINT. So when we manufacture a "fake syskey"
-      // for INSERT operators, we must cast it to INT.
-      NAColumn *syskeyColumn = 
-	getTableDesc()->getNATable()->getNAColumnArray().getColumn("SYSKEY");
-      if ( (syskeyColumn != NULL) && 
-	   (syskeyColumn->getType()->getNominalSize() == 4) )
-      {
-	// The logical way to convert a LARGEINT to an INT is by using
-	// Cast or Convert. However, they both cause the following 
-	// error during execution:
-	// *** ERROR[8411] A numeric overflow occurred during an 
-	//                 arithmetic computation or data conversion.
-	// So I am using Modulus. It's not the most efficient way
-	// to do it, but it works.
-	fakeSyskey = new (heap) 
-	  Modulus(fakeSyskey, new (heap) ConstValue(INT_MAX));
-      }
-
       fakeSyskey->bindNode(bindWA);
 
       // Make NEW@.SYSKEY point to the timestamp expression.

--- a/core/sql/optimizer/NAFileSet.cpp
+++ b/core/sql/optimizer/NAFileSet.cpp
@@ -206,10 +206,6 @@ Int32 NAFileSet::getSysKeyPosition() const
 
 NABoolean NAFileSet::hasSyskey() const
 {
-  // entry-sequenced files always have a (32 bit) syskey
-  if (isEntrySequenced())
-    return TRUE;
-
   // check the NAColumn class of the key column
   // ++MV - 7/3/01 bug fix
 
@@ -233,10 +229,6 @@ NABoolean NAFileSet::hasSyskey() const
 
 NABoolean NAFileSet::hasOnlySyskey() const
 {
-  // entry-sequenced files always have a (32 bit) syskey
-  if (isEntrySequenced())
-    return TRUE;
-
   // Syskey is the only clustering key
   return ((indexKeyColumns_.entries() == 1) &&
           (indexKeyColumns_[0]->isSyskeyColumn()));

--- a/core/sql/optimizer/NAFileSet.h
+++ b/core/sql/optimizer/NAFileSet.h
@@ -60,7 +60,6 @@ class HbaseCreateOption;
 // -----------------------------------------------------------------------
 // An enumerated type that describes how data is organized in EVERY
 // file that belongs to this file set.
-// An entry sequenced file is analogous to a FIFO list of records.
 // A key sequenced file is implemented by a B+ tree.
 // A hash file contains records whose key columns compute to the 
 // same hash value when the hash function that is used for 
@@ -68,7 +67,6 @@ class HbaseCreateOption;
 // -----------------------------------------------------------------------
 enum FileOrganizationEnum 
 {
-  ENTRY_SEQUENCED_FILE,
   KEY_SEQUENCED_FILE,
   HASH_FILE
 };
@@ -203,8 +201,6 @@ public:
   // ---------------------------------------------------------------------
   NABoolean isKeySequenced() const  
                      { return (fileOrganization_ == KEY_SEQUENCED_FILE); }
-  NABoolean isEntrySequenced() const  
-                   { return (fileOrganization_ == ENTRY_SEQUENCED_FILE); }
   NABoolean isHashed() const      
                               { return (fileOrganization_ == HASH_FILE); }
   NABoolean isSyskeyLeading() const;

--- a/core/sql/optimizer/RelExpr.cpp
+++ b/core/sql/optimizer/RelExpr.cpp
@@ -15603,13 +15603,10 @@ NABoolean Insert::isSideTreeInsertFeasible()
       return FALSE;
    }
 
-   NABoolean isEntrySequencedTable = getTableDesc()->getClusteringIndex()
-        ->getNAFileSet()->isEntrySequenced();
-
    if ( !getInliningInfo().hasPipelinedActions() ) 
      return TRUE;
 
-   if (isEntrySequencedTable || getInliningInfo().isEffectiveGU() ||
+   if (getInliningInfo().isEffectiveGU() ||
        getTolerateNonFatalError() == RelExpr::NOT_ATOMIC_)
       return FALSE;
 


### PR DESCRIPTION
I removed obsolete code concerning NSK-style entry-sequenced files from the optimizer and from the error messages. There is a little bit of code in the parser which remains, and is currently stubbed out. I left that there on the chance that in the future we implement a new entry-sequenced concept within Trafodion.