### PR TITLE
[TRAFODION-2464] failure to upsert into a table with an index

### DIFF
--- a/core/sql/optimizer/ImplRule.cpp
+++ b/core/sql/optimizer/ImplRule.cpp
@@ -2381,12 +2381,9 @@ RelExpr * HbaseUpdateRule::nextSubstitute(RelExpr * before,
   // SimpleFileScanOptimizer::constructSearchKey()
   /////////////////////////////////////////////////////////////////////////
   ValueIdSet exePreds(scan->getSelectionPred());
-
-  // only get the first member from the index set
-  if ( scan->deriveIndexOnlyIndexDesc().entries() == 0 )
-    return NULL;
-
-  IndexDesc* idesc = (scan->deriveIndexOnlyIndexDesc())[0];
+  // Use indexdesc of base table, een if the optimizer has chosen an
+  // index access path for this soon to be gone scan.
+  const IndexDesc* idesc = scan->getTableDesc()->getClusteringIndex();
   ValueIdSet clusteringKeyCols(
        idesc->getClusteringKeyCols());
   ValueIdSet generatedComputedColPreds;


### PR DESCRIPTION
During upsert into table with index there is a temporary scan in optimizer.
If index access path is chosen for this scan, query would raise an error.
This is now fixed by using the correct indexDesc from this temporary scan.