### PR TITLE
[TRAFODION - 2345] Support LOG() function of any base

### DIFF
--- a/core/sql/exp/exp_math_func.cpp
+++ b/core/sql/exp/exp_math_func.cpp
@@ -51,6 +51,7 @@
 #define MathLog(op, err) log(op)
 #define MathLog10(op, err) log10(op)
 #define MathLog2(op, err) log2(op)
+#define MathLogX(op1, op2, err) (log(op2)/log(op1))
 #define MathModf(op, err) modf(op)
 #define MathPow(op1, op2, err) pow(op1, op2)
 //extern double MathPow(double Base, double Power, short &err);
@@ -337,8 +338,22 @@ ex_expr::exp_return_type ExFunctionMath::eval(char *op_data[],
 	  **diagsArea << DgString0("LOG");
 	  return ex_expr::EXPR_ERROR;
 	}
-      
-      *(double *)op_data[0] = MathLog(*(double *)op_data[1], err);
+
+      if(3 == getNumOperands())
+    {
+        double power = *(double *)op_data[2];
+        double radix = *(double *)op_data[1];
+        if(power <= 0 || 1 == radix)
+        {
+            ExRaiseSqlError(heap, diagsArea, EXE_BAD_ARG_TO_MATH_FUNC);
+            **diagsArea << DgString0("LOG");
+            return ex_expr::EXPR_ERROR;
+        }
+        
+        *(double *)op_data[0] = MathLogX(radix, power, err);
+    }
+    else  
+        *(double *)op_data[0] = MathLog(*(double *)op_data[1], err);
       break;
 
     case ITM_LOG10:

--- a/core/sql/exp/exp_math_func.cpp
+++ b/core/sql/exp/exp_math_func.cpp
@@ -340,19 +340,19 @@ ex_expr::exp_return_type ExFunctionMath::eval(char *op_data[],
 	}
 
       if(3 == getNumOperands())
-    {
-        double power = *(double *)op_data[2];
-        double radix = *(double *)op_data[1];
-        if(power <= 0 || 1 == radix)
-        {
+	{
+          double power = *(double *)op_data[2];
+          double radix = *(double *)op_data[1];
+          if(power <= 0 || radix <= 0 || 1 == radix)
+          {
             ExRaiseSqlError(heap, diagsArea, EXE_BAD_ARG_TO_MATH_FUNC);
             **diagsArea << DgString0("LOG");
             return ex_expr::EXPR_ERROR;
+          }
+
+          *(double *)op_data[0] = MathLogX(radix, power, err);
         }
-        
-        *(double *)op_data[0] = MathLogX(radix, power, err);
-    }
-    else  
+      else
         *(double *)op_data[0] = MathLog(*(double *)op_data[1], err);
       break;
 

--- a/core/sql/parser/sqlparser.y
+++ b/core/sql/parser/sqlparser.y
@@ -9600,6 +9600,16 @@ math_function :
 	   $$ = new (PARSERHEAP()) BitOperFunc(ITM_BITEXTRACT, $3, $5, $7);
 	 }
 
+       | TOK_LOG '(' value_expression ')'
+         {
+	   $$ = new (PARSERHEAP()) MathFunc(ITM_LOG, $3);
+	 }
+
+       | TOK_LOG '(' value_expression ',' value_expression ')'
+         {
+	   $$ = new (PARSERHEAP()) MathFunc(ITM_LOG, $3, $5);
+	 }
+
        | math_func_0_operand '(' ')'
          {
 	   $$ = new (PARSERHEAP()) MathFunc($1);
@@ -9631,7 +9641,6 @@ math_func_1_operand :
            |  TOK_DEGREES {$$ = ITM_DEGREES;}
            |  TOK_EXP {$$ = ITM_EXP;}
            |  TOK_FLOOR {$$ = ITM_FLOOR;}
-           |  TOK_LOG {$$ = ITM_LOG;}
            |  TOK_LOG10 {$$ = ITM_LOG10;}
            |  TOK_LOG2 {$$ = ITM_LOG2;}
            |  TOK_RADIANS {$$ = ITM_RADIANS;}
@@ -9645,7 +9654,7 @@ math_func_1_operand :
 /* type operator_type */
 math_func_2_operands :
               TOK_ATAN2 {$$ = ITM_ATAN2;}
-	   |  TOK_POWER {$$ = ITM_POWER;}
+           |  TOK_POWER {$$ = ITM_POWER;}
 //           |  TOK_TRUNCATE {$$ = ITM_SCALE_TRUNC;}
 
 

--- a/core/sql/regress/compGeneral/EXPECTED006.SB
+++ b/core/sql/regress/compGeneral/EXPECTED006.SB
@@ -1825,4 +1825,46 @@ bc0050f3ff7a540c74a42664c53a7f9fd485622374a43eb4a62cd84e48f483237bed50f6562f8c6e
 18091a172d94aae1ae530ced02bde7f022229f446348f5d3b36989c2e6fd59f5252c7a7f8ecb71a74cb724448243ff71651f87aed155aee7340fad1b02567b60
 
 --- 1 row(s) selected.
+>>
+>>-- Test LOG() for any radix with 2 parameters
+>>select log(2,8) from dual;
+
+(EXPR)                   
+-------------------------
+
+ 3.00000000000000000E+000
+
+--- 1 row(s) selected.
+>>select log(5,10) from dual;
+
+(EXPR)                   
+-------------------------
+
+ 1.43067655807339328E+000
+
+--- 1 row(s) selected.
+>>select log(10,100) from dual;
+
+(EXPR)                   
+-------------------------
+
+ 2.00000000000000000E+000
+
+--- 1 row(s) selected.
+>>select log(2) from dual;
+
+(EXPR)                   
+-------------------------
+
+ 6.93147180559945344E-001
+
+--- 1 row(s) selected.
+>>select log(2.71828) from dual;
+
+(EXPR)                   
+-------------------------
+
+ 9.99999327347282176E-001
+
+--- 1 row(s) selected.
 >>log;

--- a/core/sql/regress/compGeneral/TEST006
+++ b/core/sql/regress/compGeneral/TEST006
@@ -679,3 +679,10 @@ select sha2('the original data', 224) from dual;
 select sha2('the original data', 256) from dual;
 select sha2('the original data', 384) from dual;
 select sha2('the original data', 512) from dual;
+
+-- Test LOG() for any radix with 2 parameters
+select log(2,8) from dual;
+select log(5,10) from dual;
+select log(10,100) from dual;
+select log(2) from dual;
+select log(2.71828) from dual;


### PR DESCRIPTION
Like Oracle does, the function LOG() function supports 2 parameter of call, in this way, the 1st parameter is the radix, and the second one is power, the function returns the logarithm.
This change implement this, and still, the user can call it with only one parameter (form LOG(X)), in which case the parameter X will be the power, and the function just returns the natural logarithm of X. This is also compatible with MySQL.