### PR TITLE
[TRAFODION-2418] Allow group by push-down to a fact table

### DIFF
--- a/core/sql/optimizer/TransRule.cpp
+++ b/core/sql/optimizer/TransRule.cpp
@@ -5178,8 +5178,9 @@ RelExpr * GroupByOnJoinRule::nextSubstitute(RelExpr * before,
   if (reverseT1T2)
     {
       // don't fire the rule with reversed roles if we can apply the
-      // join commutativity rule on the join
-      if (oldJoin->getGroupAttr()->getNumJoinedTables() <= 2)
+      // join commutativity rule on the join and the CQD is OFF
+      if (oldJoin->getGroupAttr()->getNumJoinedTables() <= 2 &&
+          CmpCommon::getDefault(GROUP_BY_PUSH_TO_BOTH_SIDES_OF_JOIN) != DF_ON)
         return NULL;
 
       // don't reverse the roles if the join isn't symmetric (such as a

--- a/core/sql/sqlcomp/DefaultConstants.h
+++ b/core/sql/sqlcomp/DefaultConstants.h
@@ -3878,6 +3878,8 @@ enum DefaultConstants
   // mode for AES_ENCRYPT/AED_DECRYPT
   BLOCK_ENCRYPTION_MODE,
 
+  GROUP_BY_PUSH_TO_BOTH_SIDES_OF_JOIN,
+
   // This enum constant must be the LAST one in the list; it's a count,
   // not an Attribute (it's not IN DefaultDefaults; it's the SIZE of it)!
   __NUM_DEFAULT_ATTRIBUTES

--- a/core/sql/sqlcomp/nadefaults.cpp
+++ b/core/sql/sqlcomp/nadefaults.cpp
@@ -1711,6 +1711,7 @@ SDDkwd__(EXE_DIAGNOSTIC_EVENTS,		"OFF"),
   // When less or equal to this CQD (5000 rows by default), a partial root 
   // will be running in the Master. Set to 0 to disable the feature.
   DDint__(GROUP_BY_PARTIAL_ROOT_THRESHOLD,	"5000"),
+  DDkwd__(GROUP_BY_PUSH_TO_BOTH_SIDES_OF_JOIN,    "ON"),
 
   DDkwd__(GROUP_OR_ORDER_BY_EXPR,		"ON"),
 


### PR DESCRIPTION
Trafodion has a rule that pushes a groupby down over a join when possible, but it will not push the groupby to the left child of a join - it relies on join commutativity. This might have been ok 20 years ago when this was coded (by me...), but it isn't good for some situations today. Example:

    select d.y, count(f.a), sum(f.b)
    from big_fact f join small_dim d on f.x=d.y
    where d.a = 1
    group by d.y

The plan we would like is a hash join with the group by on big_fact as the left child. To do this, we need to remove the heuristic that prevents this form of push-down.