### PR TITLE
[TRAFODION-2426] Do not set hbase master log splitting property

### DIFF
--- a/core/sqf/sql/scripts/install_apache_hadoop
+++ b/core/sqf/sql/scripts/install_apache_hadoop
@@ -1480,10 +1480,6 @@ else
     <name>hbase.snapshot.enabled</name>
     <value>true</value>
   </property>
-  <property>
-    <name>hbase.master.distributed.log.splitting</name>
-    <value>false</value>
-   </property>
    <property>
      <name>hbase.hregion.impl</name>
      <value>org.apache.hadoop.hbase.regionserver.transactional.TransactionalRegion</value>

--- a/core/sqf/sql/scripts/install_local_hadoop
+++ b/core/sqf/sql/scripts/install_local_hadoop
@@ -1628,10 +1628,6 @@ echo "$MY_LOCAL_SW_DIST/${HBASE_TAR}"
     <name>hbase.snapshot.enabled</name>
     <value>true</value>
   </property>
-  <property>
-    <name>hbase.master.distributed.log.splitting</name>
-    <value>false</value>
-   </property>
    <property>
      <name>hbase.hregion.impl</name>
      <value>org.apache.hadoop.hbase.regionserver.transactional.TransactionalRegion</value>

--- a/core/sqf/sql/scripts/update_hbase
+++ b/core/sqf/sql/scripts/update_hbase
@@ -79,9 +79,6 @@ cat <<EOF >>$HBASE_CONFIG_FILE
   <property>
     <name>hbase.hlog.splitter.impl</name>
     <value>org.apache.hadoop.hbase.regionserver.transactional.THLogSplitter</value></property>
-  <property>
-    <name>hbase.master.distributed.log.splitting</name>
-    <value>false</value> </property>
 </configuration>
 EOF
 

--- a/docs/provisioning_guide/src/asciidoc/_chapters/prepare.adoc
+++ b/docs/provisioning_guide/src/asciidoc/_chapters/prepare.adoc
@@ -319,7 +319,6 @@ Do the following:
 [cols="40%l,60%l",options="header"]
 |===
 | Attribute                                    | Setting
-| hbase.master.distributed.log.splitting       | false 
 | hbase.coprocessor.region.classes^b^          | org.apache.hadoop.hbase.coprocessor.transactional.TrxRegionObserver,org.apache.hadoop.hbase.coprocessor.transactional.TrxRegionEndpoint,
 org.apache.hadoop.hbase.coprocessor.AggregateImplementation 
 | hbase.hregion.impl                           | org.apache.hadoop.hbase.regionserver.transactional.TransactionalRegion

--- a/docs/provisioning_guide/src/asciidoc/_chapters/quickstart.adoc
+++ b/docs/provisioning_guide/src/asciidoc/_chapters/quickstart.adoc
@@ -346,11 +346,6 @@ ip-172-31-56-238 ip-172-31-61-110 ip-172-31-57-143
 USERID=admin
 PASSWORD=admin
 PORT=:8080
-########## Performing 'set' hbase.master.distributed.log.splitting:true on (Site:hbase-site, Tag:version1)
-########## PUTting json into: doSet_version1467320863286001262.json
-  % Total    % Received % Xferd  Average Speed   Time    Time     Time  Current
-                                 Dload  Upload   Total   Spent    Left  Speed
-101  5757  102  3588  103  2169    98k  60930 --:--:-- --:--:-- --:--:--  100k
 {
   "resources" : [
     {

--- a/docs/provisioning_guide/src/asciidoc/_chapters/script_install.adoc
+++ b/docs/provisioning_guide/src/asciidoc/_chapters/script_install.adoc
@@ -427,8 +427,6 @@ trafodion-2
 ***INFO: Detected JAVA version 1.7
 ***INFO: copying hbase-trx-hdp2_2-1.3.0.jar to all nodes
 PORT=:8080
-########## Performing 'set' hbase.master.distributed.log.splitting:false on (Site:hbase-site, Tag:version1)
-########## PUTting json into: doSet_version1455657199513777160.json
 .
 .
 .

--- a/install/ambari-installer/traf-mpack/common-services/TRAFODION/2.1/service_advisor.py
+++ b/install/ambari-installer/traf-mpack/common-services/TRAFODION/2.1/service_advisor.py
@@ -230,7 +230,6 @@ class TRAFODION21ServiceAdvisor(service_advisor.DefaultStackAdvisor):
   ##### Desired values in other service configs
   def getHbaseSiteDesiredValues(self):
     desired = {
-        "hbase.master.distributed.log.splitting": "false",
         "hbase.snapshot.master.timeoutMillis": "600000",
         "hbase.coprocessor.region.classes": "org.apache.hadoop.hbase.coprocessor.transactional.TrxRegionObserver,org.apache.hadoop.hbase.coprocessor.transactional.TrxRegionEndpoint,org.apache.hadoop.hbase.coprocessor.AggregateImplementation",
         "hbase.hregion.impl": "org.apache.hadoop.hbase.regionserver.transactional.TransactionalRegion",

--- a/install/installer/traf_cloudera_mods
+++ b/install/installer/traf_cloudera_mods
@@ -248,7 +248,7 @@ curl -k -X PUT -H 'Content-Type:application/json' -u $ADMIN:$PASSWORD  --data \
 	"roleType" : "MASTER",
 	"items" : [ { 
 		"name" : "hbase_master_config_safety_valve", 
-        "value" : "<property>\r\n   <name>hbase.master.distributed.log.splitting</name>\r\n   <value>true</value>\r\n</property>\r\n <property>\r\n   <name>hbase.snapshot.master.timeoutMillis</name>\r\n   <value>600000</value>\r\n</property>\r\n"
+        "value" : "<property>\r\n   <name>hbase.snapshot.master.timeoutMillis</name>\r\n   <value>600000</value>\r\n</property>\r\n"
 		} ]
     }, {
 	"roleType" : "REGIONSERVER", 

--- a/install/installer/traf_hortonworks_mods
+++ b/install/installer/traf_hortonworks_mods
@@ -208,16 +208,6 @@ ssh -q -n $HDFS_NODE 'rm -rf $HOME/traf_temp_output'
 AMBARI_DIR=/var/lib/ambari-server/resources/scripts
 cd $LOCAL_WORKDIR
 
-ssh -q -n $AMBARI_HOST "$AMBARI_DIR"'/configs.sh -u' "$ADMIN" '-p' "$PASSWORD"  '-port' "$PORT" 'set' "$AMBARI_HOST" "$CLUSTER_NAME" 'hbase-site hbase.master.distributed.log.splitting true'
-if [ $? != 0 ]; then
-    echo "***ERROR: unable to modify hbase.master.distributed.log.splitting through Ambari's configs.sh script."
-    echo "***ERROR: Check if Ambari URL is correct, may need to enter external IP address."
-    echo "***ERROR: Check if iptables/firewall is configured correctly and ports a
-    re enabled."
-    echo "***ERROR: Check that HBase is running without error."
-    exit -1
-fi
-sleep 2
 # Bug: install removes hbase co-processors installed as part of kerberozing Hadoop.  Add them
 # as part of adding trafodion co-processor (add JIRA #)
 if [[ "$SECURE_HADOOP" == "Y" ]]; then

--- a/install/python-installer/configs/mod_cfgs.json
+++ b/install/python-installer/configs/mod_cfgs.json
@@ -1,7 +1,6 @@
 {
 "MOD_CFGS": {
     "hbase-site": {
-        "hbase.master.distributed.log.splitting": "true",
         "hbase.snapshot.master.timeoutMillis": "600000",
         "hbase.coprocessor.region.classes": "org.apache.hadoop.hbase.coprocessor.transactional.TrxRegionObserver,org.apache.hadoop.hbase.coprocessor.transactional.TrxRegionEndpoint,org.apache.hadoop.hbase.coprocessor.AggregateImplementation",
         "hbase.hregion.impl": "org.apache.hadoop.hbase.regionserver.transactional.TransactionalRegion",
@@ -21,7 +20,7 @@
         "roleType" : "MASTER",
         "items" : [ {
                 "name" : "hbase_master_config_safety_valve",
-        "value" : "<property>\r\n   <name>hbase.master.distributed.log.splitting</name>\r\n   <value>true</value>\r\n</property>\r\n <property>\r\n   <name>hbase.snapshot.master.timeoutMillis</name>\r\n   <value>600000</value>\r\n</property>\r\n"
+        "value" : "<property>\r\n   <name>hbase.snapshot.master.timeoutMillis</name>\r\n   <value>600000</value>\r\n</property>\r\n"
                 } ]
     } ]
 },


### PR DESCRIPTION
This changes all install methods to no longer touch the log splitting
property.