### PR TITLE
[TRAFODION-2342] hdfs access threads init/cleanup changes

### DIFF
--- a/core/sql/executor/ExExeUtilMisc.cpp
+++ b/core/sql/executor/ExExeUtilMisc.cpp
@@ -2275,13 +2275,6 @@ void ExExeUtilHiveTruncateTcb::freeResources()
 Int32 ExExeUtilHiveTruncateTcb::fixup()
 {
   lobGlob_ = NULL;
-
-  ExpLOBinterfaceInit
-    (lobGlob_, getGlobals()->getDefaultHeap(),
-     getGlobals()->castToExExeStmtGlobals()->getContext(),TRUE, 
-     htTdb().getHdfsHost(),
-     htTdb().getHdfsPort());
-
   return 0;
 }
 //////////////////////////////////////////////////////
@@ -2310,6 +2303,11 @@ short ExExeUtilHiveTruncateTcb::work()
     {
       case INITIAL_:
       {
+        ExpLOBinterfaceInit
+        (lobGlob_, getGlobals()->getDefaultHeap(),
+         getGlobals()->castToExExeStmtGlobals()->getContext(),TRUE, 
+         htTdb().getHdfsHost(),
+         htTdb().getHdfsPort());
 
         if (htTdb().getModTS() > 0)
           step_ = DATA_MOD_CHECK_;
@@ -2461,6 +2459,12 @@ short ExExeUtilHiveTruncateTcb::work()
         if (qparent_.up->isFull())
           return WORK_OK;
 
+        if (lobGlob_)
+        {
+          ExpLOBinterfaceCleanup(lobGlob_, getHeap());
+          lobGlob_ = NULL;
+        }
+        
         // Return EOF.
         ex_queue_entry * up_entry = qparent_.up->getTailEntry();
 

--- a/core/sql/executor/ExFastTransport.cpp
+++ b/core/sql/executor/ExFastTransport.cpp
@@ -529,6 +529,7 @@ ExHdfsFastExtractTcb::~ExHdfsFastExtractTcb()
 
   if (lobGlob_ != NULL)
   {
+    ExpLOBinterfaceCleanup(lobGlob_, getGlobals()->getDefaultHeap());
     lobGlob_ = NULL;
   }
 

--- a/core/sql/executor/ExHdfsScan.cpp
+++ b/core/sql/executor/ExHdfsScan.cpp
@@ -205,6 +205,12 @@ ExHdfsScanTcb::ExHdfsScanTcb(
                                         jniDebugPort,
                                         jniDebugTimeout);
 
+  //Initialize hdfs access interface.
+  lobGlob_ = NULL;
+  ExpLOBinterfaceInit(lobGlob_,getGlobals()->getDefaultHeap(),
+                      getGlobals()->castToExExeStmtGlobals()->getContext(),
+                      TRUE, hdfsScanTdb.hostName_,hdfsScanTdb.port_);
+
 }
     
 ExHdfsScanTcb::~ExHdfsScanTcb()
@@ -341,11 +347,6 @@ ex_tcb_private_state *ExHdfsScanTcb::allocatePstates(
 
 Int32 ExHdfsScanTcb::fixup()
 {
-  lobGlob_ = NULL;
-
-  ExpLOBinterfaceInit
-    (lobGlob_, getGlobals()->getDefaultHeap(),getGlobals()->castToExExeStmtGlobals()->getContext(),TRUE, hdfsScanTdb().hostName_,hdfsScanTdb().port_);
-  
   return 0;
 }
 

--- a/core/sql/exp/ExpLOBaccess.h
+++ b/core/sql/exp/ExpLOBaccess.h
@@ -635,7 +635,7 @@ class ExLobGlobals
     {
       return heap_;
     }
-  void traceMessage(const char *logMessage, ExLobCursor *c, int line);
+  void traceMessage(const char *logMessage, ExLobCursor *c, int line, long num = 0);
   
   public :
     lobMap_t *lobMap_;

--- a/core/sql/exp/ExpLOBinterface.cpp
+++ b/core/sql/exp/ExpLOBinterface.cpp
@@ -67,7 +67,10 @@ Lng32 ExpLOBinterfaceInit(void *& exLobGlob, void * lobHeap,
       ((ExLobGlobals *)exLobGlob)->setIsHive(isHive);
       NAHeap *heap = new ((NAHeap *)lobHeap) NAHeap("LOB Heap", (NAHeap *)lobHeap);
       if (isHive)
-        ((ExLobGlobals *)exLobGlob)->startWorkerThreads();
+      {
+        if( (err = ((ExLobGlobals *)exLobGlob)->startWorkerThreads()) != LOB_OPER_OK)
+          return err;
+      }
       heap->setThreadSafe();
       ((ExLobGlobals *)exLobGlob)->setHeap(heap);
       


### PR DESCRIPTION
In the effort to identify zombie threads , there were few places in code that require init and cleanup calls be made that create and destroy the hdfs access threads. This set of changes is initial set. More investigation to identify root cause of zombie threads in progress.