### PR TITLE
[TRAFODION-2358] Implement builtin function SOUNDEX

### DIFF
--- a/core/sql/exp/ExpPackDefs.cpp
+++ b/core/sql/exp/ExpPackDefs.cpp
@@ -611,6 +611,11 @@ NA_EIDPROC Long ExFunctionIsIP::pack(void * space)
   return packClause(space, sizeof(ExFunctionIsIP));
 }
 
+NA_EIDPROC Long ExFunctionSoundex::pack(void * space)
+{
+  return packClause(space, sizeof(ExFunctionSoundex));
+}
+
 NA_EIDPROC Long ExFunctionInetAton::pack(void * space)
 {
   return packClause(space, sizeof(ExFunctionInetAton));

--- a/core/sql/exp/exp_clause.cpp
+++ b/core/sql/exp/exp_clause.cpp
@@ -535,6 +535,9 @@ ex_clause::ex_clause(clause_type type,
 	case ITM_HBASE_VERSION:
 	  setClassID(FUNC_HBASE_VERSION);
 	  break;
+	case ITM_SOUNDEX:
+	  setClassID(FUNC_SOUNDEX_ID);
+	  break;
 	default:
 	  GenAssert(0, "ex_clause: Unknown Class ID.");
 	  break;
@@ -1022,6 +1025,9 @@ NA_EIDPROC char *ex_clause::findVTblPtr(short classID)
       break;
     case ex_clause::FUNC_INETNTOA_ID:
       GetVTblPtr(vtblPtr, ExFunctionInetNtoa);
+      break;
+    case ex_clause::FUNC_SOUNDEX_ID:
+      GetVTblPtr(vtblPtr, ExFunctionSoundex);
       break;
      default:
       GetVTblPtr(vtblPtr, ex_clause);

--- a/core/sql/exp/exp_clause.h
+++ b/core/sql/exp/exp_clause.h
@@ -207,7 +207,8 @@ public:
     FUNC_CRC32_ID            = 122,
     FUNC_MD5_ID              = 123,
     FUNC_SHA1_ID             = 124,
-    FUNC_SHA2_ID             = 125
+    FUNC_SHA2_ID             = 125,
+    FUNC_SOUNDEX_ID          = 126
   };
 
   // max number of operands (including result) in a clause.

--- a/core/sql/exp/exp_function.h
+++ b/core/sql/exp/exp_function.h
@@ -943,6 +943,35 @@ public:
   // ---------------------------------------------------------------------
 };
 
+class SQLEXP_LIB_FUNC ExFunctionSoundex: public ex_function_clause {
+public:
+  NA_EIDPROC ExFunctionSoundex(OperatorTypeEnum oper_type,
+				Attributes ** attr,
+				Space * space);
+  NA_EIDPROC ExFunctionSoundex();
+
+  NA_EIDPROC ex_expr::exp_return_type eval(char *op_data[], CollHeap*, 
+					   ComDiagsArea** = 0);  
+  NA_EIDPROC Long pack(void *);
+
+  // ---------------------------------------------------------------------
+  // Redefinition of methods inherited from NAVersionedObject.
+  // ---------------------------------------------------------------------
+  NA_EIDPROC virtual unsigned char getClassVersionID()
+  {
+    return 1;
+  }
+
+  NA_EIDPROC virtual void populateImageVersionIDArray()
+  {
+    setImageVersionID(2,getClassVersionID());
+    ex_function_clause::populateImageVersionIDArray();
+  }
+
+  NA_EIDPROC virtual short getClassSize() { return (short)sizeof(*this); }
+  // ---------------------------------------------------------------------
+};
+
 class SQLEXP_LIB_FUNC ExFunctionMd5: public ex_function_clause {
 public:
   NA_EIDPROC ExFunctionMd5(OperatorTypeEnum oper_type,

--- a/core/sql/generator/GenItemFunc.cpp
+++ b/core/sql/generator/GenItemFunc.cpp
@@ -627,6 +627,15 @@ short BuiltinFunction::codeGen(Generator * generator)
 							space);
       }
     break;
+   
+    case ITM_SOUNDEX:
+    {
+        function_clause =
+            new(generator->getSpace()) ExFunctionSoundex(getOperatorType(),
+                    attr,
+                    space);
+    }
+    break;
       
     default:
       break;

--- a/core/sql/optimizer/BindItemExpr.cpp
+++ b/core/sql/optimizer/BindItemExpr.cpp
@@ -3167,6 +3167,7 @@ ItemExpr *BuiltinFunction::bindNode(BindWA *bindWA)
     case ITM_CRC32:
     case ITM_SHA1:
     case ITM_SHA2:
+    case ITM_SOUNDEX:
       {
          break;
       }

--- a/core/sql/optimizer/ItemExpr.cpp
+++ b/core/sql/optimizer/ItemExpr.cpp
@@ -7785,6 +7785,7 @@ ItemExpr * BuiltinFunction::copyTopNode(ItemExpr * derivedNode,
       switch (getOperatorType())
 	{
 	case ITM_NULLIFZERO:
+	case ITM_SOUNDEX:
 	  {
 	    result = new (outHeap) BuiltinFunction(getOperatorType(),
 						   outHeap, 1, child(0));

--- a/core/sql/optimizer/SynthType.cpp
+++ b/core/sql/optimizer/SynthType.cpp
@@ -1277,6 +1277,30 @@ const NAType *BuiltinFunction::synthesizeType()
       }
       break;
 
+    case ITM_SOUNDEX:
+      {
+          // type cast any params
+          ValueId vid1 = child(0)->getValueId();
+          SQLChar c1(ComSqlId::MAX_QUERY_ID_LEN);
+          vid1.coerceType(c1, NA_CHARACTER_TYPE);
+          
+          //input type must be string
+          const NAType &typ1 = vid1.getType();
+
+          if (typ1.getTypeQualifier() != NA_CHARACTER_TYPE)
+          {
+              *CmpCommon::diags() << DgSqlCode(-4067) << DgString0("SOUNDEX");
+              return NULL;
+          }
+
+          retType = new HEAP SQLChar(4, FALSE);
+          if (typ1.supportsSQLnull())
+          {
+              retType->setNullable(TRUE);
+          }
+      }
+      break;
+
     default:
       {
 	retType = (NAType *)ItemExpr::synthesizeType();

--- a/core/sql/parser/ParKeyWords.cpp
+++ b/core/sql/parser/ParKeyWords.cpp
@@ -1005,6 +1005,7 @@ ParKeyWord ParKeyWords::keyWords_[] = {
   ParKeyWord("SNAPSHOT",           TOK_SNAPSHOT,    NONRESTOKEN_),
   ParKeyWord("SOFTWARE",           TOK_SOFTWARE,    NONRESTOKEN_),
   ParKeyWord("SOME",               TOK_SOME,        ANS_|RESWORD_|MPWORD_),
+  ParKeyWord("SOUNDEX",            TOK_SOUNDEX,     NONRESTOKEN_),
   ParKeyWord("SORT",               TOK_SORT,        NONRESTOKEN_),
   ParKeyWord("SORT_KEY",           TOK_SORT_KEY,    NONRESTOKEN_),
   ParKeyWord("SOURCE",             TOK_SOURCE,      NONRESTOKEN_),

--- a/core/sql/parser/sqlparser.y
+++ b/core/sql/parser/sqlparser.y
@@ -1075,6 +1075,7 @@ static void enableMakeQuotedStringISO88591Mechanism()
 %token <tokval> TOK_SPACE
 %token <tokval> TOK_SMALLINT
 %token <tokval> TOK_SOME
+%token <tokval> TOK_SOUNDEX
 %token <tokval> TOK_SORT                /* Tandem extension non-reserved word */
 %token <tokval> TOK_SORT_KEY
 %token <tokval> TOK_SP_RESULT_SET
@@ -9801,6 +9802,13 @@ misc_function :
                                   $$ = new (PARSERHEAP())
                                     CompEncode ( $3, NOT $4 );
                                 }
+     | TOK_SOUNDEX '(' value_expression ')'
+                {
+                    $$ = new (PARSERHEAP())
+                    BuiltinFunction(ITM_SOUNDEX,
+                            CmpCommon::statementHeap(),
+                            1, $3);
+                }
      | TOK_SORT_KEY '(' value_expression optional_Collation_type optional_sort_direction ')'
                                 {
                                   if ($5 != CollationInfo::DefaultDir  && $4 != CollationInfo::Sort)
@@ -33805,6 +33813,7 @@ nonreserved_func_word:  TOK_ABS
                       | TOK_SIGN
                       | TOK_SIN
                       | TOK_SINH
+                      | TOK_SOUNDEX
                       | TOK_SORT_KEY
                       | TOK_SPACE
                       | TOK_SQRT

--- a/core/sql/regress/compGeneral/EXPECTED006.SB
+++ b/core/sql/regress/compGeneral/EXPECTED006.SB
@@ -158,7 +158,34 @@
 
 --- 16 row(s) inserted.
 >>
+>>-- Used for builtin function SOUNDEX() tests
+>>create table t006emp1(name varchar(20));
+
+--- SQL operation complete.
 >>
+>>create table t006emp2(name varchar(20) character set UCS2);
+
+--- SQL operation complete.
+>>
+>>insert into t006emp1 values
++>('Smith'),
++>('Lynn'),
++>('Ruoyu'),
++>('John'),
++>('Lane')
++>;
+
+--- 5 row(s) inserted.
+>>
+>>insert into t006emp2 values
++>('Smith'),
++>('Lynn'),
++>('Ruoyu'),
++>('John'),
++>('Lane')
++>;
+
+--- 5 row(s) inserted.
 >>
 >>obey TEST006(negative_tests);
 >>
@@ -1675,4 +1702,81 @@ d3d9446802a44259755d38e6d163e820   852952723  b1d5781111d84f7b3fe45a0852e59758cd
 
 *** ERROR[8822] The statement was not prepared.
 
+>>
+>>select SOUNDEX('Jon') from dual;
+
+(EXPR)
+------
+
+J500
+
+--- 1 row(s) selected.
+>>select SOUNDEX('Roy') from dual;
+
+(EXPR)
+------
+
+R000
+
+--- 1 row(s) selected.
+>>select SOUNDEX('Lynn') from dual;
+
+(EXPR)
+------
+
+L500
+
+--- 1 row(s) selected.
+>>
+>>select name, SOUNDEX(name) from t006emp1 where SOUNDEX(name)=SOUNDEX('Jon');
+
+NAME (EXPR)
+----------
+
+John J500
+
+--- 1 row(s) selected.
+>>select name, SOUNDEX(name) from t006emp1 where SOUNDEX(name)=SOUNDEX('Roy');
+
+NAME (EXPR)
+----------
+
+Ruoyu R000
+
+--- 1 row(s) selected.
+>>select name, SOUNDEX(name) from t006emp1 where SOUNDEX(name)=SOUNDEX('Lynn');
+
+NAME (EXPR)
+----------
+
+Lane L500
+Lynn L500
+
+--- 2 row(s) selected.
+>>
+>>select name, SOUNDEX(name) from t006emp2 where SOUNDEX(name)=SOUNDEX('Jon');
+
+NAME (EXPR)
+----------
+
+John J500
+
+--- 1 row(s) selected.
+>>select name, SOUNDEX(name) from t006emp2 where SOUNDEX(name)=SOUNDEX('Roy');
+
+NAME (EXPR)
+----------
+
+Ruoyu R000
+
+--- 1 row(s) selected.
+>>select name, SOUNDEX(name) from t006emp2 where SOUNDEX(name)=SOUNDEX('Lynn');
+
+NAME (EXPR)
+----------
+
+Lane L500
+Lynn L500
+
+--- 2 row(s) selected.
 >>log;

--- a/core/sql/regress/compGeneral/TEST006
+++ b/core/sql/regress/compGeneral/TEST006
@@ -60,6 +60,9 @@ drop mv mvx cascade;
 drop table t006tao;
 drop table t006_employees;
 drop table t006taoc;
+-- Used for builtin function SOUNDEX() tests
+drop table t006emp1;
+drop table t006emp2;
 
 ?section create_tables
 
@@ -170,7 +173,26 @@ insert into t006taoc values
 ('10','14','9')
 ;
 
+-- Used for builtin function SOUNDEX() tests
+create table t006emp1(name varchar(20));
 
+create table t006emp2(name varchar(20) character set UCS2);
+
+insert into t006emp1 values
+('Smith'),
+('Lynn'),
+('Ruoyu'),
+('John'),
+('Lane')
+;
+
+insert into t006emp2 values
+('Smith'),
+('Lynn'),
+('Ruoyu'),
+('John'),
+('Lane')
+;
 
 ?section negative_tests
 
@@ -639,3 +661,15 @@ from T006_EMPLOYEES <<+ cardinality 10e6 >> order by emp_name;
 select md5('10'), crc32(10), sha('10') from dual;
 select md5(10) from dual;
 select sha1(10) from dual;
+
+select SOUNDEX('Jon') from dual;
+select SOUNDEX('Roy') from dual;
+select SOUNDEX('Lynn') from dual;
+
+select name, SOUNDEX(name) from t006emp1 where SOUNDEX(name)=SOUNDEX('Jon');
+select name, SOUNDEX(name) from t006emp1 where SOUNDEX(name)=SOUNDEX('Roy');
+select name, SOUNDEX(name) from t006emp1 where SOUNDEX(name)=SOUNDEX('Lynn');
+
+select name, SOUNDEX(name) from t006emp2 where SOUNDEX(name)=SOUNDEX('Jon');
+select name, SOUNDEX(name) from t006emp2 where SOUNDEX(name)=SOUNDEX('Roy');
+select name, SOUNDEX(name) from t006emp2 where SOUNDEX(name)=SOUNDEX('Lynn');


### PR DESCRIPTION
Support SQL builtin function SOUNDEX() like Oracle does. It allows you compare words that are spelled differently, but sound alike in English, which is useful for searching people's names that sound alike, e.g. “Ruoyu” and “Roy”