### PR TITLE
[TRAFODION-2446] Remove java 1.8 check from ambari plug-in

### DIFF
--- a/install/ambari-installer/traf-mpack/common-services/TRAFODION/2.1/package/scripts/trafodionnode.py
+++ b/install/ambari-installer/traf-mpack/common-services/TRAFODION/2.1/package/scripts/trafodionnode.py
@@ -75,12 +75,6 @@ class Node(Script):
          content=sshopt,
          mode=0600)
 
-    # env files use java_home, be sure we are on 1.8 
-    # might be better to check this earlier (in service_advisor.py)
-    if params.java_version < 8:
-      print "Error: Java 1.8 required for Trafodion and HBase"
-      print "       Use 'ambari-server setup' to change JDK and restart HBase before continuing"
-      exit(1)
     ##################
     # create env files
     env.set_params(params)


### PR DESCRIPTION
Trafodion works fine with 1.7 or 1.8.