### PR TITLE
[TRAFODION-2456] Improve documentation for UDF parallelism

### DIFF
--- a/core/sql/pom.xml
+++ b/core/sql/pom.xml
@@ -106,6 +106,13 @@
           </archive>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-javadoc-plugin</artifactId>
+        <configuration>
+          <show>public</show>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
 </project>

--- a/core/sql/sqludr/sqludr.cpp
+++ b/core/sql/sqludr/sqludr.cpp
@@ -7458,7 +7458,8 @@ int UDRPlanInfo::getDesiredDegreeOfParallelism() const
  *  @li @c DEFAULT_DEGREE_OF_PARALLELISM:
  *        Currently the same as ANY_DEGREE_OF_PARALLELISM.
  *        The optimizer will use a heuristic based on
- *        the estimated cardinality.
+ *        the estimated cardinality (which you can set in
+ *        the UDR::describeStatistics() interface).
  *  @li @c MAX_DEGREE_OF_PARALLELISM:
  *        Choose the highest possible degree of parallelism.
  *  @li @c ONE_INSTANCE_PER_NODE:
@@ -8080,6 +8081,15 @@ void UDR::describeStatistics(UDRInvocationInfo &info)
  *    plan.setDesiredDegreeOfParallelism(1); // serial execution
  *  @endcode
  *
+ *  Note that this is NOT foolproof, and that the TMUDF might still
+ *  need to validate the PARTITION BY and ORDER BY syntax used in its
+ *  invocation.
+ *
+ *  Note also that in order to get parallel execution, you may need to
+ *  implement the UDR::describeStatistics() interface and provide a
+ *  cardinality estimate. Alternatively, you can set the
+ *  PARALLEL_NUM_ESPS CQD.
+ *
  *  @see UDRPlanInfo::setDesiredDegreeOfParallelism()
  *  @see UDRInvocationInfo::setFuncType()
  *
@@ -8109,7 +8119,7 @@ void UDR::describeDesiredDegreeOfParallelism(UDRInvocationInfo &info,
  *  or ordering of the table-valued inputs is required to produce the required
  *  result properties.
  *
- *  TBD: Default behavior.
+ *  This interface is currently not used.
  *  
  *  @param info A description of the UDR invocation.
  *  @param plan Plan-related description of the UDR invocation.

--- a/core/sql/src/main/java/org/trafodion/sql/udr/ColumnInfo.java
+++ b/core/sql/src/main/java/org/trafodion/sql/udr/ColumnInfo.java
@@ -115,7 +115,7 @@ import java.nio.ByteBuffer;
        *  setUniqueEntries() method, or in some cases it can also be
        *  provided by the Trafodion compiler.
        *
-       *  @see ColumnInfo#setUniqueEntries(long)
+       *  @see ColumnInfo#setEstimatedUniqueEntries(long)
        *
        *  @return Estimated number of unique entries.
        */
@@ -173,16 +173,16 @@ import java.nio.ByteBuffer;
        *
        *  <p> Only use this method from within the following methods:
        *  <ul>
-       *  <li> UDR#describeParamsAndColumns()
-       *  <li> UDR#describeDataflowAndPredicates()
-       *  <li> UDR#describeConstraints()
-       *  <li> UDR#describeStatistics()
+       *  <li> @link UDR#describeParamsAndColumns
+       *  <li> @link UDR#describeDataflowAndPredicates
+       *  <li> @link UDR#describeConstraints
+       *  <li> @link UDR#describeStatistics
        *  </ul>
-       *  @see ColumnInfo#getUniqueEntries()
+       *  @see ColumnInfo#getEstimatedUniqueEntries
        *
        *  @param estimatedUniqueEntries Estimate of the number of unique entries.
        */
-      public void setUniqueEntries(long estimatedUniqueEntries) {
+      public void setEstimatedUniqueEntries(long estimatedUniqueEntries) {
           estimatedUniqueEntries_ = estimatedUniqueEntries ;
       }
 
@@ -263,10 +263,10 @@ import java.nio.ByteBuffer;
       }
       
       // UDR writers can ignore these methods
-      public static short getCurrentVersion() { return 1; }
+      static short getCurrentVersion() { return 1; }
 
       @Override
-      public int serializedLength() throws UDRException{
+      int serializedLength() throws UDRException{
         return (super.serializedLength() + 
                 serializedLengthOfString(name_) + 
                 type_.serializedLength() + 
@@ -275,7 +275,7 @@ import java.nio.ByteBuffer;
       }
 
       @Override
-      public int serialize(ByteBuffer outputBuffer) throws UDRException{
+      int serialize(ByteBuffer outputBuffer) throws UDRException{
         int origPos = outputBuffer.position();
 
         super.serialize(outputBuffer);
@@ -305,7 +305,7 @@ import java.nio.ByteBuffer;
       }
 
       @Override
-      public int deserialize(ByteBuffer inputBuffer) throws UDRException {
+      int deserialize(ByteBuffer inputBuffer) throws UDRException {
 
        int origPos = inputBuffer.position();
        

--- a/core/sql/src/main/java/org/trafodion/sql/udr/ComparisonPredicateInfo.java
+++ b/core/sql/src/main/java/org/trafodion/sql/udr/ComparisonPredicateInfo.java
@@ -74,21 +74,21 @@ public class ComparisonPredicateInfo extends PredicateInfo
     }
 
     // UDR writers can ignore these methods
-    public ComparisonPredicateInfo() {
+    ComparisonPredicateInfo() {
         super(TMUDRObjectType.COMP_PREDICATE_INFO_OBJ);
         columnNumber_ = -1;
         value_ = "";
     }
 
-    public void setColumnNumber(int columnNumber) {
+    void setColumnNumber(int columnNumber) {
         columnNumber_ = columnNumber;
     }
 
-    public void setValue(String value) {
+    void setValue(String value) {
         value_ = value;
     }
        
-    public String toString(TableInfo ti) throws UDRException {
+    String toString(TableInfo ti) throws UDRException {
         
         String s = ti.getColumn(columnNumber_).getColName();
 
@@ -130,15 +130,16 @@ public class ComparisonPredicateInfo extends PredicateInfo
         return s;
     }
     
-    public static short getCurrentVersion() { return 1; }
+    static short getCurrentVersion() { return 1; }
     @Override
     public int serializedLength() throws UDRException{
       return super.serializedLength() +
         serializedLengthOfInt() +
         serializedLengthOfString(value_);
     }
+
     @Override
-    public int serialize(ByteBuffer outputBuffer) throws UDRException{
+    int serialize(ByteBuffer outputBuffer) throws UDRException{
 
       int origPos = outputBuffer.position();
 
@@ -158,7 +159,7 @@ public class ComparisonPredicateInfo extends PredicateInfo
     }
 
     @Override
-    public int deserialize(ByteBuffer inputBuffer) throws UDRException{
+    int deserialize(ByteBuffer inputBuffer) throws UDRException{
 
       int origPos = inputBuffer.position();
 

--- a/core/sql/src/main/java/org/trafodion/sql/udr/ConstraintInfo.java
+++ b/core/sql/src/main/java/org/trafodion/sql/udr/ConstraintInfo.java
@@ -70,15 +70,18 @@ public abstract class ConstraintInfo extends TMUDRSerializableObject
     }   
 
     // UDR writers can ignore these methods
-    public abstract String toString(TableInfo ti) throws UDRException;
-    public static short getCurrentVersion() { return 1; }
+
+    abstract String toString(TableInfo ti) throws UDRException;
+
+    static short getCurrentVersion() { return 1; }
+
     @Override
-    public int serializedLength() throws UDRException{
+    int serializedLength() throws UDRException{
       return super.serializedLength() + serializedLengthOfInt();
     }
  
     @Override
-    public int serialize(ByteBuffer outputBuffer) throws UDRException{
+    int serialize(ByteBuffer outputBuffer) throws UDRException{
       int origPos = outputBuffer.position();
 
       super.serialize(outputBuffer);
@@ -92,7 +95,7 @@ public abstract class ConstraintInfo extends TMUDRSerializableObject
     }
 
     @Override
-    public int deserialize(ByteBuffer inputBuffer) throws UDRException{
+    int deserialize(ByteBuffer inputBuffer) throws UDRException{
 
       int origPos = inputBuffer.position();
 

--- a/core/sql/src/main/java/org/trafodion/sql/udr/OrderInfo.java
+++ b/core/sql/src/main/java/org/trafodion/sql/udr/OrderInfo.java
@@ -71,6 +71,9 @@ public class OrderInfo
         orderTypes_ = new Vector<OrderTypeCode>();
     }
 
+/**
+ *  Copy constructor.
+ */
     public OrderInfo(OrderInfo o) {
         columnNumbers_ = new Vector<Integer>(o.columnNumbers_);
         orderTypes_ = new Vector<OrderTypeCode>(o.orderTypes_);
@@ -193,6 +196,7 @@ public class OrderInfo
     }
 
     // UDR writers can ignore these methods
+
     void clear()
     {
       columnNumbers_.clear();

--- a/core/sql/src/main/java/org/trafodion/sql/udr/ParameterListInfo.java
+++ b/core/sql/src/main/java/org/trafodion/sql/udr/ParameterListInfo.java
@@ -33,21 +33,23 @@ import java.nio.ByteBuffer;
 
 public class ParameterListInfo extends TupleInfo
 {
-    public ParameterListInfo() {
+    // UDR writers can ignore these methods
+
+    ParameterListInfo() {
         super(TMUDRObjectType.PARAMETER_LIST_INFO_OBJ, getCurrentVersion());
     }
     
-    // UDR writers can ignore these methods    
-    public static short getCurrentVersion() { return 1; }
+    static short getCurrentVersion() { return 1; }
+
     @Override
-    public int serializedLength() throws UDRException {
+    int serializedLength() throws UDRException {
       int result = super.serializedLength();
 
       return result;
     }
 
     @Override
-    public int serialize(ByteBuffer outputBuffer) throws UDRException {
+    int serialize(ByteBuffer outputBuffer) throws UDRException {
       int origPos = outputBuffer.position();
       super.serialize(outputBuffer);
 
@@ -59,7 +61,7 @@ public class ParameterListInfo extends TupleInfo
     }
 
     @Override
-    public int deserialize(ByteBuffer inputBuffer) throws UDRException {
+    int deserialize(ByteBuffer inputBuffer) throws UDRException {
 
       int origPos = inputBuffer.position();
 

--- a/core/sql/src/main/java/org/trafodion/sql/udr/PartitionInfo.java
+++ b/core/sql/src/main/java/org/trafodion/sql/udr/PartitionInfo.java
@@ -84,7 +84,9 @@ public class PartitionInfo
         type_ = PartitionTypeCode.UNKNOWN;
     }
 
-    // copy constructor for internal use
+    /**
+     *  Copy constructor
+     */
     public  PartitionInfo(PartitionInfo p) {
         type_ = p.type_;
         partCols_ = new Vector<Integer>(p.partCols_);
@@ -176,7 +178,7 @@ public class PartitionInfo
           partCols_.clear();
     }
 
-    public Vector<Integer> getPartCols() {
+    Vector<Integer> getPartCols() {
         return partCols_;
     }
 

--- a/core/sql/src/main/java/org/trafodion/sql/udr/PredicateInfo.java
+++ b/core/sql/src/main/java/org/trafodion/sql/udr/PredicateInfo.java
@@ -148,30 +148,31 @@ public abstract class PredicateInfo extends TMUDRSerializableObject
     }
     
     // UDR writers can ignore these methods
-    public PredicateInfo(TMUDRSerializableObject.TMUDRObjectType t) {
+    PredicateInfo(TMUDRSerializableObject.TMUDRObjectType t) {
         super(t, getCurrentVersion());
         evalCode_ = EvaluationCode.UNKNOWN_EVAL;
         operator_ = PredOperator.UNKNOWN_OP;
     }
     
-    public void setOperator(PredOperator op) {
+    void setOperator(PredOperator op) {
         operator_ = op;
     }
     
-    public void setEvaluationCode(EvaluationCode c) {
+    void setEvaluationCode(EvaluationCode c) {
         evalCode_ = c ;
     }
-    public abstract String toString(TableInfo ti) throws UDRException;
+
+    abstract String toString(TableInfo ti) throws UDRException;
     
-    public static short getCurrentVersion() { return 1; }
+    static short getCurrentVersion() { return 1; }
 
     @Override
-    public int serializedLength() throws UDRException{
+    int serializedLength() throws UDRException{
       return super.serializedLength() + 2 * serializedLengthOfInt();
     }
 
     @Override
-    public int serialize(ByteBuffer outputBuffer) throws UDRException{
+    int serialize(ByteBuffer outputBuffer) throws UDRException{
 
       int origPos = outputBuffer.position();
 
@@ -190,7 +191,7 @@ public abstract class PredicateInfo extends TMUDRSerializableObject
     }
 
     @Override
-    public int deserialize(ByteBuffer inputBuffer) throws UDRException {
+    int deserialize(ByteBuffer inputBuffer) throws UDRException {
      int origPos = inputBuffer.position();
 
       super.deserialize(inputBuffer);

--- a/core/sql/src/main/java/org/trafodion/sql/udr/TMUDRSerializableObject.java
+++ b/core/sql/src/main/java/org/trafodion/sql/udr/TMUDRSerializableObject.java
@@ -31,7 +31,7 @@ import java.nio.ByteBuffer;
 public class TMUDRSerializableObject
 {
 
-  public enum Endianness
+  enum Endianness
    {
      UNKNOWN_ENDIANNESS,
      IS_LITTLE_ENDIAN,
@@ -53,7 +53,7 @@ public class TMUDRSerializableObject
   
    };
 
-  public enum TMUDRObjectType
+  enum TMUDRObjectType
     {
       UNKNOWN_OBJECT_TYPE (0),
       TYPE_INFO_OBJ (100),
@@ -99,7 +99,7 @@ public class TMUDRSerializableObject
 
     };
 
-  public TMUDRSerializableObject(
+  TMUDRSerializableObject(
        TMUDRObjectType objectType,
        short version) { 
   objectType_  = objectType.value_;
@@ -111,13 +111,13 @@ public class TMUDRSerializableObject
   filler_      = 0;
   }
 
-  public int sizeOf()
+  int sizeOf()
   {
     return  SIZEOF_INT + SIZEOF_INT + SIZEOF_SHORT +
             SIZEOF_SHORT + SIZEOF_INT + SIZEOF_INT;
   }
 
-  public TMUDRObjectType getObjectType()
+  TMUDRObjectType getObjectType()
   {
     switch (objectType_)
     {
@@ -154,7 +154,7 @@ public class TMUDRSerializableObject
   }
 
 
-  public TMUDRObjectType getObjectType(int objectType)
+  TMUDRObjectType getObjectType(int objectType)
   {
     switch (objectType)
     {
@@ -190,17 +190,17 @@ public class TMUDRSerializableObject
     }
   }
 
-  public short getVersion() 
+  short getVersion() 
   {
     return version_;
   }
 
-  public int serializedLength() throws UDRException
+  int serializedLength() throws UDRException
   {
     return sizeOf();
   }
 
-  public  int serialize(ByteBuffer outputBuffer) throws UDRException
+  int serialize(ByteBuffer outputBuffer) throws UDRException
   {
     totalLength_ = serializedLength();
 
@@ -221,7 +221,7 @@ public class TMUDRSerializableObject
     return allocatedBytes;
   }
 
-  public int deserialize(ByteBuffer inputBuffer) throws UDRException
+  int deserialize(ByteBuffer inputBuffer) throws UDRException
   {
     int bufSize = inputBuffer.limit() - inputBuffer.position();
     if (bufSize < sizeOf())
@@ -251,7 +251,7 @@ public class TMUDRSerializableObject
   }
 
 
-  public void validateObjectType(TMUDRObjectType o) throws UDRException
+  void validateObjectType(TMUDRObjectType o) throws UDRException
   {
     if (objectType_ != o.getValue())
       throw new UDRException(38900,
@@ -261,7 +261,7 @@ public class TMUDRSerializableObject
 
   }
 
-  public void validateSerializedLength(int l) throws UDRException
+  void validateSerializedLength(int l) throws UDRException
   {
       if (l != totalLength_)
          throw new UDRException(38900,
@@ -272,7 +272,7 @@ public class TMUDRSerializableObject
 
   }
 
-  public void validateDeserializedLength(int l) throws UDRException
+  void validateDeserializedLength(int l) throws UDRException
   {
     if (l != totalLength_)
       throw new UDRException(38900,
@@ -285,27 +285,27 @@ public class TMUDRSerializableObject
 
   // helper methods to serialize ints and strings, they
   // return the length of the serialized information
-  public int serializedLengthOfInt()
+  int serializedLengthOfInt()
   {
     return SIZEOF_INT;
   }
 
-  public int serializedLengthOfLong()
+  int serializedLengthOfLong()
   {
     return SIZEOF_LONG;
   }
 
-  public int serializedLengthOfString(byte[] s)
+  int serializedLengthOfString(byte[] s)
   {
     return (SIZEOF_INT + s.length);
   }
 
-  public int serializedLengthOfString(int stringLength)
+  int serializedLengthOfString(int stringLength)
   {
     return SIZEOF_INT + stringLength;
   }
 
-  public int serializedLengthOfString(String s) throws UDRException
+  int serializedLengthOfString(String s) throws UDRException
   {
     byte[] temp;
     try {
@@ -319,13 +319,13 @@ public class TMUDRSerializableObject
     return serializedLengthOfString(temp.length);
   }
 
-  public int serializedLengthOfBinary(int binaryLength)
+  int serializedLengthOfBinary(int binaryLength)
   {
     return serializedLengthOfString(binaryLength);
   }
 
-  public int serializeInt(int i,
-                          ByteBuffer outputBuffer) throws UDRException
+  int serializeInt(int i,
+                   ByteBuffer outputBuffer) throws UDRException
   {
     int bufSize = outputBuffer.limit() - outputBuffer.position();
     if (bufSize < SIZEOF_INT)
@@ -337,8 +337,8 @@ public class TMUDRSerializableObject
     return allocatedBytes;
   }
 
-  public int serializeLong(long i,
-                           ByteBuffer outputBuffer) throws UDRException
+  int serializeLong(long i,
+                    ByteBuffer outputBuffer) throws UDRException
   {
     int bufSize = outputBuffer.limit() - outputBuffer.position();
     if (bufSize < SIZEOF_LONG)
@@ -350,8 +350,8 @@ public class TMUDRSerializableObject
     return allocatedBytes;
   }
 
-  public int serializeBinary(byte[] s,
-                             ByteBuffer outputBuffer) throws UDRException
+  int serializeBinary(byte[] s,
+                      ByteBuffer outputBuffer) throws UDRException
   {
     int bufSize = outputBuffer.limit() - outputBuffer.position();
     if (bufSize < SIZEOF_INT + s.length)
@@ -367,9 +367,9 @@ public class TMUDRSerializableObject
     return allocatedBytes;
   }
 
-  public int serializeBinary(byte[] s,
-                             int len,
-                             ByteBuffer outputBuffer) throws UDRException
+  int serializeBinary(byte[] s,
+                      int len,
+                      ByteBuffer outputBuffer) throws UDRException
   {
     int bufSize = outputBuffer.limit() - outputBuffer.position();
     if (bufSize < SIZEOF_INT + len)
@@ -384,8 +384,8 @@ public class TMUDRSerializableObject
     return allocatedBytes;
   }
 
-  public int serializeString(String s,
-                             ByteBuffer outputBuffer) throws UDRException
+  int serializeString(String s,
+                      ByteBuffer outputBuffer) throws UDRException
   {
     byte[] b;
     try {
@@ -398,7 +398,7 @@ public class TMUDRSerializableObject
     return serializeBinary(b, outputBuffer);
   }
 
-  public int deserializeInt(ByteBuffer inputBuffer) throws UDRException
+  int deserializeInt(ByteBuffer inputBuffer) throws UDRException
   {
     int bufSize = inputBuffer.limit() - inputBuffer.position();
     if (bufSize < SIZEOF_INT)
@@ -407,7 +407,7 @@ public class TMUDRSerializableObject
     return inputBuffer.getInt();
   }
 
-  public long deserializeLong(ByteBuffer inputBuffer) throws UDRException
+  long deserializeLong(ByteBuffer inputBuffer) throws UDRException
   {
     int bufSize = inputBuffer.limit() - inputBuffer.position();
     if (bufSize < SIZEOF_LONG)
@@ -417,7 +417,7 @@ public class TMUDRSerializableObject
   }
 
 /*
-  public byte[] deserializeString(ByteBuffer inputBuffer) throws UDRException
+  byte[] deserializeString(ByteBuffer inputBuffer) throws UDRException
   {
     int bufSize = inputBuffer.limit() - inputBuffer.position();
     if (bufSize <  SIZEOF_INT)
@@ -442,7 +442,7 @@ public class TMUDRSerializableObject
   }
 */
 
-  public byte[] deserializeBinary(ByteBuffer inputBuffer) throws UDRException {
+  byte[] deserializeBinary(ByteBuffer inputBuffer) throws UDRException {
     int bufSize = inputBuffer.limit() - inputBuffer.position();
     if (bufSize <  SIZEOF_INT)
           throw new UDRException(38900,
@@ -460,7 +460,7 @@ public class TMUDRSerializableObject
     return b;
   }
   
-  public String deserializeString(ByteBuffer inputBuffer) throws UDRException
+  String deserializeString(ByteBuffer inputBuffer) throws UDRException
   {
     int bufSize = inputBuffer.limit() - inputBuffer.position();
     if (bufSize <  SIZEOF_INT)
@@ -486,7 +486,7 @@ public class TMUDRSerializableObject
     return result;
   }
 
-  public TMUDRObjectType getNextObjectType(ByteBuffer inputBuffer) throws UDRException
+  TMUDRObjectType getNextObjectType(ByteBuffer inputBuffer) throws UDRException
   {
     int bufSize = inputBuffer.limit() - inputBuffer.position();
     int origPos = inputBuffer.position();

--- a/core/sql/src/main/java/org/trafodion/sql/udr/TableInfo.java
+++ b/core/sql/src/main/java/org/trafodion/sql/udr/TableInfo.java
@@ -281,16 +281,18 @@ public class TableInfo extends TupleInfo {
     
 
     // UDR writers can ignore these methods
-    public void setQueryPartitioning(PartitionInfo partInfo) {
+    void setQueryPartitioning(PartitionInfo partInfo) {
         queryPartitioning_ = partInfo;
     }
-    public void setQueryOrdering(OrderInfo orderInfo) {
+
+    void setQueryOrdering(OrderInfo orderInfo) {
         queryOrdering_ = orderInfo;
     }
     
-    public static short getCurrentVersion() { return 1; }
+    static short getCurrentVersion() { return 1; }
+
     @Override
-    public int serializedLength() throws UDRException{
+    int serializedLength() throws UDRException{
       int result = super.serializedLength() +
                    2 * serializedLengthOfLong() +
                    4 * serializedLengthOfInt() +
@@ -304,7 +306,7 @@ public class TableInfo extends TupleInfo {
     }
 
     @Override
-    public int serialize(ByteBuffer outputBuffer) throws UDRException {
+    int serialize(ByteBuffer outputBuffer) throws UDRException {
 
       int origPos = outputBuffer.position();
 
@@ -355,7 +357,7 @@ public class TableInfo extends TupleInfo {
     }
 
     @Override
-    public int deserialize(ByteBuffer inputBuffer) throws UDRException{
+    int deserialize(ByteBuffer inputBuffer) throws UDRException{
 
       int origPos = inputBuffer.position();
 

--- a/core/sql/src/main/java/org/trafodion/sql/udr/TupleInfo.java
+++ b/core/sql/src/main/java/org/trafodion/sql/udr/TupleInfo.java
@@ -2396,17 +2396,17 @@ public class TupleInfo extends TMUDRSerializableObject {
     } 
     
     // UDR writers can ignore these methods
-    public TupleInfo(TMUDRObjectType objType, short version) {
+    TupleInfo(TMUDRObjectType objType, short version) {
         super(objType, version);
         recordLength_ = -1;
         wasNull_ = false;
         columns_ = new Vector<ColumnInfo>();
     }
     
-    public static short getCurrentVersion() { return 1; }
+    static short getCurrentVersion() { return 1; }
 
     @Override
-    public int serializedLength() throws UDRException {
+    int serializedLength() throws UDRException {
       int result = super.serializedLength() +
         2 * serializedLengthOfInt();
 
@@ -2417,7 +2417,7 @@ public class TupleInfo extends TMUDRSerializableObject {
     }
 
     @Override
-    public int serialize(ByteBuffer outputBuffer) throws UDRException{
+    int serialize(ByteBuffer outputBuffer) throws UDRException{
       int origPos = outputBuffer.position();
 
       super.serialize(outputBuffer);
@@ -2440,7 +2440,7 @@ public class TupleInfo extends TMUDRSerializableObject {
     }
 
     @Override
-    public int deserialize(ByteBuffer inputBuffer) throws UDRException{
+    int deserialize(ByteBuffer inputBuffer) throws UDRException{
 
       int origPos = inputBuffer.position();
 
@@ -2471,14 +2471,15 @@ public class TupleInfo extends TMUDRSerializableObject {
       return bytesDeserialized;
     }
     
-    public ByteBuffer getRow(){
+    ByteBuffer getRow(){
         return row_ ;
     }
-    public int getRecordLength() {
+
+    int getRecordLength() {
         return recordLength_;
     }
 
-    public void setRow(byte[] rowByteArr) throws UDRException {
+    void setRow(byte[] rowByteArr) throws UDRException {
         row_ = ByteBuffer.wrap(rowByteArr);
         row_.order(ByteOrder.LITTLE_ENDIAN);
 
@@ -2491,7 +2492,7 @@ public class TupleInfo extends TMUDRSerializableObject {
                                    rowByteArr.length);
     }
 
-    public ByteBuffer encode(TypeInfo t, String val) throws UDRException
+    ByteBuffer encode(TypeInfo t, String val) throws UDRException
     {
         CharsetEncoder encoder;
         ByteBuffer result;
@@ -2548,7 +2549,7 @@ public class TupleInfo extends TMUDRSerializableObject {
         return result;
     }
 
-    public String decode(TypeInfo t, byte[] buf) throws UDRException
+    String decode(TypeInfo t, byte[] buf) throws UDRException
     {
         CharsetDecoder decoder;
         String result;

--- a/core/sql/src/main/java/org/trafodion/sql/udr/TypeInfo.java
+++ b/core/sql/src/main/java/org/trafodion/sql/udr/TypeInfo.java
@@ -1121,7 +1121,7 @@ public class TypeInfo extends TMUDRSerializableObject {
         return (dataOffset_ >= 0);
     }
 
-    public int minBytesPerChar() throws UDRException {
+    int minBytesPerChar() throws UDRException {
         switch (getCharset())
         {
         case CHARSET_ISO88591:
@@ -1135,7 +1135,8 @@ public class TypeInfo extends TMUDRSerializableObject {
                                    charset_);
         }
     }
-    public int convertToBinaryPrecision(int decimalPrecision) throws UDRException {
+
+    int convertToBinaryPrecision(int decimalPrecision) throws UDRException {
         if (decimalPrecision < 1 || decimalPrecision > 18)
             throw new UDRException(
                                    38900,
@@ -1329,7 +1330,7 @@ public class TypeInfo extends TMUDRSerializableObject {
         return sb.toString();
     }
 
-    public void putEncodedStringIntoByteBuffer(ByteBuffer tgt, ByteBuffer src) throws UDRException
+    void putEncodedStringIntoByteBuffer(ByteBuffer tgt, ByteBuffer src) throws UDRException
     {
         // Copy the byte buffer with encoded characters into the target buffer.
         // For fixed-length strings, remove or add trailing blanks as necessary.
@@ -1406,15 +1407,15 @@ public class TypeInfo extends TMUDRSerializableObject {
             }
     }
 
-    public static short getCurrentVersion() { return 1; }
+    static short getCurrentVersion() { return 1; }
 
     @Override
-    public int serializedLength() throws UDRException{
+    int serializedLength() throws UDRException{
         return super.serializedLength() +  (17 * serializedLengthOfInt());
     }
         
     @Override
-    public int serialize(ByteBuffer outputBuffer) throws UDRException{
+    int serialize(ByteBuffer outputBuffer) throws UDRException{
 
       int origPos = outputBuffer.position();
 
@@ -1446,7 +1447,7 @@ public class TypeInfo extends TMUDRSerializableObject {
     }
 
     @Override
-    public int deserialize(ByteBuffer inputBuffer) throws UDRException{
+    int deserialize(ByteBuffer inputBuffer) throws UDRException{
 
       int origPos = inputBuffer.position();
 
@@ -1481,24 +1482,24 @@ public class TypeInfo extends TMUDRSerializableObject {
       return bytesDeserialized;
     }
 
-    public void setOffsets(int dataOffset, int indOffset, int vcOffset) {
+    void setOffsets(int dataOffset, int indOffset, int vcOffset) {
         nullIndOffset_  = indOffset;
         vcLenIndOffset_ = vcOffset;
         dataOffset_     = dataOffset;
     }
-    public int getDataOffset() {
+    int getDataOffset() {
         return dataOffset_ ;
     }
-    public int getIndOffset() {
+    int getIndOffset() {
         return nullIndOffset_ ;
     }
-    public int getVcLenIndOffset() {
+    int getVcLenIndOffset() {
         return vcLenIndOffset_ ;
     }
     
 
     // flags
-    public static final int TYPE_FLAG_4_BYTE_VC_LEN    = 0x00000001;
+    static final int TYPE_FLAG_4_BYTE_VC_LEN    = 0x00000001;
     
     private int /*SQLTypeCode */ sqlType_;      
     private int nullable_; // boolean

--- a/core/sql/src/main/java/org/trafodion/sql/udr/UDRInvocationInfo.java
+++ b/core/sql/src/main/java/org/trafodion/sql/udr/UDRInvocationInfo.java
@@ -301,7 +301,7 @@ public class UDRInvocationInfo extends TMUDRSerializableObject
      *  @return Enum for the call phase we are in.
      */
     public CallPhase getCallPhase() { return callPhase_; }
-    public void setCallPhase(int cp) { callPhase_ = CallPhase.getEnum(cp); }
+    void setCallPhase(int cp) { callPhase_ = CallPhase.getEnum(cp); }
     /**
      *  Get current user.
      *
@@ -1259,9 +1259,10 @@ public class UDRInvocationInfo extends TMUDRSerializableObject
         callPhase_ = savedCallPhase;
     }
 
-    // UDR writers can ignore these methods
-    public static short getCurrentVersion() { return 1; }
-    public int serializedLength() throws UDRException{
+    // UDR writers can ignore these package-private methods
+    static short getCurrentVersion() { return 1; }
+
+    int serializedLength() throws UDRException{
       int result = super.serializedLength() +
               serializedLengthOfString(name_) +
               serializedLengthOfString(currentUser_) +
@@ -1287,7 +1288,7 @@ public class UDRInvocationInfo extends TMUDRSerializableObject
       return result;
     }
 
-    public int serialize(ByteBuffer outputBuffer) throws UDRException {
+    int serialize(ByteBuffer outputBuffer) throws UDRException {
       int i;
 
       int origPos = outputBuffer.position();
@@ -1355,7 +1356,7 @@ public class UDRInvocationInfo extends TMUDRSerializableObject
       return bytesSerialized;
     }
 
-    public int deserialize(ByteBuffer inputBuffer) throws UDRException{
+    int deserialize(ByteBuffer inputBuffer) throws UDRException{
       int tempInt = 0;
 
       int origPos = inputBuffer.position();
@@ -1459,9 +1460,10 @@ public class UDRInvocationInfo extends TMUDRSerializableObject
         inputTableInfo_ = new TableInfo[MAX_INPUT_TABLES];
         predicates_ = new Vector<PredicateInfo>();
     }
-    public void validateCallPhase(CallPhase start,
-                                  CallPhase end,
-                                  String callee) throws UDRException {
+
+    void validateCallPhase(CallPhase start,
+                           CallPhase end,
+                           String callee) throws UDRException {
         if (callPhase_.ordinal() < start.ordinal() && 
             callPhase_ != CallPhase.UNKNOWN_CALL_PHASE)
             throw new UDRException(
@@ -1502,9 +1504,9 @@ public class UDRInvocationInfo extends TMUDRSerializableObject
         }
     }
 
-    public void setRuntimeInfo(String qid,
-                               int totalNumInstances,
-                               int myInstanceNum)
+    void setRuntimeInfo(String qid,
+                        int totalNumInstances,
+                        int myInstanceNum)
     {
         // set information that is not yet known at compile time
         queryId_ = qid;

--- a/core/sql/src/main/java/org/trafodion/sql/udr/UDRPlanInfo.java
+++ b/core/sql/src/main/java/org/trafodion/sql/udr/UDRPlanInfo.java
@@ -23,14 +23,22 @@ package org.trafodion.sql.udr;
 import java.nio.ByteBuffer;
 
 
-/** Special degrees of parallelism.
+/** Describes the query plan used for a UDR invocation
  *
- *  <p> Values that can be used in the setDesiredDegreeOfParallelism()
- *  method, in addition to positive numbers for the degree of
- *  parallelism (DoP).
+ *  <p>Objects of this type are used together with UDRInvocationInfo
+ *  objects and in the future they may contain additional info on
+ *  plan-related such as the chosen partitioning and ordering.
  */
 public class UDRPlanInfo extends TMUDRSerializableObject {
 
+    /** Special degrees of parallelism.
+     *
+     *  <p> Values that can be used in the setDesiredDegreeOfParallelism()
+     *  method, in addition to positive numbers for the degree of
+     *  parallelism (DoP).
+     *
+     *  @see UDR#describeStatistics
+     */
     public enum SpecialDegreeOfParallelism
     {
         /** Optimizer decides DoP */
@@ -92,21 +100,24 @@ public class UDRPlanInfo extends TMUDRSerializableObject {
      *  addition to positive numbers. These are defined in
      *  class UDRPlanInfo.
      *<ul>
-     *  <li> @c ANY_DEGREE_OF_PARALLELISM:
+     *  <li> ANY_DEGREE_OF_PARALLELISM:
      *        This will allow the optimizer to choose any degree
      *        of parallelism, including 1 (serial execution)
-     *  <li> @c DEFAULT_DEGREE_OF_PARALLELISM:
+     *  <li> DEFAULT_DEGREE_OF_PARALLELISM:
      *        Currently the same as ANY_DEGREE_OF_PARALLELISM.
      *        The optimizer will use a heuristic based on
-     *        the estimated cardinality.
-     *  <li> @c MAX_DEGREE_OF_PARALLELISM:
+     *        the estimated cardinality (which you can set in
+     *        the {@link UDR#describeStatistics} interface).
+     *  <li> MAX_DEGREE_OF_PARALLELISM:
      *        Choose the highest possible degree of parallelism.
-     *  <li> @c ONE_INSTANCE_PER_NODE:
+     *  <li> ONE_INSTANCE_PER_NODE:
      *        Start one parallel instance on every Trafodion node.
      *        This is mostly meant for internal TMUDFs, e.g. a
      *        TMUDF to read the log files on every node.
      * </ul>
      *  @see UDRPlanInfo#getDesiredDegreeOfParallelism()
+     *  @see UDR#describeStatistics
+     *  @see TableInfo#setEstimatedNumRows
      *  @param dop desired degree of parallelism (a positive number or
      *             one of the enum values in
      *             UDRPlanInfo#SpecialDegreeOfParallelism).
@@ -255,9 +266,10 @@ public class UDRPlanInfo extends TMUDRSerializableObject {
     }
     
     // UDR writers can ignore these methods
-    public static short getCurrentVersion() { return 1; }
+    static short getCurrentVersion() { return 1; }
+
     @Override
-    public int serializedLength() throws UDRException {
+    int serializedLength() throws UDRException {
       int result = super.serializedLength() +
                    serializedLengthOfLong() +
                    serializedLengthOfInt() +
@@ -267,7 +279,7 @@ public class UDRPlanInfo extends TMUDRSerializableObject {
     }
 
     @Override
-    public int serialize(ByteBuffer outputBuffer) throws UDRException {
+    int serialize(ByteBuffer outputBuffer) throws UDRException {
       
       int origPos = outputBuffer.position();
 
@@ -290,7 +302,7 @@ public class UDRPlanInfo extends TMUDRSerializableObject {
     }
 
     @Override
-    public int deserialize(ByteBuffer inputBuffer) throws UDRException {
+    int deserialize(ByteBuffer inputBuffer) throws UDRException {
       int origPos = inputBuffer.position();
 
       super.deserialize(inputBuffer);


### PR DESCRIPTION
Just setting the desired degree of parallelism often doesn't
actually choose a parallel plan, the UDF writer may also need
to specify an estimate of the number of rows produced.

Also made the methods that are not intended for the UDR writer
package-private (no qualifier). This has two good side-effects: One is
that UDR writers no longer can call these methods (accidentally) and
the other is that we can set Javadoc to display only public methods,
which suppresses these package-private methods.