### PR TITLE
Improve concurrency of drop constraint, log memory pressure

### DIFF
--- a/core/sql/cli/memorymonitor.h
+++ b/core/sql/cli/memorymonitor.h
@@ -123,6 +123,7 @@ private:
   static ULng32 threadId_;
   FILE* fd_meminfo_;
   FILE* fd_vmstat_;
+  FILE* fd_logfile_;
 };
 #endif
 

--- a/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
@@ -9270,7 +9270,9 @@ void CmpSeabaseDDL::alterSeabaseTableDropConstraint(
       // find the index that corresponds to this constraint
       char query[1000];
       
-      str_sprintf(query, "select I.keytag, I.is_explicit from %s.\"%s\".%s T, %s.\"%s\".%s I where T.table_uid = %Ld and T.constraint_uid = %Ld and T.table_uid = I.base_table_uid and T.index_uid = I.index_uid ",
+      // the cardinality hint should force a nested join with
+      // TABLE_CONSTRAINTS as the outer and INDEXES as the inner
+      str_sprintf(query, "select I.keytag, I.is_explicit from %s.\"%s\".%s T, %s.\"%s\".%s I /*+ cardinality 1e9 */ where T.table_uid = %Ld and T.constraint_uid = %Ld and T.table_uid = I.base_table_uid and T.index_uid = I.index_uid ",
                   getSystemCatalog(), SEABASE_MD_SCHEMA, SEABASE_TABLE_CONSTRAINTS,
                   getSystemCatalog(), SEABASE_MD_SCHEMA, SEABASE_INDEXES,
                   naTable->objectUid().castToInt64(),


### PR DESCRIPTION
Two minor changes found as result of some experiments:

Add a cardinality hint to a join query used during drop constraint.
This should cause us to use a nested join, reducing the chances of
a write conflict during commit processing.

Also added debugging support for memory pressure, setting an environment
variable allows to log the parameters to a file. It's best to use
this with a single sqlci tool, like this:

export SQL_MEMMONITOR_LOGFILE=mylogfile
sqlci

Sample output:

Fri Feb  3 01:33:42 2017: pctFree=0.274771, pageFaultRate=24.115740, (free*normpagefault*commitratio) = (-0.099085 * 0.246121 * 0.535585), pressure=0
Fri Feb  3 01:33:48 2017: pctFree=0.274772, pageFaultRate=25.187914, (free*normpagefault*commitratio) = (-0.099086 * 0.257064 * 0.535585), pressure=0
Fri Feb  3 01:33:54 2017: pctFree=0.274771, pageFaultRate=25.458275, (free*normpagefault*commitratio) = (-0.099085 * 0.259823 * 0.535587), pressure=0
Fri Feb  3 01:34:00 2017: pctFree=0.274785, pageFaultRate=20.749832, (free*normpagefault*commitratio) = (-0.099139 * 0.211769 * 0.535575), pressure=0