### PR TITLE
[TRAFODION-2341] Redesign UPDATE STATISTICS retry logic

### DIFF
--- a/core/sql/ustat/hs_read.cpp
+++ b/core/sql/ustat/hs_read.cpp
@@ -2031,8 +2031,10 @@ Lng32 updateHistogram(const char *histogramTableName, Int32 stmtNum, short readC
   qry.append(count_str);
   qry.append(" WHERE CURRENT OF CURSOR106_MX_2300");
 
+  // Note that the UPDATE cannot be retried since the transaction will
+  // likely abort on any failure, invalidating the cursor.
   Lng32 retcode = HSFuncExecQuery(qry.data(), -UERR_INTERNAL_ERROR, NULL,
-                                  HS_QUERY_ERROR, NULL, NULL, TRUE);
+                                  HS_QUERY_ERROR, NULL, NULL);
   HSFilterWarning(retcode);
   if (LM->LogNeeded())
   {


### PR DESCRIPTION
This set of changes revamps the retry logic used by UPDATE STATISTICS.

The problem was that very often in Trafodion when a DDL or DML statement fails, the transaction is aborted. (In predecessor products, the statement itself often could be rolled back without aborting the transaction containing it.) The retry loop in HSFuncExecQuery did not take this into account, so most retries would ultimately fail with a confusing and uninformative error 8605 (“Committing a transaction which has not started.”).

Therefore, the retry logic has been redesigned. The logic to begin and commit transactions has been pushed down into the retry loop. The retry loop has been moved to a new function, HSFuncExecTransactionalQueryWithRetry, while the old function, HSFuncExecQuery, is now limited to non-retryable queries.

While investigating and debugging this problem, I found several places in the code where a retry was being attempted but was not appropriate. In general, there were two kinds of issues. One was that retries were being done inside transactions having multiple statements. This is not appropriate because work done by earlier statements would be silently undone by retrying the current statement in a new transaction. The other is that some statements should not be retried. For example, an UPSERT USING LOAD with a SAMPLE clause is non-transactional, and therefore its effects are not necessarily rolled back by a transaction abort. The SAMPLE clause makes the set of data processed non-deterministic. So, retrying such a statement, e.g., while populating a sample table, risks generating more sample data than expected.

Some changes were required in the use of the HSTranController object. This object is very elegant: It starts a transaction in its constructor and commits or rolls it back in its destructor. If transaction behavior matched up nicely with lexical scope, it would be perfect. Unfortunately, as described above for retries, it does not. So in places where retries are attempted, I had to remove use of this object.

An awkward change was required in the use of the HSErrorCatcher object. This is another elegant object: It is used to move any CLI errors into the UPDATE STATISTICS ComDiagsArea at the end of a lexical scope. Unfortunately, if one makes a call from an HSErrorCatcher object scope to another method that also has an HSErrorCatcher object, any errors reported in the latter get reported twice. In the past, the usual practice has been to avoid doing this by carefully choosing the scopes for HSErrorCatcher objects. However, with the current changes, there is a recursion which makes this unavoidable. The HSFuncExecTransactionalQueryWithRetry function needs an HSErrorCatcher object to capture any ultimate errors after all retries have failed. However, it indirectly uses HSFuncExecQuery to do “BEGIN WORK” and “COMMIT WORK” (as it needs to manage transactions), and that function also has an HSErrorCatcher object. To avoid having transient transaction commit conflict errors (8616) being reported in the retry loop, we needed a mechanism to inactivate the latter HSErrorCatcher object. So, a flag has been added to its constructor that optionally tells it to turn itself off. Not very elegant, I know.

Finally, some obsolete code, HSTranController::lockTable, has been removed. This method used to do LOCK TABLE statements in the predecessor product, but these are not supported in Trafodion.