### PR TITLE
[TRAFODION 1441]ODBC:Cancel button dismisses the SQLDriverConnect prompt dialog but still establish connection

### DIFF
--- a/win-odbc64/odbcclient/drvr35/cconnect.cpp
+++ b/win-odbc64/odbcclient/drvr35/cconnect.cpp
@@ -1086,7 +1086,7 @@ INT_PTR CALLBACK ConnectDriverKWDialogProc(
 			PostMessage(hwndDlg,WM_QUIT,0,0);
 			break;
 		case IDCANCEL:
-			PostMessage(hwndDlg,WM_QUIT,0,0);
+			PostMessage(hwndDlg,WM_QUIT,1,0);
 			break;
 		}
 		return TRUE;
@@ -1761,10 +1761,16 @@ SQLRETURN CConnect::DriverConnect(SQLHWND WindowHandle,
 					 DispatchMessage(&msg);
 				 }
 				}
+				
 				DestroyWindow(hWndDlg);
 				EnableWindow(WindowHandle,!b);
-
 				FreeLibrary(hinst);
+
+				if (msg.wParam == 1)//IDCANCEL
+				{
+					setDiagRec(DRIVER_ERROR, IDS_HY_000, 0, "Operation Aborted.");
+					return SQL_ERROR;
+				}
 			 }
 			 else {
 				BOOL b=EnableWindow(WindowHandle,FALSE);
@@ -1783,8 +1789,13 @@ SQLRETURN CConnect::DriverConnect(SQLHWND WindowHandle,
 				}
 				DestroyWindow(hWndDlg);
 				EnableWindow(WindowHandle,!b);
-
 				FreeLibrary(hinst);
+
+				if (msg.wParam == 1)//IDCANCEL
+				{
+					setDiagRec(DRIVER_ERROR, IDS_HY_000, 0, "Operation Aborted.");
+					return SQL_ERROR;
+				}
 			 }
 
 		}


### PR DESCRIPTION
1.When cancel button of prompt dialog is clicked(IDCANCEL msg is signaled), set WM_QUIT msg's wParam value to 1, to differentiate from ok button click msg processing.
2.When prompt dialog's msg loop finishes(WM_QUIT msg is encountered), if WM_QUIT msg's wParam equals 1, return SQL_ERROR HY000 with additional promption"Operation Aborted." instead of establishing connection to server anyway.