### PR TITLE
[TRAFODION-2452] Fix upgrade or removal of Ambari mpack

### DIFF
--- a/install/.gitignore
+++ b/install/.gitignore
@@ -5,5 +5,5 @@ DISCLAIMER
 ambari-installer/RPMROOT
 ambari-installer/traf-mpack.tar.gz
 ambari-installer/mpack-install/repo
-ambari-installer/traf-mpack/custom-services/TRAFODION/*/repos
+ambari-installer/traf-mpack/custom-services
 ambari-installer/traf-mpack/mpack.json

--- a/install/.gitignore
+++ b/install/.gitignore
@@ -6,3 +6,4 @@ ambari-installer/RPMROOT
 ambari-installer/traf-mpack.tar.gz
 ambari-installer/mpack-install/repo
 ambari-installer/traf-mpack/custom-services/TRAFODION/*/repos
+ambari-installer/traf-mpack/mpack.json

--- a/install/ambari-installer/Makefile
+++ b/install/ambari-installer/Makefile
@@ -32,9 +32,9 @@ BUILDROOTDIR=$(RPMROOT)/BUILDROOT
 all: rpmbuild
 
 # need repoinfo file per release
-# traf_ambari needs to support multiple releases so ambari can select 
-# correct trafodion version for a given HDP stack
-REPO_VER= 2.1
+# traf_ambari needs to support multiple releases so ambari can
+# select trafodion version for given HDP stack
+REPO_LIST= $(TRAFODION_VER) # for now, list is current release only
 
 $(SOURCEDIR)/ambari_rpm.tar.gz: mpack-install/LICENSE repofiles traf-mpack/mpack.json
 	rm -rf $(RPMROOT)
@@ -43,11 +43,14 @@ $(SOURCEDIR)/ambari_rpm.tar.gz: mpack-install/LICENSE repofiles traf-mpack/mpack
 
 # To do: needs enhancement when supporting RH6 & RH7 os
 repofiles:
-	for v in $(REPO_VER); do \
-	   rdir=traf-mpack/custom-services/TRAFODION/$${v}/repos; \
-	   mkdir -p $${rdir} ; \
-	   sed -e "s#REPLACE_WITH_RH6_REPO_URL#$(REPO_URL)/RH6/$${v}#" repo.template > $${rdir}/repoinfo.xml ; \
-	   echo $${rdir}/repoinfo.xml ; \
+	for v in $(REPO_LIST); do \
+	   rdir=traf-mpack/custom-services/TRAFODION/$${v}; \
+	   mkdir -p $${rdir}/repos ; \
+	   sed -e "s#REPLACE_WITH_RH6_REPO_URL#$(REPO_URL)/RH6/$${v}#" \
+	       -e "s#REPO_VER#$${v}#" \
+	       repo.template > $${rdir}/repos/repoinfo.xml ; \
+	   sed -e "s#REPO_VER#$${v}#" \
+	       meta.template > $${rdir}/metainfo.xml ; \
 	done
 
 traf-mpack/mpack.json: mpack.json
@@ -80,4 +83,5 @@ clean:
 	rm -rf $(RPMROOT)
 	rm -rf mpack-install/LICENSE
 	rm -rf traf-mpack/custom-services/TRAFODION/*/repos
+	rm -f traf-mpack/custom-services/TRAFODION/*/metainfo.xml
 	rm -rf traf-mpack/mpack.json

--- a/install/ambari-installer/Makefile
+++ b/install/ambari-installer/Makefile
@@ -36,7 +36,7 @@ all: rpmbuild
 # correct trafodion version for a given HDP stack
 REPO_VER= 2.1
 
-$(SOURCEDIR)/ambari_rpm.tar.gz: mpack-install/LICENSE repofiles
+$(SOURCEDIR)/ambari_rpm.tar.gz: mpack-install/LICENSE repofiles traf-mpack/mpack.json
 	rm -rf $(RPMROOT)
 	mkdir -p $(SOURCEDIR)
 	tar czf $@ traf-mpack mpack-install
@@ -49,6 +49,9 @@ repofiles:
 	   sed -e "s#REPLACE_WITH_RH6_REPO_URL#$(REPO_URL)/RH6/$${v}#" repo.template > $${rdir}/repoinfo.xml ; \
 	   echo $${rdir}/repoinfo.xml ; \
 	done
+
+traf-mpack/mpack.json: mpack.json
+	sed -e "s#MPACK_VERSION#$(TRAFODION_VER)#" $? > $@
 
 mpack-install/LICENSE: ../../licenses/LICENSE-install
 	cp -f $? $@
@@ -77,3 +80,4 @@ clean:
 	rm -rf $(RPMROOT)
 	rm -rf mpack-install/LICENSE
 	rm -rf traf-mpack/custom-services/TRAFODION/*/repos
+	rm -rf traf-mpack/mpack.json

--- a/install/ambari-installer/meta.template
+++ b/install/ambari-installer/meta.template
@@ -28,7 +28,7 @@
     <service>
        <name>TRAFODION</name>
        <extends>common-services/TRAFODION/2.1</extends>
-       <version>2.1</version>
+       <version>REPO_VER</version>
     </service>
   </services>
 </metainfo>

--- a/install/ambari-installer/mpack-install/am_install.sh
+++ b/install/ambari-installer/mpack-install/am_install.sh
@@ -26,8 +26,11 @@ rm -f ${tf}*
 /usr/bin/ssh-keygen -q -t rsa -N '' -f $tf
 
 instloc="$1"
+mpack="$2"
+vers="$3"
+pkgcnt="$4" #RPM package count
 
-config="${instloc}/traf-mpack/common-services/TRAFODION/2.1/configuration/trafodion-env.xml"
+config="${instloc}/${mpack}/common-services/TRAFODION/2.1/configuration/trafodion-env.xml"
 
 chmod 0600 $config  # protect key
 sed -i -e "/TRAFODION-GENERATED-SSH-KEY/r $tf" $config # add key to config properties
@@ -35,13 +38,19 @@ sed -i -e "/TRAFODION-GENERATED-SSH-KEY/r $tf" $config # add key to config prope
 rm -f ${tf}*
 
 # tar up the mpack, included generated key
-tball="${instloc}/traf-mpack.tar.gz"
+tball="${instloc}/${mpack}-${vers}.tar.gz"
 
 cd "${instloc}"
-tar czf "$tball" traf-mpack
+tar czf "$tball" ${mpack}
 
 # install ambari mpack
-ambari-server install-mpack --verbose --mpack="$tball"
+if (( pkgcnt > 1 ))
+then
+  cmd="upgrade-mpack"
+else
+  cmd="install-mpack"
+fi
+ambari-server $cmd --verbose --mpack="$tball"
 ret=$?
 
 exit $ret

--- a/install/ambari-installer/mpack.json
+++ b/install/ambari-installer/mpack.json
@@ -1,7 +1,7 @@
 {
     "type" : "full-release",
     "name" : "traf-mpack",
-    "version": "2.1",
+    "version": "MPACK_VERSION",
     "description" : "Trafodion Management Pack",
     "prerequisites": {
         "min_ambari_version" : "2.4.2.0",

--- a/install/ambari-installer/repo.template
+++ b/install/ambari-installer/repo.template
@@ -17,7 +17,7 @@
   <os family="redhat6">
     <repo>
        <baseurl>REPLACE_WITH_RH6_REPO_URL</baseurl>
-       <repoid>Trafodion</repoid>
+       <repoid>Trafodion-REPO_VER</repoid>
        <reponame>Trafodion</reponame>
     </repo>
   </os>

--- a/install/ambari-installer/traf-mpack/common-services/TRAFODION/2.1/package/scripts/trafodiondcs.py
+++ b/install/ambari-installer/traf-mpack/common-services/TRAFODION/2.1/package/scripts/trafodiondcs.py
@@ -47,7 +47,7 @@ class DCS(Script):
     cmd = "source ~%s/.bashrc >/dev/null 2>&1; ls $DCS_INSTALL_DIR/tmp/dcs*master.pid" % status_params.traf_user
     ofile = TemporaryFile()
     try:
-      Execute(cmd,stdout=ofile) # cannot switch user in status mode for some reason
+      Execute(cmd,stdout=ofile,user=status_params.traf_user)
     except:
       ofile.close()
       raise ComponentIsNotRunning()

--- a/install/ambari-installer/traf-mpack/common-services/TRAFODION/2.1/package/scripts/trafodionnode.py
+++ b/install/ambari-installer/traf-mpack/common-services/TRAFODION/2.1/package/scripts/trafodionnode.py
@@ -90,8 +90,8 @@ class Node(Script):
          group = params.traf_group, 
          content=InlineTemplate(params.traf_env_template,trim_blocks=False),
          mode=0644)
-    # initialize & verify env (e.g., creates $TRAF_HOME/tmp as trafodion user)
-    cmd = "source ~/.bashrc"
+    # initialize & verify env (e.g., bashrc creates $TRAF_HOME/tmp as trafodion user)
+    cmd = "source ~" + params.traf_user + "/.bashrc ; ls -l $TRAF_HOME/tmp"
     Execute(cmd,user=params.traf_user)
 
     ##################

--- a/install/ambari-installer/traf-mpack/common-services/TRAFODION/2.1/package/scripts/trafodionnode.py
+++ b/install/ambari-installer/traf-mpack/common-services/TRAFODION/2.1/package/scripts/trafodionnode.py
@@ -91,7 +91,7 @@ class Node(Script):
          content=InlineTemplate(params.traf_env_template,trim_blocks=False),
          mode=0644)
     # initialize & verify env (e.g., bashrc creates $TRAF_HOME/tmp as trafodion user)
-    cmd = "source ~" + params.traf_user + "/.bashrc ; ls -l $TRAF_HOME/tmp"
+    cmd = "source ~/.bashrc"
     Execute(cmd,user=params.traf_user)
 
     ##################

--- a/install/ambari-installer/traf_ambari.spec
+++ b/install/ambari-installer/traf_ambari.spec
@@ -50,7 +50,19 @@ mkdir -p %{buildroot}/opt/trafodion
 cp -rf %{name}/* %{buildroot}/opt/trafodion
 
 %post
-$RPM_INSTALL_PREFIX/mpack-install/am_install.sh "$RPM_INSTALL_PREFIX"
+$RPM_INSTALL_PREFIX/mpack-install/am_install.sh "$RPM_INSTALL_PREFIX" "traf-mpack" "%{version}-%{release}" "$1"
+
+%postun
+if [[ $1 == 0 ]]  # removing final version
+then
+  # no ambari command for this yet -- coming in Ambari 2.5.0
+  rm -r /var/lib/ambari-server/resources/mpacks/traf-mpack*
+  rm -r /var/lib/ambari-server/resources/common-services/TRAFODION
+  rm -r /var/lib/ambari-server/resources/stacks/HDP/*/services/TRAFODION
+  # clean up items created by am_install.sh script
+  rm /opt/trafodion/traf-mpack*.tar.gz
+  rm -r /opt/trafodion/traf-mpack
+fi
 
 %clean
 /bin/rm -rf %{buildroot}


### PR DESCRIPTION
Enhance traf_ambari RPM to call upgrade-mpack instead of install-mpack
when we are upgrading the mpack.  Unfortunately, the upgrade-mpack command
does not (yet) seem to do the needed things.  More tweaks may be needed
in the future to support upgrade from trafodion 2.1.0 to later release.

Also support removal of the RPM to clean up everything.