### PR TITLE
[TRAFODION-2314] MXOSRVR sometimes exits abnormally with NAMutex assert

### DIFF
--- a/core/sql/common/NAMemory.cpp
+++ b/core/sql/common/NAMemory.cpp
@@ -2972,7 +2972,7 @@ void NAHeap::setThreadSafe()
   // set this heap and heaps it is derived from
   while (heap)
   {
-    if (heap->threadSafe_ == false);
+    if (heap->threadSafe_ == false)
     {
       rc = pthread_mutex_init(&(heap->mutex_), &attr);
       assert(rc == 0);

--- a/core/sql/exp/ExpLOBinterface.cpp
+++ b/core/sql/exp/ExpLOBinterface.cpp
@@ -66,8 +66,10 @@ Lng32 ExpLOBinterfaceInit(void *& exLobGlob, void * lobHeap,
     {
       NAHeap *heap = new ((NAHeap *)lobHeap) NAHeap("LOB Heap", (NAHeap *)lobHeap);
       if (isHiveRead)
-        ((ExLobGlobals *)exLobGlob)->startWorkerThreads();
-      heap->setThreadSafe();
+        {
+          ((ExLobGlobals *)exLobGlob)->startWorkerThreads();
+          heap->setThreadSafe();
+        }
       ((ExLobGlobals *)exLobGlob)->setHeap(heap);
       
     }

--- a/core/sql/generator/GenPreCode.cpp
+++ b/core/sql/generator/GenPreCode.cpp
@@ -4177,9 +4177,11 @@ RelExpr * FileScan::preCodeGen(Generator * generator,
 	 TRUE);
 
       if (isHiveTable())
-	// assign individual files and blocks to each ESPs
-	((NodeMap *) getPartFunc()->getNodeMap())->assignScanInfos(hiveSearchKey_);
-       generator->setProcessLOB(TRUE);
+        {
+          // assign individual files and blocks to each ESPs
+          ((NodeMap *) getPartFunc()->getNodeMap())->assignScanInfos(hiveSearchKey_);
+          generator->setProcessLOB(TRUE);
+        }
     }
 
   


### PR DESCRIPTION
Fixes as suggested by @selvaganesang and @sandhyasun 

We were hitting the code to make heap thread safe repeatedly while running
jdbc and phoenix tests.

PROCESS_LOB flag was being set incorrectly in some cases.

Unlocking a mutex owned by a different thread lead to the assertion.

This could also result in heap corruption.