### PR TITLE
[TRAFODION-2529] Pass proper table name to getRowCount for _CELL_ and…

### DIFF
--- a/core/sql/optimizer/NATable.cpp
+++ b/core/sql/optimizer/NATable.cpp
@@ -7778,6 +7778,8 @@ Int64 NATable::estimateHBaseRowCount(Int32 retryLimitMilliSeconds, Int32& errorC
     {
       HbaseStr fqTblName;
       NAString tblName = getTableName().getQualifiedNameAsString();
+      if (getTableName().isHbaseCellOrRow())
+        tblName = getTableName().getObjectName();
       fqTblName.len = tblName.length();
       fqTblName.val = new(STMTHEAP) char[fqTblName.len+1];
       strncpy(fqTblName.val, tblName.data(), fqTblName.len);

--- a/core/sql/optimizer/ObjectNames.cpp
+++ b/core/sql/optimizer/ObjectNames.cpp
@@ -676,6 +676,31 @@ NABoolean QualifiedName::isHbaseMappedName() const
           (ComIsHbaseMappedSchemaName(getSchemaName())));
 }
 
+NABoolean QualifiedName::isHbaseCell() const
+{
+  if (isHbase() && (getSchemaName() == "_CELL_"))
+    return TRUE;
+  else
+    return FALSE;
+}
+
+NABoolean QualifiedName::isHbaseRow() const
+{
+  if (isHbase() && (getSchemaName() == "_ROW_"))
+    return TRUE;
+  else
+    return FALSE;
+}
+
+NABoolean QualifiedName::isHbaseCellOrRow() const
+{
+  if (isHbase() && 
+      ((getSchemaName() == "_CELL_") || (getSchemaName() == "_ROW_")))
+    return TRUE;
+  else
+    return FALSE;
+}
+
 // -----------------------------------------------------------------------
 // Methods for class CorrName
 // -----------------------------------------------------------------------
@@ -969,20 +994,12 @@ NABoolean CorrName::isHbase() const
 
 NABoolean CorrName::isHbaseCell() const
 {
-  if ((getQualifiedNameObj().isHbase()) &&
-      (getQualifiedNameObj().getSchemaName() == "_CELL_"))
-    return TRUE;
-  else
-    return FALSE;
+  return getQualifiedNameObj().isHbaseCell();
 }
 
 NABoolean CorrName::isHbaseRow() const
 {
-  if ((getQualifiedNameObj().isHbase()) &&
-      (getQualifiedNameObj().getSchemaName() == "_ROW_"))
-    return TRUE;
-  else
-    return FALSE;
+ return getQualifiedNameObj().isHbaseRow();
 }
 
 NABoolean CorrName::isHbaseMap() const

--- a/core/sql/optimizer/ObjectNames.h
+++ b/core/sql/optimizer/ObjectNames.h
@@ -323,6 +323,10 @@ public:
   NABoolean isSeabasePrivMgrMD() const;
   NABoolean isHbaseMappedName() const;
 
+  NABoolean isHbaseCell() const;
+  NABoolean isHbaseRow() const;
+  NABoolean isHbaseCellOrRow() const;
+
   NABoolean isHistograms() const;
   NABoolean isHistogramIntervals() const;
 


### PR DESCRIPTION
… _ROW_

The old code would pass 'HBASE._CELL_."trafodion object name"' down to the row count estimation code. The new code checks for schemas "HBASE._CELL_" and "HBASE._ROW_" and if found, passes just the object name down (which is already a fully-qualified Trafodion table name).