### PR TITLE
[TRAFODION-2420] RMS Enhancements

### DIFF
--- a/core/sqf/export/limited-support-tools/LSO/README
+++ b/core/sqf/export/limited-support-tools/LSO/README
@@ -15,7 +15,7 @@ consumed memory resources exceeding over a certain threshold. These are:
 a)	MEM_OFFENDER
 b)	WM_MEM_OFFENDER
 
-In addition, we have 7 types of filtering mechanism based on query execution 
+In addition, we have several types of filtering mechanism based on query execution 
 time and/or state that can help the DBA and/or support personnel in analyzing 
 the live state of the Trafodion instance for problems. These are:
 
@@ -26,7 +26,7 @@ d)	INACTIVE_QUERIES
 e)	DEAD_QUERIES
 f)	UNMONITORED_QUERIES
 g)      SE_BLOCKED_QUERIES
-
+h)      SE_OFFENDER_QUERIES
 
 All dynamic SQL queries including child queries can be monitored using this 
 mechanism, because it uses direct access to the RMS infrastructure. RMS 
@@ -277,6 +277,22 @@ CURRENT_TIMESTAMP           NO_OF_PROCESSES  BLOCKED_FOR_SECS   QUERY_ID        
 --------------------------  ---------------  ----------------  ------------------------------------------------------------  ------------------------------
 
 2016-12-28 10:29:43.941455                1                83  MXID11000030514212349680799580002000000000206U3333300_18_S1   TRAFODION.SCH.T022   
+
+SE_OFFENDING_QUERIES
+====================
+
+This statement lists queries which has a total IO time of any operator 
+accessing the storage engine longer than the given number of seconds
+
+The SQL commands to list SE_BLOCKED queries are available at:
+$TRAF_HOME/export/limited-support-tools/LSO/se_offender.sql  
+
+CURRENT_TIMESTAMP           TOTAL_IO_TIME_IN_SECS  PROCESS_ID   QUERY_ID                                                                             TABLE_NAME
+--------------------------  ---------------------  ------------  -----------------------------------------------------------------------------------  ----------------------------------------------------------------------------------------------------------------
+
+2017-01-18 14:20:03.604532                 1         000, 06390  MXID11000026007212351477539057002000000000206U3333300_107___SQLCI_DML_LAST__         TRAFODION.SELVA.CUSTOMER 
+2017-01-18 14:20:03.604532                 1         001, 06391  MXID11000026007212351477539057002000000000206U3333300_107___SQLCI_DML_LAST__         TRAFODION.SELVA.CUSTOMER
+
 
 LIMITING THE OUTPUT TO A NODE
 =============================

--- a/core/sqf/export/limited-support-tools/LSO/offender
+++ b/core/sqf/export/limited-support-tools/LSO/offender
@@ -44,6 +44,7 @@ function usage()
                           wm_mem_offender
                           active
                           se_blocked
+                          se_offender
                           inactive
                           in_sql
                           in_client
@@ -193,6 +194,10 @@ case $SCRIPT in
    se_blocked)
      PREAMBLE="set param ?filter 'SE_BLOCKED=$TIME$NODE'; "
      QUERY_FILE="$LSO_DIR/se_blocked.sql"
+     ;;
+   se_offender)
+     PREAMBLE="set param ?filter 'SE_OFFENDER=$TIME$NODE'; "
+     QUERY_FILE="$LSO_DIR/se_offender.sql"
      ;;
    cpu_offender)
      PREAMBLE="set param ?filter 'CPU_OFFENDER=$OFFENDER_NODE'; "

--- a/core/sql/cli/Context.cpp
+++ b/core/sql/cli/Context.cpp
@@ -4487,13 +4487,6 @@ ExStatisticsArea *ContextCli::getMergedStats(
           setDeleteStats(TRUE);
         }
       }
-
-      if (stats->getMasterStats() != NULL)
-      {
-        stats->getMasterStats()->setNumSqlProcs((short)(stats->getMasterStats()->numOfTotalEspsUsed()+1));
-// see ExRtFragTable::countSQLNodes in ex_frag_rt.cpp.  The compiler's dop
-// counts cores.  We want nodes here.
-      }
       return stats;
     }
     else

--- a/core/sql/executor/ExStats.h
+++ b/core/sql/executor/ExStats.h
@@ -3791,9 +3791,9 @@ NA_EIDPROC
   short  &cmpPriority() {return cmpPriority_;}
   short  &dp2Priority() {return dp2Priority_;}
   short  &fixupPriority() {return fixupPriority_;}
-  inline void setNumSqlProcs(short i) {numSqlProcs_ = i; }
+  void  incNumEspsInUse() { numOfTotalEspsUsed_++; }
   inline void setNumCpus(short i) {numCpus_ = i; }
-  inline short getNumSqlProcs() { return numSqlProcs_; }
+  inline short getNumSqlProcs() { return numOfTotalEspsUsed_+1; }
   inline short getNumCpus() { return numCpus_; }
 
   inline void setAqrLastErrorCode(Lng32 ec) {aqrLastErrorCode_ = ec;}
@@ -3960,7 +3960,6 @@ private:
   short stmtState_;
   UInt16 masterFlags_;
 
-  short numSqlProcs_;
   short numCpus_;
 
   QueryCostInfo queryCostInfo_;

--- a/core/sql/executor/ex_root.cpp
+++ b/core/sql/executor/ex_root.cpp
@@ -282,7 +282,6 @@ ex_tcb * ex_root_tdb::build(CliGlobals *cliGlobals, ex_globals * glob)
                                                 NULL);
       if (masterStats)
         {
-          masterStats->numOfTotalEspsUsed() = numOfTotalEspsUsed;
           masterStats->numOfNewEspsStarted() = numOfNewEspsStarted;
           masterStats->setNumCpus(rtFragTable->
                                   countSQLNodes(cliGlobals->myCpu()));

--- a/core/sql/runtimestats/ssmpipc.cpp
+++ b/core/sql/runtimestats/ssmpipc.cpp
@@ -2436,7 +2436,6 @@ void SscpClientMsgStream::sendMergedStats()
     masterStats = mergedStats_->getMasterStats();
     if (masterStats != NULL)
     {
-      masterStats->setNumSqlProcs(getNumSqlProcs());
       masterStats->setNumCpus(getNumCpus());
     }
   }


### PR DESCRIPTION
Added yet another offender feature to list query ids that has a total
IO time for any storage engine opertor consuming longer than a given
number of seconds.

./offender -s se_offender

Will list the query ids along with the table name. SEE
$TRAF_HOME/export/limited-support-tools/LSO/README

The "Number of SQL Processes" counter is now made multi-fragment aware
and hence contains the actual number of ESPs used + 1 for master
process.