### PR TITLE
[TRAFODION-2314] MXOSRVR sometimes exit abnormally with NAMutex assert

### DIFF
--- a/core/conn/odbc/src/odbc/nsksrvr/Makefile
+++ b/core/conn/odbc/src/odbc/nsksrvr/Makefile
@@ -121,7 +121,7 @@ DBT_LIBS =
 
 EARLY_LIBS = -ljsig
 
-COMMON_LIBS = -lsbfs -lsbms -levlsq -lwin -ltdm_sqlcli -larkcmp_dll -L../nsksrvrcore -lmxocore -llog4cxx
+COMMON_LIBS = -lsbfs -lsbms -levlsq -lwin -lpthread -ltdm_sqlcli -larkcmp_dll -L../nsksrvrcore -lmxocore -llog4cxx
 
 ifeq ($(SQ_MTYPE),64)
 LOC_JSIG=$(JAVA_HOME)/jre/lib/amd64/server

--- a/core/conn/odbc/src/odbc/nsksrvrcore/Makefile
+++ b/core/conn/odbc/src/odbc/nsksrvrcore/Makefile
@@ -73,7 +73,7 @@ CODEGEN = -fPIC
 
 # Produce libmxocore.so
 libmxocore.so: $(OBJS)
-	$(CXX) -shared $(GCCMODE) -o $@ $(DBG_FLGS) -L$(LIBEXPDIR) -levlsq -lsqauth -lsqcert $(OBJS)
+	$(CXX) -shared $(GCCMODE) -o $@ $(DBG_FLGS) -L$(LIBEXPDIR) -levlsq -lsqauth -lsqcert -lpthread $(OBJS)
 	cp -up $@ $(LIBEXPDIR)
 
 $(OUTDIR)/libmxocore_version.o: $(TRAF_HOME)/export/include/SCMBuildStr.h


### PR DESCRIPTION
The test suite fails becuase pthread_mutex_unlock returns EPERM error

pthread_mutex_lock and pthread_mutex_unlock always return success when
a program is not linked with -lpthread option. It is linked this way
when a multi-threaded program is run in single thread mode to avoid the
overhead of locking.

The mxosrvr program is now linked with -lpthread. However, it is not
clear how and why it would fix the EPERM error returned from
pthread_mutex_unlock API. But it is good to ensure that mxosrvr .sos and
the binaries are compiled with -lpthread.

Will revisit this issue if the problem persists.