### PR TITLE
[TRAFODION-2469] TM clients like dtmci don't exit cleanly

### DIFF
--- a/core/sqf/export/include/dtm/tm.h
+++ b/core/sqf/export/include/dtm/tm.h
@@ -315,6 +315,7 @@ extern "C" short JOINTRANSACTION(int64 transid);
 extern "C" short TMF_GETTXHANDLE_(short *handle);
 extern "C" short TMF_SETTXHANDLE_(short *handle);
 extern "C" short TMWAIT();
+extern "C" short TMCLIENTEXIT();
 
 // Extended API
 extern "C" short GETTRANSID_EXT (TM_Transid_Type *transid);
@@ -343,7 +344,6 @@ extern "C" short DTM_GETTRANSINFO_EXT(TM_Transid_Type pv_transid, int32 *pp_seq_
                                       int16 *pp_checksum, int64 *pp_timestamp);
 extern "C" short DTM_GETTRANSIDSTR(int64 pv_transid, char *pp_transidstr);
 extern "C" short DTM_GETTRANSIDSTR_EXT(TM_Transid_Type pv_transid, char *pp_transidstr);
-
 
 // Internal use only!!
 extern "C" short DTM_QUIESCE(int32 pv_node); //Use for testing only

--- a/core/sqf/src/tm/tmlib.cpp
+++ b/core/sqf/src/tm/tmlib.cpp
@@ -2491,6 +2491,18 @@ int16 TMWAIT()
         return lv_rsp.iv_msg_hdr.miv_err.error;
 }
 
+//------------------------------------------------------------------------
+// TMCLIENTEXIT
+//
+// Purpose  : To close all the TM opens from the clients before exiting 
+// Params   : none.
+// ---------------------------------------------------------------------
+int16 TMCLIENTEXIT()
+{
+   int16 lv_error = FEOK;
+   lv_error = gv_tmlib.close_tm();
+   return lv_error;
+}
 
 
 // -------------------------------------------------------------------
@@ -3274,6 +3286,17 @@ short TMLIB::abortTransactionLocal(long transactionID)
   return jresult;
 } //abortTransactionLocal
 
+bool TMLIB::close_tm() 
+{
+   TPT_DECL       (lv_phandle);
+   if (!gv_tmlib.is_initialized())
+      return true;
+   for (int i = 0; i < iv_node_count; i++) {
+      if (phandle_get(&lv_phandle, i) == true)
+         msg_mon_close_process(&lv_phandle);
+   }
+   return true;
+}
 
 //----------------------------------------------------------------------------
 // DTM_LOCALTRANSACTION

--- a/core/sqf/src/tm/tmlib.h
+++ b/core/sqf/src/tm/tmlib.h
@@ -141,6 +141,7 @@ class TMLIB : public JavaObjectInterfaceTM
         short abortTransactionLocal(long transactionID);
         short endTransactionLocal(long transactionID);
         void cleanupTransactionLocal(long transactionID);
+        bool close_tm();
 };
 
 // helper methods, C style 

--- a/core/sqf/src/tm/tools/dtmci.cpp
+++ b/core/sqf/src/tm/tools/dtmci.cpp
@@ -1830,6 +1830,7 @@ int main(int argc, char *argv[])
     } // while
     if(lv_shellExec)
         fclose(lp_in);
+    TMCLIENTEXIT();
     msg_mon_process_shutdown();
 
     return 0;


### PR DESCRIPTION
Created a new API TMCLIENTEXIT in TM library to clean up
opens. dtmci now calls this API before exiting