### PR TITLE
Change file location of Hadoop hdfs jar file [TRAFODION-2528]

### DIFF
--- a/core/sqf/sqenvcom.sh
+++ b/core/sqf/sqenvcom.sh
@@ -407,7 +407,7 @@ elif [[ -n "$(ls /etc/init.d/ambari* 2>/dev/null)" ]]; then
   export HADOOP_JAR_DIRS="/usr/hdp/current/hadoop-client
                           /usr/hdp/current/hadoop-client/lib
                           /usr/hdp/current/hadoop-yarn-client"
-  export HADOOP_JAR_FILES="/usr/hdp/current/hadoop-client/client/hadoop-hdfs-*.jar"
+  export HADOOP_JAR_FILES="/usr/hdp/current/hadoop-hdfs-client/hadoop-hdfs-*.jar"
   export HIVE_JAR_DIRS="/usr/hdp/current/hive-client/lib"
   export HIVE_JAR_FILES="/usr/hdp/current/hadoop-mapreduce-client/hadoop-mapreduce-client-core*.jar"
 


### PR DESCRIPTION
Some HDP installations d not have the directory /usr/hdp/current/hadoop-client/client .
Eg Hbase version  1.1.2.2.3.4.7-4
This caused errors when running Trafodion . 

This could be the result of changes due to the following 2 JIRAs
https://issues.apache.org/jira/browse/HDFS-9815
https://issues.apache.org/jira/browse/HDFS-6200
