### PR TITLE
[TRAFODION-2465] Fix two bugs

### DIFF
--- a/core/sql/ustat/hs_cli.cpp
+++ b/core/sql/ustat/hs_cli.cpp
@@ -401,8 +401,10 @@ Lng32 HSFuncExecTransactionalQueryWithRetry( const char *dml
     return retcode;
   }
 
-  // The HSErrorCatcher captures any diagnostics when it goes out-of-scope.
-  HSErrorCatcher errorCatcher(retcode, sqlcode, errorToken, TRUE);
+  // Note: We don't use the HSErrorCatcher object to capture diagnostic
+  // information here. The reason is, HSErrorCatcher works by lexical scope,
+  // but the place where diagnostics are available to us does not nicely
+  // match lexical scope. Instead, we call HSFuncMergeDiags directly.
  
   // On very busy system, some "update statistics" implementation steps like
   // "COLLECT FILE STATISTICS" step in HSTableDef::collectFileStatistics()
@@ -450,6 +452,15 @@ Lng32 HSFuncExecTransactionalQueryWithRetry( const char *dml
         if (diags.contains(-EXE_CANCELED))
           retry = limit+1; // don't retry canceled query
       }
+    }
+
+    // If we are on our last retry, capture any diagnostics from
+    // the begin or statement failure. (If we don't capture them
+    // now, they will be cleared out of the CLI when we do the
+    // ROLLBACK below.)
+    if (retcode && (retry >= limit))
+    {
+      HSFuncMergeDiags(sqlcode, errorToken, NULL, TRUE /* get CLI diags */);
     }
 
     // If we had an error (on the begin, the statement or the commit),
@@ -1036,7 +1047,7 @@ Lng32 HSTranMan::Begin(const char *title,NABoolean inactivateErrorCatcher)
           {
             NAString stmtText = "BEGIN WORK";
             retcode_ = HSFuncExecQuery(stmtText.data(), - UERR_INTERNAL_ERROR, NULL,
-                                       HS_QUERY_ERROR, NULL, NULL, inactivateErrorCatcher);
+                                       HS_QUERY_ERROR, NULL, NULL, 0, FALSE, inactivateErrorCatcher);
             if (retcode_ >= 0)
               {
                 transStarted_ = TRUE;
@@ -1091,7 +1102,7 @@ Lng32 HSTranMan::Commit(NABoolean inactivateErrorCatcher)
           {
             NAString stmtText = "COMMIT WORK";
             retcode_ = HSFuncExecQuery(stmtText.data(), - UERR_INTERNAL_ERROR, NULL,
-                                       HS_QUERY_ERROR, NULL, NULL, inactivateErrorCatcher);
+                                       HS_QUERY_ERROR, NULL, NULL, 0, FALSE, inactivateErrorCatcher);
 
             // transaction has ended
             transStarted_ = FALSE;
@@ -1173,7 +1184,7 @@ Lng32 HSTranMan::Rollback(NABoolean inactivateErrorCatcher)
           {
             NAString stmtText = "ROLLBACK WORK";
             retcode_ = HSFuncExecQuery(stmtText.data(), - UERR_INTERNAL_ERROR, NULL,
-                                       HS_QUERY_ERROR, NULL, NULL, inactivateErrorCatcher);
+                                       HS_QUERY_ERROR, NULL, NULL, 0, FALSE, inactivateErrorCatcher);
             // transaction has ended
             transStarted_ = FALSE;
             if (retcode_ < 0)


### PR DESCRIPTION
This set of changes fixes two problems (both introduced by me):

1. When UPDATE STATISTICS retries a statement, and the statement continues to fail, the error diagnostics are incorrect. The root cause of the error is not reported, and some irrelevant errors are reported (i.e. 8609, error on transaction rollback, which happens because the Executor sometimes has already rolled back the transaction when UPDATE STATISTICS attempts a ROLLBACK after a statement failure). This bug was introduced when I rewrote the retry logic in JIRA TRAFODION-2341. My unit test was not thorough enough. (ustat/hs_cli.cpp)
2. Performing UPDATE STATISTICS ON EXISTING COLUMNS PERSISTENT would fail on Hive tables with varchar columns over 200000 characters long. I fixed a similar issue in JIRA TRAFODION-2322, but failed to notice that this issue existed separately in the ON EXISTING COLUMNS code path. (ustat/hs_parser.cpp).
