### PR TITLE
[TRAFODION-2450] copy file error for python-installer/templates

### DIFF
--- a/install/python-installer/scripts/common.py
+++ b/install/python-installer/scripts/common.py
@@ -45,7 +45,6 @@ INSTALLER_LOC = re.search('(.*)/\w+',os.path.dirname(os.path.abspath(__file__)))
 
 CONFIG_DIR = INSTALLER_LOC + '/configs'
 SCRIPTS_DIR = INSTALLER_LOC + '/scripts'
-TEMPLATES_DIR = INSTALLER_LOC + '/templates'
 
 USER_PROMPT_FILE = CONFIG_DIR + '/prompt.json'
 SCRCFG_FILE = CONFIG_DIR + '/script.json'

--- a/install/python-installer/scripts/traf_setup.py
+++ b/install/python-installer/scripts/traf_setup.py
@@ -55,6 +55,12 @@ def run():
     run_cmd('sysctl -w kernel.pid_max=65535 2>&1 > /dev/null')
     run_cmd('echo "kernel.pid_max=65535" >> /etc/sysctl.conf')
 
+    ### copy trafodion bashrc ###
+    BASHRC_TEMPLATE = '%s/sysinstall/home/trafodion/.bashrc' % TRAF_HOME
+    BASHRC_FILE = '%s/%s/.bashrc' % (HOME_DIR, TRAF_USER)
+    run_cmd('cp -f %s %s' % (BASHRC_TEMPLATE, BASHRC_FILE))
+    run_cmd('chown -R %s:%s %s*' % (TRAF_USER, TRAF_USER, BASHRC_FILE))
+
     ### copy init script ###
     init_script = '%s/sysinstall/etc/init.d/trafodion' % TRAF_HOME
     if os.path.exists(init_script):

--- a/install/python-installer/scripts/traf_user.py
+++ b/install/python-installer/scripts/traf_user.py
@@ -59,8 +59,6 @@ def run():
     KEY_FILE = '/tmp/id_rsa'
     AUTH_KEY_FILE = '%s/.ssh/authorized_keys' % TRAF_USER_DIR
     SSH_CFG_FILE = '%s/.ssh/config' % TRAF_USER_DIR
-    BASHRC_TEMPLATE = '%s/sqf/sysinstall/home/trafodion/.bashrc' % TRAF_HOME
-    BASHRC_FILE = '%s/.bashrc' % TRAF_USER_DIR
     ULIMITS_FILE = '/etc/security/limits.d/%s.conf' % TRAF_USER
     HSPERFDATA_FILE = '/tmp/hsperfdata_trafodion'
 
@@ -70,9 +68,6 @@ def run():
 
     if not cmd_output('getent passwd %s' % TRAF_USER):
         run_cmd('useradd --shell /bin/bash -m %s -g %s --home %s --password "$(openssl passwd %s)"' % (TRAF_USER, TRAF_GROUP, TRAF_USER_DIR, TRAF_PWD))
-        # copy bashrc to trafodion's home only if user doesn't exist
-        run_cmd('cp %s %s' % (BASHRC_TEMPLATE, BASHRC_FILE))
-        run_cmd('chown -R %s:%s %s*' % (TRAF_USER, TRAF_GROUP, BASHRC_FILE))
     elif not os.path.exists(TRAF_USER_DIR):
         run_cmd('mkdir -p %s' % TRAF_USER_DIR)
         run_cmd('chmod 700 %s' % TRAF_USER_DIR)

--- a/install/python-installer/scripts/wrapper.py
+++ b/install/python-installer/scripts/wrapper.py
@@ -29,7 +29,7 @@ from glob import glob
 from threading import Thread
 from common import err_m, run_cmd, time_elapse, get_logger, Remote, \
                    ParseJson, INSTALLER_LOC, TMP_DIR, SCRCFG_FILE, \
-                   CONFIG_DIR, SCRIPTS_DIR, TEMPLATES_DIR
+                   CONFIG_DIR, SCRIPTS_DIR
 
 class RemoteRun(Remote):
     """ run commands or scripts remotely using ssh """
@@ -44,7 +44,7 @@ class RemoteRun(Remote):
         self.execute('mkdir -p %s' % TMP_DIR)
 
         # copy all needed files to remote host
-        all_files = [CONFIG_DIR, SCRIPTS_DIR, TEMPLATES_DIR]
+        all_files = [CONFIG_DIR, SCRIPTS_DIR]
 
         self.copy(all_files, remote_folder=TMP_DIR)
 


### PR DESCRIPTION
remove unused templates folder.
copy bashrc file in 'traf_setup' step, because trafodion package is not extracted in 'traf_user' step.