### PR TITLE
[TRAFODION-2541]"UPDATE LOB" default max lob size error

### DIFF
--- a/core/sql/generator/GenRelExeUtil.cpp
+++ b/core/sql/generator/GenRelExeUtil.cpp
@@ -4431,7 +4431,7 @@ short ExeUtilLobUpdate::codeGen(Generator * generator)
   }
  
   exe_util_lobupdate_tdb->setTotalBufSize(CmpCommon::getDefaultNumeric(LOB_MAX_CHUNK_MEM_SIZE));
-  exe_util_lobupdate_tdb->setLobMaxSize( CmpCommon::getDefaultNumeric(LOB_MAX_SIZE));
+  exe_util_lobupdate_tdb->setLobMaxSize( CmpCommon::getDefaultNumeric(LOB_MAX_SIZE) * 1024 * 1024);
   exe_util_lobupdate_tdb->setLobMaxChunkSize(CmpCommon::getDefaultNumeric(LOB_MAX_CHUNK_MEM_SIZE));
   exe_util_lobupdate_tdb->setLobGCLimit(CmpCommon::getDefaultNumeric(LOB_GC_LIMIT_SIZE));
                                            

--- a/core/sql/optimizer/ItemFunc.h
+++ b/core/sql/optimizer/ItemFunc.h
@@ -2869,7 +2869,7 @@ public:
    obj_(obj),
    lobNum_(-1),
    lobStorageType_(Lob_Invalid_Storage),
-   lobMaxSize_(CmpCommon::getDefaultNumeric(LOB_MAX_SIZE)),
+   lobMaxSize_((Int64)CmpCommon::getDefaultNumeric(LOB_MAX_SIZE) * 1024 * 1024),
      lobMaxChunkMemSize_(CmpCommon::getDefaultNumeric(LOB_MAX_CHUNK_MEM_SIZE)),
      lobGCLimit_(CmpCommon::getDefaultNumeric(LOB_GC_LIMIT_SIZE)),
      hdfsPort_((Lng32)CmpCommon::getDefaultNumeric(LOB_HDFS_PORT)),
@@ -2910,9 +2910,9 @@ public:
   short &lobNum() {return lobNum_; }
   LobsStorage &lobStorageType() { return lobStorageType_; }
   NAString &lobStorageLocation() { return lobStorageLocation_; }
-  Int64 getLobMaxSize() {return lobMaxSize_*1024*1024; }
+  Int64 getLobMaxSize() {return lobMaxSize_; }
   Int64 getLobMaxChunkMemSize() { return lobMaxChunkMemSize_*1024*1024;}
-  Int64 getLobGCLimit() { return lobGCLimit_*1025*1024;}
+  Int64 getLobGCLimit() { return lobGCLimit_*1024*1024;}
   Int32 getLobHdfsPort() { return hdfsPort_;}
   NAString &getLobHdfsServer(){return hdfsServer_;}
  protected:


### PR DESCRIPTION
The default lob max size for "UPDATE LOB" operator should be 10000MB
rather than 10000B