### PR TITLE
[TRAFODION-2351] Bulk load with log error rows enhancements

### DIFF
--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/TransactionalTable.java
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/TransactionalTable.java
@@ -867,10 +867,8 @@ public class TransactionalTable extends HTable implements TransactionalTableClie
                                 size++;
    			}
 
-   			final List<Delete> rowsInSameRegion = new ArrayList<Delete>();
                         for (Map.Entry<TransactionRegionLocation, List<Delete>> entry : rows.entrySet()) {
-   				rowsInSameRegion.clear();
-   				rowsInSameRegion.addAll(entry.getValue());
+   				final List<Delete> rowsInSameRegion = entry.getValue();
    				final String regionName = entry.getKey().getRegionInfo().getRegionNameAsString();
    				   				
    			 Batch.Call<TrxRegionService, DeleteMultipleTransactionalResponse> callable =
@@ -965,10 +963,8 @@ public class TransactionalTable extends HTable implements TransactionalTableClie
                         size++;
 		}
 
-		final List<Put> rowsInSameRegion = new ArrayList<Put>();
 		for (Map.Entry<TransactionRegionLocation, List<Put>> entry : rows.entrySet()) {
-			rowsInSameRegion.clear();
-			rowsInSameRegion.addAll(entry.getValue());
+			final List<Put> rowsInSameRegion = entry.getValue();
 			final String regionName = entry.getKey().getRegionInfo().getRegionNameAsString();
 			Batch.Call<TrxRegionService, PutMultipleTransactionalResponse> callable =
 	        new Batch.Call<TrxRegionService, PutMultipleTransactionalResponse>() {

--- a/core/sql/executor/ExHbaseIUD.cpp
+++ b/core/sql/executor/ExHbaseIUD.cpp
@@ -1679,9 +1679,7 @@ ExWorkProcRetcode ExHbaseAccessBulkLoadPrepSQTcb::work()
           if (eodSeen)
           {
             ehi_->closeHFile(table_);
-            // sss This is one place that is unconditionally closing the 
-            // hdfsFs that's part of this thread's JNIenv.
-            //ehi_->hdfsClose();
+            ehi_->hdfsClose();
             hFileParamsInitialized_ = false;
             retcode = ehi_->close();
           }

--- a/core/sql/executor/ExHdfsScan.cpp
+++ b/core/sql/executor/ExHdfsScan.cpp
@@ -1479,10 +1479,7 @@ ExWorkProcRetcode ExHdfsScanTcb::work()
                                     getLobErrStr(intParam1));
                     pentry_down->setDiagsArea(diagsArea);
                   }
-                // sss This is one place that is unconditionally closing the 
-                // hdfsFs that's part of this thread's JNIenv.
-                // if (ehi_)
-                //   retcode = ehi_->hdfsClose();
+                  retcode = ehi_->hdfsClose();
             } 
 	    if (step_ == CLOSE_FILE)
 	      {


### PR DESCRIPTION
[Trafodion 2325] Reduce path length by avoiding expensive APIs

Load with log error rows missing some error rows being logged.
The hdfs file where the error rows are not logged wasn't closed

Avoided unnecessary copy of the transactional put list