### PR TITLE
[TRAFODION-2473] sqnodestatus report wrong status if ssh banner is configured.

### DIFF
--- a/core/sqf/sql/scripts/sqnodestatus
+++ b/core/sqf/sql/scripts/sqnodestatus
@@ -84,7 +84,7 @@ sub check_node_status($)
     my $node_id, $node_status;
     my $check_node=shift;
     #print "node=${check_node}\n";
-    my $command="ssh -M $sq_mon_ssh_options $check_node hostname 2>&1";
+    my $command="ssh -M -q $sq_mon_ssh_options $check_node hostname 2>&1";
     #print "command=${command}\n";
     my $down_character="ssh:";
     #print "down_character=${down_character}\n";


### PR DESCRIPTION
specify the '-q' command to ignore ssh banner.