### PR TITLE
[TRAFODION-2332] SequenceFileReader cleanup.

### DIFF
--- a/core/sql/executor/ExHdfsScan.cpp
+++ b/core/sql/executor/ExHdfsScan.cpp
@@ -228,6 +228,11 @@ void ExHdfsScanTcb::freeResources()
     NADELETEBASIC(hdfsAsciiSourceBuffer_, getSpace());
     hdfsAsciiSourceBuffer_ = NULL;
   }
+  if(sequenceFileReader_)
+  {
+    NADELETE(sequenceFileReader_,SequenceFileReader, getHeap());
+    sequenceFileReader_ = NULL;
+  }
  
   // hdfsSqlTupp_.release() ; // ??? 
   if (hdfsSqlBuffer_)
@@ -537,8 +542,8 @@ ExWorkProcRetcode ExHdfsScanTcb::work()
 	    retcode = 0;
 	    if (isSequenceFile() && !sequenceFileReader_)
 	      {
-	        sequenceFileReader_ = new(getSpace()) 
-                    SequenceFileReader((NAHeap *)getSpace());
+	        sequenceFileReader_ = new(getHeap()) 
+                    SequenceFileReader((NAHeap *)getHeap());
 	        sfrRetCode = sequenceFileReader_->init();
 	        
 	        if (sfrRetCode != JNI_OK)


### PR DESCRIPTION
Fixes cleanup of SequenceFileReader instance. Without this fix, we see this error where jvm is out of memory,

2016-10-28 17:39:00,079, ERROR, SQL, Node Number: 0, CPU: 0, PIN: 55991, Process Name: $Z001APR, SQLCODE: 8447, QID: MXID11000020372212344459045477158000000000106U3333300_4993_HS_CLI_DYNSTMT, *** ERROR[8447] An error occurred during hdfs access. Error Detail: JNI NewObject() failed

