### PR TITLE
TRAFODION-2281 - Unable to install Kerberos

### DIFF
--- a/core/sqf/sql/scripts/traf_authentication_setup
+++ b/core/sqf/sql/scripts/traf_authentication_setup
@@ -162,7 +162,7 @@ function copy_config
   # before propagating the configuration file to nodes in the cluster, verify 
   # that the current file can successfully contact the identity store
   ldapcheck --username=micky.mouse > auth_configcheck
-  isValid=`cat auth_configcheck | grep "User micky.mouse not found" | wc -l`
+  isValid=`cat auth_configcheck | grep "(Invalid username or password)" | wc -l`
   if [ $isValid -ne 1 ]; then
     echo
     echo "***ERROR: Configuration file is invalid, error contacting LDAP server"

--- a/install/installer/traf_config_setup
+++ b/install/installer/traf_config_setup
@@ -812,10 +812,5 @@ sudo cp $LOCAL_TRAF_CONFIG $TRAF_CONFIG
 sudo chmod 777 $TRAF_CONFIG
 
 #==============================================
-#Call user defined prompting script
-
-$LOCAL_WORKDIR/traf_user_prompt | tee -a $INSTALL_LOG
-
-#==============================================
 
 echo "***INFO: Trafodion configuration setup complete"

--- a/install/installer/traf_secure_setup
+++ b/install/installer/traf_secure_setup
@@ -30,6 +30,18 @@ LDAP_AUTH_FILE="traf_authentication_config_${HOSTNAME}"
 
 HOST_NAME=`hostname -f`
 
+#==============================================
+#  Setup Trafodion environment for secure Hadoop
+#==============================================
+
+LOCAL_WORKDIR="$( cd "$( dirname "$0" )" && pwd )"
+
+TRAF_CONFIG="/etc/trafodion/trafodion_config"
+LOCAL_SECURE_CONFIG="$LOCAL_WORKDIR/trafodion_secure_config"
+rm $LOCAL_SECURE_CONFIG  2>/dev/null
+source $TRAF_CONFIG
+
+# Get Kerberos key details
 # These differ depending on the distribution
 if [[ $HADOOP_TYPE == "cloudera" ]]; then
   TRAF_KEYTAB_DIR='/etc/trafodion'
@@ -42,16 +54,6 @@ else
   HBASE_KEYTAB='/etc/security/keytabs/hbase.service.keytab'
   HDFS_KEYTAB='/etc/security/keytabs/hdfs.headless.keytab'
 fi
-
-#==============================================
-#  Setup Trafodion environment for secure Hadoop
-#==============================================
-
-LOCAL_WORKDIR="$( cd "$( dirname "$0" )" && pwd )"
-
-TRAF_CONFIG="/etc/trafodion/trafodion_config"
-LOCAL_SECURE_CONFIG="$LOCAL_WORKDIR/trafodion_secure_config"
-rm $LOCAL_SECURE_CONFIG  2>/dev/null
 
 
 #==============================================
@@ -135,7 +137,8 @@ if [[ "$SECURE_HADOOP" == "Y" ]]; then
    echo -n "Enter keytab location, default is [$TRAF_KEYTAB_DIR]:"
    read answer
    if [[ ! -d $TRAF_KEYTAB_DIR ]]; then
-     echo "**Missing keytab directory $TRAF_KEYTAB_DIR, create it (Y/N), default is [Y]:"
+     echo -n "**Missing keytab directory $TRAF_KEYTAB_DIR, create it (Y/N), default is [Y]:"
+     read answer
      if [[ "${answer}" =~ ^[Yy]$ ]]; then
        if [[ "$all_node_count" -ne "1" ]]; then
          echo "***INFO: creating $TRAF_KEYTAB_DIR"

--- a/install/installer/trafodion_install
+++ b/install/installer/trafodion_install
@@ -378,6 +378,19 @@ if [ -z "$USER_CONFIG" ]; then
       echo "***ERROR: No security configuration file created." | tee -a $INSTALL_LOG
       exit -1
    fi
+
+  #Call user defined prompting script
+  if [[ -e $LOCAL_WORKDIR/traf_user_prompt ]]; then
+    $LOCAL_WORKDIR/traf_user_prompt | tee -a $INSTALL_LOG
+    $LOCAL_WORKDIR/traf_user_prompt_check | tee -a $INSTALL_LOG
+
+    if [ ${PIPESTATUS[0]} != "0" ]; then
+       echo "***ERROR: Error found while checking config file."
+       echo "***ERROR: Exiting..."
+       exit -1
+    fi
+fi
+
 else
    # copy the user's config file to the default location
    sudo cp $USER_CONFIG $TRAF_CONFIG


### PR DESCRIPTION
Fixed a couple of problems with security installation scripts:

- Need to source config file in traf_secure_config before checking HADOOP_TYPE
- Need to check for answer regarding creation of keytabs directory
- Perform traf_user_prompt after determining if LDAP is enabled
- Fixed issue with traf_authentication_setup with ldapcheck results