### PR TITLE
[TRAFODION-2375]ODBC:SQLGetDiagRec return wrong msg length when data truncate

### DIFF
--- a/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/cdiag.cpp
+++ b/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/cdiag.cpp
@@ -427,8 +427,8 @@ SQLRETURN CDiagRec::GetDiagRec(SQLSMALLINT	RecNumber,
 			{
 				if((rc = icuConv->OutArgTranslationHelper((SQLCHAR *)MsgStruct.lpsMsgText.c_str(), tmpStrLen,
 							(char*)MessageText, translateLengthMax,  (int *)&translateLength, NULL, (char *)errorMsg)) != SQL_SUCCESS)
-					rc = SQL_SUCCESS; // Supress SQL_ERROR or SQL_SUCCESS_WITH_INFO to prevent trace from looping;
-					strLen = translateLength;
+					rc = SQL_SUCCESS_WITH_INFO;
+				strLen = tmpStrLen;
 			}
 			if (TextLengthPtr != NULL)
 				*TextLengthPtr = strLen;

--- a/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/cdiag.cpp
+++ b/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/cdiag.cpp
@@ -430,6 +430,12 @@ SQLRETURN CDiagRec::GetDiagRec(SQLSMALLINT	RecNumber,
 					rc = SQL_SUCCESS_WITH_INFO;
 				strLen = tmpStrLen;
 			}
+			else
+			{
+				rc = SQL_SUCCESS_WITH_INFO;
+				strLen = tmpStrLen;
+			}
+			
 			if (TextLengthPtr != NULL)
 				*TextLengthPtr = strLen;
 		}

--- a/win-odbc64/odbcclient/drvr35/cdiag.cpp
+++ b/win-odbc64/odbcclient/drvr35/cdiag.cpp
@@ -389,8 +389,8 @@ SQLRETURN CDiagRec::GetDiagRec(SQLSMALLINT	RecNumber,
 					translateLengthMax/2, (int *)&translateLength, (char *)errorMsg)) != SQL_SUCCESS )
 				rc = SQL_SUCCESS_WITH_INFO; //ERROR;
 
-			strLen = translateLength; 
-			((wchar_t *)MessageText)[strLen] = L'\0' ; 
+			((wchar_t *)MessageText)[translateLength] = L'\0';
+			strLen = tmpStrLen;
 		}
 		if (TextLengthPtr != NULL)
 		*TextLengthPtr = strLen;

--- a/win-odbc64/odbcclient/drvr35/cdiag.cpp
+++ b/win-odbc64/odbcclient/drvr35/cdiag.cpp
@@ -392,8 +392,14 @@ SQLRETURN CDiagRec::GetDiagRec(SQLSMALLINT	RecNumber,
 			((wchar_t *)MessageText)[translateLength] = L'\0';
 			strLen = tmpStrLen;
 		}
+		else
+		{
+			rc = SQL_SUCCESS_WITH_INFO;
+			strLen = tmpStrLen;
+		}
+
 		if (TextLengthPtr != NULL)
-		*TextLengthPtr = strLen;
+			*TextLengthPtr = strLen;
 	}
 	else
 	{


### PR DESCRIPTION
Acoording to ODBC reference, in function SQLGetDiagRec,  param _TextLengthPtr_  should point to a buffer in which to return the total number of characters, but it returns number of truncated characters when param _BufferLength_ is smaller than character number of error message text.
Thus, modifications are made relating to win/unix odbc driver code as following:
Unix ODBC: if truncation occurs, return SQL_SUCCESS_WITH_INFO, and set variable strLen as total number of error message text whenever data is truncated.
Windows ODBC: set variable strLen as total number of error message text whenever data is truncated.