### PR TITLE
[TRAFODION-2470] Fixed one cause of 6004 warnings

### DIFF
--- a/core/sql/parser/SqlParserAux.cpp
+++ b/core/sql/parser/SqlParserAux.cpp
@@ -863,8 +863,7 @@ ItemExpr *literalOfNumericPassingScale(NAString *strptr, char sign,
   } else if (strSize <= 19) {
     datatype = (createSignedDatatype ? REC_BIN64_SIGNED : REC_BIN64_UNSIGNED);
     length = sizeof(Int64);
-  } else if (strSize == 20) {
-    createSignedDatatype = FALSE;
+  } else if ((strSize == 20) && (!createSignedDatatype)) {
     datatype = REC_BIN64_UNSIGNED;
     length = sizeof(Int64);
   }    

--- a/core/sql/parser/SqlParserAux.cpp
+++ b/core/sql/parser/SqlParserAux.cpp
@@ -847,6 +847,8 @@ ItemExpr *literalOfNumericPassingScale(NAString *strptr, char sign,
 
   NABoolean createTinyLiteral = 
     ((CmpCommon::getDefault(TRAF_CREATE_TINYINT_LITERAL)) == DF_ON);
+  NABoolean createLargeintUnsignedLiteral =
+    ((CmpCommon::getDefault(TRAF_LARGEINT_UNSIGNED_IO)) == DF_ON);
   
   char numericVal[8];
   short datatype = -1;
@@ -861,9 +863,9 @@ ItemExpr *literalOfNumericPassingScale(NAString *strptr, char sign,
     datatype = (createSignedDatatype ? REC_BIN32_SIGNED : REC_BIN32_UNSIGNED);
     length = sizeof(Lng32);
   } else if (strSize <= 19) {
-    datatype = (createSignedDatatype ? REC_BIN64_SIGNED : REC_BIN64_UNSIGNED);
+    datatype = (createSignedDatatype || !createLargeintUnsignedLiteral ? REC_BIN64_SIGNED : REC_BIN64_UNSIGNED);
     length = sizeof(Int64);
-  } else if ((strSize == 20) && (!createSignedDatatype)) {
+  } else if ((strSize == 20) && (!createSignedDatatype) && (createLargeintUnsignedLiteral)) {
     datatype = REC_BIN64_UNSIGNED;
     length = sizeof(Int64);
   }    


### PR DESCRIPTION
The function literalOfNumericPassingScale (parser/SqlParserAux.cpp) is used to parse literals into ConstValue nodes and encoded values. It was incorrectly handling signed numeric literals of 20 characters in length: it would encode these as an unsigned 64-bit integer, then create a signed SQLLargeInt or SQLNumeric with that unsigned encoded value. One symptom of this is that histograms for NUMERIC datatypes would encounter 6004 errors (out-of-order histogram intervals) if there were some values requiring less than 20 characters and others requiring 20 or more.

The fix here reverts to using SQLBigNum instead for such values. 