### PR TITLE
TRAFODION-2538 Revoking privileges from role not invoking query inval…

### DIFF
--- a/core/sql/common/ComSecurityKey.h
+++ b/core/sql/common/ComSecurityKey.h
@@ -37,22 +37,24 @@ class ComSecurityKey;
 
 typedef NASet<ComSecurityKey>  ComSecurityKeySet;
 
+bool buildSecurityKeys( const int32_t userID,
+                        const int32_t granteeID,
+                        const int64_t objectUID,
+                        const PrivMgrCoreDesc &privs,
+                        ComSecurityKeySet &secKeySet);
+
 NABoolean qiCheckForInvalidObject (const Int32 numInvalidationKeys, 
                                    const SQL_QIKEY* invalidationKeys, 
                                    const Int64 objectUID,
                                    const ComSecurityKeySet & objectKeys);
-
-bool buildSecurityKeys( const int32_t granteeID,
-                        const int32_t roleID,
-                        const int64_t objectUID,
-                        const PrivMgrCoreDesc &privs,
-                        ComSecurityKeySet &secKeySet);
 
 void qiInvalidationType (const Int32 numInvalidationKeys,
                          const SQL_QIKEY* invalidationKeys,
                          const Int32 userID,
                          bool &resetRoleList,
                          bool &updateCaches);
+
+NABoolean qiSubjectMatchesRole(uint32_t subjectKey);
 
 // ****************************************************************************
 // Class:  ComSecurityKey 
@@ -129,9 +131,9 @@ public:
   ComQIActionType convertBitmapToQIActionType(const PrivType which, const QIType inputType) const;
 
   // Basic method to generate hash values
-  uint32_t generateHash(int64_t hashInput) const;
+  static uint32_t generateHash(int64_t hashInput);
   // Generate hash value based on authorization ID
-  uint32_t generateHash(int32_t hashID) const;
+  static uint32_t generateHash(int32_t hashID);
 
   // For debugging purposes
   void print() const ;

--- a/core/sql/common/ComUser.cpp
+++ b/core/sql/common/ComUser.cpp
@@ -374,6 +374,17 @@ bool ComUser::currentUserHasRole(Int32 roleID)
   return false;
 }
 
+void ComUser::getCurrentUserRoles(NAList <Int32> &roleList)
+{
+  Int32 numRoles = 0;
+  Int32 *roleIDs = 0;
+  Int32 retcode = SQL_EXEC_GetRoleList(numRoles, roleIDs);
+  assert(retcode == 0);
+
+  for (Int32 i = 0; i < numRoles; i++)
+    roleList.insert (roleIDs[i]);
+}
+
 
 // ----------------------------------------------------------------------------
 // method: getRoleList

--- a/core/sql/common/ComUser.h
+++ b/core/sql/common/ComUser.h
@@ -91,6 +91,7 @@ class ComUser
                                          Int32 & authID);
 
      static bool currentUserHasRole(Int32 roleID);
+     static void getCurrentUserRoles(NAList <Int32> &roleList);
 
      static Int32 getRoleList (char *roleList,
                                Int32 &actualLen,

--- a/core/sql/regress/privs1/EXPECTED120
+++ b/core/sql/regress/privs1/EXPECTED120
@@ -15,7 +15,7 @@
 >>--
 >>--    games     - multiple roles giving same privileges
 >>--    teams     - multiple privileges through different roles
->>--    players   - control, not roles involved in privileges
+>>--    players   - control, no roles involved in privileges
 >>--    standings - used to test sequence privileges and revoke role
 >>--    stats     - tests revoke PUBLIC authorization ID
 >>-- =================================================================
@@ -570,12 +570,14 @@ End of MXCI Session
 >>--   AR - role involved, check query plans that rely on roles during revoke
 >>log;
 Query_Invalidation_Keys explain output for select_games, select_teams, insert_teams, update_teams, select_players, select_standings: 
-Query_Invalidation_Keys{,,UR}
-Query_Invalidation_Keys{,,OS}
-Query_Invalidation_Keys{,,UR}
 Query_Invalidation_Keys{,,OS}{,,UR}
 Query_Invalidation_Keys{,,OS}
-Query_Invalidation_Keys{,,OS}{,,UR}
+Query_Invalidation_Keys{,,OI}{,,UR}
+Query_Invalidation_Keys{,,OS}{,,
+OU}{,,UR}
+Query_Invalidation_Keys{,,OS}
+Query_Invalidation_Keys{,,OS}{,,
+OG}{,,UR}
 >>
 >>-- Verify that sql_user9 can select from games
 >>sh sqlci -i "TEST120(select_queries)" -u sql_user9;
@@ -746,6 +748,109 @@ TEAM_NUMBER  TEAM_NAME
 
 --- 5 row(s) selected.
 >>
+>>-- revoke insert, delete privilege from t120role2
+>>sh sqlci -i "TEST120(revoke_t120role2p)" -u sql_user3;
+>>values (current_user);
+
+(EXPR)
+---------------------------------------------------------------------------------------------------------------------------------
+
+SQL_USER3                                                                                                                        
+
+--- 1 row(s) selected.
+>>cqd SHOWDDL_DISPLAY_PRIVILEGE_GRANTS 'ON';
+
+--- SQL operation complete.
+>>cqd AUTO_QUERY_RETRY_WARNINGS 'ON';
+
+--- SQL operation complete.
+>>set schema t120sch;
+
+--- SQL operation complete.
+>>
+>>revoke insert, delete on teams from t120role2;
+
+--- SQL operation complete.
+>>
+>>exit;
+
+End of MXCI Session
+
+>>-- still have privilege
+>>execute select_teams;
+
+TEAM_NUMBER  TEAM_NAME           
+-----------  --------------------
+
+          1  White Socks         
+          2  Giants              
+          3  Cardinals           
+          4  Indians             
+          5  Tigers              
+
+--- 5 row(s) selected.
+>>-- no longer has privilege (4481) and query attempted recompilation
+>>execute insert_teams;
+
+*** ERROR[4481] The user does not have INSERT privilege on table or view TRAFODION.T120SCH.TEAMS.
+
+*** ERROR[8822] The statement was not prepared.
+
+*** WARNING[8597] Statement was automatically retried 1 time(s). Delay before each retry was 0 seconds. See next entry for the error that caused this retry.
+
+*** WARNING[8734] Statement must be recompiled to allow privileges to be re-evaluated.
+
+--- 0 row(s) inserted.
+>>
+>>-- grant privilege back
+>>sh sqlci -i "TEST120(grant_t120role2p)" -u sql_user3;
+>>values (current_user);
+
+(EXPR)
+---------------------------------------------------------------------------------------------------------------------------------
+
+SQL_USER3                                                                                                                        
+
+--- 1 row(s) selected.
+>>cqd SHOWDDL_DISPLAY_PRIVILEGE_GRANTS 'ON';
+
+--- SQL operation complete.
+>>cqd AUTO_QUERY_RETRY_WARNINGS 'ON';
+
+--- SQL operation complete.
+>>set schema t120sch;
+
+--- SQL operation complete.
+>>
+>>grant insert, delete on teams to t120role2;
+
+--- SQL operation complete.
+>>
+>>exit;
+
+End of MXCI Session
+
+>>execute select_teams;
+
+TEAM_NUMBER  TEAM_NAME           
+-----------  --------------------
+
+          1  White Socks         
+          2  Giants              
+          3  Cardinals           
+          4  Indians             
+          5  Tigers              
+
+--- 5 row(s) selected.
+>>-- now works and query recompiled (8597)
+>>execute insert_teams;
+
+*** WARNING[8597] Statement was automatically retried 1 time(s). Delay before each retry was 0 seconds. See next entry for the error that caused this retry.
+
+*** WARNING[8583] This statement contains no generated plan to execute at runtime. An error during query compilation caused this condition.
+
+--- 1 row(s) inserted.
+>>
 >>-- revoke t120role2 from sql_user6
 >>sh sqlci -i "TEST120(revoke_t120role2)" -u sql_user3;
 >>values (current_user);
@@ -797,8 +902,9 @@ TEAM_NUMBER
           3
           4
           5
+          6
 
---- 5 row(s) selected.
+--- 6 row(s) selected.
 >>select player_number from players;
 
 PLAYER_NUMBER
@@ -879,8 +985,9 @@ TEAM_NUMBER  TEAM_NAME
           3  Cardinals           
           4  Indians             
           5  Tigers              
+          6  Braves              
 
---- 5 row(s) selected.
+--- 6 row(s) selected.
 >>execute select_standings;
 
 TEAM_NUMBER  (EXPR)              
@@ -980,8 +1087,9 @@ TEAM_NUMBER
           3
           4
           5
+          6
 
---- 5 row(s) selected.
+--- 6 row(s) selected.
 >>select player_number from players;
 
 PLAYER_NUMBER
@@ -1055,8 +1163,9 @@ TEAM_NUMBER  TEAM_NAME
           3  Cardinals           
           4  Indians             
           5  Tigers              
+          6  Braves              
 
---- 5 row(s) selected.
+--- 6 row(s) selected.
 >>execute select_players;
 
 (EXPR)              
@@ -1125,7 +1234,7 @@ End of MXCI Session
 --- SQL command prepared.
 >>log;
 Query_Invalidation_Keys explain output for select_stats: 
-Query_Invalidation_Keys{,,UZ}
+Query_Invalidation_Keys{,,OS}{,,UZ}
 >>shecho"Query_Invalidation_Keysexplainoutputforselect_stats:">>LOG;
 >>
 >>execute select_stats;

--- a/core/sql/regress/privs1/TEST120
+++ b/core/sql/regress/privs1/TEST120
@@ -168,7 +168,7 @@ obey TEST120(queries);
 --
 --    games     - multiple roles giving same privileges
 --    teams     - multiple privileges through different roles
---    players   - control, not roles involved in privileges
+--    players   - control, no roles involved in privileges
 --    standings - used to test sequence privileges and revoke role
 --    stats     - tests revoke PUBLIC authorization ID
 -- =================================================================
@@ -242,6 +242,19 @@ sh sqlci -i "TEST120(select_queries)" -u sql_user9;
 sh sqlci -i "TEST120(revoke_t120role4)" -u sql_user3;
 execute select_games;
 execute select_teams;
+
+-- revoke insert, delete privilege from t120role2
+sh sqlci -i "TEST120(revoke_t120role2p)" -u sql_user3;
+-- still have privilege
+execute select_teams;
+-- no longer has privilege (4481) and query attempted recompilation
+execute insert_teams;
+
+-- grant privilege back
+sh sqlci -i "TEST120(grant_t120role2p)" -u sql_user3;
+execute select_teams;
+-- now works and query recompiled (8597)
+execute insert_teams;
 
 -- revoke t120role2 from sql_user6
 sh sqlci -i "TEST120(revoke_t120role2)" -u sql_user3;
@@ -319,6 +332,24 @@ showddl role t120role1;
 showddl role t120role2;
 showddl role t120role3;
 showddl role t120role4;
+
+?section revoke_t120role2p
+log LOG120;
+values (current_user);
+cqd SHOWDDL_DISPLAY_PRIVILEGE_GRANTS 'ON';
+cqd AUTO_QUERY_RETRY_WARNINGS 'ON';
+set schema t120sch;
+
+revoke insert, delete on teams from t120role2;
+
+?section grant_t120role2p
+log LOG120;
+values (current_user);
+cqd SHOWDDL_DISPLAY_PRIVILEGE_GRANTS 'ON';
+cqd AUTO_QUERY_RETRY_WARNINGS 'ON';
+set schema t120sch;
+
+grant insert, delete on teams to t120role2;
 
 ?section revoke_t120role2
 log LOG120;

--- a/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
@@ -9700,6 +9700,9 @@ void CmpSeabaseDDL::seabaseGrantRevoke(
 
   // Determine effective grantor ID and grantor name based on GRANTED BY clause
   // current user, and object owner
+  //
+  // NOTE: If the user can grant privilege based on a role, we may want the 
+  // effective grantor to be the role instead of the current user.
   Int32 effectiveGrantorID;
   std::string effectiveGrantorName;
   PrivStatus result = command.getGrantorDetailsForObject( 

--- a/core/sql/sqlcomp/PrivMgrCommands.cpp
+++ b/core/sql/sqlcomp/PrivMgrCommands.cpp
@@ -162,17 +162,13 @@ bool PrivMgrUserPrivs::initUserPrivs(
     }
 
     // set up security invalidation keys
-    Int32 grantee = privs.getGrantee();
-    Int32 role = (ComUser::isPublicUserID(grantee) || PrivMgr::isRoleID(grantee)) 
-        ? grantee : NA_UserIdDefault;
-
-    if (!buildSecurityKeys(userID, role, objectUID, privs.getTablePrivs(), secKeySet))
+    if (!buildSecurityKeys(userID, privs.getGrantee(), objectUID, privs.getTablePrivs(), secKeySet))
       return false;
 
     for (int k = 0; k < colPrivsList_.size(); k++)
     {
       PrivMgrCoreDesc colDesc(colPrivsList_[k], colGrantableList_[k]);
-      if (!buildSecurityKeys(userID, role, objectUID, colDesc, secKeySet))
+      if (!buildSecurityKeys(userID, privs.getGrantee(), objectUID, colDesc, secKeySet))
         return false;
     }
   }

--- a/core/sql/sqlcomp/PrivMgrPrivileges.h
+++ b/core/sql/sqlcomp/PrivMgrPrivileges.h
@@ -112,7 +112,6 @@ public:
   // -------------------------------------------------------------------
    PrivStatus buildSecurityKeys(
       const int32_t granteeID, 
-      const int32_t roleID,
       const PrivMgrCoreDesc &privs,
       std::vector <ComSecurityKey *> & secKeySet);
       


### PR DESCRIPTION
…idation

Fixed a issue where query invalidation keys were not being sent correctly when
a privilege was revoked from a role.

When a table is cached, a list of all the query invalidation keys for the user
are stored.  Later, when a query is run, the compiler picks the relevant keys
and places them in the plan.  When a revoke occurs, a key is sent to RMS and
the executor processes check for keys at the next execution. If the key affects
any caches, the cache entries are refreshed and plans recompiled.

Incorrect keys were being created when privileges were revoked from roles, so
queries continued to work even though the user had no more privileges.