### PR TITLE
[TRAFODION-2417] Installer pre-work for ambari integration

### DIFF
--- a/core/sqf/Makefile
+++ b/core/sqf/Makefile
@@ -283,6 +283,7 @@ PKG_DCS_TEST_TAR ?= "../../${DISTRIBUTION_DIR}/${PKG_DCS}-tests.tgz"
 
 PKG_BIN_OBJS ?= export/bin$(SQ_MBTYPE) export/include export/lib export/lib$(SQ_MBTYPE) export/share gdb sql/scripts sqenvcom.sh opt tools conf hbase_utilities/backup_and_restore
 
+PKG_BIN_OBJS += sysinstall
 PKG_BIN_OBJS += trafci
 PKG_BIN_OBJS += samples
 PKG_BIN_OBJS += export/limited-support-tools

--- a/core/sqf/sqenvcom.sh
+++ b/core/sqf/sqenvcom.sh
@@ -45,7 +45,7 @@ export PRODUCT_COPYRIGHT_HEADER="2015-2016 Apache Software Foundation"
 # LDAP configuration must also be setup--see
 # $TRAF_HOME/sql/scripts/traf_authentication_config for details.
 ##############################################################
-export TRAFODION_ENABLE_AUTHENTICATION=NO
+export TRAFODION_ENABLE_AUTHENTICATION=${TRAFODION_ENABLE_AUTHENTICATION:-NO}
 
 
 # default SQ_IC to TCP if it is not set in sqenv.sh. Values are
@@ -138,6 +138,10 @@ else
    export RH_MAJ_VERS=6
 fi
 export TRAF_HOME=$PWD
+
+# normal installed location, can be overridden in .trafodion
+export DCS_INSTALL_DIR=$TRAF_HOME/dcs-$TRAFODION_VER
+export REST_INSTALL_DIR=$TRAF_HOME/rest-$TRAFODION_VER
 
 # set common version to be consistent between shared lib and maven dependencies
 export HBASE_DEP_VER_CDH=1.2.0-cdh5.7.1

--- a/core/sqf/sql/scripts/install_traf_components
+++ b/core/sqf/sql/scripts/install_traf_components
@@ -147,6 +147,7 @@ else
   mv dcs-env.sh dcs-env.sh.orig
   echo "TRAF_HOME=$TRAF_HOME" > dcs-env.sh
   sed -e "s@#[ ]*export DCS_MANAGES_ZK=true@export DCS_MANAGES_ZK=false@" dcs-env.sh.orig >> dcs-env.sh
+  echo "export DCS_MASTER_PORT=$MY_DCS_MASTER_PORT" >> dcs-env.sh
   mv -f dcs-site.xml dcs-site.xml.orig
   sed -e "s@</configuration>@@" dcs-site.xml.orig > dcs-site.xml
   cat >>dcs-site.xml <<EOF
@@ -286,14 +287,10 @@ echo "Configuring TRAFCI " | tee -a ${MY_LOG_FILE}
 TRAFCI_BIN_DIR=$TRAF_HOME/trafci/bin
 if [[ -f $TRAFCI_BIN_DIR/trafci ]]
 then
-  mv $TRAFCI_BIN_DIR/trafci  $TRAFCI_BIN_DIR/trafci.orig | tee -a ${MY_LOG_FILE}
-  sed -e "s@localhost:23400@localhost:$MY_DCS_MASTER_PORT@" $TRAFCI_BIN_DIR/trafci.orig >> $TRAFCI_BIN_DIR/trafci | tee -a ${MY_LOG_FILE}
-  chmod +x $TRAFCI_BIN_DIR/trafci | tee -a ${MY_LOG_FILE}
   echo "Adding swtrafci script..." | tee -a ${MY_LOG_FILE}
   cat <<EOF >$TRAF_HOME/sql/scripts/swtrafci
 #!/bin/sh
-# command to run trafci
-$TRAF_HOME/trafci/bin/trafci.sh -h localhost:$MY_DCS_MASTER_PORT -u zz -p zz
+$TRAF_HOME/trafci/bin/trafci
 EOF
   chmod +x $TRAF_HOME/sql/scripts/swtrafci
 else

--- a/core/sqf/sysinstall/etc/init.d/trafodion
+++ b/core/sqf/sysinstall/etc/init.d/trafodion
@@ -42,7 +42,7 @@ if [ ! -f /etc/trafodion/trafodion_config ]; then
    exit 1
 fi
 . /etc/trafodion/trafodion_config
-if [ -z $SQ_ROOT ]; then
+if [ -z $TRAF_HOME ]; then
    exit 1
 fi
 TRAF_USER=${TRAF_USER:-"trafodion"}
@@ -57,7 +57,7 @@ echo "trafodion start not implemented"
 }
 
 node_stop() {
-nid=`${TRAF_SUDO_CMD} -c "${SQ_ROOT}/sql/scripts/${TRAF_SHELL_CMD} -c node info | grep -B1 ${TRAF_NODE_NAME} | grep Up | head -1 | cut -d ' ' -f 2"`
+nid=`${TRAF_SUDO_CMD} -c "${TRAF_HOME}/sql/scripts/${TRAF_SHELL_CMD} -c node info | grep -B1 ${TRAF_NODE_NAME} | grep Up | head -1 | cut -d ' ' -f 2"`
 if [ $? != 0 ]; then 
    echo -n `date` >> ${TRAF_OUT} 2>&1 </dev/null 
    echo " trafodion on ${TRAF_NODE_NAME} is already stopped" >> ${TRAF_OUT} 2>&1 </dev/null 
@@ -72,13 +72,13 @@ else
    echo "Stopping trafodion node $nid on ${TRAF_NODE_NAME}"
    echo -n `date` >> ${TRAF_OUT} 2>&1 </dev/null 
    echo " Stopping trafodion node $nid on ${TRAF_NODE_NAME}" >> ${TRAF_OUT} 2>&1 </dev/null 
-   ${TRAF_SUDO_CMD} /bin/bash -c "${SQ_ROOT}/sql/scripts/${TRAF_SHELL_CMD} -c down $nid" >> ${TRAF_OUT}  2>&1 </dev/null &
+   ${TRAF_SUDO_CMD} /bin/bash -c "${TRAF_HOME}/sql/scripts/${TRAF_SHELL_CMD} -c down $nid" >> ${TRAF_OUT}  2>&1 </dev/null &
 fi
 return 0
 }
 
 node_status() {
-nid=`${TRAF_SUDO_CMD} -c "${SQ_ROOT}/sql/scripts/${TRAF_SHELL_CMD} -c node info | grep -B1 ${TRAF_NODE_NAME} | grep Up | head -1 | cut -d ' ' -f 2"`
+nid=`${TRAF_SUDO_CMD} -c "${TRAF_HOME}/sql/scripts/${TRAF_SHELL_CMD} -c node info | grep -B1 ${TRAF_NODE_NAME} | grep Up | head -1 | cut -d ' ' -f 2"`
 if [ $? != 0 ]; then 
    echo "trafodion on node $nid is not yet started"
    return 0

--- a/core/sqf/sysinstall/etc/security/limits.d/trafodion.conf
+++ b/core/sqf/sysinstall/etc/security/limits.d/trafodion.conf
@@ -1,4 +1,3 @@
-#!/bin/sh
 # @@@ START COPYRIGHT @@@
 #
 # Licensed to the Apache Software Foundation (ASF) under one
@@ -20,28 +19,7 @@
 #
 # @@@ END COPYRIGHT @@@
 
-if [[ $# -gt 0 ]]; then
-  echo
-  echo "This wrapper script(trafci) does not accept any arguments."
-  echo "Please use trafci.sh for command line arguments"
-  echo
-  exit 1
-fi
 
-if [[ -r $DCS_INSTALL_DIR/bin/dcs-config.sh ]]
-then
-  source $DCS_INSTALL_DIR/bin/dcs-config.sh
-fi
-if [[ -n $DCS_MASTER_FLOATING_IP ]]
-then
-  MASTER_NODE=$DCS_MASTER_FLOATING_IP
-elif [[ -r $DCS_PRIMARY_MASTER ]]
-then
-  MASTER_NODE=$(cat $DCS_PRIMARY_MASTER)
-fi
-
-HNAME="${MASTER_NODE:-localhost}:${DCS_MASTER_PORT:-23400}"
-UNAME=zz
-PWORD=zz
-
-$TRAF_HOME/trafci/bin/trafci.sh -h $HNAME -u $UNAME -p $PWORD
+trafodion - nofile 32768
+trafodion - nproc  100000
+trafodion - memlock  unlimited

--- a/core/sqf/sysinstall/etc/sudoers.d/trafodion
+++ b/core/sqf/sysinstall/etc/sudoers.d/trafodion
@@ -1,4 +1,5 @@
-#!/bin/sh
+# Trafodion permissions
+
 # @@@ START COPYRIGHT @@@
 #
 # Licensed to the Apache Software Foundation (ASF) under one
@@ -20,28 +21,12 @@
 #
 # @@@ END COPYRIGHT @@@
 
-if [[ $# -gt 0 ]]; then
-  echo
-  echo "This wrapper script(trafci) does not accept any arguments."
-  echo "Please use trafci.sh for command line arguments"
-  echo
-  exit 1
-fi
+## Allow trafodion id to run commands needed for backup and restore
+trafodion ALL =(hbase) NOPASSWD: /usr/bin/hbase
 
-if [[ -r $DCS_INSTALL_DIR/bin/dcs-config.sh ]]
-then
-  source $DCS_INSTALL_DIR/bin/dcs-config.sh
-fi
-if [[ -n $DCS_MASTER_FLOATING_IP ]]
-then
-  MASTER_NODE=$DCS_MASTER_FLOATING_IP
-elif [[ -r $DCS_PRIMARY_MASTER ]]
-then
-  MASTER_NODE=$(cat $DCS_PRIMARY_MASTER)
-fi
+## Trafodion Floating IP commands
+Cmnd_Alias IP = /sbin/ip
+Cmnd_Alias ARP = /sbin/arping
 
-HNAME="${MASTER_NODE:-localhost}:${DCS_MASTER_PORT:-23400}"
-UNAME=zz
-PWORD=zz
-
-$TRAF_HOME/trafci/bin/trafci.sh -h $HNAME -u $UNAME -p $PWORD
+## Allow Trafodion id to run commands needed to configure floating IP
+trafodion ALL = NOPASSWD: IP, ARP

--- a/core/sqf/sysinstall/home/trafodion/.bashrc
+++ b/core/sqf/sysinstall/home/trafodion/.bashrc
@@ -1,0 +1,69 @@
+#!/bin/sh
+
+# @@@ START COPYRIGHT @@@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# @@@ END COPYRIGHT @@@
+
+
+# This is the .bashrc for the Trafodion environment
+#
+#-------------------------------------------
+# Execute the system's default .bashrc first
+#-------------------------------------------
+if [ -f /etc/bashrc ]; then
+	. /etc/bashrc
+fi
+
+#-------------------------------------------
+# Execute the trafodion_config script
+#-------------------------------------------
+
+if [ -f /etc/trafodion/trafodion_config ]; then
+   source /etc/trafodion/trafodion_config
+fi
+
+#-------------------------------------------
+# Execute the sqenv.sh script if it exists.
+#-------------------------------------------
+PATH=".:$PATH"
+
+if [ -f $TRAF_HOME/sqenv.sh ]; then
+        pushd . >/dev/null
+        cd $TRAF_HOME
+        source ./sqenv.sh
+        popd >/dev/null
+        export MANPATH=$MANPATH:$MPI_ROOT/share/man
+        #setup_my_nodes
+fi
+
+#-------------------------------------------
+# additional settings for Trafodion environment
+#-------------------------------------------
+ETC_SECURITY_MSG="***ERROR: To fix this please configure /etc/security/limits.conf properly on $HOSTNAME."
+
+# set core file size
+ulimit -c unlimited
+
+# set max open files
+ulimit -n 32768
+if [ $? -ne 0 ]; then
+    echo "***ERROR: Unable to set max open files. Current value $(ulimit -n)"
+    echo $ETC_SECURITY_MSG
+fi

--- a/dcs/conf/dcs-env.sh
+++ b/dcs/conf/dcs-env.sh
@@ -107,7 +107,13 @@ export DCS_OPTS="-XX:+UseConcMarkSweepGC"
 # export DCS_PID_DIR=/var/dcs/pids
 
 # Tell DCS whether it should manage it's own instance of Zookeeper or not.
-# export DCS_MANAGES_ZK=true
+export DCS_MANAGES_ZK=false
 
 # Tell DCS where the user program environment lives.
- export DCS_USER_PROGRAM_HOME=$TRAF_HOME
+export DCS_USER_PROGRAM_HOME=$TRAF_HOME
+
+# DCS master port (from dcs-site.xml)
+export DCS_MASTER_PORT=23400
+
+# DCS floating IP, if HA is enabled (from dcs-site.xml)
+export DCS_MASTER_FLOATING_IP=""

--- a/install/installer/dcs_installer
+++ b/install/installer/dcs_installer
@@ -130,33 +130,11 @@ fi
 mkdir -p $DCS_INSTALL_PATH
 cd $DCS_INSTALL_PATH
 
-if [[ "$ONE_TAR_INSTALL" == "Y" ]]; then
-   DCS_DIR=$(ls $TRAF_HOME | grep dcs)
-   DCS_DIR=$TRAF_HOME/$DCS_DIR
-   echo "***INFO: DCS Install Directory: $DCS_DIR"
-else
-   # untar DCS build into install directory
-   echo "***INFO: untarring build file $DCS_BUILD_FILE"
-   tar -xzf $DCS_BUILD_FILE
-
-   # get the dcs install directory name which is imbedded in the tar file
-   DCS_DIR=$(tar -tf $DCS_BUILD_FILE | grep --max-count=1 bin | sed -e "s@\(^.*\)/bin/@\1@")
-
-   DCS_DIR=$DCS_INSTALL_PATH/$DCS_DIR
-fi
-
-# set env var in sqenvcom.sh for DCS install directory
-grep --invert-match "DCS_INSTALL_DIR=" $TRAF_HOME/sqenvcom.sh > $TRAF_HOME/sqenvcom.temp
-echo "export DCS_INSTALL_DIR=$DCS_DIR" >> $TRAF_HOME/sqenvcom.temp
-mv $TRAF_HOME/sqenvcom.temp $TRAF_HOME/sqenvcom.sh
+DCS_DIR=$(ls $TRAF_HOME | grep dcs)
+DCS_DIR=$TRAF_HOME/$DCS_DIR
+echo "***INFO: DCS Install Directory: $DCS_DIR"
 
 cd $DCS_DIR/conf
-
-echo "***INFO: modifying $DCS_DIR/conf/dcs-env.sh"
-rm dcs-env.temp 2>/dev/null
-cat dcs-env.sh | sed -e "s@#[ ]*export DCS_MANAGES_ZK=true@export DCS_MANAGES_ZK=false@" > dcs-env.temp
-cp dcs-env.temp dcs-env.sh
-rm dcs-env.temp 2>/dev/null
 
 
 echo "***INFO: modifying $DCS_DIR/conf/dcs-site.xml"
@@ -213,15 +191,8 @@ if [[ "$ENABLE_HA" == "true" ]]; then
        echo $node >> $DCS_DIR/conf/backup-masters
    done
   
-   ######Configure trafci wrapper script to use Floating IP address
-   newHName="HNAME=$FLOATING_IP:23400"
-   sed -i -e "s/HNAME=localhost:23400/$newHName/g" $TRAF_HOME/trafci/bin/trafci
- 
-else
-
-   ######Configure trafci wrapper script
-   newHName="HNAME=$DCS_PRIMARY_MASTER_NODE:23400"
-   sed -i -e "s/HNAME=localhost:23400/$newHName/g" $TRAF_HOME/trafci/bin/trafci
+   ######Configure dcs-env.sh
+   sed -i -e "s@DCS_MASTER_FLOATING_IP=.*\$@DCS_MASTER_FLOATING_IP=$FLOATING_IP@" dcs-env.sh
 
 fi
 

--- a/install/installer/rest_installer
+++ b/install/installer/rest_installer
@@ -93,25 +93,10 @@ fi
 mkdir -p $REST_INSTALL_PATH
 cd $REST_INSTALL_PATH
 
-if [[ "$ONE_TAR_INSTALL" == "Y" ]]; then
-   REST_DIR=$(ls $TRAF_HOME | grep rest)
-   REST_DIR=$TRAF_HOME/$REST_DIR
-   echo "***INFO: Rest Install Directory: $REST_DIR"
+REST_DIR=$(ls $TRAF_HOME | grep rest)
+REST_DIR=$TRAF_HOME/$REST_DIR
+echo "***INFO: Rest Install Directory: $REST_DIR"
 
-else
-   # untar REST build into install directory
-   echo "***INFO: untarring build file $REST_BUILD_FILE"
-   tar -xzf $REST_BUILD_FILE
-
-   # get the REST install directory name which is imbedded in the tar file
-   REST_DIR=$(tar -tf $REST_BUILD_FILE | grep --max-count=1 bin | sed -e "s@\(^.*\)/bin/@\1@")
-   REST_DIR=$REST_INSTALL_PATH/$REST_DIR
-fi
-
-# set env var in sqenvcom.sh for DCS install directory
-grep --invert-match "REST_INSTALL_DIR=" $TRAF_HOME/sqenvcom.sh > $TRAF_HOME/sqenvcom.temp
-echo "export REST_INSTALL_DIR=$REST_DIR" >> $TRAF_HOME/sqenvcom.temp
-mv $TRAF_HOME/sqenvcom.temp $TRAF_HOME/sqenvcom.sh
 
 cd $REST_DIR/conf
 

--- a/install/installer/traf_add_ldap
+++ b/install/installer/traf_add_ldap
@@ -83,7 +83,7 @@ fi
 echo "***INFO: Modifying sqenvcom.sh to turn on authentication"
 sudo cp -r $TRAF_HOME/sqenvcom.sh $LOCAL_WORKDIR/sqenvcom.sh
 sudo chown $(whoami).$(whoami) $LOCAL_WORKDIR/sqenvcom.sh
-sed -i -e "s@TRAFODION_ENABLE_AUTHENTICATION=NO@TRAFODION_ENABLE_AUTHENTICATION=YES@g" $LOCAL_WORKDIR/sqenvcom.sh 
+sed -i -e 's@TRAFODION_ENABLE_AUTHENTICATION=.*$@TRAFODION_ENABLE_AUTHENTICATION=YES@g' $LOCAL_WORKDIR/sqenvcom.sh
 sudo cp $LOCAL_WORKDIR/sqenvcom.sh $HOME_DIR/$TRAF_USER/sqenvcom.sh
 sudo chown $TRAF_USER.$TRAF_GROUP $HOME_DIR/$TRAF_USER/sqenvcom.sh
 sudo chmod 664 $HOME_DIR/$TRAF_USER/sqenvcom.sh

--- a/install/python-installer/scripts/dcs_setup.py
+++ b/install/python-installer/scripts/dcs_setup.py
@@ -36,18 +36,12 @@ def run():
     TRAF_VER = dbcfgs['traf_version']
     HBASE_XML_FILE = dbcfgs['hbase_xml_file']
 
-    DCS_INSTALL_ENV = 'export DCS_INSTALL_DIR=%s/dcs-%s' % (TRAF_HOME, TRAF_VER)
-    REST_INSTALL_ENV = 'export REST_INSTALL_DIR=%s/rest-%s' % (TRAF_HOME, TRAF_VER)
-
     DCS_CONF_DIR = '%s/dcs-%s/conf' % (TRAF_HOME, TRAF_VER)
     DCS_SRV_FILE = DCS_CONF_DIR + '/servers'
     DCS_MASTER_FILE = DCS_CONF_DIR + '/master'
     DCS_BKMASTER_FILE = DCS_CONF_DIR + '/backup-masters'
-    DCS_ENV_FILE = DCS_CONF_DIR + '/dcs-env.sh'
     DCS_SITE_FILE = DCS_CONF_DIR + '/dcs-site.xml'
     REST_SITE_FILE = '%s/rest-%s/conf/rest-site.xml' % (TRAF_HOME, TRAF_VER)
-    TRAFCI_FILE = TRAF_HOME + '/trafci/bin/trafci'
-    SQENV_FILE = TRAF_HOME + '/sqenvcom.sh'
 
     ### dcs setting ###
     # servers
@@ -63,18 +57,6 @@ def run():
     # modify master
     dcs_master = nodes[0]
     append_file(DCS_MASTER_FILE, dcs_master)
-
-    # modify sqenvcom.sh
-    append_file(SQENV_FILE, DCS_INSTALL_ENV)
-    append_file(SQENV_FILE, REST_INSTALL_ENV)
-
-    # modify dcs-env.sh
-    mod_file(DCS_ENV_FILE, {'.*DCS_MANAGES_ZK=.*':'export DCS_MANAGES_ZK=false'})
-
-    ports = ParseInI(DEF_PORT_FILE, 'ports').load()
-    dcs_master_port = ports['dcs_master_port']
-    # modify trafci
-    mod_file(TRAFCI_FILE, {'HNAME=.*':'HNAME=%s:%s' % (dcs_master, dcs_master_port)})
 
     # modify dcs-site.xml
     net_interface = run_cmd('ip route |grep default|awk \'{print $5}\'')

--- a/install/python-installer/scripts/traf_ldap.py
+++ b/install/python-installer/scripts/traf_ldap.py
@@ -63,7 +63,7 @@ def run():
     #    err('Failed to access LDAP server with user %s' % DB_ROOT_USER)
 
     print 'Modfiy sqenvcom.sh to turn on authentication'
-    mod_file(SQENV_FILE, {'TRAFODION_ENABLE_AUTHENTICATION=NO':'TRAFODION_ENABLE_AUTHENTICATION=YES'})
+    mod_file(SQENV_FILE, {'TRAFODION_ENABLE_AUTHENTICATION=.*\n':'TRAFODION_ENABLE_AUTHENTICATION=YES\n'})
 
 # main
 try:


### PR DESCRIPTION
Simplify install operations for dcs and rest by setting default values
in env files. Also make trafci use config files rather than have hard-coded
setting. This reduces code in existing command-line installers.

Add system setting files to RPM. These files are stored in core/sqf/sysinstall.
The existing command-line installers could also take advantage of these files,
but it is not required, and I have not made those changes in this commit.