### PR TITLE
[TRAFODION-1077] AQR info missing from GET STATISTICS

### DIFF
--- a/core/sql/cli/Cli.cpp
+++ b/core/sql/cli/Cli.cpp
@@ -2270,14 +2270,17 @@ static Lng32 SQLCLI_RetryQuery(
 			    flags
 			    );
 
-  if (savedStmtStats)
-    savedStmtStats->setAqrInProgress(FALSE);
-
-  if (isERROR(retcode))
+  if (isERROR(retcode)) {
+      if (savedStmtStats)
+          savedStmtStats->setAqrInProgress(FALSE);
       return retcode;
+  }
       
-  if (afterPrepare)
+  if (afterPrepare) {
+     if (savedStmtStats)
+        savedStmtStats->setAqrInProgress(FALSE);
     return 0;
+  }
 
   // before executing this statement,
   // validate that the new prepare's input/output descriptors are the same


### PR DESCRIPTION
Automatic query retry info was populated, but it got reset as part
of successful retry prepare.