### PR TITLE
[TRAFODION-2414] enhance 8616 commit conflict error message to include tx conflict details

### DIFF
--- a/core/sqf/export/include/dtm/tm.h
+++ b/core/sqf/export/include/dtm/tm.h
@@ -297,9 +297,12 @@ extern "C" short BEGINTRANSACTION(int *tag);
 extern "C" short BEGINTX(int *tag, int timeout=0, int64 type_flags=0);
 extern "C" short ENDTRANSACTION();
 
-//errStr is allocated if errlen is not zero. Caller must deallocate errStr.
+//ENDTRANSACTION_ERR() is same as ENDTRANSACTION(). However,
+//errStr is allocated if errlen is not zero. Caller must deallocate errStr
+//by calling DELLAOCATE_ERR.
 //Rest of functionality same as ENDTRANSACTION.
 extern "C" short ENDTRANSACTION_ERR(char *&errStr, int &errlen);
+extern "C" void  DEALLOCATE_ERR(char *&errStr);
 
 extern "C" short STATUSTRANSACTION(short *status, int64 transid = 0);
 extern "C" short GETTRANSID(short *transid);

--- a/core/sqf/export/include/dtm/tm.h
+++ b/core/sqf/export/include/dtm/tm.h
@@ -296,6 +296,11 @@ extern "C" short ABORTTRANSACTION();
 extern "C" short BEGINTRANSACTION(int *tag);
 extern "C" short BEGINTX(int *tag, int timeout=0, int64 type_flags=0);
 extern "C" short ENDTRANSACTION();
+
+//errStr is allocated if errlen is not zero. Caller must deallocate errStr.
+//Rest of functionality same as ENDTRANSACTION.
+extern "C" short ENDTRANSACTION_ERR(char *&errStr, int &errlen);
+
 extern "C" short STATUSTRANSACTION(short *status, int64 transid = 0);
 extern "C" short GETTRANSID(short *transid);
 extern "C" short GETTRANSINFO(short *transid, int64 *type_flags);

--- a/core/sqf/export/include/dtm/tmtransaction.h
+++ b/core/sqf/export/include/dtm/tmtransaction.h
@@ -47,7 +47,7 @@ public:
     ~TM_Transaction();
 
         // transaction actions
-    short end();
+    short end(char* &pv_err_str, int &pv_err_len);
     short abort(bool pv_doom = false);
     short suspend(TM_Transid *transid, bool coordinator_role=true);
     short resume();

--- a/core/sqf/inc/cextdecs/cextdecs.h
+++ b/core/sqf/inc/cextdecs/cextdecs.h
@@ -289,9 +289,12 @@ _declspec(dllimport) short   DNUMOUT
 
 _declspec(dllimport) short   ENDTRANSACTION();
 
-//errStr is allocated if errlen is not zero. Caller must deallocate errStr.
-//Rest of functionality same as ENDTRANSACTION();
+//ENDTRANSACTION_ERR() is same as ENDTRANSACTION(). However,
+//errStr is allocated if errlen is not zero. Caller must deallocate errStr
+//by calling DELLAOCATE_ERR.
+//Rest of functionality same as ENDTRANSACTION.
 _declspec(dllimport) short   ENDTRANSACTION_ERR(char *&errStr, int &errlen);
+_declspec(dllimport) void    DEALLOCATE_ERR(char *&errStr);
 
 _declspec(dllimport) short   FILENAME_COMPARE_
 #ifdef TDM_ROSETTA_COMPATIBILITY_

--- a/core/sqf/inc/cextdecs/cextdecs.h
+++ b/core/sqf/inc/cextdecs/cextdecs.h
@@ -1585,10 +1585,12 @@ _declspec(dllimport) short   DNUMOUT
 
 _declspec(dllimport) short   ENDTRANSACTION();
 
-//errStr is allocated if errlen is not zero. Caller must deallocate errStr.
-//Rest of functionality same as ENDTRANSACTION();
+//ENDTRANSACTION_ERR() is same as ENDTRANSACTION(). However,
+//errStr is allocated if errlen is not zero. Caller must deallocate errStr
+//by calling DELLAOCATE_ERR.
+//Rest of functionality same as ENDTRANSACTION.
 _declspec(dllimport) short   ENDTRANSACTION_ERR(char *&errStr, int &errlen);
-
+_declspec(dllimport) void    DEALLOCATE_ERR(char *&errStr);
 
 _declspec(dllimport) short   FILENAME_COMPARE_
 #ifdef TDM_ROSETTA_COMPATIBILITY_

--- a/core/sqf/inc/cextdecs/cextdecs.h
+++ b/core/sqf/inc/cextdecs/cextdecs.h
@@ -289,6 +289,10 @@ _declspec(dllimport) short   DNUMOUT
 
 _declspec(dllimport) short   ENDTRANSACTION();
 
+//errStr is allocated if errlen is not zero. Caller must deallocate errStr.
+//Rest of functionality same as ENDTRANSACTION();
+_declspec(dllimport) short   ENDTRANSACTION_ERR(char *&errStr, int &errlen);
+
 _declspec(dllimport) short   FILENAME_COMPARE_
 #ifdef TDM_ROSETTA_COMPATIBILITY_
   (unsigned char  *name1,    //IN
@@ -1577,6 +1581,11 @@ _declspec(dllimport) short   DNUMOUT
 ;
 
 _declspec(dllimport) short   ENDTRANSACTION();
+
+//errStr is allocated if errlen is not zero. Caller must deallocate errStr.
+//Rest of functionality same as ENDTRANSACTION();
+_declspec(dllimport) short   ENDTRANSACTION_ERR(char *&errStr, int &errlen);
+
 
 _declspec(dllimport) short   FILENAME_COMPARE_
 #ifdef TDM_ROSETTA_COMPATIBILITY_

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/TransactionManager.java
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/TransactionManager.java
@@ -644,7 +644,7 @@ public class TransactionManager {
                 retry = true;
              }
              else if(result.size() == 1){
-               LOG.info("doPrepareX(MVCC), received result size: " + result.size() + " for transaction "
+               if(LOG.isInfoEnabled()) LOG.info("doPrepareX(MVCC), received result size: " + result.size() + " for transaction "
                    + transactionId + " participantNum " + participantNum + " Location " + location.getRegionInfo().getRegionNameAsString());
                 // size is 1
                 for (CommitRequestResponse cresponse : result.values()){

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/TransactionManager.java
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/TransactionManager.java
@@ -107,6 +107,7 @@ import org.apache.hadoop.hbase.client.transactional.TmDDL;
 import org.apache.hadoop.hbase.regionserver.transactional.IdTm;
 import org.apache.hadoop.hbase.regionserver.transactional.IdTmException;
 import org.apache.hadoop.hbase.regionserver.transactional.IdTmId;
+import org.apache.hadoop.hbase.coprocessor.transactional.CommitConflictException;
 
 // Sscc imports
 import org.apache.hadoop.hbase.coprocessor.transactional.generated.SsccRegionProtos.SsccRegionService;
@@ -643,13 +644,18 @@ public class TransactionManager {
                 retry = true;
              }
              else if(result.size() == 1){
+               LOG.info("doPrepareX(MVCC), received result size: " + result.size() + " for transaction "
+                   + transactionId + " participantNum " + participantNum + " Location " + location.getRegionInfo().getRegionNameAsString());
                 // size is 1
                 for (CommitRequestResponse cresponse : result.values()){
                    // Should only be one result
                    int value = cresponse.getResult();
                    commitStatus = value;
                    if(cresponse.getHasException()) {
-                      if(transactionState.hasRetried() &&
+                      if(commitStatus == TransactionalReturn.COMMIT_CONFLICT){
+                        transactionState.recordException(cresponse.getException());                        
+                      }
+                      else if(transactionState.hasRetried() &&
                           cresponse.getException().contains("encountered unknown transactionID")) {
                         retry = false;
                         commitStatus = TransactionalReturn.COMMIT_OK_READ_ONLY;
@@ -693,7 +699,10 @@ public class TransactionManager {
                      commitStatus = cresponse.getResult();
 
                      if(cresponse.getHasException()) {
-                       if(cresponse.getException().contains("encountered unknown transactionID")) {
+                       if(commitStatus == TransactionalReturn.COMMIT_CONFLICT){
+                         transactionState.recordException(cresponse.getException());
+                       }
+                       else if(cresponse.getException().contains("encountered unknown transactionID")) {
                          retry = false;
                          commitStatus = TransactionalReturn.COMMIT_OK_READ_ONLY;
                        }
@@ -711,6 +720,7 @@ public class TransactionManager {
                     commitStatus == TransactionalReturn.COMMIT_RESEND) {
                    commitStatus = TransactionalReturn.COMMIT_OK;
                  }
+                 
                retry = false;
              }
           }

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/TransactionState.java
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/client/transactional/TransactionState.java
@@ -72,6 +72,7 @@ public class TransactionState {
     private static boolean useConcurrentHM = false;
     private boolean hasRetried = false;
     private boolean uteLogged = false;
+    private String recordException;
 
     public Set<String> tableNames = Collections.synchronizedSet(new HashSet<String>());
     public Set<TransactionRegionLocation> participatingRegions;
@@ -114,6 +115,7 @@ public class TransactionState {
         commitSendDone = false;
         hasError = null;
         ddlTrans = false;
+        recordException = null;
 
         if(useConcurrentHM) {
           participatingRegions = Collections.newSetFromMap((new ConcurrentHashMap<TransactionRegionLocation, Boolean>()));
@@ -253,6 +255,28 @@ public class TransactionState {
             commitSendDone = true;
             commitSendLock.notify();
         }
+    }
+    
+    /**
+    *
+    * Method  : recordException
+    * Params  : 
+    * Return  : void
+    * Purpose : Record an exception encountered by executor threads. 
+    */
+    public synchronized void recordException(String exception)
+    {
+      if (exception != null && recordException == null)
+        recordException = exception;
+    }
+    
+    public String getRecordedException()
+    {
+      return recordException;
+    }
+    public void resetRecordedException()
+    {
+      recordException = null;
     }
 
       public void registerLocation(final TransactionRegionLocation location) throws IOException {

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/coprocessor/transactional/CommitConflictException.java
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/coprocessor/transactional/CommitConflictException.java
@@ -1,0 +1,61 @@
+/**
+* @@@ START COPYRIGHT @@@
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+* @@@ END COPYRIGHT @@@
+**/
+
+package org.apache.hadoop.hbase.coprocessor.transactional;
+import java.io.IOException;
+
+/** Thrown when a transaction conflicts with another transaction. 
+ * 
+ */
+public class CommitConflictException extends IOException {
+
+  private static final long serialVersionUID = 7062921444531109202L;
+
+  /** Default Constructor */
+  public CommitConflictException() {
+    super();
+  }
+
+  /**
+   * @param arg0 message
+   * @param arg1 cause
+   */
+  public CommitConflictException(String arg0, Throwable arg1) {
+    super(arg0, arg1);
+  }
+
+  /**
+   * @param arg0 message
+   */
+  public CommitConflictException(String arg0) {
+    super(arg0);
+  }
+
+  /**
+   * @param arg0 cause
+   */
+  public CommitConflictException(Throwable arg0) {
+    super(arg0);
+  }
+
+}

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/coprocessor/transactional/TrxRegionEndpoint.java.tmpl
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/coprocessor/transactional/TrxRegionEndpoint.java.tmpl
@@ -836,6 +836,7 @@ CoprocessorService, Coprocessor {
     int status = 0;
     IOException ioe = null;
     UnknownTransactionException ute = null;
+    CommitConflictException cce = null;
     Throwable t = null;
     WrongRegionException wre = null;
     long transactionId = request.getTransactionId();
@@ -854,6 +855,10 @@ CoprocessorService, Coprocessor {
        if (LOG.isTraceEnabled()) LOG.trace("TrxRegionEndpoint coprocessor: commitRequest - txId " + transactionId + ", Caught UnknownTransactionException after internal commitRequest call - " + u.toString());
        ute = u;
        status = COMMIT_UNSUCCESSFUL_FROM_COPROCESSOR;
+    } catch (CommitConflictException c) {
+       if (LOG.isTraceEnabled()) LOG.trace("TrxRegionEndpoint coprocessor: commitRequest - txId " + transactionId + ", Caught CommitConflictException after internal commitRequest call - "+ c.toString());
+       cce = c;
+       status = COMMIT_CONFLICT;
     } catch (IOException e) {
        if (LOG.isTraceEnabled()) LOG.trace("TrxRegionEndpoint coprocessor: commitRequest - txId " + transactionId + ", Caught IOException after internal commitRequest call - "+ e.toString());
        ioe = e;
@@ -868,6 +873,12 @@ CoprocessorService, Coprocessor {
     {
       commitRequestResponseBuilder.setHasException(true);
       commitRequestResponseBuilder.setException(t.toString());
+    }
+    
+    if (cce != null)
+    {
+      commitRequestResponseBuilder.setHasException(true);
+      commitRequestResponseBuilder.setException(cce.toString());
     }
 
     if (wre != null)
@@ -5730,18 +5741,25 @@ CoprocessorService, Coprocessor {
    * @return TransactionRegionInterface commit code
    * @throws IOException
    */
-  public int commitRequest(final long transactionId, final long startEpoch, final int participantNum) throws IOException, UnknownTransactionException {
+  public int commitRequest(final long transactionId, final long startEpoch, final int participantNum) 
+                                                 throws IOException,
+                                                 CommitConflictException,
+                                                 UnknownTransactionException {
      return commitRequest(transactionId, startEpoch, participantNum, true, false);
   }
 
   public int commitRequest(final long transactionId, final long startEpoch, final int participantNum, final boolean dropTableRecorded)
-                                                    throws IOException, UnknownTransactionException {
+                                                 throws IOException,
+                                                 CommitConflictException,
+                                                 UnknownTransactionException {
       return commitRequest(transactionId, startEpoch, participantNum, true, dropTableRecorded);
   }
   
   public int commitRequest(final long transactionId, final long startEpoch, final int participantNum, boolean flushHLOG,
-                                                               boolean dropTableRecorded) throws IOException,
-                                                                                UnknownTransactionException {
+                                                               boolean dropTableRecorded) 
+                                                 throws IOException,
+                                                 CommitConflictException,
+                                                 UnknownTransactionException {
     long txid = 0;
     String lv_regionName = new String(m_Region.getRegionInfo().getRegionNameAsString());
     if (LOG.isDebugEnabled()) LOG.debug("TrxRegionEndpoint coprocessor: commitRequest -- ENTRY txId: "
@@ -5797,7 +5815,9 @@ CoprocessorService, Coprocessor {
       hasConflictStartTime = System.nanoTime();
 
     synchronized (commitCheckLock) {
-      if (hasConflict(state)) {
+      try{
+          checkConflict(state);
+      } catch (IOException e) {
         if (LOG.isInfoEnabled()) {
           hasConflictEndTime = System.nanoTime();
           hasConflictTimes[lv_timeIndex] = hasConflictEndTime - hasConflictStartTime;
@@ -5806,8 +5826,8 @@ CoprocessorService, Coprocessor {
         state.setStatus(Status.ABORTED);
         retireTransaction(state, true);
         if (LOG.isTraceEnabled()) LOG.trace("TrxRegionEndpoint coprocessor: commitRequest encountered conflict txId: "
-                 + transactionId + "returning COMMIT_CONFLICT");
-        return COMMIT_CONFLICT;
+                 + transactionId + "returning COMMIT_CONFLICT", e);
+        throw new CommitConflictException(e);
       }
 
       if (LOG.isInfoEnabled()) 
@@ -6020,7 +6040,8 @@ CoprocessorService, Coprocessor {
    * @param TrxTransactionState state
    * @return boolean
    */
-  private boolean hasConflict(final TrxTransactionState state) {
+  private void checkConflict(final TrxTransactionState state)
+                                        throws IOException {
     // Check transactions that were committed while we were running
       
     synchronized (commitedTransactionsBySequenceNumber) {
@@ -6036,8 +6057,8 @@ CoprocessorService, Coprocessor {
         state.addTransactionToCheck(other);
       }
     }
-
-    return state.hasConflict();
+    state.checkConflict();
+    return;
   }
 
   public void abortTransaction(final long transactionId) throws IOException, UnknownTransactionException {

--- a/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/regionserver/transactional/TrxTransactionState.java.tmpl
+++ b/core/sqf/src/seatrans/hbase-trx/src/main/java/org/apache/hadoop/hbase/regionserver/transactional/TrxTransactionState.java.tmpl
@@ -426,33 +426,17 @@ public class TrxTransactionState extends TransactionState {
         transactionsToCheck.add(transaction);
     }
 
-    public synchronized boolean hasConflict() {
+    public synchronized void checkConflict() throws IOException {
 
         for (TrxTransactionState transactionState : transactionsToCheck) {
-            try {
-                if (hasConflict(transactionState)) {
-                    if (LOG.isTraceEnabled())
-                        LOG.trace("TrxTransactionState hasConflict: Returning true for " + transactionState.toString()
-                                + ", regionInfo is [" + regionInfo.getRegionNameAsString() + "]");
-                    return true;
-                }
-            } catch (Exception e) {
-                // We are unable to ascertain if we have had a conflict with
-                // the rows we are trying to modify. We will return true,
-                // indicating that we can not allow the pending changes
-                // for this transaction to commit.
-                LOG.error("TrxTransactionState hasConflict: Returning true. Caught exception for transaction "
-                        + transactionState.toString() + ", regionInfo is [" + regionInfo.getRegionNameAsString()
-                        + "], exception ", e);
-                return true;
-            }
+              checkConflict(transactionState);
         }
-        return false;
     }
 
-    private boolean hasConflict(final TrxTransactionState checkAgainst) throws Exception {
+    private void checkConflict(final TrxTransactionState checkAgainst) 
+                                                           throws IOException {
         if (checkAgainst.getStatus().equals(TransactionState.Status.ABORTED)) {
-            return false; // Cannot conflict with aborted transactions
+            return; // Cannot conflict with aborted transactions
         }
 
         ListIterator<WriteAction> writeOrderIter = null;
@@ -465,6 +449,7 @@ public class TrxTransactionState extends TransactionState {
                 if (row == null) {
                     LOG.warn("TrxTransactionState hasConflict: row is null - this Transaction [" + this.toString()
                             + "] checkAgainst Transaction [" + checkAgainst.toString() + "] ");
+                    //continue; ??
                 }
                 if (this.getTransactionId() == checkAgainst.getTransactionId()) {
                     if (LOG.isTraceEnabled())
@@ -482,35 +467,35 @@ public class TrxTransactionState extends TransactionState {
                             if (LOG.isTraceEnabled())
                                 LOG.trace("Transaction [" + this.toString() + "] scansRange is null");
                         if (scanRange != null && scanRange.contains(row)) {
-                            LOG.warn("Transaction [" + this.toString() + "] has scan which conflicts with ["
-                                    + checkAgainst.toString() + "]: region [" + regionInfo.getRegionNameAsString()
-                                    + "], scanRange[" + scanRange.toString() + "] ,row[" + Bytes.toStringBinary(row) + "]");
-                            return true;
+                            String tmp = (otherUpdate.isDelete())? ", deleted":", inserted";
+                            String msg = "Transaction [" + this.toString() + "] has scan which conflicts with ["
+                                    + checkAgainst.toString() + "]: region [" + regionInfo.getRegionNameAsString() 
+                                    + "], scanRange[" + scanRange.toString() + "]"
+                                    +  tmp
+                                    + " row[" + Bytes.toStringBinary(row) + "]";
+                                    
+                            throw new IOException(msg);
                         }
-                        // else {
-                        // LOG.trace("Transaction [" + this.toString() + "] has scanRange checked against ["
-                        // + checkAgainst.toString() + "]: region [" + regionInfo.getRegionNameAsString()
-                        // + "], scanRange[" + scanRange.toString() + "] ,row[" + Bytes.toStringBinary(row) + "]");
-                        // }
                     }
                 } else {
-                    if (this.scans == null)
-                        LOG.trace("Transaction [" + this.toString() + "] scans was equal to null");
-                    else
-                        LOG.trace("Transaction [" + this.toString() + "] scans was empty ");
+                    if (LOG.isTraceEnabled()) {
+                        if (this.scans == null)
+                            LOG.trace("Transaction [" + this.toString() + "] scans was equal to null");
+                        else
+                            LOG.trace("Transaction [" + this.toString() + "] scans was empty ");
+                    }
                 }
-            } catch (Exception e) {
+            } catch (IOException e) {
                if (checkAgainst.getStatus().equals(TransactionState.Status.ABORTED)){
-                  return false;
+                  return;
                }
                else {
-                  LOG.warn("TrxTransactionState hasConflict: Unable to get row - this Transaction [" + this.toString()
-                       + "] checkAgainst Transaction [" + checkAgainst.toString() + "] " + " Exception: ", e);
+                  LOG.warn("TrxTransactionState hasConflict: Exception: ", e);
                   throw e;
                }
             }
         }
-        return false;
+        return;
     }
 
     public WALEdit getEdit() {
@@ -920,6 +905,15 @@ public class TrxTransactionState extends TransactionState {
             return delete;
         }
 
+        public boolean isDelete() {
+          if (put != null) {
+            return false;
+        } else if (delete != null) {
+            return true;
+          }
+          throw new IllegalStateException("WriteAction is invalid");
+        }
+        
         public synchronized byte[] getRow() {
             if (put != null) {
                 return put.getRow();

--- a/core/sqf/src/seatrans/tm/hbasetmlib2/hbasetm.cpp
+++ b/core/sqf/src/seatrans/tm/hbasetmlib2/hbasetm.cpp
@@ -333,7 +333,7 @@ short CHbaseTM::prepareCommit(int64 pv_transid , char *errstr, int &errstrlen) {
   }
 
   jshort jresult = _tlp_jenv->CallShortMethod(javaObj_, JavaMethods_[JM_PRECOMMIT].methodID, jlv_transid);
-  if (getExceptionDetails(lv_joi_retcode, NULL)) {
+  if (getExceptionDetails(NULL, (short*)&lv_joi_retcode)) {
       int errMsgLen = (int)_tlp_error_msg->length();
       errstrlen = ((errMsgLen < errstrlen) && (errMsgLen > 0)) ? errMsgLen  : errstrlen -1;
       strncpy(errstr, _tlp_error_msg->c_str(), errstrlen);

--- a/core/sqf/src/seatrans/tm/hbasetmlib2/hbasetm.cpp
+++ b/core/sqf/src/seatrans/tm/hbasetmlib2/hbasetm.cpp
@@ -323,7 +323,7 @@ short CHbaseTM::abortTransaction(int64 pv_transid) {
 }
 
 
-short CHbaseTM::prepareCommit(int64 pv_transid) {
+short CHbaseTM::prepareCommit(int64 pv_transid , char *errstr, int &errstrlen) {
   jlong   jlv_transid = pv_transid;
   JOI_RetCode lv_joi_retcode = JOI_OK;
   lv_joi_retcode = initJNIEnv();
@@ -333,10 +333,24 @@ short CHbaseTM::prepareCommit(int64 pv_transid) {
   }
 
   jshort jresult = _tlp_jenv->CallShortMethod(javaObj_, JavaMethods_[JM_PRECOMMIT].methodID, jlv_transid);
-  if (getExceptionDetails(NULL)) {
-     tm_log_write(DTM_TM_JNI_ERROR, SQ_LOG_ERR, (char *)"CHbaseTM::prepareCommit()", (char *)_tlp_error_msg->c_str(), pv_transid);
-     _tlp_jenv->PopLocalFrame(NULL);
-     return RET_EXCEPTION;
+  if (getExceptionDetails(lv_joi_retcode, NULL)) {
+      int errMsgLen = (int)_tlp_error_msg->length();
+      errstrlen = ((errMsgLen < errstrlen) && (errMsgLen > 0)) ? errMsgLen  : errstrlen -1;
+      strncpy(errstr, _tlp_error_msg->c_str(), errstrlen);
+      errstr[errstrlen] = '\0';
+      tm_log_write(DTM_TM_JNI_ERROR, SQ_LOG_ERR,(char*)"CHbaseTM::prepareCommit()", (char *)_tlp_error_msg->c_str(), pv_transid);
+     
+     //If an exception is received, it is only due to some issue.
+     //Exception can come back with error code set or not set.
+     //If there is an error code passed as part of exception, pass this
+     //back to my caller. Else return RET_EXCEPTION; 
+     if(lv_joi_retcode != JOI_OK)
+       jresult = lv_joi_retcode;
+     else
+     {
+       _tlp_jenv->PopLocalFrame(NULL);
+       return RET_EXCEPTION;
+     }
   }
 
   _tlp_jenv->PopLocalFrame(NULL);

--- a/core/sqf/src/seatrans/tm/hbasetmlib2/hbasetm.h
+++ b/core/sqf/src/seatrans/tm/hbasetmlib2/hbasetm.h
@@ -174,7 +174,7 @@ public:
    // TM interface methods
    short initConnection(short pv_nid);
    short beginTransaction(int64 *pp_transid);
-   short prepareCommit(int64 pv_transid);
+   short prepareCommit(int64 pv_transid, char *errstr, int &errstrlen);
    short doCommit(int64 pv_transid);
    short tryCommit(int64 pv_transid);
    short completeRequest(int64 pv_transid);

--- a/core/sqf/src/seatrans/tm/hbasetmlib2/javaobjectinterfacetm.cpp
+++ b/core/sqf/src/seatrans/tm/hbasetmlib2/javaobjectinterfacetm.cpp
@@ -422,6 +422,15 @@ bool  JavaObjectInterfaceTM::getExceptionDetails(JNIEnv *jenv, short *errCode)
       set_error_msg(error_msg);
       return false;
    }
+   
+   if(!jenv->ExceptionCheck())
+   {
+     //jenv_->ExceptionCheck() is a light weight call
+     //to determine exception exists. Return here if 
+     //no exception object to probe.
+     return false;
+   }
+   
    if (gThrowableClass == NULL)
    {
       jenv->ExceptionDescribe();
@@ -429,6 +438,7 @@ bool  JavaObjectInterfaceTM::getExceptionDetails(JNIEnv *jenv, short *errCode)
       set_error_msg(error_msg);
       return false;
    }
+   
    jthrowable a_exception = jenv->ExceptionOccurred();
    if (a_exception == NULL)
    {
@@ -509,6 +519,10 @@ short JavaObjectInterfaceTM::getExceptionErrorCode(JNIEnv *jenv, jthrowable a_ex
     {
       errCode =(jshort) jenv->CallShortMethod(a_exception,
                                               gGetErrorCodeMethodID);
+      if(jenv->ExceptionCheck())
+      {
+        jenv->ExceptionClear();
+      }
     }
   }
   return errCode;

--- a/core/sqf/src/seatrans/tm/hbasetmlib2/javaobjectinterfacetm.h
+++ b/core/sqf/src/seatrans/tm/hbasetmlib2/javaobjectinterfacetm.h
@@ -140,8 +140,7 @@ public:
   {
     return isInitialized_;
   }
-  bool getExceptionDetails(JNIEnv *jenv);
-  bool getExceptionDetails(JOI_RetCode &retCode, JNIEnv *jenv);
+  bool getExceptionDetails(JNIEnv *jenv, short *errCode = NULL);
   void appendExceptionMessages(JNIEnv *jenv, jthrowable a_exception, std::string &error_msg);
   short getExceptionErrorCode(JNIEnv *jenv, jthrowable a_exception);
   
@@ -155,10 +154,12 @@ protected:
   int       debugTimeout_;
   static jclass gThrowableClass;
   static jclass gStackTraceClass;
+  static jclass gTransactionManagerExceptionClass;
   static jmethodID gGetStackTraceMethodID;
   static jmethodID gThrowableToStringMethodID;
   static jmethodID gStackFrameToStringMethodID;
   static jmethodID gGetCauseMethodID;
+  static jmethodID gGetErrorCodeMethodID;
 };
 
 void set_error_msg(std::string &error_msg); 

--- a/core/sqf/src/seatrans/tm/hbasetmlib2/javaobjectinterfacetm.h
+++ b/core/sqf/src/seatrans/tm/hbasetmlib2/javaobjectinterfacetm.h
@@ -141,7 +141,9 @@ public:
     return isInitialized_;
   }
   bool getExceptionDetails(JNIEnv *jenv);
+  bool getExceptionDetails(JOI_RetCode &retCode, JNIEnv *jenv);
   void appendExceptionMessages(JNIEnv *jenv, jthrowable a_exception, std::string &error_msg);
+  short getExceptionErrorCode(JNIEnv *jenv, jthrowable a_exception);
   
 protected:
   static JavaVM*   jvm_;

--- a/core/sqf/src/seatrans/tm/hbasetmlib2/src/main/java/org/trafodion/dtm/HBaseTxClient.java
+++ b/core/sqf/src/seatrans/tm/hbasetmlib2/src/main/java/org/trafodion/dtm/HBaseTxClient.java
@@ -67,6 +67,7 @@ import org.apache.hadoop.hbase.NotServingRegionException;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.trafodion.dtm.HBaseTmZK;
 import org.trafodion.dtm.TmAuditTlog;
+import org.trafodion.dtm.TransactionManagerException;
 
 import org.apache.hadoop.hbase.regionserver.transactional.IdTm;
 import org.apache.hadoop.hbase.regionserver.transactional.IdTmException;
@@ -476,7 +477,9 @@ public class HBaseTxClient {
       return TransReturnCode.RET_OK.getShort();
    }
 
-   public short prepareCommit(long transactionId) throws IOException {
+   public short prepareCommit(long transactionId) throws 
+                                                 TransactionManagerException,
+                                                 IOException{
      if (LOG.isDebugEnabled()) LOG.debug("Enter prepareCommit, txid: " + transactionId);
      if (LOG.isTraceEnabled()) LOG.trace("mapTransactionStates " + mapTransactionStates + " entries " + mapTransactionStates.size());
         TransactionState ts = mapTransactionStates.get(transactionId);
@@ -499,22 +502,41 @@ public class HBaseTxClient {
              if (LOG.isTraceEnabled()) LOG.trace("Exit OK_READ_ONLY prepareCommit, txid: " + transactionId);
              return TransReturnCode.RET_READONLY.getShort();
           case TransactionalReturn.COMMIT_UNSUCCESSFUL:
-             LOG.info("Exit RET_EXCEPTION prepareCommit, txid: " + transactionId);
-             return TransReturnCode.RET_EXCEPTION.getShort();
+             if(!ts.getRecordedException().isEmpty())
+               throw new TransactionManagerException(ts.getRecordedException(),
+                                     TransReturnCode.RET_EXCEPTION.getShort());
+             else
+               throw new TransactionManagerException("Encountered COMMIT_UNSUCCESSFUL Exception, txid:" + transactionId,
+                                     TransReturnCode.RET_EXCEPTION.getShort());
           case TransactionalReturn.COMMIT_CONFLICT:
-             LOG.info("Exit RET_HASCONFLICT prepareCommit, txid: " + transactionId);
-             return TransReturnCode.RET_HASCONFLICT.getShort();
+             if(! ts.getRecordedException().isEmpty())
+               throw new TransactionManagerException(ts.getRecordedException(),
+                                   TransReturnCode.RET_HASCONFLICT.getShort());
+             else
+               throw new TransactionManagerException("Encountered COMMIT_CONFLICT Exception, txid:" + transactionId,
+                                   TransReturnCode.RET_HASCONFLICT.getShort());
           default:
-             LOG.info("Exit default RET_EXCEPTION prepareCommit, txid: " + transactionId);
-             return TransReturnCode.RET_EXCEPTION.getShort();
+             if(! ts.getRecordedException().isEmpty())
+               throw new TransactionManagerException(ts.getRecordedException(),
+                                   TransReturnCode.RET_EXCEPTION.getShort());
+             else
+               throw new TransactionManagerException("Encountered COMMIT_UNSUCCESSFUL Exception, txid:" + transactionId,
+                                   TransReturnCode.RET_EXCEPTION.getShort());
+             
         }
-     } catch (CommitUnsuccessfulException e) {
+     }catch (TransactionManagerException t) {
+       LOG.error("Returning from HBaseTxClient:prepareCommit, txid: " + transactionId + " retval: " + t.getErrorCode(), t);
+       throw t;
+     } 
+     catch (CommitUnsuccessfulException e) {
        LOG.error("Returning from HBaseTxClient:prepareCommit, txid: " + transactionId + " retval: " + TransReturnCode.RET_NOCOMMITEX.toString() + " CommitUnsuccessfulException", e);
-       return TransReturnCode.RET_NOCOMMITEX.getShort();
+       throw new TransactionManagerException(e,
+                                   TransReturnCode.RET_NOCOMMITEX.getShort());
      }
      catch (IOException e) {
        LOG.error("Returning from HBaseTxClient:prepareCommit, txid: " + transactionId + " retval: " + TransReturnCode.RET_IOEXCEPTION.toString() + " IOException", e);
-       return TransReturnCode.RET_IOEXCEPTION.getShort();
+       throw new TransactionManagerException(e,
+                                   TransReturnCode.RET_IOEXCEPTION.getShort());
      }
    }
 

--- a/core/sqf/src/seatrans/tm/hbasetmlib2/src/main/java/org/trafodion/dtm/TransactionManagerException.java
+++ b/core/sqf/src/seatrans/tm/hbasetmlib2/src/main/java/org/trafodion/dtm/TransactionManagerException.java
@@ -1,0 +1,70 @@
+/**
+* @@@ START COPYRIGHT @@@
+*
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*   http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing,
+* software distributed under the License is distributed on an
+* "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+* KIND, either express or implied.  See the License for the
+* specific language governing permissions and limitations
+* under the License.
+*
+* @@@ END COPYRIGHT @@@
+**/
+
+package org.trafodion.dtm;
+import java.io.IOException;
+
+/** Thrown when a transaction conflicts with another transaction. 
+ * 
+ */
+public class TransactionManagerException extends IOException {
+
+  private static final long serialVersionUID = 7062921444531109202L;
+  private static short errorCode;
+
+  /** Default Constructor */
+  public TransactionManagerException() {
+    super();
+    errorCode = 0;
+  }
+
+  /**
+   * @param arg0 message
+   * @param arg1 cause
+   */
+  public TransactionManagerException(String arg0, Throwable arg1, short errCode) {
+    super(arg0, arg1);
+    errorCode = errCode;
+  }
+
+  /**
+   * @param arg0 message
+   */
+  public TransactionManagerException(String arg0, short errCode) {
+    super(arg0);
+    errorCode = errCode;
+  }
+
+  /**
+   * @param arg0 cause
+   */
+  public TransactionManagerException(Throwable arg0, short errCode) {
+    super(arg0);
+    errorCode = errCode;
+  }
+  
+  public short getErrorCode(){
+    return errorCode;
+  }
+
+}

--- a/core/sqf/src/seatrans/tm/hbasetmlib2/testrun.cpp
+++ b/core/sqf/src/seatrans/tm/hbasetmlib2/testrun.cpp
@@ -39,6 +39,8 @@ int main () {
    short lv_retcode = 0;
    long  lv_txid = 20500;
    short lv_dtmid = 0;
+   char *errStr = NULL;
+   int   errStrLen = 0;
    long ctrlPtNum;
    CHbaseTM *lp_myHbaseTM = 0;
 
@@ -58,7 +60,7 @@ int main () {
    lp_myHbaseTM->beginTransaction(&lv_txid);
    printf("After lp_myHbaseTM->beginTransaction, transactionId = %ld \n", lv_txid);
 
-   lv_retcode = lp_myHbaseTM->prepareCommit(lv_txid);
+   lv_retcode = lp_myHbaseTM->prepareCommit(lv_txid, errStr, errStrLen);
    printf("After lp_myHbaseTM->prepareCommit(transactionId = %ld), retcode = %d \n", lv_txid, lv_retcode);
 
    lv_retcode = lp_myHbaseTM->participatingRegions(lv_txid);
@@ -127,7 +129,7 @@ int main () {
    lp_myHbaseTM->beginTransaction(&lv_txid);
    printf("After lp_myHbaseTM->beginTransaction, transactionId = %ld \n", lv_txid);
 
-   lv_retcode = lp_myHbaseTM->prepareCommit(lv_txid);
+   lv_retcode = lp_myHbaseTM->prepareCommit(lv_txid, errStr, errStrLen);
    printf("After lp_myHbaseTM->prepareCommit(transactionId = %ld), retcode = %d \n", lv_txid, lv_retcode);
 
    lv_retcode = lp_myHbaseTM->participatingRegions(lv_txid);

--- a/core/sqf/src/tm/tmlib.cpp
+++ b/core/sqf/src/tm/tmlib.cpp
@@ -965,7 +965,10 @@ short BEGINTX(int *pp_tag, int pv_timeout, int64 pv_type_flags)
 void DEALLOCATE_ERR(char *&errStr)
 {
   if(errStr)
+  {
     delete errStr;
+    errStr = NULL;
+  }
 }
 
 //--------------------------------------------------------------------

--- a/core/sqf/src/tm/tmlib.cpp
+++ b/core/sqf/src/tm/tmlib.cpp
@@ -957,6 +957,18 @@ short BEGINTX(int *pp_tag, int pv_timeout, int64 pv_type_flags)
 } //BEGINTX
 
 //--------------------------------------------------------------------
+//DEALLOCATE_ERR
+//
+//Purpose   : Called subsequent to ENDTRANSACTION_ERR
+//Params    : none
+//--------------------------------------------------------------------
+void DEALLOCATE_ERR(char *&errStr)
+{
+  if(errStr)
+    delete errStr;
+}
+
+//--------------------------------------------------------------------
 //ENDTRANSACTION
 //
 //Purpose   : end the current transaction
@@ -967,8 +979,7 @@ short ENDTRANSACTION()
   char *errStr = NULL;
   int   errlen = 0;
   short lv_error = ENDTRANSACTION_ERR(errStr,errlen);
-  if(errStr && errlen)
-    delete errStr;
+  DEALLOCATE_ERR(errStr);
   return lv_error;
 }
 // --------------------------------------------------------------------

--- a/core/sqf/src/tm/tmlib.cpp
+++ b/core/sqf/src/tm/tmlib.cpp
@@ -956,13 +956,28 @@ short BEGINTX(int *pp_tag, int pv_timeout, int64 pv_type_flags)
     return lv_error;
 } //BEGINTX
 
+//--------------------------------------------------------------------
+//ENDTRANSACTION
+//
+//Purpose   : end the current transaction
+//Params    : none
+//--------------------------------------------------------------------
+short ENDTRANSACTION()
+{
+  char *errStr = NULL;
+  int   errlen = 0;
+  short lv_error = ENDTRANSACTION_ERR(errStr,errlen);
+  if(errStr && errlen)
+    delete errStr;
+  return lv_error;
+}
 // --------------------------------------------------------------------
 // ENDTRANSACTION
 //
 // Purpose   : end the current transaction
 // Params    : none
 // --------------------------------------------------------------------
-short ENDTRANSACTION() 
+short ENDTRANSACTION_ERR(char *&errStr, int &errlen) 
 {
     short lv_error = FEOK;
     // instantiate a gp_trans_thr object for this thread if needed.
@@ -979,7 +994,7 @@ short ENDTRANSACTION()
      }
 
     TMlibTrace(("TMLIB_TRACE : ENDTRANSACTION ENTRY: txid: %d\n", lp_trans->getTransid()->get_seq_num()), 1);
-    lv_error =  lp_trans->end();
+    lv_error =  lp_trans->end(errStr, errlen);
     TMlibTrace(("TMLIB_TRACE : ENDTRANSACTION EXIT: txid: %d\n", lp_trans->getTransid()->get_seq_num()), 1);
 
      // cleanup for legacy API

--- a/core/sqf/src/tm/tmlibmsg.h
+++ b/core/sqf/src/tm/tmlibmsg.h
@@ -848,6 +848,8 @@ typedef struct _tmlibmsg_h_as_35 {
 } Begin_Trans_Rsp_Type;
 
 typedef struct _tmlibmsg_h_as_36 {
+  char      iv_err_str[TM_MAX_ERROR_STRING];
+  int       iv_err_str_len;
 } End_Trans_Rsp_Type;
 
 typedef struct _tmlibmsg_h_as_37 {

--- a/core/sqf/src/tm/tmrm.h
+++ b/core/sqf/src/tm/tmrm.h
@@ -54,7 +54,7 @@ class RM_Info
       virtual int32 end_branches (CTmTxBase *pp_txn, int64 pv_flags) = 0;  
       virtual int32 forget_branches (CTmTxBase *pp_txn, int64 pv_flags) = 0;    
       virtual int32 forget_heur_branches (CTmTxBase *pp_txn, int64 pv_flags) = 0; 
-      virtual int32 prepare_branches (CTmTxBase *pp_txn, int64 pv_flags) = 0;
+      virtual int32 prepare_branches (CTmTxBase *pp_txn, int64 pv_flags, CTmTxMessage * pp_msg) = 0;
       virtual int32 rollback_branches (CTmTxBase *pp_txn, int64 pv_flags, CTmTxMessage * pp_msg,
                               bool lv_error_condition = false) = 0;       
       virtual int32 start_branches (CTmTxBase *pp_txn, int64 pv_flags, CTmTxMessage * pp_msg) = 0;

--- a/core/sqf/src/tm/tmrmhbase.cpp
+++ b/core/sqf/src/tm/tmrmhbase.cpp
@@ -306,12 +306,17 @@ int32 RM_Info_HBASE::forget_branches (CTmTxBase *pp_txn, int64 pv_flags)
 // prepare_branches
 // Purpose : Send prepare to HBase TM Library
 // ------------------------------------------------------------
-int32 RM_Info_HBASE::prepare_branches (CTmTxBase *pp_txn, int64 pv_flags)
+int32 RM_Info_HBASE::prepare_branches (CTmTxBase *pp_txn, int64 pv_flags, CTmTxMessage * pp_msg)
 {
    TMTrace (2, ("RM_Info_HBASE::prepare_branches, Txn ID (%d,%d), ENTRY, flags " PFLL "\n",
                 pp_txn->node(), pp_txn->seqnum(), pv_flags));
 
-   short lv_err = gv_HbaseTM.prepareCommit(pp_txn->legacyTransid());
+   pp_msg->response()->u.iv_end_trans.iv_err_str_len = 
+     sizeof(pp_msg->response()->u.iv_end_trans.iv_err_str);
+   
+   short lv_err = gv_HbaseTM.prepareCommit(pp_txn->legacyTransid(),
+                             pp_msg->response()->u.iv_end_trans.iv_err_str,
+                             pp_msg->response()->u.iv_end_trans.iv_err_str_len);
 
    TMTrace (2, ("RM_Info_HBASE::prepare_branches, Txn ID (%d,%d), EXIT, Error %d, UnResolved branches %d.\n",
                 pp_txn->node(), pp_txn->seqnum(), lv_err, num_rms_unresolved(pp_txn)));

--- a/core/sqf/src/tm/tmrmhbase.h
+++ b/core/sqf/src/tm/tmrmhbase.h
@@ -49,7 +49,7 @@ class RM_Info_HBASE :public virtual RM_Info
       virtual int32 end_branches (CTmTxBase *pp_txn, int64 pv_flags);  
       virtual int32 forget_branches (CTmTxBase *pp_txn, int64 pv_flags);    
       virtual int32 forget_heur_branches (CTmTxBase *pp_txn, int64 pv_flags); 
-      virtual int32 prepare_branches (CTmTxBase *pp_txn, int64 pv_flags);
+      virtual int32 prepare_branches (CTmTxBase *pp_txn, int64 pv_flags, CTmTxMessage * pp_msg);
       virtual int32 rollback_branches (CTmTxBase *pp_txn, int64 pv_flags, CTmTxMessage * pp_msg,
                                        bool lv_error_condition = false);       
       virtual int32 start_branches (CTmTxBase *pp_txn, int64 pv_flags, CTmTxMessage * pp_msg);

--- a/core/sqf/src/tm/tmrmtse.cpp
+++ b/core/sqf/src/tm/tmrmtse.cpp
@@ -1333,7 +1333,7 @@ int32 RM_Info_TSE::forget_branches (CTmTxBase *pp_txn, int64 pv_flags)
 // participants are prepared (have both the partic and resolved flags
 // set on the branch.
 // ------------------------------------------------------------
-int32 RM_Info_TSE::prepare_branches (CTmTxBase *pp_txn, int64 pv_flags)
+int32 RM_Info_TSE::prepare_branches (CTmTxBase *pp_txn, int64 pv_flags, CTmTxMessage * pp_msg)
 {
    int32 lv_err = FEOK;
    int32 lv_iterations = 1;

--- a/core/sqf/src/tm/tmrmtse.h
+++ b/core/sqf/src/tm/tmrmtse.h
@@ -83,7 +83,7 @@ class RM_Info_TSE :public virtual RM_Info
       virtual int32 end_branches (CTmTxBase *pp_txn, int64 pv_flags);  
       virtual int32 forget_branches (CTmTxBase *pp_txn, int64 pv_flags);    
       virtual int32 forget_heur_branches (CTmTxBase *pp_txn, int64 pv_flags); 
-      virtual int32 prepare_branches (CTmTxBase *pp_txn, int64 pv_flags);
+      virtual int32 prepare_branches (CTmTxBase *pp_txn, int64 pv_flags, CTmTxMessage * pp_msg);
       virtual int32 rollback_branches (CTmTxBase *pp_txn, int64 pv_flags, CTmTxMessage * pp_msg,
                                        bool lv_error_condition = false);       
       virtual int32 start_branches (CTmTxBase *pp_txn, int64 pv_flags, CTmTxMessage * pp_msg);

--- a/core/sqf/src/tm/tmtransaction.cpp
+++ b/core/sqf/src/tm/tmtransaction.cpp
@@ -389,7 +389,7 @@ short TM_Transaction::begin(int abort_timeout, int64 transactiontype_bits)
 // -- end transaction
 // Trafodion: added support for local transactions.
 // --------------------------------------------------------------------------
-short TM_Transaction::end()
+short TM_Transaction::end(char* &pv_err_str, int &pv_err_len)
 {
     Tm_Req_Msg_Type lv_req;
     Tm_Rsp_Msg_Type lv_rsp;
@@ -456,6 +456,13 @@ short TM_Transaction::end()
        }
     
        iv_last_error = lv_rsp.iv_msg_hdr.miv_err.error;
+       if(iv_last_error)
+       {
+           int maxErrStrBufLen = sizeof(lv_rsp.u.iv_end_trans.iv_err_str);
+           pv_err_len = lv_rsp.u.iv_end_trans.iv_err_str_len < maxErrStrBufLen ? lv_rsp.u.iv_end_trans.iv_err_str_len : maxErrStrBufLen;
+           pv_err_str = new char[pv_err_len];
+           memcpy(pv_err_str, lv_rsp.u.iv_end_trans.iv_err_str, pv_err_len); 
+       }
     }
     TMlibTrace(("TMLIB_TRACE : TM_Transaction::end  (seq num %d) EXIT\n", iv_transid.get_seq_num()), 2);
 

--- a/core/sqf/src/tm/tmtx.cpp
+++ b/core/sqf/src/tm/tmtx.cpp
@@ -361,7 +361,7 @@ bool TM_TX_Info::state_change_commit_helper (CTmTxMessage * pp_msg, bool pv_read
 bool TM_TX_Info::state_change_prepare_helper(CTmTxMessage * pp_msg)
 {
    bool lv_continue = true;
-   int32 lv_error = branches()->prepare_branches (this, TT_flags());
+   int32 lv_error = branches()->prepare_branches (this, TT_flags(), pp_msg);
    if (iv_mark_for_rollback == true)
    {
       short lv_replyErr = FEOK;

--- a/core/sqf/src/tm/tmtxbranches.cpp
+++ b/core/sqf/src/tm/tmtxbranches.cpp
@@ -302,15 +302,16 @@ int32 CTmTxBranches::forget_branches (CTmTxBase *pp_txn,
 // return        Error2  | Error2  Error2      Error2
 // ------------------------------------------------------------
 int32 CTmTxBranches::prepare_branches (CTmTxBase *pp_txn,
-                                       int64 pv_flags)
+                                       int64 pv_flags,
+                                       CTmTxMessage *pp_msg)
 {
    int32 lv_err = XA_OK, lv_err1 = RET_OK, lv_err2 = XA_OK;
 
    TMTrace (2, ("CTmTxBranches::prepare_branches, Txn ID (%d,%d), ENTRY, flags " PFLL "\n",
                 pp_txn->node(), pp_txn->seqnum(), pv_flags));
 
-   lv_err1 = iv_HBASEBranches.prepare_branches(pp_txn, pv_flags);
-   lv_err2 = iv_TSEBranches.prepare_branches(pp_txn, pv_flags);
+   lv_err1 = iv_HBASEBranches.prepare_branches(pp_txn, pv_flags, pp_msg);
+   lv_err2 = iv_TSEBranches.prepare_branches(pp_txn, pv_flags, pp_msg);
 
    // The transaction is only read-only if both branch types return read-only.
    if (lv_err1 == RET_READONLY && 

--- a/core/sqf/src/tm/tmtxbranches.h
+++ b/core/sqf/src/tm/tmtxbranches.h
@@ -57,7 +57,7 @@ public:
    virtual int32 end_branches (CTmTxBase *pp_txn, int64 pv_flags);  
    virtual int32 forget_branches (CTmTxBase *pp_txn, int64 pv_flags);    
    virtual int32 forget_heur_branches (CTmTxBase *pp_txn, int64 pv_flags); 
-   virtual int32 prepare_branches (CTmTxBase *pp_txn, int64 pv_flags);
+   virtual int32 prepare_branches (CTmTxBase *pp_txn, int64 pv_flags, CTmTxMessage * pp_msg);
    virtual int32 rollback_branches (CTmTxBase *pp_txn, int64 pv_flags, CTmTxMessage * pp_msg,
                            bool lv_error_condition = false);       
    virtual int32 start_branches (CTmTxBase *pp_txn, int64 pv_flags, CTmTxMessage * pp_msg);

--- a/core/sqf/src/tm/tmxatxn.cpp
+++ b/core/sqf/src/tm/tmxatxn.cpp
@@ -349,7 +349,7 @@ TM_TX_STATE CTmXaTxn::state_change_commit_helper (CTmTxMessage * pp_msg, bool pv
 TM_TX_STATE CTmXaTxn::state_change_prepare_helper(CTmTxMessage * pp_msg)
 {
    TM_TX_STATE lv_nextState = tx_state();
-   int32 lv_error = mapErr(branches()->prepare_branches(this, TT_flags()));
+   int32 lv_error = mapErr(branches()->prepare_branches(this, TT_flags(), pp_msg));
    if (iv_mark_for_rollback == true)
    {
       pp_msg->responseError(FEABORTEDTRANSID);

--- a/core/sql/bin/SqlciErrors.txt
+++ b/core/sql/bin/SqlciErrors.txt
@@ -1635,7 +1635,7 @@ $1~String1 --------------------------------
 8613 25000 99999 BEGINNER MAJOR DBADMIN SQL cannot commit or rollback a transaction that was started by application.
 8614 25000 99999 ADVANCED CRTCL DIALOUT SQL cannot begin a transaction when multiple contexts exist.
 8615 ZZZZZ 99999 BEGINNER MAJOR DBADMIN A user-defined transaction has been started. Long Running Update operation cannot be performed.
-8616 ZZZZZ 99999 BEGINNER MAJOR DBADMIN A conflict was detected during commit processing. Transaction has been aborted.
+8616 ZZZZZ 99999 BEGINNER MAJOR DBADMIN A conflict was detected during commit processing. Transaction has been aborted. Detail :$0~string0
 8640 ZZZZZ 99999 UUUUUUUU UUUUU UUUUUUU ---- unused ----
 8641 ZZZZZ 99999 UUUUUUUU UUUUU UUUUUUU ---- unused ----
 8642 ZZZZZ 99999 UUUUUUUU UUUUU UUUUUUU ---- unused ----

--- a/core/sql/executor/ex_transaction.cpp
+++ b/core/sql/executor/ex_transaction.cpp
@@ -710,12 +710,12 @@ short ExTransaction::commitTransaction(NABoolean waited)
       else
         createDiagsArea (EXE_COMMIT_ERROR_FROM_TRANS_SUBSYS, rc,
                           (errStr && errlen)? errStr: "DTM");
-      
-      if(errStr && errlen)
-      {
-        delete errStr;
-      }
     }
+  
+  //Call to ENDTRANSACTION_ERR must always be followed by
+  //calling DEALLOCATE_ERR so memory of allocated error str
+  //is deallocated appropriately.
+  DEALLOCATE_ERR(errStr);
   
   if (waited)
     waitForCommitCompletion(transid_);

--- a/core/sql/executor/ex_transaction.cpp
+++ b/core/sql/executor/ex_transaction.cpp
@@ -689,8 +689,9 @@ short ExTransaction::commitTransaction(NABoolean waited)
     }
  
   Int32 rc = 0;
-
-  rc = ENDTRANSACTION();
+  char *errStr = NULL;
+  Int32 errlen = 0;
+  rc = ENDTRANSACTION_ERR(errStr,errlen);
   if (rc != 0)
     {
       if (rc == FETRANSNOWAITOUT)
@@ -704,10 +705,16 @@ short ExTransaction::commitTransaction(NABoolean waited)
 	}
 
       if (rc == FEHASCONFLICT)
-        createDiagsArea (EXE_COMMIT_CONFLICT_FROM_TRANS_SUBSYS, rc, "DTM");
+        createDiagsArea (EXE_COMMIT_CONFLICT_FROM_TRANS_SUBSYS, rc,
+                         (errStr && errlen)? errStr: "DTM");
       else
         createDiagsArea (EXE_COMMIT_ERROR_FROM_TRANS_SUBSYS, rc,
-                         "DTM");
+                          (errStr && errlen)? errStr: "DTM");
+      
+      if(errStr && errlen)
+      {
+        delete errStr;
+      }
     }
   
   if (waited)

--- a/core/sql/regress/core/EXPECTED116
+++ b/core/sql/regress/core/EXPECTED116
@@ -341,7 +341,7 @@ A1           C1           B1
 >>invoke t116t1;
 
 -- Definition of Trafodion table TRAFODION.SCH.T116T1
--- Definition current  Thu Sep 22 05:38:39 2016
+-- Definition current  Wed Dec 21 21:00:30 2016
 
   (
     SYSKEY                           LARGEINT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -359,7 +359,7 @@ A1           C1           B1
 >>invoke t116t1;
 
 -- Definition of Trafodion table TRAFODION.SCH.T116T1
--- Definition current  Thu Sep 22 05:38:39 2016
+-- Definition current  Wed Dec 21 21:00:30 2016
 
   (
     SYSKEY                           LARGEINT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -374,7 +374,7 @@ A1           C1           B1
 >>invoke t116v1;
 
 -- Definition of Trafodion view TRAFODION.SCH.T116V1
--- Definition current  Thu Sep 22 05:38:40 2016
+-- Definition current  Wed Dec 21 21:00:31 2016
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -391,7 +391,7 @@ A1           C1           B1
 >>invoke t116t1;
 
 -- Definition of Trafodion table TRAFODION.SCH.T116T1
--- Definition current  Thu Sep 22 05:38:42 2016
+-- Definition current  Wed Dec 21 21:00:43 2016
 
   (
     SYSKEY                           LARGEINT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -406,7 +406,7 @@ A1           C1           B1
 >>invoke t116v1;
 
 -- Definition of Trafodion view TRAFODION.SCH.T116V1
--- Definition current  Thu Sep 22 05:38:42 2016
+-- Definition current  Wed Dec 21 21:00:44 2016
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -423,7 +423,7 @@ A1           C1           B1
 >>invoke t116t1;
 
 -- Definition of Trafodion table TRAFODION.SCH.T116T1
--- Definition current  Thu Sep 22 05:38:45 2016
+-- Definition current  Wed Dec 21 21:00:47 2016
 
   (
     SYSKEY                           LARGEINT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -438,7 +438,7 @@ A1           C1           B1
 >>invoke t116v1;
 
 -- Definition of Trafodion view TRAFODION.SCH.T116V1
--- Definition current  Thu Sep 22 05:38:46 2016
+-- Definition current  Wed Dec 21 21:00:48 2016
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -456,7 +456,7 @@ A1           C1           B1
 >>invoke t116t1;
 
 -- Definition of Trafodion table TRAFODION.SCH.T116T1
--- Definition current  Thu Sep 22 05:38:46 2016
+-- Definition current  Wed Dec 21 21:00:48 2016
 
   (
     SYSKEY                           LARGEINT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -471,7 +471,7 @@ A1           C1           B1
 >>invoke t116v1;
 
 -- Definition of Trafodion view TRAFODION.SCH.T116V1
--- Definition current  Thu Sep 22 05:38:46 2016
+-- Definition current  Wed Dec 21 21:00:48 2016
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -488,7 +488,7 @@ A1           C1           B1
 >>invoke t116t1;
 
 -- Definition of Trafodion table TRAFODION.SCH.T116T1
--- Definition current  Thu Sep 22 05:38:51 2016
+-- Definition current  Wed Dec 21 21:01:00 2016
 
   (
     SYSKEY                           LARGEINT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -503,7 +503,7 @@ A1           C1           B1
 >>invoke t116v1;
 
 -- Definition of Trafodion view TRAFODION.SCH.T116V1
--- Definition current  Thu Sep 22 05:38:51 2016
+-- Definition current  Wed Dec 21 21:01:01 2016
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -521,7 +521,7 @@ A1           C1           B1
 >>invoke t116t1;
 
 -- Definition of Trafodion table TRAFODION.SCH.T116T1
--- Definition current  Thu Sep 22 05:38:55 2016
+-- Definition current  Wed Dec 21 21:01:07 2016
 
   (
     SYSKEY                           LARGEINT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -536,7 +536,7 @@ A1           C1           B1
 >>invoke t116v1;
 
 -- Definition of Trafodion view TRAFODION.SCH.T116V1
--- Definition current  Thu Sep 22 05:38:56 2016
+-- Definition current  Wed Dec 21 21:01:08 2016
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -595,7 +595,7 @@ End of MXCI Session
 >>invoke t116t1;
 
 -- Definition of Trafodion table TRAFODION.SCH.T116T1
--- Definition current  Thu Sep 22 05:39:13 2016
+-- Definition current  Wed Dec 21 21:01:31 2016
 
   (
     SYSKEY                           LARGEINT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -717,7 +717,7 @@ T116T1
 >>invoke t116t2;
 
 -- Definition of Trafodion table TRAFODION.SCH.T116T2
--- Definition current  Thu Sep 22 05:40:00 2016
+-- Definition current  Wed Dec 21 21:02:32 2016
 
   (
     SYSKEY                           LARGEINT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -742,7 +742,7 @@ T116T1
 >>invoke t116t2;
 
 -- Definition of Trafodion table TRAFODION.SCH.T116T2
--- Definition current  Thu Sep 22 05:40:11 2016
+-- Definition current  Wed Dec 21 21:02:51 2016
 
   (
     SYSKEY                           LARGEINT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -953,7 +953,8 @@ End of MXCI Session
 >>-- should show conflict
 >>commit work;
 
-*** ERROR[8616] A conflict was detected during commit processing. Transaction has been aborted.
+*** ERROR[8616] A conflict was detected during commit processing. Transaction has been aborted. Detail :org.trafodion.dtm.TransactionManagerException: org.apache.hadoop.hbase.coprocessor.transactional.CommitConflictException: java.io.IOException: Transaction [[transactionId: 16975 regionTX: false status: PENDING scan Size: 2 write Size: 1 startSQ: 2]] has scan which conflicts with [[transactionId: 1554361158723058 regionTX: true status: COMMITED scan Size: 2 write Size: 1 startSQ: 2 commitedSQ:2]]: region [TRAFODION.SCH.T116T6,,1482354300713.03a05b08f387a4eb4ef6323976d73e36.], scanRange[startRow: \x80\x00\x00\x01, endRow: \x80\x00\x00\x01], inserted row[\x80\x00\x00\x01]
+org.trafodion.dtm.HBaseTxClient.prepareCommit(HBaseTxClient.java:513)
 
 --- SQL operation failed with errors.
 >>select * from t116t6;
@@ -1061,7 +1062,8 @@ End of MXCI Session
 >>-- should show conflict
 >>commit work;
 
-*** ERROR[8616] A conflict was detected during commit processing. Transaction has been aborted.
+*** ERROR[8616] A conflict was detected during commit processing. Transaction has been aborted. Detail :org.trafodion.dtm.TransactionManagerException: org.apache.hadoop.hbase.coprocessor.transactional.CommitConflictException: java.io.IOException: Transaction [[transactionId: 16979 regionTX: false status: PENDING scan Size: 1 write Size: 1 startSQ: 6]] has scan which conflicts with [[transactionId: 1554361174452391 regionTX: true status: COMMITED scan Size: 1 write Size: 1 startSQ: 6 commitedSQ:6]]: region [TRAFODION.SCH.T116T6,,1482354300713.03a05b08f387a4eb4ef6323976d73e36.], scanRange[startRow: \x80\x00\x00\x01, endRow: \x80\x00\x00\x01], inserted row[\x80\x00\x00\x01]
+org.trafodion.dtm.HBaseTxClient.prepareCommit(HBaseTxClient.java:513)iona
 
 --- SQL operation failed with errors.
 >>select * from t116t6;
@@ -1170,7 +1172,8 @@ End of MXCI Session
 >>-- should show conflict
 >>commit work;
 
-*** ERROR[8616] A conflict was detected during commit processing. Transaction has been aborted.
+*** ERROR[8616] A conflict was detected during commit processing. Transaction has been aborted. Detail :org.trafodion.dtm.TransactionManagerException: org.apache.hadoop.hbase.coprocessor.transactional.CommitConflictException: java.io.IOException: Transaction [[transactionId: 16985 regionTX: false status: PENDING scan Size: 1 write Size: 1 startSQ: 11]] has scan which conflicts with [[transactionId: 1554361190181566 regionTX: true status: COMMITED scan Size: 0 write Size: 1 startSQ: 11 commitedSQ:11]]: region [TRAFODION.SCH.T116T6,,1482354300713.03a05b08f387a4eb4ef6323976d73e36.], scanRange[startRow: \x80\x00\x00\x01, endRow: \x80\x00\x00\x01], deleted row[\x80\x00\x00\x01]
+org.trafodion.dtm.HBaseTxClient.prepareCommit(HBaseTxClient.java:513)
 
 --- SQL operation failed with errors.
 >>select * from t116t6;
@@ -1274,7 +1277,8 @@ End of MXCI Session
 >>-- should show conflict
 >>commit work;
 
-*** ERROR[8616] A conflict was detected during commit processing. Transaction has been aborted.
+*** ERROR[8616] A conflict was detected during commit processing. Transaction has been aborted. Detail :org.trafodion.dtm.TransactionManagerException: org.apache.hadoop.hbase.coprocessor.transactional.CommitConflictException: java.io.IOException: Transaction [[transactionId: 16991 regionTX: false status: PENDING scan Size: 1 write Size: 1 startSQ: 15]] has scan which conflicts with [[transactionId: 1554361202764668 regionTX: true status: COMMITED scan Size: 0 write Size: 1 startSQ: 15 commitedSQ:15]]: region [TRAFODION.SCH.T116T6,,1482354300713.03a05b08f387a4eb4ef6323976d73e36.], scanRange[startRow: \x80\x00\x00\x01, endRow: \x80\x00\x00\x01], deleted row[\x80\x00\x00\x01]
+org.trafodion.dtm.HBaseTxClient.prepareCommit(HBaseTxClient.java:513)Za
 
 --- SQL operation failed with errors.
 >>select * from t116t6;
@@ -1383,7 +1387,8 @@ End of MXCI Session
 >>-- should show conflict
 >>commit work;
 
-*** ERROR[8616] A conflict was detected during commit processing. Transaction has been aborted.
+*** ERROR[8616] A conflict was detected during commit processing. Transaction has been aborted. Detail :org.trafodion.dtm.TransactionManagerException: org.apache.hadoop.hbase.coprocessor.transactional.CommitConflictException: java.io.IOException: Transaction [[transactionId: 16997 regionTX: false status: PENDING scan Size: 2 write Size: 1 startSQ: 20]] has scan which conflicts with [[transactionId: 1554361218493621 regionTX: true status: COMMITED scan Size: 1 write Size: 1 startSQ: 20 commitedSQ:20]]: region [TRAFODION.SCH.T116T6,,1482354300713.03a05b08f387a4eb4ef6323976d73e36.], scanRange[startRow: \x80\x00\x00\x01, endRow: \x80\x00\x00\x01], inserted row[\x80\x00\x00\x01]
+org.trafodion.dtm.HBaseTxClient.prepareCommit(HBaseTxClient.java:513)1
 
 --- SQL operation failed with errors.
 >>select * from t116t6;

--- a/core/sql/regress/tools/regress-filter-linux
+++ b/core/sql/regress/tools/regress-filter-linux
@@ -371,6 +371,10 @@ s/WARNING.8024.*/WARNING 8024 filtered/g
 
 s/WARNING.1389.*/WARNING 1389 Object does not exist in TRAFODION./g
 
+#Added for core/TEST116
+s/Detail :.*$/Detail @conflict details@/
+/org.TRAFODION.dtm.HBaseTxClient.prepareCommit*/d
+
 # ... NonStop(TM) SQL/MX Compiler 2.0
 #                                 ^^^
 s:\( NonStop.TM. SQL/MX Compiler \)[0-9][0-9]*\.[0-9][0-9]*:\1@version_id@:

--- a/core/sql/src/main/java/org/trafodion/sql/HBaseClient.java
+++ b/core/sql/src/main/java/org/trafodion/sql/HBaseClient.java
@@ -96,8 +96,6 @@ import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.client.DtmConst;
 import org.apache.commons.codec.binary.Hex;
 
-import org.trafodion.sql.TransactionManagerException;
-
 import com.google.protobuf.ServiceException;
 
 public class HBaseClient {
@@ -439,14 +437,9 @@ public class HBaseClient {
    public boolean createk(String tblName, Object[] tableOptions,
        Object[]  beginEndKeys, long transID, int numSplits, int keyLength,
        boolean isMVCC)
-       throws IOException, MasterNotRunningException,
-                           TransactionManagerException{
+       throws IOException, MasterNotRunningException {
             if (logger.isDebugEnabled()) logger.debug("HBaseClient.createk(" + tblName + ") called.");
             String trueStr = "TRUE";
-            //int p = 2;
-            //if(p < 5)
-              //throw new TransactionManagerException("dummy",(short) 123);
-            
             HTableDescriptor desc = new HTableDescriptor(tblName);
             addCoprocessor(desc);
             int defaultVersionsValue = 0;

--- a/core/sql/src/main/java/org/trafodion/sql/HBaseClient.java
+++ b/core/sql/src/main/java/org/trafodion/sql/HBaseClient.java
@@ -96,6 +96,8 @@ import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.client.DtmConst;
 import org.apache.commons.codec.binary.Hex;
 
+import org.trafodion.sql.TransactionManagerException;
+
 import com.google.protobuf.ServiceException;
 
 public class HBaseClient {
@@ -437,9 +439,14 @@ public class HBaseClient {
    public boolean createk(String tblName, Object[] tableOptions,
        Object[]  beginEndKeys, long transID, int numSplits, int keyLength,
        boolean isMVCC)
-       throws IOException, MasterNotRunningException {
+       throws IOException, MasterNotRunningException,
+                           TransactionManagerException{
             if (logger.isDebugEnabled()) logger.debug("HBaseClient.createk(" + tblName + ") called.");
             String trueStr = "TRUE";
+            //int p = 2;
+            //if(p < 5)
+              //throw new TransactionManagerException("dummy",(short) 123);
+            
             HTableDescriptor desc = new HTableDescriptor(tblName);
             addCoprocessor(desc);
             int defaultVersionsValue = 0;


### PR DESCRIPTION
commit conflict error detail is available in the region.
This error is raised as a commit conflict exception and carried back to
transaction manager and further back to sql client. 
Careful attention is given to make sure TM behaviour does not change
by making sure to the error codes continue to be returned along with 
new exception strings.   
Current set of change takes are of multi region transaction. 
Additional change will be checked in to support single region transactions.

Error message looks like this:
>>commit work;

*** ERROR[8616] A conflict was detected during commit processing. Transaction has been aborted. Detail :org.trafodion.dtm.TransactionManagerException: org.apache.hadoop.hbase.coprocessor.transactional.CommitConflictException: java.io.IOException: Transaction [[transactionId: 17114 regionTX: false status: PENDING scan Size: 2 write Size: 1 startSQ: 2]] has scan which conflicts with [[transactionId: 1554366944090715 regionTX: true status: COMMITED scan Size: 2 write Size: 1 startSQ: 2 commitedSQ:2]]: region [TRAFODION.SCH.T116T6,,1482359816577.c4a43321f6a96035c3deeb0d85e55ccb.], scanRange[startRow: \x80\x00\x00\x01, endRow: \x80\x00\x00\x01], inserted row[\x80\x00\x00\x01]
