### PR TITLE
TRAFODION-2421

### DIFF
--- a/dcs/src/main/java/org/trafodion/dcs/Constants.java
+++ b/dcs/src/main/java/org/trafodion/dcs/Constants.java
@@ -199,7 +199,7 @@ public final class Constants {
     public static final String DCS_SERVER_USER_PROGRAM_RESTART_HANDLER_RETRY_INTERVAL_MILLIS = "dcs.server.user.program.restart.handler.retry.interval.millis";
 
     /** Default value for user program restart handler retry interval millis */
-    public static final int DEFAULT_DCS_SERVER_USER_PROGRAM_RESTART_HANDLER_RETRY_INTERVAL_MILLIS = 450;
+    public static final int DEFAULT_DCS_SERVER_USER_PROGRAM_RESTART_HANDLER_RETRY_INTERVAL_MILLIS = 5000;
 
     /** Name of ZooKeeper quorum configuration parameter. */
     public static final String ZOOKEEPER_QUORUM = "dcs.zookeeper.quorum";

--- a/dcs/src/main/java/org/trafodion/dcs/Constants.java
+++ b/dcs/src/main/java/org/trafodion/dcs/Constants.java
@@ -199,7 +199,7 @@ public final class Constants {
     public static final String DCS_SERVER_USER_PROGRAM_RESTART_HANDLER_RETRY_INTERVAL_MILLIS = "dcs.server.user.program.restart.handler.retry.interval.millis";
 
     /** Default value for user program restart handler retry interval millis */
-    public static final int DEFAULT_DCS_SERVER_USER_PROGRAM_RESTART_HANDLER_RETRY_INTERVAL_MILLIS = 5000;
+    public static final int DEFAULT_DCS_SERVER_USER_PROGRAM_RESTART_HANDLER_RETRY_INTERVAL_MILLIS = 450;
 
     /** Name of ZooKeeper quorum configuration parameter. */
     public static final String ZOOKEEPER_QUORUM = "dcs.zookeeper.quorum";

--- a/dcs/src/main/java/org/trafodion/dcs/util/RetryCounter.java
+++ b/dcs/src/main/java/org/trafodion/dcs/util/RetryCounter.java
@@ -50,7 +50,7 @@ public class RetryCounter {
    */
   public void sleepUntilNextRetry() throws InterruptedException {
     int attempts = getAttemptTimes();
-    long sleepTime = (long) (retryIntervalMillis * Math.pow(2, attempts));
+    long sleepTime = (long) (retryIntervalMillis * Math.log(attempts+15));
     LOG.info("Sleeping " + sleepTime + "ms before retry #" + attempts + "...");
     timeUnit.sleep(sleepTime);
   }


### PR DESCRIPTION
once down & up a node there will cost a few time , currently the check policy of whether node up is check&wait ( (2^attempts)*5 ), the wait time is 10s-20s-40s-80s-160s-320s, totally will be 630s. 
now after check, normally, it will cost about 11s to up a node, so the first wait should be longger than 10s, and be more smooth, now there use ( log(attempts+15)*5 ), the wait time will be 13.5s-13.8s-14.1s-14.4s-14.7s-14.9s, total time is 75s.
