### PR TITLE
[TRAFODION-2442] Small correction to previous fix

### DIFF
--- a/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
@@ -649,12 +649,12 @@ short CmpSeabaseDDL::createSeabaseTableExternal(
       if (retcode)
         return -1;
 
-      if (length > 1048576)
+      if (length > CmpCommon::getDefaultNumeric(TRAF_MAX_CHARACTER_COL_LENGTH))
         {
           *CmpCommon::diags()
             << DgSqlCode(-4247)
             << DgInt0(length)
-            << DgInt1(1048576) 
+            << DgInt1(CmpCommon::getDefaultNumeric(TRAF_MAX_CHARACTER_COL_LENGTH)) 
             << DgString0(naCol->getColName().data());
           
           return -1;


### PR DESCRIPTION
A previous change for this JIRA to CmpSeabaseDDL::createSeabaseTableExternal meant to use a CQD for maximum column length but used a hard-coded constant instead. This change just replaces the hard-coded constant with the intended CQD. (Compare with the use of this CQD in CmpSeabaseDDLcommon.cpp.)