### PR TITLE
[TRAFODION-2315] Heuristic decision for common subexpressions

### DIFF
--- a/core/sql/arkcmp/CmpStatement.h
+++ b/core/sql/arkcmp/CmpStatement.h
@@ -227,8 +227,11 @@ public:
   short getDDLExprAndNode(char * sqlStr, Lng32 inputCS,
                           DDLExpr* &ddlExpr, ExprNode* &ddlNode);
 
-  CSEInfo *getCSEInfo(const char *cseName);
-  const LIST(CSEInfo *) *getCSEInfoList() { return cses_; }
+  CSEInfo *getCSEInfo(const char *cseName) const;
+  CSEInfo *getCSEInfoForMainQuery() const;
+  static Int32 getCSEIdForMainQuery() { return 0; }
+  CSEInfo *getCSEInfoById(Int32 cseId) const;
+  const LIST(CSEInfo *) *getCSEInfoList() const { return cses_; }
   void addCSEInfo(CSEInfo *info);
 
 protected:

--- a/core/sql/bin/SqlciErrors.txt
+++ b/core/sql/bin/SqlciErrors.txt
@@ -1447,7 +1447,7 @@ $1~String1 --------------------------------
 4492 ZZZZZ 99999 BEGINNER MINOR LOGONLY BULK LOAD option UPDATE STATISTICS cannot be used with UPSERT USING LOAD option.
 4493 ZZZZZ 99999 BEGINNER MINOR LOGONLY Stored Descriptor Status: $0~String0
 5000 ZZZZZ 99999 ADVANCED MAJOR DBADMIN Internal error in the query normalizer.
-5001 ZZZZZ 99999 ADVANDED MINOR LOGONLY Common subexpression $0~String0 cannot be shared among multiple consumers. Reason: $1~String1.
+5001 ZZZZZ 99999 ADVANDED MINOR LOGONLY Common subexpression $0~String0 will not be shared among multiple consumers. Reason: $1~String1.
 6000 ZZZZZ 99999 ADVANCED MAJOR DBADMIN Internal error in the query optimizer.
 6001 0A000 99999 BEGINNER MAJOR DBADMIN DISTINCT aggregates can be computed for only one column per table expression.
 6002 ZZZZZ 99999 BEGINNER MAJOR DBADMIN The metadata table HISTOGRAMS or HISTOGRAM_INTERVALS contains invalid values.  If you have manually modified the metadata table, then you should undo your changes using the CLEAR option in UPDATE STATISTICS.

--- a/core/sql/comexe/ComTdbHdfsScan.h
+++ b/core/sql/comexe/ComTdbHdfsScan.h
@@ -242,7 +242,7 @@ public:
   void   setHiveScanMode(UInt32 v ) { hiveScanMode_ = v; }
   UInt32 getHiveScanMode() { return hiveScanMode_; }
 
-  Queue* getHdfsFileInfoList() {return hdfsFileInfoList_;}
+  Queue* getHdfsFileInfoList() const {return hdfsFileInfoList_;}
   Queue* getHdfsFileRangeBeginList() {return hdfsFileRangeBeginList_;}
   Queue* getHdfsFileRangeNumList() {return hdfsFileRangeNumList_;}
 

--- a/core/sql/executor/ExHdfsScan.h
+++ b/core/sql/executor/ExHdfsScan.h
@@ -212,7 +212,7 @@ protected:
 
   void computeRangesAtRuntime();
   void deallocateRuntimeRanges();
-  HdfsFileInfo *getRange(Int32 r);
+  HdfsFileInfo *getRange(Int32 r) { return getHdfsFileInfoListAsArray().at(r); }
 
   short moveRowToUpQueue(const char * row, Lng32 len, 
                          short * rc, NABoolean isVarchar);
@@ -222,6 +222,10 @@ protected:
 
   short setupError(Lng32 exeError, Lng32 retcode, 
                    const char * str, const char * str2, const char * str3);
+
+  // Get the array representation of the HdfsFileInfoList to aid in
+  // o(1) access of an entry given an index.
+  HdfsFileInfoArray& getHdfsFileInfoListAsArray() {return hdfsFileInfoListAsArray_;}
 
   /////////////////////////////////////////////////////
   // Private data.
@@ -275,8 +279,6 @@ protected:
   Lng32 myInstNum_;
   Lng32 beginRangeNum_;
   Lng32 numRanges_;
-  HdfsFileInfo *runTimeRanges_;
-  Int32 numRunTimeRanges_;
   Lng32 currRangeNum_;
   char *endOfRequestedRange_ ; // helps rows span ranges.
   char * hdfsFileName_;
@@ -299,6 +301,9 @@ protected:
 
   NABoolean dataModCheckDone_;
   ComDiagsArea * loggingErrorDiags_;
+
+  // this array is populated from the info list stored as Queue.
+  HdfsFileInfoArray hdfsFileInfoListAsArray_;
 };
 
 class ExOrcScanTcb  : public ExHdfsScanTcb

--- a/core/sql/exp/ExpLOBinterface.h
+++ b/core/sql/exp/ExpLOBinterface.h
@@ -66,6 +66,9 @@ class HdfsFileInfo
   Int64 bytesToRead_;
 };
 
+typedef HdfsFileInfo* HdfsFileInfoPtr;
+typedef NAArray<HdfsFileInfoPtr> HdfsFileInfoArray;
+
 #include "ExpLOBaccess.h"
 
 #define LOB_ACCESS_SUCCESS 0

--- a/core/sql/generator/GenPreCode.cpp
+++ b/core/sql/generator/GenPreCode.cpp
@@ -6195,6 +6195,11 @@ RelExpr * MapValueIds::preCodeGen(Generator * generator,
                   {
                     availableValues -= subtractions;
                     availableValues += additions;
+                    // do the same for valuesNeededForVEGRewrite_,
+                    // which will be used for rewriting the char.
+                    // outputs
+                    valuesNeededForVEGRewrite_ -= subtractions;
+                    valuesNeededForVEGRewrite_ += additions;
                   }
               }
 

--- a/core/sql/optimizer/BindRelExpr.cpp
+++ b/core/sql/optimizer/BindRelExpr.cpp
@@ -17669,20 +17669,22 @@ RelExpr * CommonSubExprRef::bindNode(BindWA *bindWA)
 
   DCMPASSERT(info);
 
+  // eliminate any CommonSubExprRef nodes that are not truly common,
+  // i.e. those that are referenced only once
+  if (info->getNumConsumers() <= 1)
+    {
+      info->eliminate();
+      return child(0).getPtr()->bindNode(bindWA);
+    }
+
   bindWA->setInCSE(this);
 
-  if (parentCSE)
-    // establish the parent/child relationship, if not done already
-    CmpCommon::statement()->getCSEInfo(parentCSE->getName())->addChildCSE(info);
+  // establish the parent/child relationship
+  addParentRef(parentCSE);
 
   bindChildren(bindWA);
   if (bindWA->errStatus())
     return this;
-
-  // eliminate any CommonSubExprRef nodes that are not truly common,
-  // i.e. those that are referenced only once
-  if (CmpCommon::statement()->getCSEInfo(internalName_)->getNumConsumers() <= 1)
-    return child(0).getPtr();
 
   // we know that our child is a RenameTable (same name as this CSE,
   // whose child is a RelRoot, defining the CTE. Copy the bound select

--- a/core/sql/optimizer/ColStatDesc.h
+++ b/core/sql/optimizer/ColStatDesc.h
@@ -205,14 +205,14 @@ public:
   // HIST_MISSING_STATS_WARNING_LEVEL - The CQD has 5 values
   // It is used to control the number of missing stats warnings
   // that should be generated. 
-  // 0 � Display no warnings.
-  // 1 � Display only missing single column stats warnings. These include 6008 and 6011 
-  // 2 � Display all single column missing stats warnings and 
-  //     multi-column missing stats warnings for Scans only. 
-  // 3 � Display all missing single column stats warnings and missing 
-  //     multi-column stats warnings for Scans and GroupBy operators only..
-  // 4 � Display all missing single column stats and missing multi-column 
-  //     stats warnings for all operators including Scans, Joins and groupBys.
+  // 0: Display no warnings.
+  // 1: Display only missing single column stats warnings. These include 6008 and 6011 
+  // 2: Display all single column missing stats warnings and 
+  //    multi-column missing stats warnings for Scans only. 
+  // 3: Display all missing single column stats warnings and missing 
+  //    multi-column stats warnings for Scans and GroupBy operators only..
+  // 4: Display all missing single column stats and missing multi-column 
+  //    stats warnings for all operators including Scans, Joins and groupBys.
   // THE CQD also does not have an impact on the auto update stats behavior. The stats will
   // still be automatically generated even if the warnings have been suppressed.
   // Default behavior is to generate all warnings
@@ -304,6 +304,9 @@ public:
   // add the <table-column-valueidset, uec-value> pairs from OTHER into
   // THIS (the ones that aren't already there)
   void insertList (const MultiColumnUecList * other) ;
+
+  void insertMappedList(const MultiColumnUecList *other,
+                        const ValueIdMap &map); // map is used in "up" direction
 
   // this routine answers whether there's any bona fide multi-column
   // information contained in this list -- i.e., any
@@ -495,6 +498,8 @@ public:
   void setInputCard (CostScalar rows) {inputCard_ = rows; }
 
   CostScalar getInputCard()  { return inputCard_; }
+
+  void mapUpAndCopy (const ColStatDesc& other, ValueIdMap &map) ;
 
   // synchronize/map the RowCount and UEC change of one set of aggregate
   // statistics with the current set of aggregate statistics
@@ -723,6 +728,10 @@ public:
                          const ColStatDescSharedPtr & source,
                          const CostScalar & scale = 1,
                          const NABoolean shapeChangedMask = TRUE) ;
+  void makeMappedDeepCopy(
+                         const ColStatDescList & source,
+                         ValueIdMap &map, // map source "up"
+                         NABoolean includeUnmappedColumns);
 
   void removeDeepCopyAt (const CollIndex entry) ;
 

--- a/core/sql/optimizer/NormRelExpr.cpp
+++ b/core/sql/optimizer/NormRelExpr.cpp
@@ -4673,8 +4673,9 @@ NABoolean Join::prepareMeForCSESharing(
      const ValueIdSet &predicatesToRemove,
      const ValueIdSet &commonPredicatesToAdd,
      const ValueIdSet &inputsToRemove,
-     CSEInfo *info,
-     NABoolean testRun)
+     ValueIdSet &valuesForVEGRewrite,
+     ValueIdSet &keyColumns,
+     CSEInfo *info)
 {
   if (isTSJForWrite() ||
       isTSJForUndo() ||
@@ -4682,15 +4683,12 @@ NABoolean Join::prepareMeForCSESharing(
       getIsForTrafLoadPrep())
     return FALSE;
 
-  if (!testRun)
-    {
-      // The caller of this methods added "commonPredicatesToAdd" to
-      // predicates_ (the generic selection predicates stored in the
-      // RelExpr). That works for both inner and non-inner joins.  The
-      // only thing we have left to do is to recompute the equi-join
-      // predicates.
-      findEquiJoinPredicates();
-    }
+  // The caller of this methods added "commonPredicatesToAdd" to
+  // predicates_ (the generic selection predicates stored in the
+  // RelExpr). That works for both inner and non-inner joins.  The
+  // only thing we have left to do is to recompute the equi-join
+  // predicates.
+  findEquiJoinPredicates();
 
   return TRUE;
 }
@@ -5013,8 +5011,9 @@ NABoolean Union::prepareTreeForCSESharing(
      const ValueIdSet &predicatesToRemove,
      const ValueIdSet &commonPredicatesToAdd,
      const ValueIdSet &inputsToRemove,
-     CSEInfo *info,
-     NABoolean testRun)
+     ValueIdSet &valuesForVEGRewrite,
+     ValueIdSet &keyColumns,
+     CSEInfo *info)
 {
   NABoolean result = TRUE;
 
@@ -5024,8 +5023,7 @@ NABoolean Union::prepareTreeForCSESharing(
   if (getSelectionPred().entries() > 0)
     {
       info->getConsumer(0)->emitCSEDiagnostics(
-           "Selection predicates on union node not supported",
-           !testRun);
+           "Selection predicates on union node not supported");
       return FALSE;
     }
 
@@ -5038,6 +5036,9 @@ NABoolean Union::prepareTreeForCSESharing(
       ValueIdSet childPredsToAdd;
       ValueIdMap *map = (i==0 ? &getLeftMap() : &getRightMap());
       ValueIdSet availableValues(map->getTopValues());
+      ValueIdSet dummyValuesForVEGRewrite;
+      ValueIdSet mappedKeyColumns;
+      ValueIdSet childKeyColumns;
 
       // if there are outputs to add, we can only do that for
       // outputs that already exist in the ValueIdMap
@@ -5045,8 +5046,7 @@ NABoolean Union::prepareTreeForCSESharing(
       if (locOutputsToAdd.removeUnCoveredExprs(availableValues))
         {
           info->getConsumer(0)->emitCSEDiagnostics(
-               "Not able to add output values unknown to union operator",
-               !testRun);
+               "Not able to add output values unknown to union operator");
           result = FALSE;
         }
 
@@ -5059,14 +5059,36 @@ NABoolean Union::prepareTreeForCSESharing(
            childPredsToRemove,
            childPredsToAdd,
            inputsToRemove,
-           info,
-           testRun);
+           dummyValuesForVEGRewrite,
+           childKeyColumns,
+           info);
+
+      map->mapValueIdSetUp(mappedKeyColumns, childKeyColumns);
+      // include only those that actually got mapped
+      mappedKeyColumns -= childKeyColumns;
+      keyColumns += mappedKeyColumns;
     }
 
-  if (result && !testRun)
+  if (result)
     {
+      NABoolean dummy;
+      CollIndex nu = unionMap_->leftColMap_.getBottomValues().entries();
+
       getGroupAttr()->addCharacteristicOutputs(outputsToAdd);
       getGroupAttr()->removeCharacteristicInputs(inputsToRemove);
+
+      // add columns that are a constant in at least one of the
+      // UNION's children to the key columns. Such columns can be used
+      // to eliminate entire legs of the union and therefore act like
+      // key or partition key columns.
+      for (CollIndex u=0; u<nu; u++)
+        {
+          if (unionMap_->leftColMap_.getBottomValues()[u].getItemExpr()->
+                castToConstValue(dummy) ||
+              unionMap_->rightColMap_.getBottomValues()[u].getItemExpr()->
+                castToConstValue(dummy))
+            keyColumns += unionMap_->colMapTable_[u];
+        }
     }
 
   // there is no need to call prepareMeForCSESharing() here
@@ -5702,38 +5724,37 @@ NABoolean GroupByAgg::prepareMeForCSESharing(
      const ValueIdSet &predicatesToRemove,
      const ValueIdSet &commonPredicatesToAdd,
      const ValueIdSet &inputsToRemove,
-     CSEInfo *info,
-     NABoolean testRun)
+     ValueIdSet &valuesForVEGRewrite,
+     ValueIdSet &keyColumns,
+     CSEInfo *info)
 {
   // The caller of this method took care of most adjustments to
   // make. The main thing the groupby node needs to do is to add any
   // outputs that are required to its characteristic outputs.
 
-  if (!testRun)
-    {
-      ValueIdSet myAvailableValues(groupExpr_);
-      ValueIdSet referencedValues;
-      ValueIdSet myOutputsToAdd;
-      ValueIdSet unCoveredExpr;
+  ValueIdSet myAvailableValues(groupExpr_);
+  ValueIdSet referencedValues;
+  ValueIdSet myOutputsToAdd;
+  ValueIdSet unCoveredExpr;
 
-      myAvailableValues += aggregateExpr_;
+  myAvailableValues += aggregateExpr_;
+  valuesForVEGRewrite += aggregateExpr_;
 
-      // The caller may be asking for expressions on columns, maybe
-      // even an expression involving grouping columns and aggregates
-      // and multiple tables, therefore use the isCovered method to
-      // determine those subexpressions that we can produce here.
-      NABoolean allCovered =
-        outputsToAdd.isCovered(myAvailableValues,
-                               *(getGroupAttr()),
-                               referencedValues,
-                               myOutputsToAdd,
-                               unCoveredExpr);
+  // The caller may be asking for expressions on columns, maybe
+  // even an expression involving grouping columns and aggregates
+  // and multiple tables, therefore use the isCovered method to
+  // determine those subexpressions that we can produce here.
+  NABoolean allCovered =
+    outputsToAdd.isCovered(myAvailableValues,
+                           *(getGroupAttr()),
+                           referencedValues,
+                           myOutputsToAdd,
+                           unCoveredExpr);
 
-      if (allCovered)
-        myOutputsToAdd = outputsToAdd;
+  if (allCovered)
+    myOutputsToAdd = outputsToAdd;
 
-      getGroupAttr()->addCharacteristicOutputs(myOutputsToAdd);
-    }
+  getGroupAttr()->addCharacteristicOutputs(myOutputsToAdd);
 
   return TRUE;
 }
@@ -6101,32 +6122,33 @@ NABoolean Scan::prepareMeForCSESharing(
      const ValueIdSet &predicatesToRemove,
      const ValueIdSet &commonPredicatesToAdd,
      const ValueIdSet &inputsToRemove,
-     CSEInfo *info,
-     NABoolean testRun)
+     ValueIdSet &valuesForVEGRewrite,
+     ValueIdSet &keyColumns,
+     CSEInfo *info)
 {
   // The caller of this method took care of most adjustments to
   // make. The main thing the scan node needs to do is to add any
   // outputs that are required to its characteristic outputs.
 
-  if (!testRun)
-    {
-      ValueIdSet myColSet(getTableDesc()->getColumnVEGList());
-      ValueIdSet referencedCols;
-      ValueIdSet myOutputsToAdd;
-      ValueIdSet unCoveredExpr;
+  ValueIdSet myColSet(getTableDesc()->getColumnVEGList());
+  ValueIdSet referencedCols;
+  ValueIdSet myOutputsToAdd;
+  ValueIdSet unCoveredExpr;
 
-      // The caller may be asking for expressions on columns, maybe
-      // even an expression involving multiple tables, therefore use
-      // the isCovered method to determine those subexpressions that we
-      // can produce here.
-      outputsToAdd.isCovered(myColSet,
-                             *(getGroupAttr()),
-                             referencedCols,
-                             myOutputsToAdd,
-                             unCoveredExpr);
+  // The caller may be asking for expressions on columns, maybe
+  // even an expression involving multiple tables, therefore use
+  // the isCovered method to determine those subexpressions that we
+  // can produce here.
+  outputsToAdd.isCovered(myColSet,
+                         *(getGroupAttr()),
+                         referencedCols,
+                         myOutputsToAdd,
+                         unCoveredExpr);
 
-      getGroupAttr()->addCharacteristicOutputs(myOutputsToAdd);
-    }
+  getGroupAttr()->addCharacteristicOutputs(myOutputsToAdd);
+  valuesForVEGRewrite.insertList(getTableDesc()->getColumnList());
+
+  keyColumns.insertList(getTableDesc()->getClusteringIndex()->getIndexKey());
 
   return TRUE;
 }
@@ -7674,6 +7696,11 @@ RelExpr * RelRoot::semanticQueryOptimizeNode(NormWA & normWARef)
                                 );
   }
 
+  // for debugging
+  if (normWARef.getCommonSubExprRefCount() > 0 &&
+      CmpCommon::getDefault(CSE_PRINT_DEBUG_INFO) == DF_ON)
+    CommonSubExprRef::displayAll();
+
   return this;
 
 } // RelRoot::semanticQueryOptimizeNode()
@@ -7717,8 +7744,11 @@ RelExpr * RelRoot::inlineTempTablesForCSEs(NormWA & normWARef)
         if (cses->at(i)->getInsertIntoTemp() != NULL)
           toDoVec += i;
 
-      // loop over the to-do list, finding new entries for which we
-      // already processed all of their predecessors
+      // Loop over the to-do list, finding new entries for which we
+      // already processed all of their predecessors. In this context,
+      // the children are the predecessors, since we have to build the
+      // graph bottom-up. In other words, find a topological reverse
+      // order of the lexical graph of the CSEs.
       while (toDoVec.entries() > 0)
         {
           RelExpr *thisLevelOfInserts = NULL;
@@ -7726,15 +7756,18 @@ RelExpr * RelRoot::inlineTempTablesForCSEs(NormWA & normWARef)
           for (CollIndex c=0; toDoVec.nextUsed(c); c++)
             {
               CSEInfo *info = cses->at(c);
-              // predecessor CSEs that have to be computed before we
+              // predecessor (child) CSEs that have to be computed before we
               // can attempt to compute this one
-              const LIST(CSEInfo *) &predecessors(info->getChildCSEs());
+              const LIST(CountedCSEInfo) &predecessors(info->getChildCSEs());
               NABoolean isReady = TRUE;
 
               for (CollIndex p=0; p<predecessors.entries(); p++)
                 {
-                  if (!doneVec.contains(p) &&
-                      cses->at(p)->getInsertIntoTemp() != NULL)
+                  Int32 cseId = predecessors[p].getInfo()->getCSEId();
+
+                  CMPASSERT(cses->at(cseId)->getCSEId() == cseId);
+                  if (!doneVec.contains(cseId) &&
+                      cses->at(cseId)->getInsertIntoTemp() != NULL)
                     // a predecessor CSE for which we have to
                     // materialize a temp table has not yet
                     // been processed - can't do this one
@@ -8017,8 +8050,9 @@ NABoolean RelExpr::prepareTreeForCSESharing(
      const ValueIdSet &predicatesToRemove,
      const ValueIdSet &newPredicatesToAdd,
      const ValueIdSet &inputsToRemove,
-     CSEInfo *info,
-     NABoolean testRun)
+     ValueIdSet &valuesForVEGRewrite,
+     ValueIdSet &keyColumns,
+     CSEInfo *info)
 {
   NABoolean result = TRUE;
   CollIndex nc = getArity();
@@ -8045,19 +8079,17 @@ NABoolean RelExpr::prepareTreeForCSESharing(
            childPredsToRemove,
            childPredsToAdd,
            inputsToRemove,
-           info,
-           testRun);
+           valuesForVEGRewrite,
+           keyColumns,
+           info);
 
-      if (!testRun)
-        {
-          // if the child already had or has added any of the requested
-          // outputs, then add them to our own char. outputs
-          ValueIdSet childAddedOutputs(
-               child(i).getGroupAttr()->getCharacteristicOutputs());
+      // if the child already had or has added any of the requested
+      // outputs, then add them to our own char. outputs
+      ValueIdSet childAddedOutputs(
+           child(i).getGroupAttr()->getCharacteristicOutputs());
 
-          childAddedOutputs.intersectSet(outputsToAdd);
-          getGroupAttr()->addCharacteristicOutputs(childAddedOutputs);
-        }
+      childAddedOutputs.intersectSet(outputsToAdd);
+      getGroupAttr()->addCharacteristicOutputs(childAddedOutputs);
 
       // Todo: CSE: consider using recursivePushDownCoveredExpr
       // instead of pushing these new predicates in this method
@@ -8065,10 +8097,10 @@ NABoolean RelExpr::prepareTreeForCSESharing(
       newLocalPredicates -= childPredsToAdd;
     }
 
-  if (result && !testRun)
+  if (result)
     {
       // Remove the predicates from our selection predicates.
-      // Note that the virtual method above is supposed to remove
+      // Note that prepareMeForCSESharing() is supposed to remove
       // these predicates from all other places in the node.
       predicates_ -= predicatesToRemove;
 
@@ -8103,8 +8135,9 @@ NABoolean RelExpr::prepareTreeForCSESharing(
                                     predicatesToRemove,
                                     newLocalPredicates,
                                     inputsToRemove,
-                                    info,
-                                    testRun);
+                                    valuesForVEGRewrite,
+                                    keyColumns,
+                                    info);
 
   return result;
 }
@@ -8129,8 +8162,9 @@ NABoolean RelExpr::prepareMeForCSESharing(
      const ValueIdSet &predicatesToRemove,
      const ValueIdSet &newPredicatesToAdd,
      const ValueIdSet &inputsToRemove,
-     CSEInfo *info,
-     NABoolean testRun)
+     ValueIdSet &valuesForVEGRewrite,
+     ValueIdSet &keyColumns,
+     CSEInfo *info)
 {
   // A class derived from RelExpr must explicitly define
   // this method to support being part of a shared CSE
@@ -8140,7 +8174,7 @@ NABoolean RelExpr::prepareMeForCSESharing(
   snprintf(buf, sizeof(buf), "Operator %s not supported",
            getText().data());
 
-  info->getConsumer(0)->emitCSEDiagnostics(buf, !testRun);
+  info->getConsumer(0)->emitCSEDiagnostics(buf);
 
   return FALSE;
 }
@@ -8990,6 +9024,11 @@ void CommonSubExprRef::transformNode(NormWA & normWARef,
     return;
   markAsTransformed();
 
+  // set lexicalRefNumFromParent_ for expanded refs, now that
+  // we can be sure the lexical ref has been bound
+  if (isAnExpansionOf_)
+    lexicalRefNumFromParent_ = isAnExpansionOf_->lexicalRefNumFromParent_;
+
   // Allocate a new VEG region for the child, to prevent VEGies that
   // cross the potentially common part and the rest of the query tree.
   //normWARef.allocateAndSetVEGRegion(EXPORT_ONLY, this);
@@ -9012,10 +9051,6 @@ void CommonSubExprRef::pullUpPreds()
   // pulled-up predicates here
   // RelExpr::pullUpPreds();
   // pulledPredicates_ += selectionPred();
-
-  // this is also the time to record the original set of inputs
-  // for this node, before predicate pushdown can alter the inputs
-  commonInputs_ = getGroupAttr()->getCharacteristicInputs();
 }
 
 void CommonSubExprRef::pushdownCoveredExpr(
@@ -9032,6 +9067,11 @@ void CommonSubExprRef::pushdownCoveredExpr(
   // common to all the consumers must be pulled back out before we can
   // share a common query tree.
   ValueIdSet predsPushedThisTime(predicatesOnParent);
+
+  if (pushedPredicates_.isEmpty())
+    // this is also the time to record the original set of inputs
+    // for this node, before predicate pushdown can alter the inputs
+    commonInputs_ = getGroupAttr()->getCharacteristicInputs();
 
   RelExpr::pushdownCoveredExpr(outputExpr,
                                newExternalInputs,
@@ -9059,13 +9099,13 @@ RelExpr * CommonSubExprRef::semanticQueryOptimizeNode(NormWA & normWARef)
   RelExpr *result = this;
   NABoolean ok = TRUE;
   CSEInfo *info = CmpCommon::statement()->getCSEInfo(internalName_);
-  CSEInfo::CSEAnalysisOutcome action = CSEInfo::UNKNOWN_ANALYSIS;
+
+  // do the analysis top-down
+  analyzeAndPrepareForSharing(*info);
 
   RelExpr::semanticQueryOptimizeNode(normWARef);
 
-  action = analyzeAndPrepareForSharing(*info);
-
-  switch (action)
+  switch (info->getAnalysisOutcome(id_))
     {
     case CSEInfo::EXPAND:
       // Not able to share the CSE, expand the CSE by eliminating
@@ -9108,11 +9148,6 @@ RelExpr * CommonSubExprRef::semanticQueryOptimizeNode(NormWA & normWARef)
       CMPASSERT(0);
     }
 
-  // for debugging
-  if (CmpCommon::getDefault(CSE_PRINT_DEBUG_INFO) == DF_ON &&
-      info->getIdOfAnalyzingConsumer() == id_)
-    displayAll(internalName_);
-
   if (result == NULL)
     emitCSEDiagnostics("Error in creating temp table or temp table insert",
                        TRUE);
@@ -9120,9 +9155,47 @@ RelExpr * CommonSubExprRef::semanticQueryOptimizeNode(NormWA & normWARef)
   return result;
 }
 
+NABoolean CommonSubExprRef::prepareMeForCSESharing(
+     const ValueIdSet &outputsToAdd,
+     const ValueIdSet &predicatesToRemove,
+     const ValueIdSet &commonPredicatesToAdd,
+     const ValueIdSet &inputsToRemove,
+     ValueIdSet &valuesForVEGRewrite,
+     ValueIdSet &keyColumns,
+     CSEInfo *info)
+{
+  // the caller of this method already took care of the adjustments to
+  // make, just make sure that all predicates could be pushed down to
+  // the child
+
+  if (!getSelectionPred().isEmpty())
+    {
+      // this should not happen
+      emitCSEDiagnostics("Unable to push common predicates into child tree");
+      return FALSE;
+    }
+  return TRUE;
+}
+
 CSEInfo::CSEAnalysisOutcome CommonSubExprRef::analyzeAndPrepareForSharing(CSEInfo &info)
 {
   // do a few simple shortcuts first
+
+  // Make sure this consumer is in the main list of consumers. Note
+  // that the analysis is done top-down and that currently the only
+  // two places where we make copies of the tree are in
+  // RelRoot::semanticQueryOptimizeNode() and in this method. The copy
+  // made in the root is only used when we bypass SQO completely.
+  // Although we may sometimes look at unused copies during the CSE
+  // analysis phase, this guarantees (for now) that the analyzing
+  // consumer always is and stays in the list of consumers. If we ever
+  // make additional copies of the tree we may need to reconsider this
+  // logic.
+  if (info.getConsumer(id_) != this)
+    {
+      info.replaceConsumerWithAnAlternative(this);
+      DCMPASSERT(info.getConsumer(id_) == this);
+    }
 
   // If another consumer has already done the analysis, return its result.
   // Note: Right now, all the consumers do the same, in the future, we could
@@ -9130,6 +9203,7 @@ CSEInfo::CSEAnalysisOutcome CommonSubExprRef::analyzeAndPrepareForSharing(CSEInf
   if (info.getIdOfAnalyzingConsumer() >= 0)
     return info.getAnalysisOutcome(id_);
 
+  // mark me as the analyzing consumer
   info.setIdOfAnalyzingConsumer(id_);
 
   if (CmpCommon::getDefault(CSE_USE_TEMP) == DF_OFF)
@@ -9145,6 +9219,7 @@ CSEInfo::CSEAnalysisOutcome CommonSubExprRef::analyzeAndPrepareForSharing(CSEInf
   ValueIdList tempTableColumns;
   const ValueIdSet &charOutputs(getGroupAttr()->getCharacteristicOutputs());
   CollIndex numConsumers = info.getNumConsumers();
+  RelExpr *copyOfChildTree = NULL;
 
   // A laundry list of changes to undo the effects of normalization,
   // specifically of pushing predicates down and of minimizing the
@@ -9160,6 +9235,10 @@ CSEInfo::CSEAnalysisOutcome CommonSubExprRef::analyzeAndPrepareForSharing(CSEInf
     new(CmpCommon::statementHeap()) ValueIdMap[numConsumers];
   ItemExpr *nonCommonPredicatesORed = NULL;
   int numORedPreds = 0;
+  NABoolean singleLexicalRefWithTempedAncestors =
+    (info.getNumLexicalRefs() == 1);
+  Int32 numPreliminaryRefs = 0;
+  ValueIdSet childTreeKeyColumns;
 
   // ------------------------------------------------------------------
   // CSE Analysis phase
@@ -9179,6 +9258,35 @@ CSEInfo::CSEAnalysisOutcome CommonSubExprRef::analyzeAndPrepareForSharing(CSEInf
       const ValueIdSet &cPreds(consumer->pushedPredicates_);
       ValueIdSet mappedPreds;
       ValueId dummy;
+      CSEInfo *infoToCheck = &info;
+      CommonSubExprRef *childToCheck = consumer;
+      NABoolean ancestorIsTemped = FALSE;
+
+      // look for a chain of only lexical ancestors of which one is
+      // materialized in a temp table
+      while (!ancestorIsTemped &&
+             infoToCheck->getNumLexicalRefs() == 1 &&
+             childToCheck &&
+             childToCheck->parentRefId_ >= 0)
+        {
+          // look at the ancestor and what it is planning to do
+          infoToCheck = CmpCommon::statement()->getCSEInfoById(
+               childToCheck->parentCSEId_);
+          CMPASSERT(infoToCheck);
+          CommonSubExprRef *parent =
+            infoToCheck->getConsumer(childToCheck->parentRefId_);
+          CSEInfo::CSEAnalysisOutcome parentOutcome =
+            infoToCheck->getAnalysisOutcome(parent->getId());
+
+          if (parentOutcome == CSEInfo::CREATE_TEMP ||
+              parentOutcome == CSEInfo::TEMP)
+            ancestorIsTemped = TRUE;
+
+          childToCheck = parent;
+        }
+
+      if (!ancestorIsTemped)
+        singleLexicalRefWithTempedAncestors = FALSE;
 
       requiredValues += cPreds;
       availableValues +=
@@ -9273,13 +9381,24 @@ CSEInfo::CSEAnalysisOutcome CommonSubExprRef::analyzeAndPrepareForSharing(CSEInf
             // own ValueIds
             myColsToConsumerMaps[c].rewriteValueIdSetUp(mappedPreds, cPreds);
 
-            commonPredicates.findCommonSubexpressions(mappedPreds, TRUE);
+            commonPredicates.findCommonSubexpressions(mappedPreds, FALSE);
 
           }
       // Save the mapped preds for later.
       // Note: These are not final yet, until we have found
       // common predicates among all the consumers.
       nonCommonPredicatesArray[c] = mappedPreds;
+    }
+
+  if (singleLexicalRefWithTempedAncestors)
+    {
+      // if all the parent refs are materialized and each one is a
+      // copy of a single lexical ref, then that means that we will
+      // evaluate this CSE only once, therefore no need to materialize
+      // it
+      emitCSEDiagnostics(
+           "expression is only evaluated once because parent is materialized");
+      canShare = FALSE;
     }
 
   // translate the bit vector of required columns into a set of values
@@ -9293,6 +9412,15 @@ CSEInfo::CSEAnalysisOutcome CommonSubExprRef::analyzeAndPrepareForSharing(CSEInf
   predicatesToRemove -= commonPredicates;
   info.setCommonPredicates(commonPredicates);
 
+  if (canShare && info.getNeededColumns().entries() == 0)
+    {
+      // Temp table has no columns, looks like all we care about is
+      // the number of rows returned. This is not yet supported. We
+      // could make a table with a dummy column.
+      emitCSEDiagnostics("Temp table with no columns is not yet supported");
+      canShare = FALSE;
+    }
+
   // Make an ORed predicate of all those non-common predicates of the
   // consumers, to be applied on the common subexpression when creating
   // the temp table. Also determine non-common predicates to be applied
@@ -9305,7 +9433,11 @@ CSEInfo::CSEAnalysisOutcome CommonSubExprRef::analyzeAndPrepareForSharing(CSEInf
       // tables. What we can do, however, is to OR these "uncommon"
       // predicates and apply that OR predicate when building the
       // temp table.
-      nonCommonPredicatesArray[n] -= commonPredicates;
+
+      // repeat step from above, but this time remove the common
+      // preds from the array of non-common ones
+      commonPredicates.findCommonSubexpressions(nonCommonPredicatesArray[n],
+                                                TRUE);
 
       if (nonCommonPredicatesArray[n].entries() > 0)
         {
@@ -9348,38 +9480,6 @@ CSEInfo::CSEAnalysisOutcome CommonSubExprRef::analyzeAndPrepareForSharing(CSEInf
       info.addCommonPredicates(newPredicatesToAdd);
     }
 
-  outputsToAdd -= child(0).getGroupAttr()->getCharacteristicOutputs();
-  inputsToRemove -= commonInputs_;
-
-  // do a dry-run first, before we change the child tree,
-  // because if we can't prepare the tree for CSE sharing,
-  // we'll need it in its original form to be able to expand it
-  if (canShare)
-    canShare = child(0)->prepareTreeForCSESharing(
-         outputsToAdd,
-         predicatesToRemove,
-         newPredicatesToAdd,
-         inputsToRemove,
-         &info,
-         TRUE);
-
-  if (canShare &&
-      CmpCommon::getDefault(CSE_USE_TEMP) != DF_ON)
-    {
-      // Todo: CSE: make a heuristic decision
-      emitCSEDiagnostics("Heuristically decided not to materialize");
-      canShare = FALSE;
-    }
-
-  if (canShare && info.getNeededColumns().entries() == 0)
-    {
-      // Temp table has no columns, looks like all we care about is
-      // the number of rows returned. This is not yet supported. We
-      // could make a table with a dummy column.
-      emitCSEDiagnostics("Temp table with no columns is not supported");
-      canShare = FALSE;
-    }
-
 
   // ------------------------------------------------------------------
   // Preparation phase
@@ -9387,38 +9487,152 @@ CSEInfo::CSEAnalysisOutcome CommonSubExprRef::analyzeAndPrepareForSharing(CSEInf
 
   if (canShare)
     {
-      canShare = child(0)->prepareTreeForCSESharing(
+      // make a copy of the child tree, so we can revert back to the
+      // original tree if things don't work out
+      copyOfChildTree = child(0)->copyRelExprTree(CmpCommon::statementHeap());
+
+      outputsToAdd -= child(0).getGroupAttr()->getCharacteristicOutputs();
+      inputsToRemove -= commonInputs_;
+
+      canShare = copyOfChildTree->prepareTreeForCSESharing(
            outputsToAdd,
            predicatesToRemove,
            newPredicatesToAdd,
            inputsToRemove,
-           &info,
-           FALSE);
+           nonVEGColumns_,
+           childTreeKeyColumns,
+           &info);
 
-      // If this failed we are in trouble, we potentially changed the
-      // child tree, preventing us from expanding it. Therefore we
-      // have to error out. We should therefore find most problems
-      // in the dry run above.
       if (!canShare)
-        {
-          emitCSEDiagnostics("Failed to prepare child tree for materialization",
-                             TRUE);
-          result = CSEInfo::ERROR;
-        }
-      else if (!child(0).getGroupAttr()->getCharacteristicOutputs().contains(
+        emitCSEDiagnostics("Failed to prepare child tree for materialization");
+      else if (!copyOfChildTree->getGroupAttr()->getCharacteristicOutputs().contains(
                     outputsToAdd))
         {
           // we failed to produce the requested additional outputs
-          emitCSEDiagnostics("Failed to produce all the required output columns",
-                             TRUE);
+          emitCSEDiagnostics("Failed to produce all the required output columns");
           canShare = FALSE;
-          result = CSEInfo::ERROR;
+        }
+      else
+        {
+          // remember est. log. props of the child, those will be transplanted
+          // into the temp scan later
+          cseEstLogProps_ =
+            copyOfChildTree->getGroupAttr()->outputLogProp(
+                 (*GLOBAL_EMPTY_INPUT_LOGPROP));
+          // Get a preliminary bearing on how many times we are going
+          // to evaluate this CSE if it isn't shared. Note that this
+          // looks at the parent CSE's analysis outcome, and not all
+          // of these parents may be analyzed yet, so this may be an
+          // overestimate.
+          numPreliminaryRefs = info.getTotalNumRefs();
+
+          for (CollIndex k=0; k<tempTableColumns.entries(); k++)
+            if (childTreeKeyColumns.contains(tempTableColumns[k]))
+              info.addCSEKeyColumn(k);
+        }
+    }
+
+  if (canShare &&
+      CmpCommon::getDefault(CSE_USE_TEMP) != DF_ON)
+    {
+      // When CSE_USE_TEMP is set to SYSTEM, make a heuristic decision
+
+      // calculate some metrics for the temp table, based on row length,
+      // cardinality (or max. cardinality) and number of times it is used
+      Lng32 tempTableRowLength = tempTableColumns.getRowLength();
+      CostScalar cseTempTableSize = cseEstLogProps_->getResultCardinality() *
+        tempTableRowLength / numPreliminaryRefs;
+      CostScalar cseTempTableMaxSize = cseEstLogProps_->getMaxCardEst() *
+        tempTableRowLength / numPreliminaryRefs;
+      double maxTableSize =
+        ActiveSchemaDB()->getDefaults().getAsDouble(CSE_TEMP_TABLE_MAX_SIZE);
+      double maxTableSizeBasedOnMaxCard =
+        ActiveSchemaDB()->getDefaults().getAsDouble(CSE_TEMP_TABLE_MAX_MAX_SIZE);
+
+      // cumulative number of key columns referenced in consumers
+      Int32 totalKeyColPreds = 0;
+
+      // key cols that are referenced by a predicate in all consumers
+      ValueIdSet commonKeyCols(childTreeKeyColumns);
+
+      // check the total size of the temp table, divided by the number
+      // of times it is used
+      if (maxTableSize > 0 && cseTempTableSize > maxTableSize)
+        {
+          char buf[200];
+
+          snprintf(buf, sizeof(buf),
+                   "Temp table size %e exceeds limit %e",
+                   cseTempTableSize.getValue(),
+                   maxTableSize);
+          emitCSEDiagnostics(buf);
+          canShare = FALSE;
+        }
+      else if (maxTableSizeBasedOnMaxCard > 0 &&
+               cseTempTableMaxSize > maxTableSizeBasedOnMaxCard)
+        {
+          char buf[200];
+
+          snprintf(buf, sizeof(buf),
+                   "Temp table size %e (based on max card) exceeds limit %e",
+                   cseTempTableMaxSize.getValue(),
+                   maxTableSizeBasedOnMaxCard);
+          emitCSEDiagnostics(buf);
+          canShare = FALSE;
         }
 
+      // determine which "key" columns are referenced by non-common
+      // predicates
+      for (CollIndex ncp=0; ncp<numConsumers; ncp++)
+        {
+          const ValueIdSet &nonCommonPreds(nonCommonPredicatesArray[ncp]);
+          ValueIdSet tempRefCols;
+
+          tempRefCols.accumulateReferencedValues(childTreeKeyColumns,
+                                                 nonCommonPreds);
+          totalKeyColPreds += tempRefCols.entries();
+          nonCommonPreds.weedOutUnreferenced(commonKeyCols);
+        }
+
+      // decide against materialization if the average number of "key"
+      // columns referenced in each consumer is greater than
+      // CSE_PCT_KEY_COL_PRED_CONTROL percent
+      if (totalKeyColPreds >
+          (numConsumers * childTreeKeyColumns.entries() *
+           ActiveSchemaDB()->getDefaults().getAsDouble(CSE_PCT_KEY_COL_PRED_CONTROL) / 100.0))
+        {
+          char buf[200];
+
+          snprintf(buf, sizeof(buf),
+                   "Number of potential key predicates in consumers (%d) exceeds limit %f",
+                   totalKeyColPreds,
+                   (numConsumers * childTreeKeyColumns.entries() *
+                    ActiveSchemaDB()->getDefaults().getAsDouble(CSE_PCT_KEY_COL_PRED_CONTROL) / 100.0));
+          
+          emitCSEDiagnostics(buf);
+          canShare = FALSE;
+        }
+
+      // decide against materialization if the number of key columns
+      // referenced by every consumer is > CSE_COMMON_KEY_PRED_CONTROL
+      if (commonKeyCols.entries() >
+          ActiveSchemaDB()->getDefaults().getAsLong(CSE_COMMON_KEY_PRED_CONTROL))
+        {
+          char buf[200];
+          snprintf(buf, sizeof(buf),
+                   "All consumers have a predicate on %d common key columns, limit is %d",
+                   commonKeyCols.entries(),
+                   ActiveSchemaDB()->getDefaults().getAsLong(CSE_COMMON_KEY_PRED_CONTROL));
+          emitCSEDiagnostics(buf);
+          canShare = FALSE;
+        }
     }
 
   if (canShare)
-    result = CSEInfo::CREATE_TEMP;
+    {
+      result = CSEInfo::CREATE_TEMP;
+      child(0) = copyOfChildTree;
+    }
   else if (result == CSEInfo::UNKNOWN_ANALYSIS)
     result = CSEInfo::EXPAND;
 

--- a/core/sql/optimizer/RelExeUtil.cpp
+++ b/core/sql/optimizer/RelExeUtil.cpp
@@ -116,6 +116,21 @@ void castComputedColumnsToAnsiTypes(BindWA *bindWA,
 // Member functions for class GenericUtilExpr
 // -----------------------------------------------------------------------
 
+NABoolean GenericUtilExpr::duplicateMatch(const RelExpr & other) const
+{
+  if (NOT RelExpr::duplicateMatch(other))
+    return FALSE;
+
+  // a simplified version, should really check all fields
+  GenericUtilExpr &o = (GenericUtilExpr &) other;
+  if (NOT (stmtText_ == o.stmtText_ ||
+           stmtText_ && o.stmtText_ &&
+           (strcmp(stmtText_, o.stmtText_) == 0)))
+    return FALSE;
+
+  return TRUE;
+}
+
 RelExpr * GenericUtilExpr::copyTopNode(RelExpr *derivedNode, CollHeap* outHeap)
 {
   GenericUtilExpr *result;
@@ -292,6 +307,33 @@ NABoolean ExeUtilExpr::pilotAnalysis(QueryAnalysis* qa)
     return FALSE;
 
   if (!qa->newTableAnalysis(this))
+    return FALSE;
+
+  return TRUE;
+}
+
+HashValue ExeUtilExpr::topHash()
+{
+  HashValue result = GenericUtilExpr::topHash();
+
+  result ^= tableId_;
+
+  return result;
+}
+
+NABoolean ExeUtilExpr::duplicateMatch(const RelExpr & other) const
+{
+  if (NOT GenericUtilExpr::duplicateMatch(other))
+    return FALSE;
+
+  // a simplified version, should really check all fields
+  ExeUtilExpr &o = (ExeUtilExpr &) other;
+  if (NOT (tableId_ == o.tableId_))
+    return FALSE;
+
+  // if tableDesc is not allocated, compare the names
+  if (tableId_ == NULL &&
+      NOT(tableName_ == o.tableName_))
     return FALSE;
 
   return TRUE;

--- a/core/sql/optimizer/RelExeUtil.h
+++ b/core/sql/optimizer/RelExeUtil.h
@@ -137,6 +137,7 @@ public:
 
   // get the degree of this node 
   virtual Int32 getArity() const { return 0; };
+  virtual NABoolean duplicateMatch(const RelExpr & other) const;
   virtual RelExpr * copyTopNode(RelExpr *derivedNode = NULL,
 				CollHeap* outHeap = 0);
 
@@ -597,6 +598,8 @@ public:
   ExeUtilExpr()
        : GenericUtilExpr(REL_EXE_UTIL) {};
 
+  virtual HashValue topHash();
+  virtual NABoolean duplicateMatch(const RelExpr & other) const;
   virtual RelExpr * copyTopNode(RelExpr *derivedNode = NULL,
 				CollHeap* outHeap = 0);
   virtual const NAString getText() const;

--- a/core/sql/optimizer/RelExpr.cpp
+++ b/core/sql/optimizer/RelExpr.cpp
@@ -287,6 +287,7 @@ RelExpr::RelExpr(OperatorTypeEnum otype,
   ,cachedTupleFormat_(ExpTupleDesc::UNINITIALIZED_FORMAT)
   ,cachedResizeCIFRecord_(FALSE)
   ,dopReduced_(FALSE)
+  ,originalExpr_(NULL)
 {
 
   child_[0] = leftChild;
@@ -854,6 +855,7 @@ RelExpr * RelExpr::copyTopNode(RelExpr *derivedNode,CollHeap* outHeap)
   result->sourceMemoExprId_ = sourceMemoExprId_;
   result->sourceGroupId_ = sourceGroupId_;
   result->costLimit_ = costLimit_;
+  result->originalExpr_ = this;
 
   return result;
 }
@@ -886,6 +888,32 @@ RelExpr * RelExpr::copyRelExprTree(CollHeap* outHeap)
 
   for (Lng32 i = 0; i < arity; i++)
     result->child(i) = child(i)->copyRelExprTree(outHeap);
+
+  return result;
+}
+
+const RelExpr * RelExpr::getOriginalExpr(NABoolean transitive) const
+{
+  if (originalExpr_ == NULL)
+    return this;
+
+  RelExpr *result = originalExpr_;
+
+  while (result->originalExpr_ && transitive)
+    result = result->originalExpr_;
+
+  return result;
+}
+
+RelExpr * RelExpr::getOriginalExpr(NABoolean transitive)
+{
+  if (originalExpr_ == NULL)
+    return this;
+
+  RelExpr *result = originalExpr_;
+
+  while (result->originalExpr_ && transitive)
+    result = result->originalExpr_;
 
   return result;
 }
@@ -11988,16 +12016,73 @@ void MapValueIds::pushdownCoveredExpr(
           {
             VEG *veg =
               static_cast<VEGPredicate *>(g.getItemExpr())->getVEG();
-            ValueIdSet vegMembers(veg->getAllValues());
+            ValueId vegRef(veg->getVEGReference()->getValueId());
 
-            vegMembers += veg->getVEGReference()->getValueId();
-            vegMembers.intersectSet(
-                 getGroupAttr()->getCharacteristicOutputs());
-            if (!vegMembers.isEmpty())
-              // a VEGPred on one of my characteristic outputs,
-              // assume that my child tree already has the
-              // associated VEGPreds
-              predicatesOnParent -= g;
+            if (newExternalInputs.contains(vegRef))
+              {
+                // We are trying to push down a VEGPred and we are at
+                // the same time offering the VEGRef as a new
+                // characteristic input.  Example: We want to push
+                // VEGPred_2(a=b) down and we offer its corresponding
+                // VEGRef_1(a,b) as an input. The map in our
+                // MapValueIds node maps VEGRef_1(a,b) on the top to
+                // VEGRef_99(x,y) on the bottom. Note that either one
+                // of the VEGies might contain a constant that the
+                // other one doesn't contain. Note also that the
+                // MapValueIds node doesn't map characteristic inputs,
+                // those are passed unchanged to the child. So, we need
+                // to generate a predicate for the child that:
+                // a) represents the semantics of VEGPred_2(a,b)
+                // b) compares the new characteristic input
+                //    VEGRef_1(a,b) with some value in the child
+                // c) doesn't change the members of the existing
+                //    VEGies.
+                // The best solution is probably an equals predicate
+                // between the characteristic input and the VEGRef
+                // (or other expression) that is the child's equivalent.
+                // Example:  VEGRef_1(a,b) = VEGRef_99(x,y)
+                ValueId bottomVal;
+                ItemExpr *eqPred = NULL;
+
+                map_.mapValueIdDown(vegRef, bottomVal);
+
+                if (vegRef != bottomVal && bottomVal != NULL_VALUE_ID)
+                  {
+                    eqPred = new(CmpCommon::statementHeap()) BiRelat(
+                         ITM_EQUAL,
+                         vegRef.getItemExpr(),
+                         bottomVal.getItemExpr(),
+                         veg->getSpecialNulls());
+                    eqPred->synthTypeAndValueId();
+                    // replace g with the new equals predicate
+                    // when we do the actual rewrite below
+                    map_.addMapEntry(g, eqPred->getValueId());
+                  }
+              }
+            else
+              {
+                // Don't push down VEGPredicates on columns that are
+                // characteristic outputs of the MapValueIds. Those
+                // predicates (or their equivalents) should have
+                // already been pushed down.
+                ValueIdSet vegMembers(veg->getAllValues());
+
+                vegMembers += vegRef;
+                vegMembers.intersectSet(
+                     getGroupAttr()->getCharacteristicOutputs());
+                if (!vegMembers.isEmpty())
+                  {
+                    // a VEGPred on one of my characteristic outputs,
+
+                    // assume that my child tree already has the
+                    // associated VEGPreds and remove this predicate
+                    // silently
+                    predicatesOnParent -= g;
+                  }
+                // else leave the predicate and let the code below deal
+                // with it, this will probably end up in a failed assert
+                // below for predsRewrittenForChild.isEmpty()
+              }
           }
     }
 
@@ -12237,6 +12322,90 @@ void ControlRunningQuery::setComment(NAString &comment)
 // member functions for class CSEInfo (helper for CommonSubExprRef)
 // -----------------------------------------------------------------------
 
+Int32 CSEInfo::getTotalNumRefs(Int32 restrictToSingleConsumer) const
+{
+  // shortcut for main query
+  if (cseId_ == CmpStatement::getCSEIdForMainQuery())
+    return 1;
+
+  // Calculate how many times we will evaluate this common subexpression
+  // at runtime:
+  //  - If the CSE is shared then we evaluate it once
+  //  - Otherwise, look at the consumers that are lexical refs
+  //    (avoid double-counting refs from multiple copies of a parent)
+  //    and add the times they are being executed.
+  Int32 result = 0;
+  NABoolean sharedConsumers = FALSE;
+  LIST(CountedCSEInfo) countsByCSE(CmpCommon::statementHeap());
+  CollIndex minc = 0;
+  CollIndex maxc = consumers_.entries();
+
+  if (restrictToSingleConsumer >= 0)
+    {
+      // count only the executions resulting from a single consumer
+      minc = restrictToSingleConsumer;
+      maxc = minc + 1;
+    }
+
+  // loop over all consumers or look at just one
+  for (CollIndex c=minc; c<maxc; c++)
+    {
+      if (isShared(c))
+        {
+          sharedConsumers = TRUE;
+        }
+      else
+        {
+          CommonSubExprRef *consumer = getConsumer(c);
+          CSEInfo *parentInfo = CmpCommon::statement()->getCSEInfoById(
+               consumer->getParentCSEId());
+          NABoolean duplicateDueToSharedConsumer = FALSE;
+
+          // Don't double-count consumers that originate from the
+          // same parent CSE, have the same lexical ref number from
+          // the parent, and are shared.
+          if (parentInfo->isShared(
+                   consumer->getParentConsumerId()))
+            {
+              for (CollIndex d=0; d<countsByCSE.entries(); d++)
+                if (countsByCSE[d].getInfo() == parentInfo &&
+                    countsByCSE[d].getLexicalCount() ==
+                    consumer->getLexicalRefNumFromParent())
+                  {
+                    duplicateDueToSharedConsumer = TRUE;
+                    break;
+                  }
+
+              // First consumer from this parent CSE with this lexical
+              // ref number, remember that we are going to count
+              // it. Note that we are use the lexical ref "count" in
+              // CountedCSEInfo as the lexical ref number in this
+              // method, so the name "count" means "ref number" in
+              // this context.
+              if (!duplicateDueToSharedConsumer)
+                countsByCSE.insert(
+                     CountedCSEInfo(
+                          parentInfo,
+                          consumer->getLexicalRefNumFromParent()));
+            } // parent consumer is shared
+
+          if (!duplicateDueToSharedConsumer)
+            {
+              // recursively determine number of times the parent of
+              // this consumer gets executed
+              result += parentInfo->getTotalNumRefs(
+                   consumer->getParentConsumerId());
+            }
+        } // consumer is not shared
+    } // loop over consumer(s)
+
+  if (sharedConsumers)
+    // all the shared consumers are handled by evaluating the CSE once
+    result++;
+
+  return result;
+}
+
 CSEInfo::CSEAnalysisOutcome CSEInfo::getAnalysisOutcome(Int32 id) const
 {
   if (idOfAnalyzingConsumer_ != id &&
@@ -12248,10 +12417,37 @@ CSEInfo::CSEAnalysisOutcome CSEInfo::getAnalysisOutcome(Int32 id) const
     return analysisOutcome_;
 }
 
-void CSEInfo::addChildCSE(CSEInfo *child)
+Int32 CSEInfo::addChildCSE(CSEInfo *childInfo, NABoolean addLexicalRef)
 {
-  if (!childCSEs_.contains(child))
-    childCSEs_.insert(child);
+  Int32 result = -1;
+  CollIndex foundIndex = NULL_COLL_INDEX;
+
+  // look for an existing entry
+  for (CollIndex i=0;
+       i<childCSEs_.entries() && foundIndex == NULL_COLL_INDEX;
+       i++)
+    if (childCSEs_[i].getInfo() == childInfo)
+      foundIndex = i;
+
+  if (foundIndex == NULL_COLL_INDEX)
+    {
+      // create a new entry
+      foundIndex = childCSEs_.entries();
+      childCSEs_.insert(CountedCSEInfo(childInfo));
+    }           
+
+  if (addLexicalRef)
+    {
+      // The return value for a lexical ref is the count of lexical
+      // refs for this particular parent/child CSE relationship so far
+      // (0 if this is the first one). Note that we can't say anything
+      // abount counts for expanded refs at this time, those will be
+      // handled later, during the transform phase of the normalizer.
+      result = childCSEs_[foundIndex].getLexicalCount();
+      childCSEs_[foundIndex].incrementLexicalCount();
+    }
+
+  return result;
 }
 
 void CSEInfo::addCSERef(CommonSubExprRef *cse)
@@ -12259,11 +12455,37 @@ void CSEInfo::addCSERef(CommonSubExprRef *cse)
   CMPASSERT(name_ == cse->getName());
   cse->setId(consumers_.entries());
   consumers_.insert(cse);
+  if (cse->isALexicalRef())
+    numLexicalRefs_++;
+}
+
+void CSEInfo::replaceConsumerWithAnAlternative(CommonSubExprRef *c)
+{
+  Int32 idToReplace = c->getId();
+
+  if (consumers_[idToReplace] != c)
+    {
+      CollIndex foundPos = alternativeConsumers_.index(c);
+
+      CMPASSERT(foundPos != NULL_COLL_INDEX);
+      CMPASSERT(consumers_[idToReplace]->getOriginalRef() ==
+                c->getOriginalRef());
+      // c moves from the list of copies to the real list and another
+      // consumer moves the opposite way
+      alternativeConsumers_.removeAt(foundPos);
+      alternativeConsumers_.insert(consumers_[idToReplace]);
+      consumers_[idToReplace] = c;
+    }
 }
 
 // -----------------------------------------------------------------------
 // member functions for class CommonSubExprRef
 // -----------------------------------------------------------------------
+
+NABoolean CommonSubExprRef::isAChildOfTheMainQuery() const
+{
+  return (parentCSEId_ == CmpStatement::getCSEIdForMainQuery());
+}
 
 CommonSubExprRef::~CommonSubExprRef()
 {
@@ -12275,12 +12497,18 @@ Int32 CommonSubExprRef::getArity() const
   return 1;
 }
 
-void CommonSubExprRef::addToCmpStatement()
+void CommonSubExprRef::addToCmpStatement(NABoolean lexicalRef)
 {
   NABoolean alreadySeen = TRUE;
 
   // look up whether a CSE with this name already exists
   CSEInfo *info = CmpCommon::statement()->getCSEInfo(internalName_);
+
+  // sanity check, make sure that the caller knows whether this is a
+  // lexical ref (generated with CommonSubExprRef constructor) or an
+  // expanded ref (generated with CommonSubExprRef::copyTopNode()
+  // before the bind phase)
+  CMPASSERT(isALexicalRef() == lexicalRef);
 
   if (!info)
     {
@@ -12298,13 +12526,47 @@ void CommonSubExprRef::addToCmpStatement()
     CmpCommon::statement()->addCSEInfo(info);
 }
 
-NABoolean CommonSubExprRef::isFirstReference()
+void CommonSubExprRef::addParentRef(CommonSubExprRef *parentRef)
 {
-  return (
-       // this is the first reference added, or
-       id_ == 0 ||
-       // this is not yet added an no other reference has been added yet
-       id_ < 0 && CmpCommon::statement()->getCSEInfo(internalName_) == NULL);
+  // Establish the parent/child relationship between two
+  // CommonSubExprRef nodes, or between the main query and a
+  // CommonSubExprRef node (parentRef == NULL). Also, record
+  // the dependency between parent and child CSEs in the lexical
+  // dependency multigraph. Bookkeeping to do:
+  //
+  // - Add the child's CSE to the list of child CSEs of the
+  //   parent CSE
+  // - Set the data members in the child ref that point to the
+  //   parent CSE and parent ref
+
+  // parent info is for a parent CSE or for the main query
+  CSEInfo *parentInfo =
+    (parentRef ? CmpCommon::statement()->getCSEInfo(parentRef->getName())
+               : CmpCommon::statement()->getCSEInfoForMainQuery());
+  CSEInfo *childInfo =
+    CmpCommon::statement()->getCSEInfo(getName());
+
+  CMPASSERT(parentInfo && childInfo);
+
+  // Update the lexical CSE multigraph, and also return the
+  // count of previously existing edges in the graph.
+  // LexicalRefNumFromParent is set to a positive value only for
+  // lexical refs, the other refs will be handled later, in the SQO
+  // phase. This is since expanded refs may be processed before their
+  // lexical ref and we may not know this value yet.
+  lexicalRefNumFromParent_ =
+    parentInfo->addChildCSE(childInfo, isALexicalRef());
+
+  parentCSEId_ = parentInfo->getCSEId();
+  if (parentRef)
+    parentRefId_ = parentRef->getId();
+  else
+    parentRefId_ = -1;  // main query does not have a CommonSubExprRef
+}
+
+NABoolean CommonSubExprRef::isFirstReference() const
+{
+  return (CmpCommon::statement()->getCSEInfo(internalName_) == NULL);
 }
 
 void CommonSubExprRef::addLocalExpr(LIST(ExprNode *) &xlist,
@@ -12360,20 +12622,46 @@ RelExpr * CommonSubExprRef::copyTopNode(RelExpr *derivedNode,
   else
     result = static_cast<CommonSubExprRef *>(derivedNode);
 
+  // copy fields that are common for bound and unbound nodes
+  result->hbAccessOptionsFromCTE_ = hbAccessOptionsFromCTE_;
+
   if (nodeIsBound())
     {
       // if the node is bound, we assume that the copy is serving the same function
-      // as the original
+      // as the original, as an alternative, create an "alternative ref"
       result->setId(id_);
+
+      result->parentCSEId_ = parentCSEId_;
+      result->parentRefId_ = parentRefId_;
+      result->lexicalRefNumFromParent_ = lexicalRefNumFromParent_;
       result->columnList_ = columnList_;
+      result->nonVEGColumns_ = nonVEGColumns_;
+      result->commonInputs_ = commonInputs_;
       result->pushedPredicates_ = pushedPredicates_;
+      result->nonSharedPredicates_ = nonSharedPredicates_;
+      result->cseEstLogProps_ = cseEstLogProps_;
+      // don't copy the tempScan_
+
+      // Mark this as an alternative ref, not that this does not
+      // change the status of lexical vs. expanded ref
+      result->isAnExpansionOf_ = isAnExpansionOf_;
+      result->isAnAlternativeOf_ =
+        ( isAnAlternativeOf_ ? isAnAlternativeOf_ : this);
+
+      CmpCommon::statement()->getCSEInfo(internalName_)->
+        registerAnAlternativeConsumer(result);
     }
   else
-    // if the node is not bound, we assume that we created a new
-    // reference to a common subexpression, for example by referencing
-    // a CTE that itself contains another reference to a CTE (Common
-    // Table Expression)
-    result->addToCmpStatement();
+    {
+      // If the node is not bound, we assume that we created an
+      // "expanded" reference to a common subexpression in a tree that
+      // itself is a reference to a CTE (Common Table Expression).
+      // See the comment in RelMisc.h for method isAnExpandedRef()
+      // to explain the term "expanded" ref.
+      result->isAnExpansionOf_ =
+        (isAnExpansionOf_ ? isAnExpansionOf_ : this);
+      result->addToCmpStatement(FALSE);
+    }
 
   return result;
 }
@@ -12414,12 +12702,25 @@ Union * CommonSubExprRef::makeUnion(RelExpr *lc,
 
 void CommonSubExprRef::display()
 {
+  if (isAChildOfTheMainQuery())
+    printf("Parent: main query, lexical ref %d\n",
+           lexicalRefNumFromParent_);
+  else
+    printf("Parent: %s(consumer %d, lexical ref %d)\n",
+           CmpCommon::statement()->getCSEInfoById(
+                parentCSEId_)->getName().data(),
+           parentRefId_,
+           lexicalRefNumFromParent_);
   printf("Original columns:\n");
   columnList_.display();
   printf("\nCommon inputs:\n");
   commonInputs_.display();
   printf("\nPushed predicates:\n");
   pushedPredicates_.display();
+  printf("\nNon shared preds to be applied to scan:\n");
+  nonSharedPredicates_.display();
+  printf("\nPotential values for VEG rewrite:\n");
+  nonVEGColumns_.display();
 }
 
 void CommonSubExprRef::displayAll(const char *optionalId)
@@ -12434,16 +12735,30 @@ void CommonSubExprRef::displayAll(const char *optionalId)
         {
           CSEInfo *info = cses->at(i);
           CollIndex nc = info->getNumConsumers();
+          NABoolean isMainQuery =
+            (info->getCSEId() == CmpStatement::getCSEIdForMainQuery());
 
-          printf("==========================\n");
-          printf("CSE: %s (%d consumers)\n",
-                 info->getName().data(),
-                 nc);
+          if (isMainQuery)
+            {
+              printf("\n\n==========================\n");
+              printf("MainQuery:\n");
+            }
+          else
+            {
+              printf("\n\n==========================\n");
+              printf("CSE: %s (%d consumers, %d lexical ref(s), %d total execution(s))\n",
+                     info->getName().data(),
+                     nc,
+                     info->getNumLexicalRefs(),
+                     info->getTotalNumRefs());
+            }
 
-          const LIST(CSEInfo *) &children(info->getChildCSEs());
+          const LIST(CountedCSEInfo) &children(info->getChildCSEs());
 
           for (CollIndex j=0; j<children.entries(); j++)
-            printf("       references CSE: %s\n", children[j]->getName().data());
+            printf("       references CSE: %s %d times\n",
+                   children[j].getInfo()->getName().data(),
+                   children[j].getLexicalCount());
 
           if (info->getIdOfAnalyzingConsumer() >= 0)
             {
@@ -12479,36 +12794,50 @@ void CommonSubExprRef::displayAll(const char *optionalId)
                      info->getIdOfAnalyzingConsumer(),
                      outcome);
 
-              makeValueIdListFromBitVector(cols,
-                                           cCols,
-                                           info->getNeededColumns());
-              printf("  \ncolumns of temp table:\n");
+              makeValueIdListFromBitVector(
+                   cols,
+                   cCols,
+                   info->getNeededColumns());
+              printf("\n  columns of temp table:\n");
               cols.display();
-              printf("  \ncommonPredicates:\n");
+              printf("\n  commonPredicates:\n");
               info->getCommonPredicates().display();
               if (info->getVEGRefsWithDifferingConstants().entries() > 0)
                 {
-                  printf("  \nvegRefsWithDifferingConstants:\n");
+                  printf("\n  vegRefsWithDifferingConstants:\n");
                   info->getVEGRefsWithDifferingConstants().display();
                 }
               if (info->getVEGRefsWithDifferingInputs().entries() > 0)
                 {
-                  printf("  \nvegRefsWithDifferingInputs:\n");
+                  printf("\n  vegRefsWithDifferingInputs:\n");
                   info->getVEGRefsWithDifferingInputs().display();
                 }
-              printf("  \ntempTableName: %s\n",
-                     info->getTempTableName().
-                     getQualifiedNameAsAnsiString().data());
-              printf("  \nDDL of temp table:\n%s\n",
+              if (info->getCSETreeKeyColumns().entries() > 0)
+                {
+                  ValueIdList keyCols;
+
+                  makeValueIdListFromBitVector(
+                       keyCols,
+                       cCols,
+                       info->getCSETreeKeyColumns());
+                  printf("\n  CSE key columns:\n");
+                  keyCols.display();
+                }
+              printf("\n  DDL of temp table:\n%s\n",
                      info->getTempTableDDL().data());
-            }
+            } // analyzed
+          else if (info->getAnalysisOutcome(0) ==
+                   CSEInfo::ELIMINATED_IN_BINDER)
+            printf("  eliminated in the binder\n");
+          else if (!isMainQuery)
+            printf("  not yet analyzed\n");
 
           for (int c=0; c<nc; c++)
             {
-              printf("\n----- Consumer %d:\n", c);
+              printf("\n\n----- Consumer %d:\n", c);
               info->getConsumer(c)->display();
             }
-        }
+        } // a CSE we want to display
 }
 
 void CommonSubExprRef::makeValueIdListFromBitVector(ValueIdList &tgt,

--- a/core/sql/optimizer/RelExpr.h
+++ b/core/sql/optimizer/RelExpr.h
@@ -601,8 +601,9 @@ public:
        const ValueIdSet &predicatesToRemove,
        const ValueIdSet &commonPredicatesToAdd,
        const ValueIdSet &inputsToRemove,
-       CSEInfo *info,
-       NABoolean testRun);
+       ValueIdSet &valuesForVEGRewrite,
+       ValueIdSet &keyColumns,
+       CSEInfo *info);
 
   // A virtual method called on every node from prepareTreeForCSESharing(),
   // use this to do the actual work of removing predicates other than
@@ -629,8 +630,9 @@ public:
        const ValueIdSet &predicatesToRemove,
        const ValueIdSet &commonPredicatesToAdd,
        const ValueIdSet &inputsToRemove,
-       CSEInfo *info,
-       NABoolean testRun);
+       ValueIdSet &valuesForVEGRewrite,
+       ValueIdSet &keyColumns,
+       CSEInfo *info);
 
   // --------------------------------------------------------------------
   // Create a query execution plan.
@@ -968,6 +970,8 @@ public:
                                 CollHeap* outHeap = NULL);
   RelExpr * copyTree(CollHeap* heap = NULL);
   RelExpr * copyRelExprTree(CollHeap* outHeap = NULL);
+  const RelExpr * getOriginalExpr(NABoolean transitive = TRUE) const;
+  RelExpr * getOriginalExpr(NABoolean transitive = TRUE);
 
   // --------------------------------------------------------------------
   // Methods used internally by Cascades
@@ -1593,6 +1597,10 @@ private:
   // Record the status whether my dop has been reduced. That is, whether
   // the partfunc pointed by my spp has a dop reduction.
   NABoolean dopReduced_;
+
+  // if we copy an expression with copyTopNode() then
+  // remember the original here, e.g. to find VEG regions
+  RelExpr *originalExpr_;
 
 public:
 

--- a/core/sql/optimizer/RelGrby.h
+++ b/core/sql/optimizer/RelGrby.h
@@ -223,8 +223,9 @@ public:
        const ValueIdSet &predicatesToRemove,
        const ValueIdSet &commonPredicatesToAdd,
        const ValueIdSet &inputsToRemove,
-       CSEInfo *info,
-       NABoolean testRun);
+       ValueIdSet &valuesForVEGRewrite,
+       ValueIdSet &keyColumns,
+       CSEInfo *info);
 
   // flows compRefOpt constraints up the query tree.
   virtual void processCompRefOptConstraints(NormWA * normWAPtr) ;

--- a/core/sql/optimizer/RelJoin.h
+++ b/core/sql/optimizer/RelJoin.h
@@ -792,8 +792,9 @@ public:
        const ValueIdSet &predicatesToRemove,
        const ValueIdSet &commonPredicatesToAdd,
        const ValueIdSet &inputsToRemove,
-       CSEInfo *info,
-       NABoolean testRun);
+       ValueIdSet &valuesForVEGRewrite,
+       ValueIdSet &keyColumns,
+       CSEInfo *info);
 
   // Detect whether rows coming from the ith child contain multi-column skew for
   // a set of join predicates. The output argument vidOfEquiJoinWithSkew is the

--- a/core/sql/optimizer/RelScan.h
+++ b/core/sql/optimizer/RelScan.h
@@ -499,8 +499,9 @@ public:
        const ValueIdSet &predicatesToRemove,
        const ValueIdSet &commonPredicatesToAdd,
        const ValueIdSet &inputsToRemove,
-       CSEInfo *info,
-       NABoolean testRun);
+       ValueIdSet &valuesForVEGRewrite,
+       ValueIdSet &keyColumns,
+       CSEInfo *info);
 
  // synthesizes compRefOpt constraints.
   virtual void processCompRefOptConstraints(NormWA * normWAPtr) ;

--- a/core/sql/optimizer/RelSet.h
+++ b/core/sql/optimizer/RelSet.h
@@ -261,8 +261,9 @@ public:
        const ValueIdSet &predicatesToRemove,
        const ValueIdSet &commonPredicatesToAdd,
        const ValueIdSet &inputsToRemove,
-       CSEInfo *info,
-       NABoolean testRun);
+       ValueIdSet &valuesForVEGRewrite,
+       ValueIdSet &keyColumns,
+       CSEInfo *info);
 
   // ---------------------------------------------------------------------
   // Function for testing the eligibility of this

--- a/core/sql/optimizer/VEGTable.cpp
+++ b/core/sql/optimizer/VEGTable.cpp
@@ -1693,16 +1693,29 @@ VEGRegion * VEGTable::getVEGRegion(const ExprNode * const ownerExpr,
 				   Lng32 subtreeId) const
 {
   VEGRegion* candidateRegion = NULL;
+  const ExprNode * ownerOrOrig = ownerExpr;
   
-  // Loop through the regions to find the one for this ExprNode
-  for (RegionId i = FIRST_VEG_REGION;
-       i < (RegionId)arrayEntry_.entries();
-       i++)
+  // Loop over the node and its original expressions
+  while (ownerOrOrig)
     {
-      candidateRegion = arrayEntry_[i];
-      if ( (candidateRegion->getOwnerExpr() == ownerExpr) AND 
-	   (candidateRegion->getSubtreeId() == subtreeId))
-	return candidateRegion;
+      // Loop through the regions to find the one for this ExprNode
+      for (RegionId i = FIRST_VEG_REGION;
+           i < (RegionId)arrayEntry_.entries();
+           i++)
+        {
+          candidateRegion = arrayEntry_[i];
+          if ( (candidateRegion->getOwnerExpr() == ownerOrOrig) AND 
+               (candidateRegion->getSubtreeId() == subtreeId))
+            return candidateRegion;
+        }
+
+      // VEGRegion not found, try with one of the original expressions
+      const RelExpr *re = ownerOrOrig->castToRelExpr();
+
+      if (re && re->getOriginalExpr(FALSE) != re)
+        ownerOrOrig = re->getOriginalExpr(FALSE);
+      else
+        ownerOrOrig = NULL;
     }
 
     // Didn't find any

--- a/core/sql/optimizer/ValueDesc.cpp
+++ b/core/sql/optimizer/ValueDesc.cpp
@@ -3293,7 +3293,7 @@ void ValueIdSet::replaceOperandsOfInstantiateNull
 // For each ValueId in other check whether it is referenced anywhere
 // within an ItemExpr whose ValueId belongs to this set.
 // -----------------------------------------------------------------------
-void ValueIdSet::weedOutUnreferenced(ValueIdSet & other)
+void ValueIdSet::weedOutUnreferenced(ValueIdSet & other) const
 {
   ValueIdSet unrefSet;
   NABoolean notFound;

--- a/core/sql/optimizer/ValueDesc.h
+++ b/core/sql/optimizer/ValueDesc.h
@@ -1080,7 +1080,7 @@ public:
   // Delete all values in other that are not referenced by the value
   // expressions that belong to this set.
   // --------------------------------------------------------------------
-  void weedOutUnreferenced(ValueIdSet & other);
+  void weedOutUnreferenced(ValueIdSet & other) const;
 
   // --------------------------------------------------------------------
   // weedOutNonEquiPreds()

--- a/core/sql/parser/sqlparser.y
+++ b/core/sql/parser/sqlparser.y
@@ -6727,7 +6727,7 @@ table_name_and_hint : table_name optimizer_hint hbase_access_options
                               if ($3)
                                 cse->setHbaseAccessOptions($3);
 
-                              cse->addToCmpStatement();
+                              cse->addToCmpStatement(TRUE);
                               $$ = cse;
                             }
                           else
@@ -7061,7 +7061,7 @@ table_name_as_clause_and_hint : table_name as_clause optimizer_hint hbase_access
                                          if ($4)
                                            cse->setHbaseAccessOptions($4);
 
-                                         cse->addToCmpStatement();
+                                         cse->addToCmpStatement(TRUE);
                                          $$ = cse;
                                        }
                                      else

--- a/core/sql/regress/compGeneral/EXPECTED045
+++ b/core/sql/regress/compGeneral/EXPECTED045
@@ -466,6 +466,29 @@
 
 --- SQL operation complete.
 >>
+>>insert into date_dim values (
++>  1, '1', date '2000-01-01', 1, 1, 1, 2000, 1, 1, 1, 1, 2000, 1, 1, 'aday', 'aq', ' ', ' ', ' ', 1, 31, 0, 0, ' ', ' ', ' ', ' ', ' '
++>);
+
+--- 1 row(s) inserted.
+>>
+>>insert into store_sales values (
++>  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0
++>);
+
+--- 1 row(s) inserted.
+>>
+>>update statistics for table date_dim on every column;
+
+--- SQL operation complete.
+>>update statistics for table date_dim on (d_qoy, d_year);
+
+*** WARNING[9202] UPDATE STATISTICS has located previously generated histograms that are not being regenerated. This may affect the plans that will be generated. Missing columns lists are (D_CURRENT_YEAR),(D_CURRENT_QUARTER),(D_CURRENT_MONTH),(D_CURRENT_WEEK),(D_CURRENT_DAY),(D_SAME_DAY_LQ),(D_SAME_DAY_LY),(D_LAST_DOM),(D_FIRST_DOM),(D_FOLLOWING_HOLIDAY),(D_WEEKEND),(D_HOLIDAY),(D_QUARTER_NAME),(D_DAY_NAME),(D_FY_WEEK_SEQ),(D_FY_QUARTER_SEQ),(D_FY_YEAR),(D_DOM),(D_MOY),(D_DOW),(D_QUARTER_SEQ),(D_WEEK_SEQ),(D_MONTH_SEQ),(D_DATE),(D_DATE_ID),(D_DATE_SK).
+
+--- SQL operation completed with warnings.
+>>update statistics for table store_sales on every column;
+
+--- SQL operation complete.
 >>
 >>--------------------------------------------------------------------
 >>obey TEST045(queries);
@@ -712,7 +735,7 @@ SCAN TEMP                                          2
 +> where d_week_seq1=d_week_seq2-53
 +> order by d_week_seq1;
 
-*** WARNING[5001] Common subexpression WSWSCS cannot be shared among multiple consumers. Reason: Operator map_value_ids not supported.
+*** WARNING[5001] Common subexpression WSCS will not be shared among multiple consumers. Reason: expression is only evaluated once because parent is materialized.
 
 --- SQL command prepared.
 >>-- use temp for wscs only, not wswscs, due to MapValueIds
@@ -1146,7 +1169,7 @@ SCAN TEMP                                          4
 
 *** WARNING[2997]  (Subquery was not unnested. Reason: No Correlation found)
 
-*** WARNING[2997] RESULTS (Operator map_value_ids not supported)
+*** WARNING[2997]  (Subquery was not unnested. Reason: No Correlation found)
 
 --- SQL command prepared.
 >>execute show_cses;
@@ -1154,9 +1177,9 @@ SCAN TEMP                                          4
 OPERATOR                        HOW_MANY            
 ------------------------------  --------------------
 
-BLOCKED_UNION                                      2
-HIVE_INSERT                                        1
-SCAN TEMP                                         15
+BLOCKED_UNION                                      5
+HIVE_INSERT                                        3
+SCAN TEMP                                         11
 
 --- 3 row(s) selected.
 >>execute s;
@@ -1229,9 +1252,7 @@ CHANNEL  I_BRAND_ID   I_CLASS_ID   I_CATEGORY_ID  SUM_SALES             NUMBER_S
 
 *** WARNING[2997]  (Subquery was not unnested. Reason: No Correlation found)
 
-*** WARNING[5001] Common subexpression FREQUENT_SS_ITEMS cannot be shared among multiple consumers. Reason: Differing inputs in CTE references, try CQD QUERY_CACHE '0'.
-
-*** WARNING[5001] Common subexpression BEST_SS_CUSTOMER cannot be shared among multiple consumers. Reason: Differing inputs in CTE references, try CQD QUERY_CACHE '0'.
+*** WARNING[5001] Common subexpression MAX_STORE_SALES will not be shared among multiple consumers. Reason: expression is only evaluated once because parent is materialized.
 
 --- SQL command prepared.
 >>execute show_cses;
@@ -1239,9 +1260,9 @@ CHANNEL  I_BRAND_ID   I_CLASS_ID   I_CATEGORY_ID  SUM_SALES             NUMBER_S
 OPERATOR                        HOW_MANY            
 ------------------------------  --------------------
 
-BLOCKED_UNION                                      2
-HIVE_INSERT                                        1
-SCAN TEMP                                          2
+BLOCKED_UNION                                      3
+HIVE_INSERT                                        2
+SCAN TEMP                                          4
 
 --- 3 row(s) selected.
 >>execute s;
@@ -1320,9 +1341,7 @@ SCAN TEMP                                          2
 
 *** WARNING[2997]  (Subquery was not unnested. Reason: No Correlation found)
 
-*** WARNING[5001] Common subexpression FREQUENT_SS_ITEMS cannot be shared among multiple consumers. Reason: Differing inputs in CTE references, try CQD QUERY_CACHE '0'.
-
-*** WARNING[5001] Common subexpression BEST_SS_CUSTOMER cannot be shared among multiple consumers. Reason: Differing inputs in CTE references, try CQD QUERY_CACHE '0'.
+*** WARNING[5001] Common subexpression MAX_STORE_SALES will not be shared among multiple consumers. Reason: expression is only evaluated once because parent is materialized.
 
 --- SQL command prepared.
 >>execute show_cses;
@@ -1330,9 +1349,9 @@ SCAN TEMP                                          2
 OPERATOR                        HOW_MANY            
 ------------------------------  --------------------
 
-BLOCKED_UNION                                      2
-HIVE_INSERT                                        1
-SCAN TEMP                                          2
+BLOCKED_UNION                                      3
+HIVE_INSERT                                        2
+SCAN TEMP                                          4
 
 --- 3 row(s) selected.
 >>execute s;
@@ -1583,9 +1602,13 @@ SCAN TEMP                                          2
 +>       > case when ss2.store_sales > 0 then ss3.store_sales/ss2.store_sales else null end
 +> order by store_q1_q2_increase;
 
-*** WARNING[5001] Common subexpression SS cannot be shared among multiple consumers. Reason: Encountered VEGs with different constants in different consumers.
+*** WARNING[5001] Common subexpression SS will not be shared among multiple consumers. Reason: Encountered VEGs with different constants in different consumers.
 
-*** WARNING[5001] Common subexpression WS cannot be shared among multiple consumers. Reason: Encountered VEGs with different constants in different consumers.
+*** WARNING[5001] Common subexpression SS will not be shared among multiple consumers. Reason: Differing inputs in CTE references, try CQD QUERY_CACHE '0'.
+
+*** WARNING[5001] Common subexpression WS will not be shared among multiple consumers. Reason: Encountered VEGs with different constants in different consumers.
+
+*** WARNING[5001] Common subexpression WS will not be shared among multiple consumers. Reason: Differing inputs in CTE references, try CQD QUERY_CACHE '0'.
 
 --- SQL command prepared.
 >>-- Different constants used in different references of WITH clause - not yet supported

--- a/core/sql/regress/compGeneral/TEST045
+++ b/core/sql/regress/compGeneral/TEST045
@@ -486,6 +486,17 @@ create table item
 --  )
 ;
 
+insert into date_dim values (
+  1, '1', date '2000-01-01', 1, 1, 1, 2000, 1, 1, 1, 1, 2000, 1, 1, 'aday', 'aq', ' ', ' ', ' ', 1, 31, 0, 0, ' ', ' ', ' ', ' ', ' '
+);
+
+insert into store_sales values (
+  1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1.0, 1.0, 1.0, 0.0, 1.0, 1.0, 1.0, 0.0, 0.0, 1.0, 1.0, 0.0
+);
+
+update statistics for table date_dim on every column;
+update statistics for table date_dim on (d_qoy, d_year);
+update statistics for table store_sales on every column;
 
 --------------------------------------------------------------------
 ?section queries

--- a/core/sql/sqlcomp/DefaultConstants.h
+++ b/core/sql/sqlcomp/DefaultConstants.h
@@ -3880,6 +3880,11 @@ enum DefaultConstants
 
   GROUP_BY_PUSH_TO_BOTH_SIDES_OF_JOIN,
 
+  CSE_TEMP_TABLE_MAX_SIZE,
+  CSE_TEMP_TABLE_MAX_MAX_SIZE,
+  CSE_COMMON_KEY_PRED_CONTROL,
+  CSE_PCT_KEY_COL_PRED_CONTROL,
+
   // This enum constant must be the LAST one in the list; it's a count,
   // not an Attribute (it's not IN DefaultDefaults; it's the SIZE of it)!
   __NUM_DEFAULT_ATTRIBUTES

--- a/core/sql/sqlcomp/nadefaults.cpp
+++ b/core/sql/sqlcomp/nadefaults.cpp
@@ -1152,16 +1152,23 @@ SDDkwd__(CAT_ENABLE_QUERY_INVALIDATION, "ON"),
  DDkwd__(CSE_CACHE_TEMP_QUERIES,               "OFF"),
  // "cleanup obsolete volatile tables" command cleans up Hive temp tables
  DDkwd__(CSE_CLEANUP_HIVE_TABLES,              "OFF"),
+ // don't temp if all consumers have preds on n key columns
+ DDui___(CSE_COMMON_KEY_PRED_CONTROL,          "1"),
  // emit warnings that help diagnose why CSEs are not shared
  DDkwd__(CSE_DEBUG_WARNINGS,                   "OFF"),
  // create a CommonSubExpr node for CTEs defined in WITH clauses (OFF/ON)
  DDkwd__(CSE_FOR_WITH,                         "OFF"),
  // use Hive tables as temp tables
  DDkwd__(CSE_HIVE_TEMP_TABLE,                  "ON"),
+ // don't temp if avg consumer has preds on more than n percent of key cols
+ DDflt0_(CSE_PCT_KEY_COL_PRED_CONTROL,         "49.9"),
  // print debugging info on stdout
  DDkwd__(CSE_PRINT_DEBUG_INFO,                 "OFF"),
+ // limit temp table size (based on max. card and regular card)
+ DDflt0_(CSE_TEMP_TABLE_MAX_MAX_SIZE,          "1E12"),
+ DDflt0_(CSE_TEMP_TABLE_MAX_SIZE,              "1E9"),
  // implement CommonSubExpr as a temp table (OFF/SYSTEM/ON)
- DDkwd__(CSE_USE_TEMP,                         "ON"),
+ DDkwd__(CSE_USE_TEMP,                         "SYSTEM"),
 
 SDDui___(CYCLIC_ESP_PLACEMENT,                  "1"),
 


### PR DESCRIPTION
This includes various fixes in addition to the heuristic decision,
mainly an improvement on how to navigate between parent and child
common subexpressions and improvement of support for statistics.
Also, see the comment in RelMisc.h (class CommonSubExprRef) for
a definition of some terminology.