### PR TITLE
[TRAFODION-2478] Reduce the number of memory monitoring threads in Tr…

### DIFF
--- a/core/sql/bin/ex_esp_main.cpp
+++ b/core/sql/bin/ex_esp_main.cpp
@@ -357,15 +357,18 @@ Int32 runESP(Int32 argc, char** argv, GuaReceiveFastStart *guaReceiveFastStart)
   cliGlobals->initiateDefaultContext();
   NAHeap *espIpcHeap = cliGlobals->getIpcHeap();
   IpcEnvironment *ipcEnvPtr = cliGlobals->getEnvironment();
-  //
-  // Start the  memory monitor for dynamic memory management
-  Lng32 memMonitorWindowSize = 10;
-  Lng32 memMonitorSampleInterval = 10;
-  MemoryMonitor memMonitor(memMonitorWindowSize,
+  if (statsGlobals != NULL)
+     cliGlobals->setMemoryMonitor(statsGlobals->getMemoryMonitor());
+  else 
+  {
+     // Start the  memory monitor for dynamic memory management
+     Lng32 memMonitorWindowSize = 10;
+     Lng32 memMonitorSampleInterval = 10;
+     MemoryMonitor memMonitor(memMonitorWindowSize,
                            memMonitorSampleInterval,
                            espExecutorHeap);
-  cliGlobals->setMemoryMonitor(&memMonitor);
-
+     cliGlobals->setMemoryMonitor(&memMonitor);
+  }
   // After CLI globals are initialized but before we begin ESP message
   // processing, have the CLI context set its user identity based on
   // the OS user identity.

--- a/core/sql/bin/ex_esp_main.cpp
+++ b/core/sql/bin/ex_esp_main.cpp
@@ -364,10 +364,11 @@ Int32 runESP(Int32 argc, char** argv, GuaReceiveFastStart *guaReceiveFastStart)
      // Start the  memory monitor for dynamic memory management
      Lng32 memMonitorWindowSize = 10;
      Lng32 memMonitorSampleInterval = 10;
-     MemoryMonitor memMonitor(memMonitorWindowSize,
+     MemoryMonitor *memMonitor = new (espExecutorHeap) 
+                           MemoryMonitor(memMonitorWindowSize,
                            memMonitorSampleInterval,
                            espExecutorHeap);
-     cliGlobals->setMemoryMonitor(&memMonitor);
+     cliGlobals->setMemoryMonitor(memMonitor);
   }
   // After CLI globals are initialized but before we begin ESP message
   // processing, have the CLI context set its user identity based on

--- a/core/sql/cli/Globals.cpp
+++ b/core/sql/cli/Globals.cpp
@@ -235,19 +235,7 @@ void CliGlobals::init( NABoolean espProcess,
   if (! espProcess)
   {
     // Create the process global ARKCMP server.
-    // In R1.8, Each context has its own mxcmp.
     sharedArkcmp_ = NULL;
-
-    //sharedArkcmp_->setShared(FALSE);
-    // create the process global memory monitor. For now with
-    // defaults of 10 window entries and sampling every 1 second
-    Lng32 memMonitorWindowSize = 10;
-    Lng32 memMonitorSampleInterval = 1; // reduced from 10 (for M5 - May 2011)
-    memMonitor_ = new(&executorMemory_) MemoryMonitor(memMonitorWindowSize,
-						      memMonitorSampleInterval,
-						      &executorMemory_);
-
-    //    nextUniqueContextHandle = 2000;
     nextUniqueContextHandle = DEFAULT_CONTEXT_HANDLE;
 
     arlibHeap_ = new (&executorMemory_) NAHeap("MXARLIB Cache Heap",
@@ -322,6 +310,18 @@ void CliGlobals::init( NABoolean espProcess,
     capacities_.setHeap(defaultContext_->exCollHeap());
     freespaces_.setHeap(defaultContext_->exCollHeap());
     largestFragments_.setHeap(defaultContext_->exCollHeap());
+    if (statsGlobals_ != NULL) 
+       memMonitor_ = statsGlobals_->getMemoryMonitor();
+    else
+    {
+       // create the process global memory monitor. For now with
+       // defaults of 10 window entries and sampling every 1 second
+       Lng32 memMonitorWindowSize = 10;
+       Lng32 memMonitorSampleInterval = 1; // reduced from 10 (for M5 - May 2011)
+       memMonitor_ = new (&executorMemory_) MemoryMonitor(memMonitorWindowSize,
+						      memMonitorSampleInterval,
+    						      &executorMemory_);
+    }
   } // (!espProcess)
 
   else

--- a/core/sql/cli/memorymonitor.cpp
+++ b/core/sql/cli/memorymonitor.cpp
@@ -59,6 +59,7 @@ extern "C" Lng32 __stdcall
 PdhOpenQuery (LPCSTR  szD, DWORD  dw, HQUERY  *phQ );
 #endif
 
+#define FREAD_BUFFER_SIZE 2048
 
 //SQ_LINUX #ifdef NA_WINNT
 
@@ -66,7 +67,7 @@ NABoolean MemoryMonitor::threadIsCreated_ = 0;
 HANDLE MemoryMonitor::updateThread_ = (HANDLE) 0;
 ULng32 MemoryMonitor::threadId_ = 0;
 
-DWORD WINAPI memMonitorUpdateThread(void * param) {
+DWORD WINAPI MemoryMonitor::memMonitorUpdateThread(void * param) {
   // params points to the memory monitor object
   MemoryMonitor *memMonitor = (MemoryMonitor*) param;
   Lng32 sleepTime = memMonitor->getSampleInterval();
@@ -102,18 +103,17 @@ MemoryMonitor::MemoryMonitor(Lng32 windowSize,
 {
   // if the windowSize is 0, we do not need memory monitor.
   assert(windowSize);
-  char buffer[2048];
+  char buffer[FREAD_BUFFER_SIZE+1];
   char *currPtr;
-  size_t bytesRead;
+  size_t bytesRead = 0;
   fd_meminfo_ = fopen("/proc/meminfo", "r");
   if (fd_meminfo_) {
-    bytesRead = fread(buffer, 1, 2048, fd_meminfo_);
+    bytesRead = fread(buffer, 1, FREAD_BUFFER_SIZE, fd_meminfo_);
     if (ferror(fd_meminfo_))
        assert(false); 
     if (feof(fd_meminfo_))
        clearerr(fd_meminfo_); 
-    else
-       buffer[bytesRead] = '\0';
+    buffer[bytesRead] = '\0';
     currPtr = strstr(buffer, "MemTotal");
     if (currPtr) {
       sscanf(currPtr, "%*s " PF64 " kB", &memTotal_);
@@ -152,7 +152,7 @@ MemoryMonitor::MemoryMonitor(Lng32 windowSize,
     {
       // and finally start the update thread
       updateThread_ = CreateNewThread(
-                           &memMonitorUpdateThread, // Thread func
+                           &MemoryMonitor::memMonitorUpdateThread, // Thread func
                            this );   // Argument for thread
       threadIsCreated_ = TRUE;
     }
@@ -222,19 +222,18 @@ void MemoryMonitor::update(float &scale) {
         Int32 success = fseek(fd_meminfo_, 0, SEEK_SET);
         if (success != 0)
                 return;
-	char buffer[4096];
+	char buffer[FREAD_BUFFER_SIZE+1];
 	Int64 memFree = -1, memCommitAS = 0;
 	Int64 pgpgout = -1, pgpgin = -1;
-	size_t bytesRead;
+	size_t bytesRead = 0;
 	char * currPtr;
-        bytesRead = fread(buffer, 1, 2048, fd_meminfo_);
+        bytesRead = fread(buffer, 1, FREAD_BUFFER_SIZE, fd_meminfo_);
         // Make sure there wasn't an error (next fseek will clear eof)
         if (ferror(fd_meminfo_))
            assert(false); 
         if (feof(fd_meminfo_))
            clearerr(fd_meminfo_); 
-        else
-           buffer[bytesRead] = '\0';
+        buffer[bytesRead] = '\0';
         currPtr = strstr(buffer, "MemFree");
 	if (currPtr) sscanf(currPtr, "%*s " PF64 " kB", &memFree);
         currPtr = strstr(buffer, "Committed_AS");
@@ -268,13 +267,13 @@ void MemoryMonitor::update(float &scale) {
 		pressure_ = 0;
 		return;
 	}
-	bytesRead = fread(buffer, 1, 2048, fd_vmstat_);
+        bytesRead = 0;
+	bytesRead = fread(buffer, 1, FREAD_BUFFER_SIZE, fd_vmstat_);
         if (ferror(fd_vmstat_))
            assert(false); 
         if (feof(fd_vmstat_))
            clearerr(fd_vmstat_); 
-        else
-           buffer[bytesRead] = '\0';
+        buffer[bytesRead] = '\0';
         currPtr = strstr(buffer, "pgpgin");
 	if (currPtr) sscanf(currPtr, "%*s " PF64 " kB", &pgpgin);
         currPtr = strstr(buffer, "pgpgout");

--- a/core/sql/executor/ex_hash_grby.h
+++ b/core/sql/executor/ex_hash_grby.h
@@ -65,9 +65,6 @@ class ex_hash_grby_tdb;
 // Classes referenced in this file
 // -----------------------------------------------------------------------
 class ex_tcb;
-#ifndef __EID
-class memoryMonitor;
-#endif
 
 // -----------------------------------------------------------------------
 // ex_hash_grby_tdb

--- a/core/sql/runtimestats/SqlStats.cpp
+++ b/core/sql/runtimestats/SqlStats.cpp
@@ -134,6 +134,7 @@ void StatsGlobals::init()
   else
     myNodeName[0] = '\0';
   rmsStats_->setNodeName(myNodeName);
+  createMemoryMonitor();
   releaseStatsSemaphore(semId, GetCliGlobals()->myPin(), savedPriority,
             savedStopMode);
   sem_close((sem_t *)semId);
@@ -1686,6 +1687,17 @@ StatsGlobals * shareStatsSegment(Int32 &shmid, NABoolean checkForSSMP)
        statsGlobals = NULL;
   }
   return statsGlobals;
+}
+
+void StatsGlobals::createMemoryMonitor() 
+{
+
+   // defaults of 10 window entries and sampling every 1 second
+   Lng32 memMonitorWindowSize = 10;
+   Lng32 memMonitorSampleInterval = 1; // reduced from 10 (for M5 - May 2011)
+   memMonitor_ = new (&statsHeap_) MemoryMonitor(memMonitorWindowSize,
+                                                      memMonitorSampleInterval,
+                                                      &statsHeap_);
 }
 
 short getMasterCpu(char *uniqueStmtId, Lng32 uniqueStmtIdLen, char *nodeName, short maxLen, short &cpu)

--- a/core/sql/runtimestats/SqlStats.h
+++ b/core/sql/runtimestats/SqlStats.h
@@ -62,12 +62,14 @@ class RecentSikey;
 class StatsGlobals;
 class ExOperStats;
 class ExProcessStats;
+class MemoryMonitor;
 
 #ifndef __EID
 #include "rts_msg.h"
 #endif
 #include "ComTdb.h"
 #include "SQLCLIdev.h"
+#include "memorymonitor.h"
 
 #define MAX_PID_ARRAY_SIZE 65536
 
@@ -477,7 +479,6 @@ public:
       { abortedSemPid_ = semPid_; }
   Int64 getNewestRevokeTimestamp() const { return newestRevokeTimestamp_; }
   void cleanupOldSikeys(Int64 gcInterval);
-#ifndef __EID
   Lng32 getSecInvalidKeys(
                           CliGlobals * cliGlobals,
                           Int64 lastCallTimestamp,
@@ -487,7 +488,8 @@ public:
 
   void mergeNewSikeys(Int32 numSikeys, 
                     SQL_QIKEY sikeys[]);
-#endif
+  MemoryMonitor *getMemoryMonitor() { return memMonitor_; }
+  void createMemoryMonitor();
 
   void init();
   NABoolean isShmDirty() { return isBeingUpdated_; }
@@ -543,6 +545,7 @@ private:
   pid_t pidToCheck_;
   pid_t maxPid_;
   Int64 ssmpDumpedTimestamp_;
+  MemoryMonitor *memMonitor_;
 };
 StatsGlobals * shareStatsSegment(Int32 &shmid, NABoolean checkForSSMP = TRUE);
 short getMasterCpu(char *uniqueStmtId, Lng32 uniqueStmtIdLen, char *nodeName, short maxLen, short &cpu);


### PR DESCRIPTION
…afodion SQL processes

The memory monitor thread is now moved to mxsscp process and the collected data is
stored in RMS shared segment. All SQL proceses have access to it.