### PR TITLE
[TRAFODION-2296] Consistent error reporting in abort, commit transaction

### DIFF
--- a/core/sqf/conf/log4cxx.trafodion.tm.config
+++ b/core/sqf/conf/log4cxx.trafodion.tm.config
@@ -45,5 +45,5 @@ log4j.appender.tmAppender.layout.ConversionPattern=%d, %p, %c, %m%n
 log4j.appender.tmAppender.Append=true
 
 #TM
-log4j.logger.TM=ERROR, tmAppender
+log4j.logger.TM=INFO, tmAppender
 

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/TransactionState.java
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/TransactionState.java
@@ -188,22 +188,17 @@ public class TransactionState {
      * params  : none
      * return  : void
      * purpose : decrease number of outstanding replies needed and wake up any waiters
-     *           if we receive the last one or if the wakeup value is true (which means
-     *           we received an exception)
+     *           if we receive the last one 
      */
     public void  requestPendingCountDec(Throwable exception)
     {
        synchronized (countLock)
        {
           requestReceivedCount++;
-          if ((requestReceivedCount == requestPendingCount) || (exception != null))
-          {
-             //signal waiters that an error occurred
-             if (exception != null && hasError == null)
-                hasError = exception;
-
+          if (exception != null && hasError == null)
+             hasError = exception;
+          if (requestReceivedCount == requestPendingCount)
              countLock.notify();
-          }
        }
     }
 

--- a/core/sqf/src/seatrans/tm/hbasetmlib2/src/main/java/org/trafodion/dtm/TmAuditTlog.java
+++ b/core/sqf/src/seatrans/tm/hbasetmlib2/src/main/java/org/trafodion/dtm/TmAuditTlog.java
@@ -944,8 +944,8 @@ public class TmAuditTlog {
 
    }
 
-   public long addControlPoint (final int clusterId, final Map<Long, TransactionState> map, final boolean incrementCP) throws IOException {
-      if (LOG.isDebugEnabled()) LOG.info("addControlPoint start with map size " + map.size());
+   public long addControlPoint (final Map<Long, TransactionState> map) throws IOException {
+      if (LOG.isDebugEnabled()) LOG.debug("addControlPoint start with map size " + map.size());
       long lvCtrlPt = 0L;
       long agedAsn;  // Writes older than this audit seq num will be deleted
       long lvAsn;    // local copy of the asn
@@ -1001,7 +1001,7 @@ public class TmAuditTlog {
                throw e;
             }
          }
-      if (LOG.isDebugEnabled()) LOG.info("addControlPoint returning " + lvCtrlPt);
+      if (LOG.isDebugEnabled()) LOG.debug("addControlPoint returning " + lvCtrlPt);
       return lvCtrlPt;
    } 
 

--- a/core/sqf/src/seatrans/tm/hbasetmlib2/src/main/java/org/trafodion/dtm/TmAuditTlog.java
+++ b/core/sqf/src/seatrans/tm/hbasetmlib2/src/main/java/org/trafodion/dtm/TmAuditTlog.java
@@ -272,8 +272,9 @@ public class TmAuditTlog {
                   // We have received our reply in the form of an exception,
                   // so decrement outstanding count and wake up waiters to avoid
                   // getting hung forever
-                  transactionState.requestPendingCountDec(true);
-                  throw new IOException("Exceeded retry attempts (" + retryCount + ") in deleteEntriesOlderThanASNX for ASN: " + auditSeqNum);
+                  IOException ie = new IOException("Exceeded retry attempts (" + retryCount + ") in deleteEntriesOlderThanASNX for ASN: " + auditSeqNum);
+                  transactionState.requestPendingCountDec(ie);
+                  throw ie;
                }
 
                if (LOG.isWarnEnabled()) LOG.warn("deleteEntriesOlderThanASNX -- " + table.toString() + " location being refreshed");
@@ -297,7 +298,7 @@ public class TmAuditTlog {
             }
        } while (retryCount < TLOG_RETRY_ATTEMPTS && retry == true);
        // We have received our reply so decrement outstanding count
-       transactionState.requestPendingCountDec(false);
+       transactionState.requestPendingCountDec(null);
 
        if (LOG.isTraceEnabled()) LOG.trace("deleteEntriesOlderThanASNX -- EXIT ASN: " + auditSeqNum);
        return 0;
@@ -943,8 +944,8 @@ public class TmAuditTlog {
 
    }
 
-   public long addControlPoint (final Map<Long, TransactionState> map) throws IOException {
-      if (LOG.isTraceEnabled()) LOG.trace("addControlPoint start with map size " + map.size());
+   public long addControlPoint (final int clusterId, final Map<Long, TransactionState> map, final boolean incrementCP) throws IOException {
+      if (LOG.isDebugEnabled()) LOG.info("addControlPoint start with map size " + map.size());
       long lvCtrlPt = 0L;
       long agedAsn;  // Writes older than this audit seq num will be deleted
       long lvAsn;    // local copy of the asn
@@ -1000,7 +1001,7 @@ public class TmAuditTlog {
                throw e;
             }
          }
-      if (LOG.isTraceEnabled()) LOG.trace("addControlPoint returning " + lvCtrlPt);
+      if (LOG.isDebugEnabled()) LOG.info("addControlPoint returning " + lvCtrlPt);
       return lvCtrlPt;
    } 
 

--- a/core/sqf/src/tm/tmmsg.h
+++ b/core/sqf/src/tm/tmmsg.h
@@ -74,11 +74,14 @@ public:
        strcpy((char *) &ia_EID, (char *) EID_CTmMessage);
    }
 
-   bool validate()
+   bool validate(bool detectDoubleDelete = false)
     {
        if (strcmp((char *) &ia_EID, (char *) &EID_CTmMessage) != 0)
        {
-          abort();
+          if (! detectDoubleDelete)
+             abort();
+          else
+             return false;
        }
        return true;
     } //validate

--- a/core/sqf/src/tm/tmmsg.h
+++ b/core/sqf/src/tm/tmmsg.h
@@ -46,23 +46,23 @@ public:
          abort();
       memset(&iv_req, 0, sizeof(Tm_Req_Msg_Type));
       memcpy(&iv_req, pp_req, sizeof(Tm_Req_Msg_Type));
-      memset(ia_EID, 0, EID_SIZE+1);
-      //set_EID();
+      set_EID();
    }
    CTmMessage(short pv_reqType)
    {
       memset(&iv_req, 0, sizeof(Tm_Req_Msg_Type));
       requestType(pv_reqType);
-      memset(ia_EID, 0, EID_SIZE+1);
-      //set_EID();
+      set_EID();
    }
    CTmMessage(CTmMessage *pp_msg)
    {
       memcpy(&iv_req, pp_msg->request(), sizeof(iv_req));
-      memset(ia_EID, 0, EID_SIZE+1);
-      //set_EID();
+      set_EID();
    }
-   ~CTmMessage() {}
+   ~CTmMessage()
+   {
+      memset(ia_EID, 0, EID_SIZE+1);
+   }
 
    Tm_Req_Msg_Type * request() {return &iv_req;}
 
@@ -73,12 +73,14 @@ public:
    {
        strcpy((char *) &ia_EID, (char *) EID_CTmMessage);
    }
-    void validate()
+
+   bool validate()
     {
        if (strcmp((char *) &ia_EID, (char *) &EID_CTmMessage) != 0)
        {
-          ;// abort();
+          abort();
        }
+       return true;
     } //validate
 };
 

--- a/core/sqf/src/tm/tmtx.cpp
+++ b/core/sqf/src/tm/tmtx.cpp
@@ -1114,7 +1114,8 @@ void TM_TX_Info::process_eventQ()
 
       // Protect message as registerRegion could try to reply from the main thread.
       lock();
-      delete lp_msg;
+      if (lp_msg->validate())
+         delete lp_msg;
       unlock();
       // Multithreaded only:
       // Worker threads release the transaction after every request

--- a/core/sqf/src/tm/tmtx.cpp
+++ b/core/sqf/src/tm/tmtx.cpp
@@ -1113,8 +1113,9 @@ void TM_TX_Info::process_eventQ()
       } // switch
 
       // Protect message as registerRegion could try to reply from the main thread.
+      bool detectDoubleDelete = true;
       lock();
-      if (lp_msg->validate())
+      if (lp_msg->validate(detectDoubleDelete))
          delete lp_msg;
       unlock();
       // Multithreaded only:

--- a/core/sql/cli/CliExtern.cpp
+++ b/core/sql/cli/CliExtern.cpp
@@ -90,6 +90,7 @@ CLISemaphore globalSemaphore ;
 #include "SqlStats.h"
 #include "ComExeTrace.h"
 #include "Context.h"
+#include <unistd.h>
 #include "QRLogger.h"
 
 #ifndef CLI_PRIV_SRL

--- a/core/sql/qmscommon/QRLogger.cpp
+++ b/core/sql/qmscommon/QRLogger.cpp
@@ -186,6 +186,9 @@ void getMyNidSuffix(char stringNidSuffix[])
 // **************************************************************************
 NABoolean QRLogger::initLog4cxx(const char* configFileName)
 {
+  if (gv_QRLoggerInitialized_)
+     return TRUE;
+
   NAString logFileName;
 
   if (gv_QRLoggerInitialized_)


### PR DESCRIPTION
When there is an error returned from commit or rollback transaction, the details of the error can be obtained in the following log files 

a) $MY_SQROOT/logs/tm_<nid>.log in the node that issued this request contains the error message as seen by the TM process in the JNI side. This event may not have transaction id.
b) $MY_SQROOT/logs/trafodion.dtm.log contains more info about this error with the transaction id. These events are logged from java side of TM.
c) In the region server logs of all the regions that participated in the transaction.

These exceptions are visible as error code on  the client side.  To get the details about the exception, the above logs need to be browsed.
