### PR TITLE
[TRAFODION-2422]

### DIFF
--- a/core/sql/executor/hiveHook.cpp
+++ b/core/sql/executor/hiveHook.cpp
@@ -468,7 +468,8 @@ struct hive_skey_desc* populateSortCols(HiveMetaData *md, Int32 sdID,
                   "populateSortCols::sortCols:],###"))
     return NULL;
   
-  
+  if ((foundE - pos)<=10) //this is important to avoid major performance impact when looking for non existent Order(col over and over, parsing to the end of string. hot spot flagged using gprof
+    return NULL;
   Int32 colIdx = 0;
   while (pos < foundE)
     {

--- a/core/sql/qmscommon/QRLogger.cpp
+++ b/core/sql/qmscommon/QRLogger.cpp
@@ -473,7 +473,7 @@ void QRLogger::logQVP(ULng32 eventId,
         if ( configuredLevel > requestedLevel)
           return;
     }
-  }
+  }else return;
 
   va_list args;
   va_start(args, logMsgTemplate);
@@ -598,7 +598,7 @@ void QRLogger::log(std::string &cat,
         if ( configuredLevel > requestedLevel)
           return;
     }
-  }
+  } else return;
   
   va_list args ;
   va_start(args, logMsgTemplate);
@@ -647,7 +647,7 @@ void QRLogger::log(std::string &cat,
         if ( configuredLevel > requestedLevel)
           return;
     }
-  }
+  }else return;
 
   va_list args ;
   va_start(args, logMsgTemplate);


### PR DESCRIPTION
populateSortCols was flagged as major perf offender during profiling
the reason being an unbound iterative string search on huge string.
Added a minor fix: When not setting category in log conf file, extra code is executed, potentially impacting performance