### PR TITLE
[TRAFODION-2391]: monitor failed to start when hostname contains uppe…

### DIFF
--- a/core/sqf/sql/scripts/sqnodestatus
+++ b/core/sqf/sql/scripts/sqnodestatus
@@ -31,7 +31,7 @@
 #   export SQ_MON_SSH_OPTIONS=' -o "ConnectTimeout 1" -o "ConnectionAttempts 3" '
 #
 
-my $node_context=readpipe("echo \$NODE_LIST");
+my $node_context=lc(readpipe("echo \$NODE_LIST"));
 my %node_hash=();
 my $sq_mon_ssh_options=readpipe("echo -n \$SQ_MON_SSH_OPTIONS");
 my $json=$ARGV[0];
@@ -89,7 +89,7 @@ sub check_node_status($)
     my $down_character="ssh:";
     #print "down_character=${down_character}\n";
 
-    my @check_results=(readpipe($command));
+    my @check_results=lc((readpipe($command)));
 
     foreach my $check_result(@check_results)
     {


### PR DESCRIPTION
…rcase.

return lowercase hostname in ‘sqnodestatus’ to match the hostname in monitor.