### PR TITLE
[TRAFODION-2228]Add AES_ENCRYPT/AES_DECRYPT functions

### DIFF
--- a/core/conn/odbc/src/odbc/Common/QSData.cpp
+++ b/core/conn/odbc/src/odbc/Common/QSData.cpp
@@ -1532,6 +1532,13 @@ string getExeErrorCodeString(ExeErrorCode value)
 //-------------------------------------------------------------
 	case EXE_INTERNALLY_GENERATED_COMMAND: 			return FMT_EXE_INTERNALLY_GENERATED_COMMAND;
 
+//-------------------------------------------------------------
+// Error codes for AES encrpt/decrypt functions
+//-------------------------------------------------------------
+    case EXE_AES_INVALID_IV:                        return FMT_EXE_AES_INVALID_IV;
+    case EXE_ERR_PARAMCOUNT_FOR_FUNC:               return FMT_EXE_ERR_PARAMCOUNT_FOR_FUNC;
+    case EXE_OPTION_IGNORED:                        return FMT_EXE_OPTION_IGNORED;
+    case EXE_OPENSSL_ERROR:                         return FMT_EXE_OPENSSL_ERROR;
 
 //fast transport
 

--- a/core/conn/odbc/src/odbc/Common/QSData.h
+++ b/core/conn/odbc/src/odbc/Common/QSData.h
@@ -3571,6 +3571,10 @@ enum ExeErrorCode
 	EXE_INTERNALLY_GENERATED_COMMAND      = 8950,
 
 
+    EXE_AES_INVALID_IV                    = 8954,
+    EXE_ERR_PARAMCOUNT_FOR_FUNC           = 8955,
+    EXE_OPTION_IGNORED                    = 8956,
+    EXE_OPENSSL_ERROR                     = 8957,
 //fast transport
 
 	EXE_EXTRACT_ERROR_CREATING_FILE       = 8960,
@@ -4072,6 +4076,14 @@ const string FMT_EXE_ROWLENGTH_EXCEEDS_BUFFER			= "[8943],EXE_ROWLENGTH_EXCEEDS_
 // Error codes for bulk replicate - Part 2
 //-------------------------------------------------------------
 const string FMT_EXE_INTERNALLY_GENERATED_COMMAND		= "[8950],EXE_INTERNALLY_GENERATED_COMMAND";
+
+//-------------------------------------------------------------
+// Error codes for AES encrypt/decrypt functions
+// ------------------------------------------------------------
+const string FMT_EXE_AES_INVALID_IV                     = "[8954],EXE_AES_INVALID_IV";
+const string FMT_EXE_ERR_PARAMCOUNT_FOR_FUNC            = "[8955],EXE_ERR_PARAMCOUNT_FOR_FUNC";
+const string FMT_EXE_OPTION_IGNORED                     = "[8956],EXE_OPTION_IGNORED";
+const string FMT_EXE_OPENSSL_ERROR                      = "[8957],EXE_OPENSSL_ERROR";
 
 
 //fast transport

--- a/core/sql/bin/SqlciErrors.txt
+++ b/core/sql/bin/SqlciErrors.txt
@@ -1848,6 +1848,10 @@ drop the default context
 8951 ZZZZZ 99999 BEGINNER MAJOR DBADMIN SeaMonster function $0~String0 returned $1~Int0 (pid $2~Int1, process $3~String1), retry code $4~NSKCode.
 8952 ZZZZZ 99999 BEGINNER MAJOR DBADMIN $0~String0: One or more SeaMonster connections were closed due to errors on an ESP control connection. The first connection to close was communicating with SeaMonster target ($1~String1) and was notified of error $2~Int0 on a control connection.
 8953 ZZZZZ 99999 BEGINNER MAJOR DBADMIN $0~String0: Query timed out after $1~Int0 seconds waiting for SeaMonster fixup replies. The number of replies expected was $2~Int1. The number of replies received was $3~Int2.
+8954 ZZZZZ 99999 BEGINNER MAJOR DBADMIN The initialization vector supplied to $0~Int0 is too short, Must be at least $1~Int1 bytes long
+8955 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Incorrect parameter count in the call to function $0~String0
+8956 ZZZZZ 99999 BEGINNER MAJOR DBADMIN $0~String0 option ignored
+8957 ZZZZZ 99999 BEGINNER MAJOR DBADMIN OpenSSL return error int the call to function $0~String0
 8960 ZZZZZ 99999 BEGINNER MAJOR DBADMIN UNLOAD is unable to create file $0~String0.
 8961 ZZZZZ 99999 BEGINNER MAJOR DBADMIN UNLOAD is unable to write to file $0~String0.
 8962 ZZZZZ 99999 BEGINNER MAJOR DBADMIN UNLOAD is unable to allocate buffers for data.

--- a/core/sql/common/ComSSL.cpp
+++ b/core/sql/common/ComSSL.cpp
@@ -1,0 +1,49 @@
+// @@@ START COPYRIGHT @@@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// @@@ END COPYRIGHT @@@
+
+#include "ComSSL.h"
+void aes_create_key(const unsigned char * input,
+                    Lng32 input_len,
+                    unsigned char * key,
+                    Int32 aes_mode)
+{
+  const Lng32 key_len = EVP_CIPHER_key_length(aes_algorithm_type[aes_mode]);
+
+  memset(key, 0, key_len);
+
+  const unsigned char * source;
+  unsigned char * ptr;
+  const unsigned char * input_end = input + input_len;
+  const unsigned char * key_end = key + key_len;
+
+  // loop through all the characters of the input string, and does an assignment
+  // with bitwise XOR between the input string and key string. If it iterate until
+  // hit the end of key_len byte buffer, just start over from begining of the key
+  // and continue doing ^=
+  // If the length of input string shorter than key_len, it will stop and the end of
+  // the input string.
+  for (ptr = key, source = input; source < input_end; source++, ptr++)
+  {
+    if (ptr == key_end)
+      ptr = key;
+    *ptr ^= *source;
+  }
+}

--- a/core/sql/common/ComSSL.h
+++ b/core/sql/common/ComSSL.h
@@ -1,0 +1,60 @@
+// @@@ START COPYRIGHT @@@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// @@@ END COPYRIGHT @@@
+#ifndef __COMAES_H__
+#define __COMAES_H__
+#include <openssl/evp.h>
+#include <openssl/err.h>
+
+#include <string.h>
+
+#include "Platform.h"
+/**
+ *  some helper struct and function for AES
+ *
+ */
+
+const EVP_CIPHER * aes_algorithm_type[] = {
+                            /* CQD value   Algorithm type   */
+  EVP_aes_128_ecb(),        /*    0        aes-128-ecb      */
+  EVP_aes_192_ecb(),        /*    1        aes_192_ecb      */
+  EVP_aes_256_ecb(),        /*    2        aes_256_ecb      */
+  EVP_aes_128_cbc(),        /*    3        aes_128_cbc      */
+  EVP_aes_192_cbc(),        /*    4        aes_192_cbc      */
+  EVP_aes_256_cbc(),        /*    5        aes_256_cbc      */
+  EVP_aes_128_cfb1(),       /*    6        aes_128_cfb1     */
+  EVP_aes_192_cfb1(),       /*    7        aes_192_cfb1     */
+  EVP_aes_256_cfb1(),       /*    8        aes_256_cfb1     */
+  EVP_aes_128_cfb8(),       /*    9        aes_128_cfb8     */
+  EVP_aes_192_cfb8(),       /*    10       aes_192_cfb8     */
+  EVP_aes_256_cfb8(),       /*    11       aes_256_cfb8     */
+  EVP_aes_128_cfb128(),     /*    12       aes_128_cfb128   */
+  EVP_aes_192_cfb128(),     /*    13       aes_192_cfb128   */
+  EVP_aes_256_cfb128(),     /*    14       aes_256_cfb128   */
+  EVP_aes_128_ofb(),        /*    15       aes_128_ofb      */
+  EVP_aes_192_ofb(),        /*    16       aes_192_ofb      */
+  EVP_aes_256_ofb(),        /*    17       aes_256_ofb      */
+};
+
+void aes_create_key(const unsigned char * input,
+                    Lng32 input_len,
+                    unsigned char * key,
+                    Int32 aes_mode);
+#endif

--- a/core/sql/common/OperTypeEnum.h
+++ b/core/sql/common/OperTypeEnum.h
@@ -801,6 +801,9 @@ enum OperatorTypeEnum {
                         ITM_SHA2_384  = 2639,
                         ITM_SHA2_512  = 2640,
 
+                        ITM_AES_ENCRYPT = 2641,
+                        ITM_AES_DECRYPT = 2642,
+
                         // Items for needed for Translating to UCS2 output strings
                         ITM_DATEFMT     = 2990,
                         ITM_CURRNT_USER = 2991,

--- a/core/sql/exp/ExpErrorEnums.h
+++ b/core/sql/exp/ExpErrorEnums.h
@@ -487,6 +487,13 @@ enum ExeErrorCode
   EXE_SM_FIXUP_REPLY_TIMEOUT            = 8953,
 
   // ---------------------------------------------------------------------
+  // Built-in Function ( encrpt/decrypt )
+  // ---------------------------------------------------------------------
+  EXE_AES_INVALID_IV                    = 8954,
+  EXE_ERR_PARAMCOUNT_FOR_FUNC           = 8955,
+  EXE_OPTION_IGNORED                    = 8956,
+  EXE_OPENSSL_ERROR                     = 8957,
+
   // Execution errors related to JSon parser
   // ---------------------------------------------------------------------
   EXE_JSON_INVALID_TOKEN                  = 8971,

--- a/core/sql/exp/ExpPackDefs.cpp
+++ b/core/sql/exp/ExpPackDefs.cpp
@@ -637,6 +637,15 @@ NA_EIDPROC Long ExFunctionInetNtoa::pack(void * space)
   return packClause(space, sizeof(ExFunctionInetNtoa));
 }
 
+NA_EIDPROC Long ExFunctionAESEncrypt::pack(void * space)
+{
+  return packClause(space, sizeof(ExFunctionAESEncrypt));
+}
+
+NA_EIDPROC Long ExFunctionAESDecrypt::pack(void * space)
+{
+  return packClause(space, sizeof(ExFunctionAESDecrypt));
+}
 // -----------------------------------------------------------------------
 // U N P A C K
 // -----------------------------------------------------------------------

--- a/core/sql/exp/exp_clause.cpp
+++ b/core/sql/exp/exp_clause.cpp
@@ -548,6 +548,12 @@ ex_clause::ex_clause(clause_type type,
 	case ITM_SOUNDEX:
 	  setClassID(FUNC_SOUNDEX_ID);
 	  break;
+        case ITM_AES_ENCRYPT:
+          setClassID(FUNC_AES_ENCRYPT);
+          break;
+        case ITM_AES_DECRYPT:
+          setClassID(FUNC_AES_DECRYPT);
+          break;
 	default:
 	  GenAssert(0, "ex_clause: Unknown Class ID.");
 	  break;
@@ -1044,6 +1050,12 @@ NA_EIDPROC char *ex_clause::findVTblPtr(short classID)
       break;
     case ex_clause::FUNC_SOUNDEX_ID:
       GetVTblPtr(vtblPtr, ExFunctionSoundex);
+      break;
+    case ex_clause::FUNC_AES_ENCRYPT:
+      GetVTblPtr(vtblPtr, ExFunctionAESEncrypt);
+      break;
+    case ex_clause::FUNC_AES_DECRYPT:
+      GetVTblPtr(vtblPtr, ExFunctionAESDecrypt);
       break;
      default:
       GetVTblPtr(vtblPtr, ex_clause);

--- a/core/sql/exp/exp_clause.h
+++ b/core/sql/exp/exp_clause.h
@@ -210,7 +210,9 @@ public:
     FUNC_SHA2_ID             = 125,
     FUNC_SOUNDEX_ID          = 126,
     REGEXP_CLAUSE_CHAR_ID    = 127,
-    FUNC_JSON_ID             = 128
+    FUNC_JSON_ID             = 128,
+    FUNC_AES_ENCRYPT         = 129,
+    FUNC_AES_DECRYPT         = 130
   };
 
   // max number of operands (including result) in a clause.

--- a/core/sql/exp/exp_function.h
+++ b/core/sql/exp/exp_function.h
@@ -1093,6 +1093,78 @@ public:
   // ---------------------------------------------------------------------
 };
 
+class SQLEXP_LIB_FUNC ExFunctionAESEncrypt : public ex_function_clause {
+public:
+  NA_EIDPROC ExFunctionAESEncrypt(OperatorTypeEnum oper_type,
+                                  Attributes ** attr,
+                                  Space * space,
+                                  int args_num,
+                                  Int32 aes_mode);
+  NA_EIDPROC ExFunctionAESEncrypt();
+
+  NA_EIDPROC ex_expr::exp_return_type eval(char *op_datap[], CollHeap*,
+                                           ComDiagsArea** = 0);
+  NA_EIDPROC long pack(void *);
+
+  // ---------------------------------------------------------------------
+  // Redefinition of methods inherited from NAVersionedObject.
+  // ---------------------------------------------------------------------
+  NA_EIDPROC virtual unsigned char getClassVersionID()
+  {
+    return 1;
+  }
+
+  NA_EIDPROC virtual void populateImageVersionIDArray()
+  {
+    setImageVersionID(2,getClassVersionID());
+    ex_function_clause::populateImageVersionIDArray();
+  }
+
+  NA_EIDPROC virtual short getClassSize() { return (short)sizeof(*this); }
+
+  // ---------------------------------------------------------------------
+private:
+  Int32 aes_mode;
+  Int32 args_num;
+};
+
+class SQLEXP_LIB_FUNC ExFunctionAESDecrypt : public ex_function_clause {
+public:
+  NA_EIDPROC ExFunctionAESDecrypt(OperatorTypeEnum oper_type,
+                                  Attributes ** attr,
+                                  Space *space,
+                                  int args_num,
+                                  Int32 aes_mode);
+
+  NA_EIDPROC ExFunctionAESDecrypt();
+
+  NA_EIDPROC ex_expr::exp_return_type eval(char *op_data[], CollHeap*,
+                                           ComDiagsArea ** = 0);
+
+  NA_EIDPROC long pack(void *);
+
+  // ---------------------------------------------------------------------
+  // Redefinition of methods inherited from NAVersionedObject.
+  // ---------------------------------------------------------------------
+  NA_EIDPROC virtual unsigned char getClassVersionID()
+  {
+    return 1;
+  }
+
+  NA_EIDPROC virtual void populateImageVersionIDArray()
+  {
+    setImageVersionID(2,getClassVersionID());
+    ex_function_clause::populateImageVersionIDArray();
+  }
+
+  NA_EIDPROC virtual short getClassSize() { return (short)sizeof(*this); }
+
+  // ---------------------------------------------------------------------
+private:
+  Int32 aes_mode;
+  Int32 args_num;
+};
+
 class SQLEXP_LIB_FUNC  ExFunctionTokenStr : public ex_function_clause {
 public:
   NA_EIDPROC ExFunctionTokenStr(OperatorTypeEnum oper_type,

--- a/core/sql/generator/GenItemFunc.cpp
+++ b/core/sql/generator/GenItemFunc.cpp
@@ -661,7 +661,7 @@ short BuiltinFunction::codeGen(Generator * generator)
 							space);
       }
     break;
-   
+
     case ITM_SOUNDEX:
     {
         function_clause =
@@ -670,7 +670,28 @@ short BuiltinFunction::codeGen(Generator * generator)
                     space);
     }
     break;
-      
+
+    case ITM_AES_ENCRYPT:
+    {
+      function_clause =
+        new(generator->getSpace()) ExFunctionAESEncrypt(getOperatorType(),
+                                                        attr,
+                                                        space,
+                                                        getArity(),
+                                                        CmpCommon::getDefaultNumeric(BLOCK_ENCRYPTION_MODE));
+      break;
+    }
+
+    case ITM_AES_DECRYPT:
+    {
+      function_clause =
+        new(generator->getSpace()) ExFunctionAESDecrypt(getOperatorType(),
+                                                        attr,
+                                                        space,
+                                                        getArity(),
+                                                        CmpCommon::getDefaultNumeric(BLOCK_ENCRYPTION_MODE));
+      break;
+    }
     default:
       break;
     }

--- a/core/sql/nskgmake/common/Makefile
+++ b/core/sql/nskgmake/common/Makefile
@@ -51,6 +51,7 @@ CPPSRC := \
 	ComSpace.cpp \
 	ComSqlId.cpp \
 	ComSqlText.cpp \
+	ComSSL.cpp \
 	ComSysUtils.cpp \
 	ComTransInfo.cpp \
 	conversionISO88591.cpp \

--- a/core/sql/optimizer/BindItemExpr.cpp
+++ b/core/sql/optimizer/BindItemExpr.cpp
@@ -3162,6 +3162,7 @@ ItemExpr *BuiltinFunction::bindNode(BindWA *bindWA)
   ItemExpr * ie = NULL;
   switch (getOperatorType())
     {
+
     case ITM_ISIPV4:
     case ITM_ISIPV6:
     case ITM_MD5:
@@ -3346,7 +3347,11 @@ ItemExpr *BuiltinFunction::bindNode(BindWA *bindWA)
          // when running on a system that is using the Unicode Config),
          // we need the following code.
       }
+    break;
 
+    case ITM_AES_ENCRYPT:
+    case ITM_AES_DECRYPT:
+      break;
     default:
       {
       }

--- a/core/sql/parser/ParKeyWords.cpp
+++ b/core/sql/parser/ParKeyWords.cpp
@@ -63,6 +63,8 @@ ParKeyWord ParKeyWords::keyWords_[] = {
   ParKeyWord("ADD",                TOK_ADD,         ANS_|RESWORD_),
   ParKeyWord("ADD_MONTHS",         TOK_ADD_MONTHS,  NONRESTOKEN_),
   ParKeyWord("ADMIN",              TOK_ADMIN,       COMPAQ_|RESWORD_),
+  ParKeyWord("AES_ENCRYPT",        TOK_AES_ENCRYPT, NONRESTOKEN_),
+  ParKeyWord("AES_DECRYPT",        TOK_AES_DECRYPT, NONRESTOKEN_),
   ParKeyWord("AFTER",              TOK_AFTER,       ANS_|RESWORD_|NONRESTOKEN_),
   ParKeyWord("AGGREGATE",          TOK_AGGREGATE,   COMPAQ_|RESWORD_),
   ParKeyWord("ALIAS",              TOK_ALIAS,       POTANS_|RESWORD_),

--- a/core/sql/parser/sqlparser.y
+++ b/core/sql/parser/sqlparser.y
@@ -446,6 +446,8 @@ static void enableMakeQuotedStringISO88591Mechanism()
 %token <tokval> TOK_ACCUMULATED
 %token <tokval> TOK_ADD_MONTHS
 %token <tokval> TOK_ADMIN               /* ANSI reserved word */
+%token <tokval> TOK_AES_ENCRYPT
+%token <tokval> TOK_AES_DECRYPT
 %token <tokval> TOK_AFTER
 %token <tokval> TOK_ALL
 %token <tokval> TOK_ALL_DDL
@@ -10240,6 +10242,26 @@ misc_function :
        | TOK_GROUPING_ID '(' value_expression_list ')'
              {
                $$ = new (PARSERHEAP()) ZZZBinderFunction(ITM_GROUPING_ID, $3);
+             }
+       | TOK_AES_ENCRYPT '(' value_expression ',' value_expression ',' value_expression ')'
+             {
+               $$ = new (PARSERHEAP()) BuiltinFunction(ITM_AES_ENCRYPT, CmpCommon::statementHeap(),
+                                                       3, $3, $5, $7);
+             }
+       | TOK_AES_ENCRYPT '(' value_expression ',' value_expression ')'
+             {
+               $$ = new (PARSERHEAP()) BuiltinFunction(ITM_AES_ENCRYPT, CmpCommon::statementHeap(),
+                                                       2, $3, $5);
+             }
+       | TOK_AES_DECRYPT '(' value_expression ',' value_expression ',' value_expression ')'
+             {
+               $$ = new (PARSERHEAP()) BuiltinFunction(ITM_AES_DECRYPT, CmpCommon::statementHeap(),
+                                                       3, $3, $5, $7);
+             }
+       | TOK_AES_DECRYPT '(' value_expression ',' value_expression ')'
+             {
+               $$ = new (PARSERHEAP()) BuiltinFunction(ITM_AES_DECRYPT, CmpCommon::statementHeap(),
+                                                       2, $3, $5);
              }
 
 hbase_column_create_list : '(' hbase_column_create_value ')'
@@ -33756,6 +33778,8 @@ nonreserved_word :      TOK_ABORT
 // QSTUFF
                       | TOK_VALIDATE
                       | TOK_RMS
+                      | TOK_AES_ENCRYPT
+                      | TOK_AES_DECRYPT
 
 // This was added for JIRA Trafodion 2367. There are oddities in
 // how PREPARE is parsed vs. how EXPLAIN is parsed, along with

--- a/core/sql/regress/compGeneral/EXPECTED006.SB
+++ b/core/sql/regress/compGeneral/EXPECTED006.SB
@@ -1867,4 +1867,572 @@ bc0050f3ff7a540c74a42664c53a7f9fd485622374a43eb4a62cd84e48f483237bed50f6562f8c6e
  9.99999327347282176E-001
 
 --- 1 row(s) selected.
+>>
+>>-- TEST aes_encrypt/aes_decrypt
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+
+(EXPR)
+----------
+
+EC10187492EB7FB319E09AFF8806B1CA4F1382B41D23C00B118B3DDD9A9CFA02
+
+--- 1 row(s) selected.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+
+*** WARNING[8956] IV option ignored
+
+(EXPR)
+----------
+
+EC10187492EB7FB319E09AFF8806B1CA4F1382B41D23C00B118B3DDD9A9CFA02
+
+--- 1 row(s) selected.
+>>select aes_decrypt(X'EC10187492EB7FB319E09AFF8806B1CA4F1382B41D23C00B118B3DDD9A9CFA02', '1234567812345678') from dual;
+
+(EXPR)
+----------
+
+abcdedfhijklmnopqrstuvwxyz
+
+--- 1 row(s) selected.
+>>select aes_decrypt(X'EC10187492EB7FB319E09AFF8806B1CA4F1382B41D23C00B118B3DDD9A9CFA02', '1234567812345678', '1234567812345678') from dual;
+
+*** WARNING[8956] IV option ignored
+
+(EXPR)
+----------
+
+abcdedfhijklmnopqrstuvwxyz
+
+--- 1 row(s) selected.
+>>
+>>cqd block_encryption_mode '1';
+
+--- SQL operation complete.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+
+(EXPR)
+----------
+
+0D9C1230E4B129757607D2E7C10805C9483C239A6A760FD1CECD8FC4D159E76F
+
+--- 1 row(s) selected.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+
+*** WARNING[8956] IV option ignored
+
+(EXPR)
+----------
+
+0D9C1230E4B129757607D2E7C10805C9483C239A6A760FD1CECD8FC4D159E76F
+
+--- 1 row(s) selected.
+>>select aes_decrypt(X'0D9C1230E4B129757607D2E7C10805C9483C239A6A760FD1CECD8FC4D159E76F', '1234567812345678') from dual;
+
+(EXPR)
+----------
+
+abcdedfhijklmnopqrstuvwxyz
+
+--- 1 row(s) selected.
+>>select aes_decrypt(X'0D9C1230E4B129757607D2E7C10805C9483C239A6A760FD1CECD8FC4D159E76F', '1234567812345678', '1234567812345678') from dual;
+
+*** WARNING[8956] IV option ignored
+
+(EXPR)
+----------
+
+abcdedfhijklmnopqrstuvwxyz
+
+--- 1 row(s) selected.
+>>
+>>cqd block_encryption_mode '2';
+
+--- SQL operation complete.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+
+(EXPR)
+----------
+
+EFB4059C8975543222830627F7433861A173BECA31B8902540174253476CA985
+
+--- 1 row(s) selected.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+
+*** WARNING[8956] IV option ignored
+
+(EXPR)
+----------
+
+EFB4059C8975543222830627F7433861A173BECA31B8902540174253476CA985
+
+--- 1 row(s) selected.
+>>select aes_decrypt(X'EFB4059C8975543222830627F7433861A173BECA31B8902540174253476CA985', '1234567812345678') from dual;
+
+(EXPR)
+----------
+
+abcdedfhijklmnopqrstuvwxyz
+
+--- 1 row(s) selected.
+>>select aes_decrypt(X'EFB4059C8975543222830627F7433861A173BECA31B8902540174253476CA985', '1234567812345678', '1234567812345678') from dual;
+
+*** WARNING[8956] IV option ignored
+
+(EXPR)
+----------
+
+abcdedfhijklmnopqrstuvwxyz
+
+--- 1 row(s) selected.
+>>
+>>cqd block_encryption_mode '3';
+
+--- SQL operation complete.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+
+*** ERROR[8955] Incorrect parameter count in the call to function AES_ENCRYPT
+
+--- 0 row(s) selected.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+
+(EXPR)
+----------
+
+12FF81AF2AB65E82DEFAE32D2CF0E7E5C14F90BAA80DF073608CE6ED0C47737F
+
+--- 1 row(s) selected.
+>>select aes_decrypt(X'12FF81AF2AB65E82DEFAE32D2CF0E7E5C14F90BAA80DF073608CE6ED0C47737F', '1234567812345678') from dual;
+
+*** ERROR[8955] Incorrect parameter count in the call to function AES_DECRYPT
+
+--- 0 row(s) selected.
+>>select aes_decrypt(X'12FF81AF2AB65E82DEFAE32D2CF0E7E5C14F90BAA80DF073608CE6ED0C47737F', '1234567812345678', '1234567812345678') from dual;
+
+(EXPR)
+----------
+
+abcdedfhijklmnopqrstuvwxyz
+
+--- 1 row(s) selected.
+>>
+>>cqd block_encryption_mode '4';
+
+--- SQL operation complete.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+
+*** ERROR[8955] Incorrect parameter count in the call to function AES_ENCRYPT
+
+--- 0 row(s) selected.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+
+(EXPR)
+----------
+
+1A1332592C987A79374609C89BB53F89A8F0B0A2B71E06B824894D1B95E1D953
+
+--- 1 row(s) selected.
+>>select aes_decrypt(X'1A1332592C987A79374609C89BB53F89A8F0B0A2B71E06B824894D1B95E1D953', '1234567812345678') from dual;
+
+*** ERROR[8955] Incorrect parameter count in the call to function AES_DECRYPT
+
+--- 0 row(s) selected.
+>>select aes_decrypt(X'1A1332592C987A79374609C89BB53F89A8F0B0A2B71E06B824894D1B95E1D953', '1234567812345678', '1234567812345678') from dual;
+
+(EXPR)
+----------
+
+abcdedfhijklmnopqrstuvwxyz
+
+--- 1 row(s) selected.
+>>
+>>cqd block_encryption_mode '5';
+
+--- SQL operation complete.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+
+*** ERROR[8955] Incorrect parameter count in the call to function AES_ENCRYPT
+
+--- 0 row(s) selected.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+
+(EXPR)
+----------
+
+E22114AB552C8613622ADD34B3FEDCE840A18C84FDEA9D6394F57A14F6DB2497
+
+--- 1 row(s) selected.
+>>select aes_decrypt(X'E22114AB552C8613622ADD34B3FEDCE840A18C84FDEA9D6394F57A14F6DB2497', '1234567812345678') from dual;
+
+*** ERROR[8955] Incorrect parameter count in the call to function AES_DECRYPT
+
+--- 0 row(s) selected.
+>>select aes_decrypt(X'E22114AB552C8613622ADD34B3FEDCE840A18C84FDEA9D6394F57A14F6DB2497', '1234567812345678', '1234567812345678') from dual;
+
+(EXPR)
+----------
+
+abcdedfhijklmnopqrstuvwxyz
+
+--- 1 row(s) selected.
+>>
+>>cqd block_encryption_mode '6';
+
+--- SQL operation complete.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+
+*** ERROR[8955] Incorrect parameter count in the call to function AES_ENCRYPT
+
+--- 0 row(s) selected.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+
+(EXPR)
+----------
+
+2A23CC234BC4175E6AE90793BFBD03E4D7F2921AC6032E45D1C0
+
+--- 1 row(s) selected.
+>>select aes_decrypt(X'2A23CC234BC4175E6AE90793BFBD03E4D7F2921AC6032E45D1C0', '1234567812345678') from dual;
+
+*** ERROR[8955] Incorrect parameter count in the call to function AES_DECRYPT
+
+--- 0 row(s) selected.
+>>select aes_decrypt(X'2A23CC234BC4175E6AE90793BFBD03E4D7F2921AC6032E45D1C0', '1234567812345678', '1234567812345678') from dual;
+
+(EXPR)
+----------
+
+abcdedfhijklmnopqrstuvwxyz
+
+--- 1 row(s) selected.
+>>
+>>cqd block_encryption_mode '7';
+
+--- SQL operation complete.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+
+*** ERROR[8955] Incorrect parameter count in the call to function AES_ENCRYPT
+
+--- 0 row(s) selected.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+
+(EXPR)
+----------
+
+09389E6E99083B18F50D2B4D14106CFCF9F9EEAD004929940C17
+
+--- 1 row(s) selected.
+>>select aes_decrypt(X'09389E6E99083B18F50D2B4D14106CFCF9F9EEAD004929940C17', '1234567812345678') from dual;
+
+*** ERROR[8955] Incorrect parameter count in the call to function AES_DECRYPT
+
+--- 0 row(s) selected.
+>>select aes_decrypt(X'09389E6E99083B18F50D2B4D14106CFCF9F9EEAD004929940C17', '1234567812345678', '1234567812345678') from dual;
+
+(EXPR)
+----------
+
+abcdedfhijklmnopqrstuvwxyz
+
+--- 1 row(s) selected.
+>>
+>>cqd block_encryption_mode '8';
+
+--- SQL operation complete.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+
+*** ERROR[8955] Incorrect parameter count in the call to function AES_ENCRYPT
+
+--- 0 row(s) selected.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+
+(EXPR)
+----------
+
+209F05F9B3E25391258A434F6FA9663F14886E9FF7E6C2CF5EF9
+
+--- 1 row(s) selected.
+>>select aes_decrypt(X'209F05F9B3E25391258A434F6FA9663F14886E9FF7E6C2CF5EF9', '1234567812345678') from dual;
+
+*** ERROR[8955] Incorrect parameter count in the call to function AES_DECRYPT
+
+--- 0 row(s) selected.
+>>select aes_decrypt(X'209F05F9B3E25391258A434F6FA9663F14886E9FF7E6C2CF5EF9', '1234567812345678', '1234567812345678') from dual;
+
+(EXPR)
+----------
+
+abcdedfhijklmnopqrstuvwxyz
+
+--- 1 row(s) selected.
+>>
+>>cqd block_encryption_mode '9';
+
+--- SQL operation complete.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+
+*** ERROR[8955] Incorrect parameter count in the call to function AES_ENCRYPT
+
+--- 0 row(s) selected.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+
+(EXPR)
+----------
+
+0C45C8DB6AE2F87AE36420AE711AC1121576FEECB26BD9B246AB
+
+--- 1 row(s) selected.
+>>select aes_decrypt(X'0C45C8DB6AE2F87AE36420AE711AC1121576FEECB26BD9B246AB', '1234567812345678') from dual;
+
+*** ERROR[8955] Incorrect parameter count in the call to function AES_DECRYPT
+
+--- 0 row(s) selected.
+>>select aes_decrypt(X'0C45C8DB6AE2F87AE36420AE711AC1121576FEECB26BD9B246AB', '1234567812345678', '1234567812345678') from dual;
+
+(EXPR)
+----------
+
+abcdedfhijklmnopqrstuvwxyz
+
+--- 1 row(s) selected.
+>>
+>>cqd block_encryption_mode '10';
+
+--- SQL operation complete.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+
+*** ERROR[8955] Incorrect parameter count in the call to function AES_ENCRYPT
+
+--- 0 row(s) selected.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+
+(EXPR)
+----------
+
+2C39ACEEBF859846261D8B1B712BBC7965F64889293C26CDFE61
+
+--- 1 row(s) selected.
+>>select aes_decrypt(X'2C39ACEEBF859846261D8B1B712BBC7965F64889293C26CDFE61', '1234567812345678') from dual;
+
+*** ERROR[8955] Incorrect parameter count in the call to function AES_DECRYPT
+
+--- 0 row(s) selected.
+>>select aes_decrypt(X'2C39ACEEBF859846261D8B1B712BBC7965F64889293C26CDFE61', '1234567812345678', '1234567812345678') from dual;
+
+(EXPR)
+----------
+
+abcdedfhijklmnopqrstuvwxyz
+
+--- 1 row(s) selected.
+>>
+>>cqd block_encryption_mode '11';
+
+--- SQL operation complete.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+
+*** ERROR[8955] Incorrect parameter count in the call to function AES_ENCRYPT
+
+--- 0 row(s) selected.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+
+(EXPR)
+----------
+
+6A3C1001A693B34DD2619B066413995BDEC5259A73E1E6D2DEBC
+
+--- 1 row(s) selected.
+>>select aes_decrypt(X'6A3C1001A693B34DD2619B066413995BDEC5259A73E1E6D2DEBC', '1234567812345678') from dual;
+
+*** ERROR[8955] Incorrect parameter count in the call to function AES_DECRYPT
+
+--- 0 row(s) selected.
+>>select aes_decrypt(X'6A3C1001A693B34DD2619B066413995BDEC5259A73E1E6D2DEBC', '1234567812345678', '1234567812345678') from dual;
+
+(EXPR)
+----------
+
+abcdedfhijklmnopqrstuvwxyz
+
+--- 1 row(s) selected.
+>>
+>>cqd block_encryption_mode '12';
+
+--- SQL operation complete.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+
+*** ERROR[8955] Incorrect parameter count in the call to function AES_ENCRYPT
+
+--- 0 row(s) selected.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+
+(EXPR)
+----------
+
+0CCE7F3282239C8853A5E704FC8A47901D8036903B6603DF43E5
+
+--- 1 row(s) selected.
+>>select aes_decrypt(X'0CCE7F3282239C8853A5E704FC8A47901D8036903B6603DF43E5', '1234567812345678') from dual;
+
+*** ERROR[8955] Incorrect parameter count in the call to function AES_DECRYPT
+
+--- 0 row(s) selected.
+>>select aes_decrypt(X'0CCE7F3282239C8853A5E704FC8A47901D8036903B6603DF43E5', '1234567812345678', '1234567812345678') from dual;
+
+(EXPR)
+----------
+
+abcdedfhijklmnopqrstuvwxyz
+
+--- 1 row(s) selected.
+>>
+>>cqd block_encryption_mode '13';
+
+--- SQL operation complete.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+
+*** ERROR[8955] Incorrect parameter count in the call to function AES_ENCRYPT
+
+--- 0 row(s) selected.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+
+(EXPR)
+----------
+
+2C6B7A87519F9E95E0F46EDA774152245E8DD142FC6CD57D57E2
+
+--- 1 row(s) selected.
+>>select aes_decrypt(X'2C6B7A87519F9E95E0F46EDA774152245E8DD142FC6CD57D57E2', '1234567812345678') from dual;
+
+*** ERROR[8955] Incorrect parameter count in the call to function AES_DECRYPT
+
+--- 0 row(s) selected.
+>>select aes_decrypt(X'2C6B7A87519F9E95E0F46EDA774152245E8DD142FC6CD57D57E2', '1234567812345678', '1234567812345678') from dual;
+
+(EXPR)
+----------
+
+abcdedfhijklmnopqrstuvwxyz
+
+--- 1 row(s) selected.
+>>
+>>cqd block_encryption_mode '14';
+
+--- SQL operation complete.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+
+*** ERROR[8955] Incorrect parameter count in the call to function AES_ENCRYPT
+
+--- 0 row(s) selected.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+
+(EXPR)
+----------
+
+6A0D74250CB7E54F4690801A7AD9CDB07435157353DAE7BC6203
+
+--- 1 row(s) selected.
+>>select aes_decrypt(X'6A0D74250CB7E54F4690801A7AD9CDB07435157353DAE7BC6203', '1234567812345678') from dual;
+
+*** ERROR[8955] Incorrect parameter count in the call to function AES_DECRYPT
+
+--- 0 row(s) selected.
+>>select aes_decrypt(X'6A0D74250CB7E54F4690801A7AD9CDB07435157353DAE7BC6203', '1234567812345678', '1234567812345678') from dual;
+
+(EXPR)
+----------
+
+abcdedfhijklmnopqrstuvwxyz
+
+--- 1 row(s) selected.
+>>
+>>cqd block_encryption_mode '15';
+
+--- SQL operation complete.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+
+*** ERROR[8955] Incorrect parameter count in the call to function AES_ENCRYPT
+
+--- 0 row(s) selected.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+
+(EXPR)
+----------
+
+0CCE7F3282239C8853A5E704FC8A4790B5D857207B417EFB52D8
+
+--- 1 row(s) selected.
+>>select aes_decrypt(X'0CCE7F3282239C8853A5E704FC8A4790B5D857207B417EFB52D8', '1234567812345678') from dual;
+
+*** ERROR[8955] Incorrect parameter count in the call to function AES_DECRYPT
+
+--- 0 row(s) selected.
+>>select aes_decrypt(X'0CCE7F3282239C8853A5E704FC8A4790B5D857207B417EFB52D8', '1234567812345678', '1234567812345678') from dual;
+
+(EXPR)
+----------
+
+abcdedfhijklmnopqrstuvwxyz
+
+--- 1 row(s) selected.
+>>
+>>cqd block_encryption_mode '16';
+
+--- SQL operation complete.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+
+*** ERROR[8955] Incorrect parameter count in the call to function AES_ENCRYPT
+
+--- 0 row(s) selected.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+
+(EXPR)
+----------
+
+2C6B7A87519F9E95E0F46EDA774152244B6E78427EC604C84868
+
+--- 1 row(s) selected.
+>>select aes_decrypt(X'2C6B7A87519F9E95E0F46EDA774152244B6E78427EC604C84868', '1234567812345678') from dual;
+
+*** ERROR[8955] Incorrect parameter count in the call to function AES_DECRYPT
+
+--- 0 row(s) selected.
+>>select aes_decrypt(X'2C6B7A87519F9E95E0F46EDA774152244B6E78427EC604C84868', '1234567812345678', '1234567812345678') from dual;
+
+(EXPR)
+----------
+
+abcdedfhijklmnopqrstuvwxyz
+
+--- 1 row(s) selected.
+>>
+>>cqd block_encryption_mode '17';
+
+--- SQL operation complete.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+
+*** ERROR[8955] Incorrect parameter count in the call to function AES_ENCRYPT
+
+--- 0 row(s) selected.
+>>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+
+(EXPR)
+----------
+
+6A0D74250CB7E54F4690801A7AD9CDB053213B2F461EA174E128
+
+--- 1 row(s) selected.
+>>select aes_decrypt(X'6A0D74250CB7E54F4690801A7AD9CDB053213B2F461EA174E128', '1234567812345678') from dual;
+
+*** ERROR[8955] Incorrect parameter count in the call to function AES_DECRYPT
+
+--- 0 row(s) selected.
+>>select aes_decrypt(X'6A0D74250CB7E54F4690801A7AD9CDB053213B2F461EA174E128', '1234567812345678', '1234567812345678') from dual;
+
+(EXPR)
+----------
+
+abcdedfhijklmnopqrstuvwxyz
+
+--- 1 row(s) selected.
 >>log;

--- a/core/sql/regress/compGeneral/TEST006
+++ b/core/sql/regress/compGeneral/TEST006
@@ -686,3 +686,111 @@ select log(5,10) from dual;
 select log(10,100) from dual;
 select log(2) from dual;
 select log(2.71828) from dual;
+
+-- TEST aes_encrypt/aes_decrypt
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+select aes_decrypt(X'EC10187492EB7FB319E09AFF8806B1CA4F1382B41D23C00B118B3DDD9A9CFA02', '1234567812345678') from dual;
+select aes_decrypt(X'EC10187492EB7FB319E09AFF8806B1CA4F1382B41D23C00B118B3DDD9A9CFA02', '1234567812345678', '1234567812345678') from dual;
+
+cqd block_encryption_mode '1';
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+select aes_decrypt(X'0D9C1230E4B129757607D2E7C10805C9483C239A6A760FD1CECD8FC4D159E76F', '1234567812345678') from dual;
+select aes_decrypt(X'0D9C1230E4B129757607D2E7C10805C9483C239A6A760FD1CECD8FC4D159E76F', '1234567812345678', '1234567812345678') from dual;
+
+cqd block_encryption_mode '2';
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+select aes_decrypt(X'EFB4059C8975543222830627F7433861A173BECA31B8902540174253476CA985', '1234567812345678') from dual;
+select aes_decrypt(X'EFB4059C8975543222830627F7433861A173BECA31B8902540174253476CA985', '1234567812345678', '1234567812345678') from dual;
+
+cqd block_encryption_mode '3';
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+select aes_decrypt(X'12FF81AF2AB65E82DEFAE32D2CF0E7E5C14F90BAA80DF073608CE6ED0C47737F', '1234567812345678') from dual;
+select aes_decrypt(X'12FF81AF2AB65E82DEFAE32D2CF0E7E5C14F90BAA80DF073608CE6ED0C47737F', '1234567812345678', '1234567812345678') from dual;
+
+cqd block_encryption_mode '4';
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+select aes_decrypt(X'1A1332592C987A79374609C89BB53F89A8F0B0A2B71E06B824894D1B95E1D953', '1234567812345678') from dual;
+select aes_decrypt(X'1A1332592C987A79374609C89BB53F89A8F0B0A2B71E06B824894D1B95E1D953', '1234567812345678', '1234567812345678') from dual;
+
+cqd block_encryption_mode '5';
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+select aes_decrypt(X'E22114AB552C8613622ADD34B3FEDCE840A18C84FDEA9D6394F57A14F6DB2497', '1234567812345678') from dual;
+select aes_decrypt(X'E22114AB552C8613622ADD34B3FEDCE840A18C84FDEA9D6394F57A14F6DB2497', '1234567812345678', '1234567812345678') from dual;
+
+cqd block_encryption_mode '6';
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+select aes_decrypt(X'2A23CC234BC4175E6AE90793BFBD03E4D7F2921AC6032E45D1C0', '1234567812345678') from dual;
+select aes_decrypt(X'2A23CC234BC4175E6AE90793BFBD03E4D7F2921AC6032E45D1C0', '1234567812345678', '1234567812345678') from dual;
+
+cqd block_encryption_mode '7';
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+select aes_decrypt(X'09389E6E99083B18F50D2B4D14106CFCF9F9EEAD004929940C17', '1234567812345678') from dual;
+select aes_decrypt(X'09389E6E99083B18F50D2B4D14106CFCF9F9EEAD004929940C17', '1234567812345678', '1234567812345678') from dual;
+
+cqd block_encryption_mode '8';
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+select aes_decrypt(X'209F05F9B3E25391258A434F6FA9663F14886E9FF7E6C2CF5EF9', '1234567812345678') from dual;
+select aes_decrypt(X'209F05F9B3E25391258A434F6FA9663F14886E9FF7E6C2CF5EF9', '1234567812345678', '1234567812345678') from dual;
+
+cqd block_encryption_mode '9';
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+select aes_decrypt(X'0C45C8DB6AE2F87AE36420AE711AC1121576FEECB26BD9B246AB', '1234567812345678') from dual;
+select aes_decrypt(X'0C45C8DB6AE2F87AE36420AE711AC1121576FEECB26BD9B246AB', '1234567812345678', '1234567812345678') from dual;
+
+cqd block_encryption_mode '10';
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+select aes_decrypt(X'2C39ACEEBF859846261D8B1B712BBC7965F64889293C26CDFE61', '1234567812345678') from dual;
+select aes_decrypt(X'2C39ACEEBF859846261D8B1B712BBC7965F64889293C26CDFE61', '1234567812345678', '1234567812345678') from dual;
+
+cqd block_encryption_mode '11';
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+select aes_decrypt(X'6A3C1001A693B34DD2619B066413995BDEC5259A73E1E6D2DEBC', '1234567812345678') from dual;
+select aes_decrypt(X'6A3C1001A693B34DD2619B066413995BDEC5259A73E1E6D2DEBC', '1234567812345678', '1234567812345678') from dual;
+
+cqd block_encryption_mode '12';
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+select aes_decrypt(X'0CCE7F3282239C8853A5E704FC8A47901D8036903B6603DF43E5', '1234567812345678') from dual;
+select aes_decrypt(X'0CCE7F3282239C8853A5E704FC8A47901D8036903B6603DF43E5', '1234567812345678', '1234567812345678') from dual;
+
+cqd block_encryption_mode '13';
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+select aes_decrypt(X'2C6B7A87519F9E95E0F46EDA774152245E8DD142FC6CD57D57E2', '1234567812345678') from dual;
+select aes_decrypt(X'2C6B7A87519F9E95E0F46EDA774152245E8DD142FC6CD57D57E2', '1234567812345678', '1234567812345678') from dual;
+
+cqd block_encryption_mode '14';
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+select aes_decrypt(X'6A0D74250CB7E54F4690801A7AD9CDB07435157353DAE7BC6203', '1234567812345678') from dual;
+select aes_decrypt(X'6A0D74250CB7E54F4690801A7AD9CDB07435157353DAE7BC6203', '1234567812345678', '1234567812345678') from dual;
+
+cqd block_encryption_mode '15';
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+select aes_decrypt(X'0CCE7F3282239C8853A5E704FC8A4790B5D857207B417EFB52D8', '1234567812345678') from dual;
+select aes_decrypt(X'0CCE7F3282239C8853A5E704FC8A4790B5D857207B417EFB52D8', '1234567812345678', '1234567812345678') from dual;
+
+cqd block_encryption_mode '16';
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+select aes_decrypt(X'2C6B7A87519F9E95E0F46EDA774152244B6E78427EC604C84868', '1234567812345678') from dual;
+select aes_decrypt(X'2C6B7A87519F9E95E0F46EDA774152244B6E78427EC604C84868', '1234567812345678', '1234567812345678') from dual;
+
+cqd block_encryption_mode '17';
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
+select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
+select aes_decrypt(X'6A0D74250CB7E54F4690801A7AD9CDB053213B2F461EA174E128', '1234567812345678') from dual;
+select aes_decrypt(X'6A0D74250CB7E54F4690801A7AD9CDB053213B2F461EA174E128', '1234567812345678', '1234567812345678') from dual;

--- a/core/sql/sqlcomp/DefaultConstants.h
+++ b/core/sql/sqlcomp/DefaultConstants.h
@@ -3871,6 +3871,9 @@ enum DefaultConstants
   CSE_CACHE_TEMP_QUERIES,
 
 
+  // mode for AES_ENCRYPT/AED_DECRYPT
+  BLOCK_ENCRYPTION_MODE,
+
   // This enum constant must be the LAST one in the list; it's a count,
   // not an Attribute (it's not IN DefaultDefaults; it's the SIZE of it)!
   __NUM_DEFAULT_ATTRIBUTES

--- a/core/sql/sqlcomp/nadefaults.cpp
+++ b/core/sql/sqlcomp/nadefaults.cpp
@@ -459,6 +459,7 @@ SDDkwd__(ALLOW_DP2_ROW_SAMPLING,               "SYSTEM"),
  // see comments in DefaultConstants.h
   DDkwd__(BIGNUM_IO,		                "SYSTEM"),
 
+  DDint__(BLOCK_ENCRYPTION_MODE,             "0"),
  XDDkwd__(BLOCK_TO_PREVENT_HALLOWEEN,           "ON"),
 
   DDflte_(BMO_CITIZENSHIP_FACTOR,             "1."),


### PR DESCRIPTION
Add two functions which used to encrypt and decrypt the data using the
  official AES (Advanced Encryption Standard) algorithm.
AES_ENCRYPT(str, key_str[, init_vector])
AES_DECRYPT(crypt_str, key_str[, init_vector])

Both these two function have optional init_vector argument which
provides an initalization vector for block encryption modes that
require it. For modes that require the optional init_vector argument, an error
occurs if init_vector is missing. For modes that don't need
init_vector, it will raise a unused argument waring if init_vector is
provided.

The new CQD block_encryption_mode controls the mode for
block-based
encryption algorithm. The default value is 0, which use
aes-128-ecb.

Here is the list for diffferent values for
block_encryption_mode

CQD value          algorithm
0             aes-128-ecb
1             aes_192_ecb
2             aes_256_ecb
3             aes_128_cbc
4             aes_192_cbc
5             aes_256_cbc
6             aes_128_cfb1
7             aes_192_cfb1
8             aes_256_cfb1
9             aes_128_cfb8
10            aes_192_cfb8
11            aes_256_cfb8
12            aes_128_cfb128
13            aes_192_cfb128
14            aes_256_cfb128
15            aes_128_ofb
16            aes_192_ofb
17            aes_256_ofb