### PR TITLE
[TRAFODION-2292] Add RPM packaging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /licenses/DISCLAIMER*
 LICENSE
 /apache-*incubating/
+/RPMROOT/

--- a/core/Makefile
+++ b/core/Makefile
@@ -182,7 +182,7 @@ P_TYPE = $(shell uname -p)
 
 ifeq ($(SQ_BUILD_TYPE),release)
   RELEASE ?= 1
-  SERVERTAR="$(PKG_PROD)_server-$(TRAFODION_VER)-${OS_TYPE}${OS_MAJOR}-${P_TYPE}.tar.gz"
+  SERVERTAR="$(PKG_PROD)_server-$(TRAFODION_VER)-${OS_TYPE}${OS_MAJOR}-${P_TYPE}-incubating.tar.gz"
 else
   RELEASE ?= devel
   SERVERTAR="$(PKG_PROD)_server-$(TRAFODION_VER)-${OS_TYPE}${OS_MAJOR}-${P_TYPE}-debug.tar.gz"

--- a/core/Makefile
+++ b/core/Makefile
@@ -132,7 +132,7 @@ cleanall: sqroot eclipseclean cleantests
 	cd ../install &&                $(MAKE) clean
 	$(RM) -r ../${DISTRIBUTION_DIR}
 
-package-all: package pkg-sql-regress pkg-phx-tests pkg-dcs-tests 
+package-all: rpmbuild package pkg-sql-regress pkg-phx-tests pkg-dcs-tests 
 
 pkg-product: all dcs rest 
 	cd sqf && $(MAKE) package 2>&1 | sed -e "s/$$/	##(Package)/";exit $${PIPESTATUS[0]}
@@ -171,6 +171,58 @@ find-absolute-dlls:
 
 check-copyrights:
 	python ./updateCopyrightCheck.py
+
+##############
+# RPM defines
+PKG_PROD=apache-trafodion
+
+OS_TYPE = RH
+OS_MAJOR ?=  $(shell lsb_release -rs | cut -f1 -d.)
+P_TYPE = $(shell uname -p)
+
+ifeq ($(SQ_BUILD_TYPE),release)
+  RELEASE ?= 1
+  SERVERTAR="$(PKG_PROD)_server-$(TRAFODION_VER)-${OS_TYPE}${OS_MAJOR}-${P_TYPE}.tar.gz"
+else
+  RELEASE ?= devel
+  SERVERTAR="$(PKG_PROD)_server-$(TRAFODION_VER)-${OS_TYPE}${OS_MAJOR}-${P_TYPE}-debug.tar.gz"
+endif
+
+ARCH=$(P_TYPE)
+
+SPECFILE = trafodion.spec
+
+RPMROOT=$(shell cd ..; /bin/pwd)/RPMROOT
+RPMDIR=$(RPMROOT)/RPMS
+SRPMDIR=$(RPMROOT)/SRPMS
+SOURCEDIR=$(RPMROOT)/SOURCES
+BUILDDIR=$(RPMROOT)/BUILD
+BUILDROOTDIR=$(RPMROOT)/BUILDROOT
+
+rpmpackage: pkg-product
+	/bin/rm -rf $(RPMROOT)
+	mkdir -p $(RPMDIR)
+	mkdir -p $(SOURCEDIR)
+	mkdir -p $(BUILDDIR)
+	mkdir -p $(BUILDROOTDIR)
+	mkdir -p $(SRPMDIR)
+	ln -L ../distribution/$(SERVERTAR) $(SOURCEDIR)/$(PKG_PROD)_server-$(TRAFODION_VER).tar.gz
+
+rpmbuild: rpmpackage
+	rpmbuild -vv -bb \
+	                --define "name $(PKG_PROD)_server" \
+	                --define "version $(TRAFODION_VER)" \
+	                --define "release $(RELEASE)" \
+	                --define "_builddir $(BUILDDIR)" \
+	                --define "_buildrootdir $(BUILDROOTDIR)" \
+	                --define "_sourcedir $(SOURCEDIR)" \
+	                --define "_rpmdir $(RPMDIR)" \
+	                --define "_arch $(ARCH)" \
+	                --define "_topdir $(RPMROOT)" \
+	                $(SPECFILE)
+	mkdir -p ../distribution/${OS_TYPE}${OS_MAJOR}
+	mv $(RPMROOT)/RPMS/$(ARCH)/$(PKG_PROD)*.rpm ../distribution/${OS_TYPE}${OS_MAJOR}/
+
 
 eclipse: rest/.project dcs/.project sql/.project sqf/src/seatrans/hbase-trx/.project .project
 	@echo

--- a/core/trafodion.spec
+++ b/core/trafodion.spec
@@ -1,0 +1,114 @@
+# @@@ START COPYRIGHT @@@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# @@@ END COPYRIGHT @@@
+
+Summary:	Trafodion: Transactional SQL-on-Hadoop DBMS
+Name:		%{name}
+Version:	%{version}
+Release:	%{release}
+AutoReqProv:	no
+License:	Apache version 2.0 -  http://www.apache.org/licenses/LICENSE-2.0
+Group:		Applications/Databases
+Source0:        %{name}-%{version}.tar.gz
+BuildArch:	%{_arch}
+BuildRoot:	%{_tmppath}/%{name}-%{version}-%{release}
+URL:            http://trafodion.incubator.apache.org
+
+
+%define _binary_filedigest_algorithm 1
+%define _source_filedigest_algorithm 1
+%define _binary_payload w9.gzdio
+%define _source_payload w9.gzdio
+
+Requires: audit-libs
+Requires: apr
+Requires: apr-util
+Requires: coreutils
+Requires: cracklib
+Requires: expect
+Requires: gawk
+Requires: glib2
+Requires: glibc
+Requires: gmp
+Requires: gnuplot
+Requires: groff
+Requires: gzip
+Requires: keyutils-libs
+Requires: libcom_err
+Requires: libgcc
+Requires: libxml2
+Requires: lsof
+Requires: lzo
+Requires: ncurses
+Requires: openssl
+Requires: pam
+Requires: pcre
+Requires: pdsh
+Requires: perl
+Requires: perl-DBD-SQLite
+Requires: perl-DBI
+Requires: perl-Module-Pluggable
+Requires: perl-Params-Validate
+Requires: perl-Pod-Escapes
+Requires: perl-Pod-Simple
+Requires: perl-Time-HiRes
+Requires: perl-version
+Requires: protobuf
+Requires: python
+Requires: readline
+Requires: sqlite
+Requires: snappy
+Requires: xerces-c
+Requires: zlib
+
+Prefix: /home/trafodion
+
+%description
+Apache Trafodion for Operational Big Data combining the power of transactional SQL and Apache HBase with the elastic scalability of Hadoop.
+
+
+%prep
+%setup -b 0 -n %{name}-%{version} -c
+
+
+%pre -n %{name}
+getent group trafodion > /dev/null || /usr/sbin/groupadd trafodion > /dev/null 2>&1
+getent passwd trafodion > /dev/null || /usr/sbin/useradd --shell /bin/bash -m trafodion -g trafodion --home /home/trafodion > /dev/null 2>&1
+
+
+%build
+# don't build debug info package
+%define debug_package:
+
+%install
+mkdir -p %{buildroot}/home/trafodion/%{name}-%{version}
+cd %{_builddir}
+cp -rf %{name}-%{version}/* %{buildroot}/home/trafodion/%{name}-%{version}
+
+%clean
+/bin/rm -rf %{buildroot}
+
+%files
+%defattr(-,trafodion,trafodion)
+/home/trafodion/%{name}-%{version}
+
+%changelog
+* Mon Oct 18 2016 Steve Varnau
+- ver 2.1


### PR DESCRIPTION
Make rpm package to contain same things as server tarball.
Only additional pre-install action is to create the trafodion user.
This mimics the regular installer default action to locate files in
/home/trafodion, owned by trafodion user.

File locations and ownership perhaps ought to be changed, but that is
a separate effort from this initial RPM packaging.