### PR TITLE
[TRAFODION-2309] Memory leak observed in Repository context

### DIFF
--- a/core/conn/odbc/src/odbc/nsksrvrcore/srvrothers.cpp
+++ b/core/conn/odbc/src/odbc/nsksrvrcore/srvrothers.cpp
@@ -2334,6 +2334,7 @@ out:
 							  &pSrvrStmt->m_need_21036_end_msg,
 							  inSqlNewQueryType);
 		delete inSqlString;
+		delete tmpSqlString;
 	}
 	//end rs
 }  // end rePrepare2


### PR DESCRIPTION
Following changes:

1. Use REALLOCSQLMXHDLS() after each execute.
2. Avoid missing stats message in repository context
3. Handle memory leak in reprepare (delete of tmpSqlString)