### PR TITLE
[TRAFODION-2499] TMUDF does not pass error to client

### DIFF
--- a/core/sql/executor/ExUdr.cpp
+++ b/core/sql/executor/ExUdr.cpp
@@ -1132,7 +1132,7 @@ NABoolean ExUdrTcb::insertUpQueueEntry(ex_queue::up_status status,
       upEntry->setDiagsArea(diags);
       diags->incrRefCount();
     }
-    else
+    else if (atpDiags != diags)
     {
       atpDiags->mergeAfter(*diags);
       // errors have been reported, clear the passed-in diags


### PR DESCRIPTION
Added check to avoid clearing out the error when source and
destination diags area are the same.