### PR TITLE
[TRAFODION-2384] Trafodion node needs to be gracefully shutdown when …

### DIFF
--- a/core/sqf/sysinstall/etc/init.d/trafodion
+++ b/core/sqf/sysinstall/etc/init.d/trafodion
@@ -1,0 +1,131 @@
+#!/bin/sh
+#
+# @@@ START COPYRIGHT @@@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# @@@ END COPYRIGHT @@@
+# trafodion
+# chkconfig: 06 96 04       
+# description:  stops trafodion  only
+#
+#
+### BEGIN INIT INFO
+# Provides: trafodion
+# Required-Start:
+# Required-Stop:
+# Default-Start: 
+# Default-Stop: 0 6
+# Short-Description: stops trafodion node 
+# Description: stops trafodion node if it is up
+### END INIT INFO
+
+# Source function library.
+. /etc/init.d/functions
+
+if [ ! -f /etc/trafodion/trafodion_config ]; then
+   exit 1
+fi
+. /etc/trafodion/trafodion_config
+if [ -z $SQ_ROOT ]; then
+   exit 1
+fi
+TRAF_USER=${TRAF_USER:-"trafodion"}
+TRAF_SUDO_CMD=${TRAF_SUDO_CMD:-"su ${TRAF_USER} --login "}
+TRAF_SHELL_CMD=${TRAF_SHELL_CMD:-sqshell}
+TRAF_OUT=${TRAF_VAR:-/var}/log/trafodion/${TRAF_SHELL_CMD}.log
+TRAF_NODE_NAME=`uname -n`
+
+
+node_start() {
+echo "Trafodion node UP not implemented"
+}
+
+node_stop() {
+nid=`${TRAF_SUDO_CMD} -c "${SQ_ROOT}/sql/scripts/${TRAF_SHELL_CMD} -c node info | grep -B1 ${TRAF_NODE_NAME} | grep Up | head -1 | cut -d ' ' -f 2"`
+if [ $? != 0 ]; then 
+   echo -n `date` >> ${TRAF_OUT} 2>&1 </dev/null 
+   echo " Trafodion on ${TRAF_NODE_NAME} is already stopped" >> ${TRAF_OUT} 2>&1 </dev/null 
+   echo "Trafodion on ${TRAF_NODE_NAME} is already stopped"
+   return 1
+fi
+if [ "$nid" == "" ]; then
+   echo -n `date` >> ${TRAF_OUT} 2>&1 </dev/null 
+   echo " Trafodion on ${TRAF_NODE_NAME} is already stopped" >> ${TRAF_OUT} 2>&1 </dev/null 
+   echo "Trafodion on node ${TRAF_NODE_NAME} is already stopped"
+else
+   echo "Stopping Trafodion node $nid on ${TRAF_NODE_NAME}"
+   echo -n `date` >> ${TRAF_OUT} 2>&1 </dev/null 
+   echo " Stopping Trafodion node $nid on ${TRAF_NODE_NAME}" >> ${TRAF_OUT} 2>&1 </dev/null 
+   ${TRAF_SUDO_CMD} /bin/bash -c "${SQ_ROOT}/sql/scripts/${TRAF_SHELL_CMD} -c down $nid" >> ${TRAF_OUT}  2>&1 </dev/null &
+fi
+return 0
+}
+
+node_status() {
+nid=`${TRAF_SUDO_CMD} -c "${SQ_ROOT}/sql/scripts/${TRAF_SHELL_CMD} -c node info | grep -B1 ${TRAF_NODE_NAME} | grep Up | head -1 | cut -d ' ' -f 2"`
+if [ $? != 0 ]; then 
+   echo "Trafodion on node $nid is not yet started"
+   return 0
+fi
+if [ "$nid" == "" ]; then
+   echo "Trafodion on node ${TRAF_NODE_NAME} is not yet started"
+else
+   echo "Trafodion on node ${TRAF_NODE_NAME} is started as logical node $nid"
+fi
+return 0
+}
+
+
+stop() {
+node_stop
+}
+
+status() {
+node_status
+}
+
+restart() {
+stop
+start
+}
+
+case "$1" in
+  start)
+    start
+    RETVAL=$?
+    ;;
+  stop)
+    stop
+    RETVAL=$?
+    ;;
+  status)
+    status
+    RETVAL=$?
+    ;;
+  restart)
+    restart
+    RETVAL=$?
+    ;;
+  *)
+    echo $"Usage: $prog {start|stop|restart|status}"
+    RETVAL=3
+esac
+
+exit $RETVAL
+

--- a/core/sqf/sysinstall/etc/init.d/trafodion
+++ b/core/sqf/sysinstall/etc/init.d/trafodion
@@ -53,25 +53,25 @@ TRAF_NODE_NAME=`uname -n`
 
 
 node_start() {
-echo "Trafodion node UP not implemented"
+echo "trafodion start not implemented"
 }
 
 node_stop() {
 nid=`${TRAF_SUDO_CMD} -c "${SQ_ROOT}/sql/scripts/${TRAF_SHELL_CMD} -c node info | grep -B1 ${TRAF_NODE_NAME} | grep Up | head -1 | cut -d ' ' -f 2"`
 if [ $? != 0 ]; then 
    echo -n `date` >> ${TRAF_OUT} 2>&1 </dev/null 
-   echo " Trafodion on ${TRAF_NODE_NAME} is already stopped" >> ${TRAF_OUT} 2>&1 </dev/null 
-   echo "Trafodion on ${TRAF_NODE_NAME} is already stopped"
+   echo " trafodion on ${TRAF_NODE_NAME} is already stopped" >> ${TRAF_OUT} 2>&1 </dev/null 
+   echo "trafodion on ${TRAF_NODE_NAME} is already stopped"
    return 1
 fi
 if [ "$nid" == "" ]; then
    echo -n `date` >> ${TRAF_OUT} 2>&1 </dev/null 
-   echo " Trafodion on ${TRAF_NODE_NAME} is already stopped" >> ${TRAF_OUT} 2>&1 </dev/null 
-   echo "Trafodion on node ${TRAF_NODE_NAME} is already stopped"
+   echo " trafodion on ${TRAF_NODE_NAME} is already stopped" >> ${TRAF_OUT} 2>&1 </dev/null 
+   echo "trafodion on node ${TRAF_NODE_NAME} is already stopped"
 else
-   echo "Stopping Trafodion node $nid on ${TRAF_NODE_NAME}"
+   echo "Stopping trafodion node $nid on ${TRAF_NODE_NAME}"
    echo -n `date` >> ${TRAF_OUT} 2>&1 </dev/null 
-   echo " Stopping Trafodion node $nid on ${TRAF_NODE_NAME}" >> ${TRAF_OUT} 2>&1 </dev/null 
+   echo " Stopping trafodion node $nid on ${TRAF_NODE_NAME}" >> ${TRAF_OUT} 2>&1 </dev/null 
    ${TRAF_SUDO_CMD} /bin/bash -c "${SQ_ROOT}/sql/scripts/${TRAF_SHELL_CMD} -c down $nid" >> ${TRAF_OUT}  2>&1 </dev/null &
 fi
 return 0
@@ -80,13 +80,13 @@ return 0
 node_status() {
 nid=`${TRAF_SUDO_CMD} -c "${SQ_ROOT}/sql/scripts/${TRAF_SHELL_CMD} -c node info | grep -B1 ${TRAF_NODE_NAME} | grep Up | head -1 | cut -d ' ' -f 2"`
 if [ $? != 0 ]; then 
-   echo "Trafodion on node $nid is not yet started"
+   echo "trafodion on node $nid is not yet started"
    return 0
 fi
 if [ "$nid" == "" ]; then
-   echo "Trafodion on node ${TRAF_NODE_NAME} is not yet started"
+   echo "trafodion on node ${TRAF_NODE_NAME} is not yet started"
 else
-   echo "Trafodion on node ${TRAF_NODE_NAME} is started as logical node $nid"
+   echo "trafodion on node ${TRAF_NODE_NAME} is started as logical node $nid"
 fi
 return 0
 }

--- a/install/python-installer/traf_setup.py
+++ b/install/python-installer/traf_setup.py
@@ -50,7 +50,7 @@ def run():
     ### kernel settings ###
     run_cmd('sysctl -w kernel.pid_max=65535 2>&1 > /dev/null')
     run_cmd('echo "kernel.pid_max=65535" >> /etc/sysctl.conf')
-    run_cmd('cp $SQ_ROOT/sysinstall/etc/init.d/trafodion /etc/init.d')
+    run_cmd('cp %s/sysinstall/etc/init.d/trafodion /etc/init.d' % SQ_ROOT)
     run_cmd('chkconfig --add trafodion')
     run_cmd('chkconfig --level 06 trafodion on')
 

--- a/install/python-installer/traf_setup.py
+++ b/install/python-installer/traf_setup.py
@@ -50,6 +50,9 @@ def run():
     ### kernel settings ###
     run_cmd('sysctl -w kernel.pid_max=65535 2>&1 > /dev/null')
     run_cmd('echo "kernel.pid_max=65535" >> /etc/sysctl.conf')
+    run_cmd('cp $SQ_ROOT/sysinstall/etc/init.d/trafodion /etc/init.d')
+    run_cmd('chkconfig --add trafodion')
+    run_cmd('chkconfig --level 06 trafodion on')
 
     ### create and set permission for scratch file dir ###
     for loc in SCRATCH_LOCS:


### PR DESCRIPTION
…the node is brought down

Added a service script for Trafodion at $MY_SQROOT/sysinstall/etc/init.d/trafodion.
As part of cluster install, this file will be copied to /etc/init.d and
configured for service startup.

The service script has the support for stop and status only.

You can do the following:
bin]$ sudo service trafodion status
trafodion on node kenai01.cluster.local is started as logical node 000
bin]$ sudo service trafodion stop
Stopping trafodion node 000 on kenai01.cluster.local
bin]$ sudo service trafodion status
trafodion on node kenai01.cluster.local is not yet started
bin]$ sudo service trafodion start
start: missing job name
Try `start --help' for more information.

This allows init 6, shutdown and reboot to execute the trafodion services to be stopped in
correct sequence.  Hence, it should fix the core dumps seen at the time of node shutdown.