### PR TITLE
[TRAFODION-2352] UPDATE STATS may fail with error 8446 on Hive tables

### DIFF
--- a/core/sql/ustat/hs_globals.h
+++ b/core/sql/ustat/hs_globals.h
@@ -1339,7 +1339,13 @@ public:
 
     // Set CQDs controlling min/max HBase cache size to minimize risk of
     // scanner timeout.
-    static NABoolean setHBaseCacheSize(double sampleRatio);
+    NABoolean setHBaseCacheSize(double sampleRatio);
+
+    // Set CQD HIVE_MAX_STRING_LENGTH_IN_BYTES if necessary
+    NABoolean setHiveMaxStringLengthInBytes(void);
+
+    // Reset any CQDs set above
+    void resetCQDs(void);
 
     // Static fns for determining minimum table sizes for sampling, and for
     // using lowest sampling rate, under default sampling protocol.
@@ -1656,9 +1662,17 @@ public:
                                                           for one instance of persistent 
                                                           sample table */
 
-     NABoolean            sample_I_generated;
+    NABoolean            sample_I_generated;
 
     Lng32          maxCharColumnLengthInBytes;   /* the value of USTAT_MAX_CHAR_COL_LENGTH_IN_BYTES */
+
+    // Error recovery flags so we can reset CQDs that we set
+    // during CollectStatistics() (We do this because the
+    // HSHandleError macro commonly used makes it hard to
+    // do the resets reliably in CollectStatistics itself. Sigh.)
+
+    NABoolean hbaseCacheSizeCQDsSet_;
+    NABoolean hiveMaxStringLengthCQDSet_;
 
 private:
     //++ MV

--- a/core/sql/ustat/hs_update.cpp
+++ b/core/sql/ustat/hs_update.cpp
@@ -457,6 +457,7 @@ Lng32 UpdateStats(char *input, NABoolean requestedByCompiler)
     if (hs_globals_obj.StatsNeeded())
       {
         retcode = hs_globals_obj.CollectStatistics();
+        hs_globals_obj.resetCQDs();
         HSExitIfError(retcode);
       }
     else if (hs_globals_obj.optFlags & IUS_PERSIST)


### PR DESCRIPTION
There are two fixes here.

1. Fix for JIRA TRAFODION-2352: Propagate the CQD HIVE_MAX_STRING_LENGTH_IN_BYTES to the grandchild tdm_arkcmp process if needed to avoid possible error 8446 on Hive tables with very long varchar columns.

2. Fix an unrelated minor problem: Warning 9234 may occur non-deterministically in test scripts for incremental UPDATE STATS. A previous pull request, https://github.com/apache/incubator-trafodion/pull/719, had changed most such warnings so they are emitted only when UPDATE STATS logging is 'ON'. I missed a couple; this change takes care of them.