### PR TITLE
[TRAFODION-2530] Add explicit transaction control in CreateHistTables

### DIFF
--- a/core/sql/ustat/hs_cli.cpp
+++ b/core/sql/ustat/hs_cli.cpp
@@ -539,6 +539,8 @@ Lng32 CreateHistTables (const HSGlobalsClass* hsGlobal)
 
     // Call createHistogramTables to create any table that does not yet exist.
     NAString histogramsLocation = getHistogramsTableLocation(hsGlobal->catSch->data(), FALSE);
+
+    HSTranController TC("Create histogram tables.",&retcode);
     retcode = (CmpSeabaseDDL::createHistogramTables(NULL, histogramsLocation, TRUE, tableNotCreated)); 
     if (retcode < 0 && LM->LogNeeded())
       {


### PR DESCRIPTION
This change causes UPDATE STATISTICS to do an explicit BEGIN WORK before creating histogram tables and an explicit COMMIT WORK (or ROLLBACK) afterwards. This will help make UPDATE STATISTICS behavior immune to autocommit settings.