### PR TITLE
[TRAFODION-2351] Bulk load with log error rows enhancements

### DIFF
--- a/core/sql/executor/ExHbaseAccess.cpp
+++ b/core/sql/executor/ExHbaseAccess.cpp
@@ -3189,10 +3189,13 @@ void ExHbaseAccessTcb::buildLoggingFileName(NAHeap *heap,
                              const char *tableName,
                              const char * loggingFileNamePrefix,
                              Lng32 instId,
-                             char * loggingFileName)
+                             char *&loggingFileName)
 {
   if (loggingFileName != NULL)
      NADELETEBASIC(loggingFileName, heap);
+  loggingFileName = NULL;
+  if (currCmdLoggingLocation == NULL)
+     return;
   short logLen = strlen(currCmdLoggingLocation)+strlen(loggingFileNamePrefix)+strlen(tableName)+100;
   loggingFileName = new (heap) char[logLen];
   sprintf(loggingFileName, "%s/%s_%s_%d",
@@ -3203,7 +3206,7 @@ void ExHbaseAccessTcb::buildLoggingPath(
                              const char *loggingLocation,
                              char * logId,
                              const char * tableName,
-                             char * currCmdLoggingLocation)
+                             char *currCmdLoggingLocation)
 {
   time_t t;
   char logId_tmp[30];

--- a/core/sql/executor/ExHbaseAccess.h
+++ b/core/sql/executor/ExHbaseAccess.h
@@ -190,7 +190,7 @@ public:
                                const char *tableName,
                                const char * loggingFileNamePrefix,
                                Lng32 instId,
-                               char * loggingFileName);
+                               char *& loggingFileName);
   static short setupError(NAHeap *heap, ex_queue_pair &qparent, Lng32 retcode, const char * str, const char * str2 = NULL);
 
 protected:

--- a/core/sql/executor/ExHdfsScan.cpp
+++ b/core/sql/executor/ExHdfsScan.cpp
@@ -189,7 +189,6 @@ ExHdfsScanTcb::ExHdfsScanTcb(
 
   Lng32 fileNum = getGlobals()->castToExExeStmtGlobals()->getMyInstanceNumber();
   ExHbaseAccessTcb::buildLoggingFileName((NAHeap *)getHeap(), ((ExHdfsScanTdb &)hdfsScanTdb).getLoggingLocation(),
-                     // (char *)((ExHdfsScanTdb &)hdfsScanTdb).getErrCountRowId(),
                      ((ExHdfsScanTdb &)hdfsScanTdb).tableName(),
                      "hive_scan_err",
                      fileNum,


### PR DESCRIPTION
Changes to fix the hive failures due to core at
ExHbaseAccessTcb::buildLoggingFileName when the logging location is not set in TDB.