### PR TITLE
[TRAFODION-2267] Fix ALTER TABLE RENAME documentation

### DIFF
--- a/core/sql/bin/SqlciErrors.txt
+++ b/core/sql/bin/SqlciErrors.txt
@@ -399,11 +399,11 @@
 1404 ZZZZZ 99999 BEGINNER MINOR DBADMIN Column $0~ColumnName cannot be altered. Reason: $0~string0
 1420 ZZZZZ 99999 BEGINNER MINOR DBADMIN Column $0~ColumnName cannot be dropped or altered as it is part of the table's primary key.
 1421 ZZZZZ 99999 BEGINNER MINOR DBADMIN Column $0~ColumnName cannot be dropped or altered as it is used in the secondary index $1~TableName.
-1422 ZZZZZ 99999 BEGINNER MINOR DBADMIN An invalid hbase name was specified in this DDL statement. A valid name can only contain these characters: [a-zA-Z_0-9-.]
+1422 ZZZZZ 99999 BEGINNER MINOR DBADMIN An invalid HBase name was specified in this DDL statement. A valid name can only contain these characters: [a-zA-Z_0-9-.]
 1423 ZZZZZ 99999 BEGINNER MINOR DBADMIN Insert into metadata table $0~string0 failed.
 1424 ZZZZZ 99999 BEGINNER MINOR DBADMIN Column $0~ColumnName cannot be dropped as that would leave the table with no user defined columns.
 1425 ZZZZZ 99999 BEGINNER MINOR DBADMIN This operation could not be performed on $0~TableName. $0~String0
-1426 ZZZZZ 99999 BEGINNER MINOR DBADMIN An invalid hbase column name $0~String0 was specified. A valid name must be of the format:   <ColumnFamily>:<ColumnName>
+1426 ZZZZZ 99999 BEGINNER MINOR DBADMIN An invalid HBase column name $0~String0 was specified. A valid name must be of the format:   <ColumnFamily>:<ColumnName>
 1427 ZZZZZ 99999 BEGINNER MINOR DBADMIN Table cannot be renamed. $0~String0
 1428 ZZZZZ 99999 BEGINNER MINOR DBADMIN Metadata definitions could not be created and preloaded in global MDdescInfo struct. Make sure that metadata table definition syntax is correct.
 1429 ZZZZZ 99999 BEGINNER MINOR DBADMIN Inserts into _ROW_ format external hbase tables can only use the VALUES clause and must use the column_create function to create values.

--- a/core/sql/regress/seabase/EXPECTED022
+++ b/core/sql/regress/seabase/EXPECTED022
@@ -406,7 +406,7 @@ ROW_ID      (EXPR)
 
 >>insert into hbase."_ROW_".t022hbt1 values ('2', column_create(':b', '201'));
 
-*** ERROR[1426] An invalid hbase column name :b was specified. A valid name must be of the format:   <ColumnFamily>:<ColumnName>
+*** ERROR[1426] An invalid HBase column name :b was specified. A valid name must be of the format:   <ColumnFamily>:<ColumnName>
 
 --- 0 row(s) inserted.
 >>insert into hbase."_ROW_".t022hbt1 values ('2', '100');

--- a/docs/messages_guide/src/asciidoc/_chapters/ddl_msgs.adoc
+++ b/docs/messages_guide/src/asciidoc/_chapters/ddl_msgs.adoc
@@ -3044,3 +3044,146 @@ statement.
 *Recovery:* Remove the creation of triggers from the CREATE SCHEMA
 statement and resubmit. Create triggers in separate statements.
 
+<<<
+[[SQL-1420]]
+== SQL 1420
+
+```
+Column <column-name> cannot be dropped or altered as it is part of the table's primary key.
+```
+
+*Cause:* You attempted to drop a column that is a part of a primary key.
+
+*Effect:* The operation fails.
+
+*Recovery:* Correct the column name or table name as appropriate and resubmit.
+
+[[SQL-1421]]
+== SQL 1421 
+
+```
+Column <column-name> cannot be dropped or altered as it is used in the secondary index <index-name>.
+```
+
+*Cause:* You attempted to drop a column, but that column is used by the secondary index named.
+
+*Effect:* The operation fails.
+
+*Recovery:* If the secondary index is no longer needed, drop it and resubmit. If the column
+name or table name are incorrect, correct them and resubmit.
+
+[[SQL-1422]]
+== SQL 1422 
+
+```
+An invalid HBase name was specified in this DDL statement. A valid name can only contain these characters: [a-zA-Z_0-9-.]
+```
+
+*Cause:* You attempted to use a name containing an invalid character for a {project-name} object that is
+stored in HBase.
+
+*Effect:* The operation fails.
+
+*Recovery:* Correct the name and resubmit.
+
+<<<
+[[SQL-1423]]
+== SQL 1423
+
+```
+Insert into metadata table <table-name> failed.
+```
+
+*Cause:* During an INITIALIZE TRAFODION, UPGRADE operation, a write to metadata table <table-name> failed. There may 
+be additional messages giving details of the failure.
+
+*Effect:* The upgrade operation fails.
+
+*Recovery:* None. Contact the {project-name} User Distribution List. Include any additional messages.
+
+[[SQL-1424]]
+== SQL 1424 
+
+```
+Column <column-name> cannot be dropped as that would leave the table with no user defined columns.
+```
+
+*Cause:* You attempted to drop the only remaining user-defined column in the table.
+
+*Effect:* The operation fails.
+
+*Recovery:* If the table is no longer needed, simply drop the table.
+
+[[SQL-1425]]
+== SQL 1425 
+
+```
+This operation could not be performed on <table-name>. <reason>
+```
+
+*Cause:* You attempted an operation on table <table-name> but the operation could not
+be performed. <reason> gives more details.
+
+*Effect:* The operation fails.
+
+*Recovery:* Correct any issues indicated by <reason> as appropriate and resubmit.
+
+<<<
+[[SQL-1426]]
+== SQL 1426
+
+```
+An invalid HBase column name <column-name> was specified. A valid name must be of the format:   <ColumnFamily>:<ColumnName>
+```
+
+*Cause:* When accessing an external HBase table (for example, using _ROW_ format), you specified
+an invalid HBase column name.
+
+*Effect:* The operation fails.
+
+*Recovery:* Correct the column name and resubmit.
+
+[[SQL-1427]]
+== SQL 1427 
+
+```
+Table cannot be renamed. <reason>
+```
+
+*Cause:* You attempted to perform ALTER TABLE RENAME but the rename could not be performed.
+The <reason> explains why.
+
+*Effect:* The operation fails.
+
+*Recovery:* Perform the operations suggested by <reason> and resubmit.
+
+[[SQL-1428]]
+== SQL 1428 
+
+```
+Metadata definitions could not be created and preloaded in global MDdescInfo struct. Make sure that metadata table definition syntax is correct.
+```
+
+*Cause:* This is a {project-name} internal error. It is highly unlikely that you will 
+encounter this error unless you are making code changes to {project-name} yourself.
+
+*Effect:* The operation fails.
+
+*Recovery:* None. Contact the {project-name} Developer Distribution List.
+
+<<<
+[[SQL-1429]]
+== SQL 1429
+
+```
+Inserts into _ROW_ format external hbase tables can only use the VALUES clause and must use the column_create function to create values.
+```
+
+*Cause:* You attempted an INSERT/SELECT into an external _ROW_ format HBase table, or you attempted an INSERT using the VALUES
+clause but did not use a COLUMN_CREATE function. 
+
+*Effect:* The operation fails.
+
+*Recovery:* Correct the statement and resubmit.
+
+

--- a/docs/messages_guide/src/asciidoc/_chapters/ddl_msgs.adoc
+++ b/docs/messages_guide/src/asciidoc/_chapters/ddl_msgs.adoc
@@ -3151,7 +3151,7 @@ Table cannot be renamed. <reason>
 ```
 
 *Cause:* You attempted to perform ALTER TABLE RENAME but the rename could not be performed.
-The <reason> explains why.
+<reason> gives more detail.
 
 *Effect:* The operation fails.
 
@@ -3176,7 +3176,7 @@ encounter this error unless you are making code changes to {project-name} yourse
 == SQL 1429
 
 ```
-Inserts into _ROW_ format external hbase tables can only use the VALUES clause and must use the column_create function to create values.
+Inserts into _ROW_ format external HBase tables can only use the VALUES clause and must use the column_create function to create values.
 ```
 
 *Cause:* You attempted an INSERT/SELECT into an external _ROW_ format HBase table, or you attempted an INSERT using the VALUES

--- a/docs/sql_reference/src/asciidoc/_chapters/sql_statements.adoc
+++ b/docs/sql_reference/src/asciidoc/_chapters/sql_statements.adoc
@@ -326,7 +326,7 @@ alter-action is:
      ADD [IF NOT EXISTS][COLUMN] column-definition
    | ADD [CONSTRAINT constraint-name] table-constraint
    | DROP CONSTRAINT constraint-name [RESTRICT]
-   | RENAME TO new-name [CASCADE]
+   | RENAME TO new-name
    | DROP COLUMN [IF EXISTS] column-name
 
 column-definition is:
@@ -514,7 +514,6 @@ is a constraint that specifies a condition that must be satisfied for each row i
 see <<search_condition,search condition>>. you cannot refer to the current_date, current_time, or current_timestamp function in a check
 constraint, and you cannot use subqueries in a check constraint.
 
-<<<
 *** `foreign key (_column-list_) references _ref-spec_ not enforced`
 +
 is a table constraint that specifies a referential constraint for the table, declaring that a column or set of columns (called a foreign key)
@@ -525,6 +524,7 @@ the two columns or sets of columns must have the same characteristics (data type
 the foreign key in _table_ is the column being defined; with the foreign key clause, the foreign key is the column or set of columns specified in
 the foreign key clause. for information about _ref-spec_, see references _ref-spec_ not enforced.
 
+<<<
 * `drop constraint _constraint-name_ [restrict]`
 +
 drops a constraint from the table. +
@@ -542,7 +542,7 @@ if you do not specify a constraint name, trafodion sql constructs an sql identif
 identifier consists of the fully qualified table name concatenated with a system-generated unique identifier. for example, a constraint on table
 a.b.c might be assigned a name such as a.b.c_123&#8230;_01&#8230;.
 
-* `rename to _new-name_ [cascade]`
+* `rename to _new-name_`
 +
 changes the logical name of the object within the same schema.
 
@@ -551,10 +551,6 @@ changes the logical name of the object within the same schema.
 specifies the new name of the object after the rename to operation occurs.
 
 <<<
-** `cascade`
-+
-specifies that indexes and constraints on the renamed object will be renamed.
-
 * `add if not exists _column-definition_`
 +
 adds a column to _table_ if it does not already exist in the table.


### PR DESCRIPTION
Problem: The SQL Reference manual describes a CASCADE keyword for ALTER TABLE RENAME, however if you try to use it, you get error message 1427, "Table cannot be renamed. Reason: Cascade option not supported."

Supporting this option seems like a fair amount of work, so for the moment, we've simply removed mention of CASCADE from the SQL reference manual.

While working on this issue, I noticed that the DDL messages section of the Messages Guide is woefully out-of-date. Among other things, it lacks several messages including the message 1427 mentioned above. Fixing all of that is a big job, but with this set of changes I did a small part of it. I added documentation for messages 1420-1429.

While doing this I noticed that ALTER TABLE RENAME to an invalid HBase name produced a very ugly 8448 error (unlike CREATE TABLE and DROP TABLE which produce a nice tidy error 1422 in this case). I fixed the error reporting code in ALTER TABLE RENAME so that we now get the nice error 1422 instead.
