### PR TITLE
handling of known failures for executor/TEST015 and compGeneral/TEST042

### DIFF
--- a/core/sql/regress/executor/DIFF015.KNOWN
+++ b/core/sql/regress/executor/DIFF015.KNOWN
@@ -1,0 +1,24 @@
+1502d1501
+<  3 1
+1505c1504
+< --- 2 row(s) selected.
+---
+> --- 1 row(s) selected.
+1540d1538
+<  3 1
+1543c1541
+< --- 2 row(s) selected.
+---
+> --- 1 row(s) selected.
+1578d1575
+<  3 1
+1581c1578
+< --- 2 row(s) selected.
+---
+> --- 1 row(s) selected.
+1620d1616
+<  3 1
+1623c1619
+< --- 2 row(s) selected.
+---
+> --- 1 row(s) selected.

--- a/core/sql/regress/tools/runregr_compGeneral.ksh
+++ b/core/sql/regress/tools/runregr_compGeneral.ksh
@@ -296,7 +296,7 @@ prettyfiles=
 # TEST043 - failure w/ VS2003 SOL 10-070227-2886
 # TEST062 fails because of non-deterministic card estimation, will be 
 #   enabled when we fix it
-skipTheseTests="TEST030 TEST044 TEST050 TEST065 TESTNIST"
+skipTheseTests="TEST030 TEST042 TEST044 TEST050 TEST065 TESTNIST"
 
 # skip these tests for SQLMX and SQLMP tables on NSK platform
 


### PR DESCRIPTION
executor/TEST015 is being tracked by TRAFODION-2438. A known diff file
is being created to handle the diff.

compGeneral/TEST042 failure is being tracked by TRAFODION-2457. Once
that jira is fixed, this test will be re-enabled.