### PR TITLE
[TRAFODION-2517] Allow scalar UDFs with delimited identifiers

### DIFF
--- a/core/sql/parser/sqlparser.y
+++ b/core/sql/parser/sqlparser.y
@@ -8332,13 +8332,19 @@ user_defined_function_name :
        regular_identifier_not_builtin 
          {
            // Function name only.
-           $1->toUpper(); // UDF names can't be delimited.
+           $1->toUpper();
            ComObjectName *name = new (PARSERHEAP()) 
              ComObjectName(*$1, COM_UDF_NAME, 1, PARSERHEAP());
            if (name == NULL) YYABORT;
            $$ = name;
          }
-
+     | DELIMITED_IDENTIFIER
+         {
+           ComObjectName *name = new (PARSERHEAP()) 
+             ComObjectName(*$1, COM_UDF_NAME, 1, PARSERHEAP());
+           if (name == NULL) YYABORT;
+           $$ = name;
+         }
      | qualified_name '.' regular_identifier_not_builtin
          {
            // qualified name can't be more than 2 parts.

--- a/core/sql/regress/udr/EXPECTED001
+++ b/core/sql/regress/udr/EXPECTED001
@@ -201,7 +201,7 @@
 >>-- DDL time. We will get an error at runtime, though.
 >>
 >>-- Testing a TMUDF with no table-valued inputs
->>create table_mapping function fibonacci(start_row int, num_rows int)
+>>create table_mapping function "Fibonacci"(start_row int, num_rows int)
 +>returns (ordinal int, fibonacci_number largeint)
 +>external name 'Fibonacci'
 +>language cpp
@@ -227,7 +227,7 @@
 Table_mapping Functions for Library SCH.TEST001
 ===============================================
 
-SCH.FIBONACCI
+SCH.Fibonacci
 SCH.SESSIONIZE_DYNAMIC
 SCH.SESSIONIZE_DYNAMIC_SHARED
 
@@ -517,7 +517,7 @@ SESSION_ID            SEQUENCE_NO           USERID                            TS
 
 --- SQL operation complete.
 >>select *
-+>from UDF(fibonacci(1,10)) XO
++>from UDF("Fibonacci"(1,10)) XO
 +>order by 1;
 
 ORDINAL      FIBONACCI_NUMBER    
@@ -540,7 +540,7 @@ ORDINAL      FIBONACCI_NUMBER
 --- SQL operation complete.
 >>
 >>select *
-+>from UDF(fibonacci(1,10)) XO
++>from UDF("Fibonacci"(1,10)) XO
 +>order by 1;
 
 ORDINAL      FIBONACCI_NUMBER    
@@ -560,7 +560,7 @@ ORDINAL      FIBONACCI_NUMBER
 --- 10 row(s) selected.
 >>
 >>select sum(fibonacci_number)
-+>from UDF(fibonacci(50,10)) XO;
++>from UDF("Fibonacci"(50,10)) XO;
 
 (EXPR)              
 --------------------
@@ -603,7 +603,7 @@ ORDINAL      FIBONACCI_NUMBER
 
 --- SQL operation complete.
 >>select *
-+>from UDF(fibonacci(1,10)) natural join UDF(fibonacci_java(1,10));
++>from UDF("Fibonacci"(1,10)) natural join UDF(fibonacci_java(1,10));
 
 ORDINAL      FIBONACCI_NUMBER    
 -----------  --------------------
@@ -625,7 +625,7 @@ ORDINAL      FIBONACCI_NUMBER
 --- SQL operation complete.
 >>
 >>select *
-+>from UDF(fibonacci(1,10)) cpp1 natural join
++>from UDF("Fibonacci"(1,10)) cpp1 natural join
 +>     UDF(fibonacci_java(1,10)) java1 natural join
 +>     UDF(fibonacci_java(1,10)) java2;
 

--- a/core/sql/regress/udr/EXPECTED107.SB
+++ b/core/sql/regress/udr/EXPECTED107.SB
@@ -35,8 +35,8 @@
 
 --- SQL operation complete.
 >>
->>-- ADDDAYS2DATE: Adds days to a date
->>create function ADDDAYS2DATE(date,int) returns (NEWDATE date)
+>>-- "AddDays2Date@": Adds days to a date
+>>create function "AddDays2Date@"(date,int) returns (NEWDATE date)
 +>language c parameter style sql external name 'addDaysToDate'
 +>library TEST107
 +>deterministic no sql final call allow any parallelism state area size 1024 ;
@@ -445,7 +445,7 @@ Functions for Library SCH.TEST107
 =================================
 
 SCH.ADD2
-SCH.ADDDAYS2DATE
+SCH.AddDays2Date@
 SCH.CURRENT_ROLE_NAME
 SCH.CURRENT_USER_NAME
 SCH.ECHOBNUM0
@@ -568,7 +568,7 @@ ADD2
 
 --- 10 row(s) selected.
 >>
->>values(adddays2date(date'2000-01-01',2));
+>>values("AddDays2Date@"(date'2000-01-01',2));
 
 NEWDATE   
 ----------
@@ -576,7 +576,7 @@ NEWDATE
 2000-01-03
 
 --- 1 row(s) selected.
->>select adddays2date(date'2000-01-01', a) from t10;
+>>select "AddDays2Date@"(date'2000-01-01', a) from t10;
 
 NEWDATE   
 ----------

--- a/core/sql/regress/udr/TEST001
+++ b/core/sql/regress/udr/TEST001
@@ -40,7 +40,7 @@ drop table t001_Datatypes;
 drop table_mapping function sessionize_dynamic;
 drop table_mapping function sessionize_dynamic_shared;
 drop table_mapping function sessionize_err;
-drop table_mapping function fibonacci;
+drop table_mapping function "Fibonacci";
 drop library TEST001;
 drop table_mapping function sessionize_java;
 drop table_mapping function fibonacci_java;
@@ -214,7 +214,7 @@ library TEST001;
 -- DDL time. We will get an error at runtime, though.
 
 -- Testing a TMUDF with no table-valued inputs
-create table_mapping function fibonacci(start_row int, num_rows int)
+create table_mapping function "Fibonacci"(start_row int, num_rows int)
 returns (ordinal int, fibonacci_number largeint)
 external name 'Fibonacci'
 language cpp
@@ -363,16 +363,16 @@ execute s;
 -- will fail until tinyint support is added for spj/procedures
 cqd traf_tinyint_spj_support 'ON';
 select *
-from UDF(fibonacci(1,10)) XO
+from UDF("Fibonacci"(1,10)) XO
 order by 1;
 cqd traf_tinyint_spj_support reset;
 
 select *
-from UDF(fibonacci(1,10)) XO
+from UDF("Fibonacci"(1,10)) XO
 order by 1;
 
 select sum(fibonacci_number)
-from UDF(fibonacci(50,10)) XO;
+from UDF("Fibonacci"(50,10)) XO;
 
 select *
 from UDF(fibonacci_java(1,10)) XO
@@ -383,11 +383,11 @@ from UDF(fibonacci_java(50,10)) XO;
 
 control query shape join(tmudf, tmudf);
 select *
-from UDF(fibonacci(1,10)) natural join UDF(fibonacci_java(1,10));
+from UDF("Fibonacci"(1,10)) natural join UDF(fibonacci_java(1,10));
 control query shape off;
 
 select *
-from UDF(fibonacci(1,10)) cpp1 natural join
+from UDF("Fibonacci"(1,10)) cpp1 natural join
      UDF(fibonacci_java(1,10)) java1 natural join
      UDF(fibonacci_java(1,10)) java2;
 

--- a/core/sql/regress/udr/TEST107
+++ b/core/sql/regress/udr/TEST107
@@ -81,7 +81,7 @@ drop table t10;
 
 drop function GETMXV;
 drop function ADD2;
-drop function ADDDAYS2DATE;
+drop function "AddDays2Date@";
 drop function GETCOLLATION;
 drop function SESSION_USER_NAME;
 drop function VALIDATE_SESSION_USER_NAME;
@@ -161,8 +161,8 @@ language c parameter style sql external name 'add2'
 library TEST107
 deterministic no sql final call allow any parallelism state area size 1024 ;
 
--- ADDDAYS2DATE: Adds days to a date
-create function ADDDAYS2DATE(date,int) returns (NEWDATE date)
+-- "AddDays2Date@": Adds days to a date
+create function "AddDays2Date@"(date,int) returns (NEWDATE date)
 language c parameter style sql external name 'addDaysToDate'
 library TEST107
 deterministic no sql final call allow any parallelism state area size 1024 ;
@@ -355,8 +355,8 @@ execute S;
 select add2(a,b) from t10;
 select add2(a,c) from t10;
 
-values(adddays2date(date'2000-01-01',2));
-select adddays2date(date'2000-01-01', a) from t10;
+values("AddDays2Date@"(date'2000-01-01',2));
+select "AddDays2Date@"(date'2000-01-01', a) from t10;
 
 values(getMXV());
 


### PR DESCRIPTION
Added a parser rule for this case. Fortunately the new rule did not
increase the number of parser conflicts. Note that TMUDFs already
allowed delimited identifiers.