### PR TITLE
TRAFODION-2330 Using trafci, a select from a table succeeds even if t…

### DIFF
--- a/core/sql/arkcmp/CmpContext.cpp
+++ b/core/sql/arkcmp/CmpContext.cpp
@@ -1157,4 +1157,16 @@ void CmpContext::resetLogmxEventSqlText()
    delete sqlTextBuf_ ;
    sqlTextBuf_ = NULL ;
 }
+
+void CmpContext::clearAllCaches()
+{
+   qcache_->makeEmpty();
+   schemaDB_->getNATableDB()->setCachingOFF();
+   schemaDB_->getNATableDB()->setCachingON();
+   schemaDB_->getNARoutineDB()->setCachingOFF();
+   schemaDB_->getNARoutineDB()->setCachingON();
+   if(histogramCache_)
+      histogramCache_->invalidateCache();
+}
+
 #endif // NA_CMPDLL

--- a/core/sql/arkcmp/CmpContext.h
+++ b/core/sql/arkcmp/CmpContext.h
@@ -479,6 +479,8 @@ public :
 
   NAList<DDLObjInfo>& ddlObjsList() { return ddlObjs_; }
 
+  void clearAllCaches();
+
 // MV
 private:
 // Adding support for multi threaded requestor (multi transactions) handling

--- a/core/sql/cli/Context.cpp
+++ b/core/sql/cli/Context.cpp
@@ -2864,7 +2864,21 @@ void ContextCli::completeSetAuthID(
 // Recreate MXCMP if previously connected and currently connected user id's 
 // are different.
    if ( recreateMXCMP )
+   {
+      // reset rolelist in anticipation of the new user
+      resetRoleList();
+
+      // create all the caches
+      CmpContextInfo *cmpCntxtInfo;
+      for (int i = 0; i < cmpContextInfo_.entries(); i++)
+      {
+         cmpCntxtInfo = cmpContextInfo_[i];
+         cmpCntxtInfo->getCmpContext()->clearAllCaches();
+      }
+
+      // clear caches in secondary arkcmps
       killAndRecreateMxcmp();
+   }
  
    if (eraseCQDs)
    {


### PR DESCRIPTION
…he user

               does not have the priv

There is a problem when the session user changes in a mxosrvr process.  The
existing compiler caches are not getting cleared so the new user will be
accessing the previous users' caches.  This could lead to allowing someone
that does not have privileges to gain access to an object.

The change is to clear all caches during a session user change operation.