### PR TITLE
TRAFODION-2442  timestamp/date comparison bug. And couple other fixes.

### DIFF
--- a/core/sql/optimizer/BindItemExpr.cpp
+++ b/core/sql/optimizer/BindItemExpr.cpp
@@ -2424,6 +2424,25 @@ static ItemExpr * ItemExpr_handleIncompatibleComparison(
       tgtOpIndex = 1;
       conversion = 4;
     }
+    else
+    if ((type1.getTypeQualifier() == NA_DATETIME_TYPE) &&
+	(type2.getTypeQualifier() == NA_DATETIME_TYPE) &&
+        (type1.getPrecision() != type2.getPrecision()))
+    {
+      conversion = 8;
+      if (type1.getPrecision() == SQLDTCODE_TIMESTAMP)
+        {
+          // convert op2 to timestamp
+          srcOpIndex = 1;
+          tgtOpIndex = 0;
+        }
+      else
+        {
+          // convert op1 to timestamp
+          srcOpIndex = 0;
+          tgtOpIndex = 1;
+        }
+    }
 
     ItemExpr * newOp = NULL;
 
@@ -2524,7 +2543,7 @@ static ItemExpr * ItemExpr_handleIncompatibleComparison(
 	     (tgtOpIndex == 0 ? op1 : op2)->castToItemExpr()->getValueId().getType().newCopy(bindWA->wHeap()));
       newOp = newOp->bindNode(bindWA);
       break;
-      
+     
       default:
         break;
     }

--- a/core/sql/optimizer/costmethod.cpp
+++ b/core/sql/optimizer/costmethod.cpp
@@ -4931,6 +4931,10 @@ void CostMethodSort::cacheParameters(RelExpr* op,
   }
 
   Lng32 myRowLength = myVis().getRowLength();
+
+  // allocate space for atleast 2 rows
+  memoryLimit_ = MAXOF(memoryLimit_, 2 * myRowLength);
+
   sortKeyLength_ = sortKeyVis.getRowLength();
   sortRecLength_ = sortKeyLength_ + myRowLength;
 

--- a/core/sql/regress/seabase/EXPECTED030
+++ b/core/sql/regress/seabase/EXPECTED030
@@ -536,10 +536,11 @@ March 01, 2016, 10:11:12
 >>drop table if exists t030t1;
 
 --- SQL operation complete.
->>create table t030t1 (a date, b char(30), c varchar(30));
+>>create table t030t1 (a date, b char(30), c varchar(30), d timestamp);
 
 --- SQL operation complete.
->>insert into t030t1 values (date '2016-03-01', '2016-03-01', '2016-03-01');
+>>insert into t030t1 values (date '2016-03-01', '2016-03-01', '2016-03-01', 
++>           timestamp '2017-01-13 13:13:13');
 
 --- 1 row(s) inserted.
 >>
@@ -577,12 +578,40 @@ March 01, 2016, 10:11:12
 --- 1 row(s) selected.
 >>select * from t030t1 where to_date(c, 'YYYY-MM-DD') = DATE '2016-03-01';
 
-A           B                               C
-----------  ------------------------------  ------------------------------
+A           B                               C                               D
+----------  ------------------------------  ------------------------------  --------------------------
 
-2016-03-01  2016-03-01                      2016-03-01                    
+2016-03-01  2016-03-01                      2016-03-01                      2017-01-13 13:13:13.000000
 
 --- 1 row(s) selected.
+>>
+>>select case when timestamp '2017-01-13 13:13:13' > date '2017-01-13' then 'pass' else 'fail' end from dual;
+
+(EXPR)
+------
+
+pass  
+
+--- 1 row(s) selected.
+>>select case when timestamp '2017-01-13 13:13:13' > date '2017-01-14' then 'pass' else 'fail' end from dual;
+
+(EXPR)
+------
+
+fail  
+
+--- 1 row(s) selected.
+>>select * from t030t1 where d > date '2017-01-13';
+
+A           B                               C                               D
+----------  ------------------------------  ------------------------------  --------------------------
+
+2016-03-01  2016-03-01                      2016-03-01                      2017-01-13 13:13:13.000000
+
+--- 1 row(s) selected.
+>>select * from t030t1 where d > date '2017-01-14';
+
+--- 0 row(s) selected.
 >>
 >>-- negative tests
 >>select to_date('2016-03-01', 'YYYYMM-DD') from (values(1)) x(a);
@@ -673,10 +702,10 @@ A           B                               C
 --- 0 row(s) selected.
 >>select * from t030t1 where to_date(c, 'YYYY-MM-DD') = '2016-03-01';
 
-A           B                               C
-----------  ------------------------------  ------------------------------
+A           B                               C                               D
+----------  ------------------------------  ------------------------------  --------------------------
 
-2016-03-01  2016-03-01                      2016-03-01                    
+2016-03-01  2016-03-01                      2016-03-01                      2017-01-13 13:13:13.000000
 
 --- 1 row(s) selected.
 >>select to_date('01.03.2016:10:11:12', 'DD.MM.YYYY:HH24:MI:SS') from (values(1)) x(a);
@@ -757,6 +786,20 @@ A           B                               C
 >>select to_date(1.2, '99:99:99:99') from (values(1)) x(a);
 
 *** ERROR[4047] The operands of function TO_DATE must have a scale of 0.
+
+*** ERROR[8822] The statement was not prepared.
+
+>>
+>>-- cannot compare timestamp to time, or date to time
+>>select case when timestamp '2017-01-17 10:10:10' > time '10:10:10' then 'pass' else 'fail' end from dual;
+
+*** ERROR[4041] Type TIMESTAMP(0) cannot be compared with type TIME(0).
+
+*** ERROR[8822] The statement was not prepared.
+
+>>select case when date '2017-01-17' > time '10:10:10' then 'pass' else 'fail' end from dual;
+
+*** ERROR[4041] Type DATE cannot be compared with type TIME(0).
 
 *** ERROR[8822] The statement was not prepared.
 

--- a/core/sql/regress/seabase/EXPECTED032
+++ b/core/sql/regress/seabase/EXPECTED032
@@ -15,7 +15,7 @@
 >>invoke t032t1;
 
 -- Definition of Trafodion table TRAFODION.SCH.T032T1
--- Definition current  Wed Sep 21 02:57:14 2016
+-- Definition current  Tue Jan 17 18:16:14 2017
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -140,7 +140,7 @@ B
 (EXPR)                        
 ------------------------------
 
-RANDOMVAL=323996797           
+RANDOMVAL=1210881081          
 
 --- 1 row(s) selected.
 >>select random() from (values(1)) x(a);
@@ -352,7 +352,7 @@ A            B     C            D           E         F                         
 
 --- 3 row(s) selected.
 >>
->>select * from (values(1)) x(a) where current_date = current_timestamp;
+>>select * from (values(1)) x(a) where current_date = cast(current_timestamp as date);
 
 A   
 ----
@@ -360,9 +360,14 @@ A
    1
 
 --- 1 row(s) selected.
->>select * from (values(1)) x(a) where current_timestamp(0) = current_timestamp(6);
+>>select * from (values(1)) x(a) where current_timestamp(0) = cast(current_timestamp(6) as timestamp(0));
 
---- 0 row(s) selected.
+A   
+----
+
+   1
+
+--- 1 row(s) selected.
 >>
 >>select cast(1e0 as interval year) from dual;
 
@@ -396,7 +401,7 @@ A
 >>invoke t032t2;
 
 -- Definition of Trafodion table TRAFODION.T032SCH.T032T2
--- Definition current  Wed Sep 21 02:57:30 2016
+-- Definition current  Tue Jan 17 18:16:25 2017
 
   (
     SYSKEY                           LARGEINT NO DEFAULT NOT NULL NOT DROPPABLE

--- a/core/sql/regress/seabase/TEST030
+++ b/core/sql/regress/seabase/TEST030
@@ -97,14 +97,20 @@ select extract (year from INTERVAL '97-02' YEAR TO MONTH) from (values (1)) as t
 select interval '8' year / 4 from dual;
 
 drop table if exists t030t1;
-create table t030t1 (a date, b char(30), c varchar(30));
-insert into t030t1 values (date '2016-03-01', '2016-03-01', '2016-03-01');
+create table t030t1 (a date, b char(30), c varchar(30), d timestamp);
+insert into t030t1 values (date '2016-03-01', '2016-03-01', '2016-03-01', 
+           timestamp '2017-01-13 13:13:13');
 
 select to_char(a, 'YYYYMMDD') from t030t1;
 select a (date, format 'YYYYMMDD') from t030t1;
 select to_date(b, 'YYYY-MM-DD') from t030t1;
 select to_date(c, 'YYYY-MM-DD') from t030t1;
 select * from t030t1 where to_date(c, 'YYYY-MM-DD') = DATE '2016-03-01';
+
+select case when timestamp '2017-01-13 13:13:13' > date '2017-01-13' then 'pass' else 'fail' end from dual;
+select case when timestamp '2017-01-13 13:13:13' > date '2017-01-14' then 'pass' else 'fail' end from dual;
+select * from t030t1 where d > date '2017-01-13';
+select * from t030t1 where d > date '2017-01-14';
 
 -- negative tests
 select to_date('2016-03-01', 'YYYYMM-DD') from (values(1)) x(a);
@@ -139,5 +145,9 @@ select to_date(123456789, '99:99:99:99') from (values(1)) x(a);
 select to_date(-12345678, '99:99:99:99') from (values(1)) x(a);
 select to_date(1e0, '99:99:99:99') from (values(1)) x(a);
 select to_date(1.2, '99:99:99:99') from (values(1)) x(a);
+
+-- cannot compare timestamp to time, or date to time
+select case when timestamp '2017-01-17 10:10:10' > time '10:10:10' then 'pass' else 'fail' end from dual;
+select case when date '2017-01-17' > time '10:10:10' then 'pass' else 'fail' end from dual;
 
 log;

--- a/core/sql/regress/seabase/TEST032
+++ b/core/sql/regress/seabase/TEST032
@@ -94,8 +94,8 @@ insert into t032t1 values ('3', 3, 3, date '2016-08-15',  time '10:11:12',
                            timestamp '2016-08-15 10:11:12', 4e0);
 select * from t032t1;
 
-select * from (values(1)) x(a) where current_date = current_timestamp;
-select * from (values(1)) x(a) where current_timestamp(0) = current_timestamp(6);
+select * from (values(1)) x(a) where current_date = cast(current_timestamp as date);
+select * from (values(1)) x(a) where current_timestamp(0) = cast(current_timestamp(6) as timestamp(0));
 
 select cast(1e0 as interval year) from dual;
 

--- a/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
@@ -649,6 +649,17 @@ short CmpSeabaseDDL::createSeabaseTableExternal(
       if (retcode)
         return -1;
 
+      if (length > 1048576)
+        {
+          *CmpCommon::diags()
+            << DgSqlCode(-4247)
+            << DgInt0(length)
+            << DgInt1(1048576) 
+            << DgString0(naCol->getColName().data());
+          
+          return -1;
+        }
+
       colInfoArray[index].colName = naCol->getColName().data(); 
       colInfoArray[index].colNumber = index;
       colInfoArray[index].columnClass = COM_USER_COLUMN;


### PR DESCRIPTION
-- TRAFODION-2442 timestamp comparison with date returns incorrect results.
  that has been fixed. Date value is expanded to timestamp datatype and
  then compared.
  Fix is for timestamp/date comparison only.
  TIMESTAMP comparison to TIME, and DATE comparison to TIME is not allowed.

-- row length of aligned format tables is now calculated correctly and
  stored in metadata.

-- optimizer cost method for sort had a high limit of MEMORY_UNITS_SIZE
   default set to 20M. For large rows in the range of 10 Mb,
   this caused an overflow.
   Fix is to allocate space for MAXOF default and size of 2 rows.