### PR TITLE
[TRAFODION-2467] HBase region start key straddling a datetime key error

### DIFF
--- a/core/sql/optimizer/NATable.cpp
+++ b/core/sql/optimizer/NATable.cpp
@@ -1449,9 +1449,38 @@ static ItemExpr * getRangePartitionBoundaryValuesFromEncodedKeys(
                     break;
 
                   case NA_DATETIME_TYPE:
+                    // those types should tolerate zeroing out trailing bytes, but
+                    // not filling with 0xFF
+                    if (isDescending)
+                      columnIsPartiallyProvided = FALSE;
+                    else if (numBytesInProvidedVal < 4)
+                      {
+                        // avoid filling year, month, day with a zero,
+                        // convert those to a 1
+
+                        // sorry, this makes use of the knowledge that
+                        // encoded date/time/timestamp all start with
+                        // 4 bytes, 2 byte big-endian year, 1 byte
+                        // month, 1 byte day
+
+                        if (actEncodedKey[valOffset] != 0 && numBytesInProvidedVal == 1)
+                          // only 1 byte of a year > 255 provided, in
+                          // this case leave the second byte zero,
+                          // only change the second byte to 1 if the
+                          // first byte is non-zero
+                          numBytesInProvidedVal = 2;
+
+                        // set bytes 1, 2, 3 (year LSB, month, day) to
+                        // 1 if they are not provided and zero
+                        for (int ymd=numBytesInProvidedVal; ymd<4; ymd++)
+                          if (actEncodedKey[valOffset+ymd] == 0)
+                            actEncodedKey[valOffset+ymd] = 1;
+                      }
+                    break;
+
                   case NA_INTERVAL_TYPE:
                     // those types should tolerate zeroing out trailing bytes, but
-                    // not filling with 0xFF 
+                    // not filling with 0xFF
                     if (isDescending)
                       columnIsPartiallyProvided = FALSE;
                     break;

--- a/core/sql/optimizer/NATable.cpp
+++ b/core/sql/optimizer/NATable.cpp
@@ -1453,13 +1453,15 @@ static ItemExpr * getRangePartitionBoundaryValuesFromEncodedKeys(
                     // not filling with 0xFF
                     if (isDescending)
                       columnIsPartiallyProvided = FALSE;
-                    else if (numBytesInProvidedVal < 4)
+                    else if (numBytesInProvidedVal < 4 &&
+                             static_cast<const DatetimeType *>(pkType)->getSubtype() !=
+                             DatetimeType::SUBTYPE_SQLTime)
                       {
                         // avoid filling year, month, day with a zero,
                         // convert those to a 1
 
                         // sorry, this makes use of the knowledge that
-                        // encoded date/time/timestamp all start with
+                        // encoded date and timestamp all start with
                         // 4 bytes, 2 byte big-endian year, 1 byte
                         // month, 1 byte day
 

--- a/core/sql/optimizer/NATable.cpp
+++ b/core/sql/optimizer/NATable.cpp
@@ -1467,7 +1467,7 @@ static ItemExpr * getRangePartitionBoundaryValuesFromEncodedKeys(
                           // only 1 byte of a year > 255 provided, in
                           // this case leave the second byte zero,
                           // only change the second byte to 1 if the
-                          // first byte is non-zero
+                          // first byte is also zero
                           numBytesInProvidedVal = 2;
 
                         // set bytes 1, 2, 3 (year LSB, month, day) to


### PR DESCRIPTION
Make sure we complete a partial region start key for a datetime column
such that year, month and day are set to at least 1.