### PR TITLE
[TRAFODION-2301]: Hadoop crash with logs TMUDF

### DIFF
--- a/core/sql/regress/udr/TEST103
+++ b/core/sql/regress/udr/TEST103
@@ -19,7 +19,7 @@
 --
 -- @@@ END COPYRIGHT @@@
 --
--- This script tests DDL operations associted with libraries
+-- This script tests DDL operations associated with libraries
 -- functions, and procedures
 --
 cqd SHOWDDL_DISPLAY_PRIVILEGE_GRANTS 'ON';


### PR DESCRIPTION
Today the UDF event_log_reader scans all logs, loads events into memory and
then discards the rows that are not needed.  Waiting until the end to discard
rows takes too much memory and causes system issues.

The immediate solution is to use predicate pushdown; that is, specify predicates
on the query using the event_log_reader UDF to limit the scope of the data flow.
These predicates will be pushed into the UDF so the UDF only returns the
required rows instead of all the rows.  Initially only comparison predicates are
pushed down to the event_log_reader UDF.

In addition to predicate pushdown, a new option has been added to the
event_log_reader UDF - the 's' (statistics) option.  This option reports how
many log files were accessed, how many records were read, and how many records
were returned.  By specifying timestamp ranges, severity types, sql_codes, and
the like, the number of returned rows can be reduced.

Example output:

Prior to change:

select count(*) from udf(event_log_reader('s'))
  where severity = 'INFO' and
        log_ts between '2016-10-18 00:00:00' and '2016-10-18 22:22:22';

(16497) EVENT_LOG_READER results:
          number log files opened: 113, number log files read: 113,
          number rows read: 2820, number rows returned: 2736

After change:

select count(*) from udf(event_log_reader('s'))
  where severity = 'INFO' and
  log_ts between '2016-10-18 00:00:00' and '2016-10-18 22:22:22';

(17046) EVENT_LOG_READER results:
          number log files opened: 115, number log files read: 115,
          number rows read: 2823, number rows returned: 109