### PR TITLE
[TRAFODION-2376] Improve UPDATE STATS performance on varchar columns

### DIFF
--- a/core/sqf/sql/scripts/analyzeULOG.py
+++ b/core/sqf/sql/scripts/analyzeULOG.py
@@ -1,0 +1,177 @@
+# @@@ START COPYRIGHT @@@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# @@@ END COPYRIGHT @@@
+#
+#  This script analyzes data from a ULOG. It looks for timer
+#  events, and pulls these out, generating SQL INSERT 
+#  statements with their data. This data can then be loaded
+#  into a SQL table for further analysis.
+#
+#  The shape of the table assumed by the script is as follows:
+#
+#  create table ulog_data
+# ( l1 int not null,
+#   l2 int not null,
+#   l3 int not null,
+#   l4 int not null,
+#   l5 int not null,
+#   l6 int not null,
+#   l7 int not null,
+#   l8 int not null,
+#   l9 int not null,
+#   l10 int not null,
+#   task varchar(80) not null,
+#   elapsed char(12) not null,
+#   primary key (l1,l2,l3,l4,l5,l6,l7,l8,l9,l10) );
+#
+#  The idea here is to capture the nested structure of the ULOG
+#  timers. L1 represents the top-most level and is incremented 
+#  for each UPDATE STATISTICS statement. L2 is the set of timers
+#  within the scope of an L1 timer, and so on.
+#
+#  By querying this ulog_data, one can get an idea of where
+#  UPDATE STATISTICS spends its time, and how expensive each
+#  task is.
+#
+import os
+import sys
+import subprocess 
+import sets
+import datetime
+import argparse  # requires Python 2.7
+
+# An object of class BeginEndInterval is created for each timer
+# found in the ULOG.
+
+class BeginEndInterval:
+    #
+    
+    def __init__(self, desc, level, previousItemNumber):
+        #print "On entry to ctor, level = " + str(level) + ", prevIN = " + str(previousItemNumber)
+        self.description = desc
+        self.elapsedTime = None
+        self.itemNumber = list(previousItemNumber)
+        if len(previousItemNumber) <= level:
+            self.itemNumber.append(1)
+        else:
+            lastIndex = len(previousItemNumber)-1
+            self.itemNumber[lastIndex] = self.itemNumber[lastIndex]+1
+        #print "Exiting ctor, Resulting in " + str(self.itemNumber)
+
+    def setEnd(self, desc, elapsed):
+        assert desc == self.description
+        self.elapsedTime = elapsed
+
+    def generateData(self):
+        text = "INSERT INTO ULOG_DATA VALUES("
+        for i in range(10):
+            if i < len(self.itemNumber):
+                text = text + str(self.itemNumber[i]) + ","
+            else:
+                text = text + "0,"
+        text = text + "'" + self.description + "','" + self.elapsedTime + "');"
+        print text
+
+
+class ParseULOG:
+    #
+
+    def __init__(self, ULOGFileName):
+        self.ULOGFileName = ULOGFileName
+        self.beginEndIntervals = []
+     
+
+    def parseULOG(self):
+        #
+        # Begin/End entries look like this:
+        #
+        # [Tue Mar 21 21:02:27 2017] :|  BEGIN Allocate storage for columns
+        # [Tue Mar 21 21:02:30 2017] :|  END   Allocate storage for columns elapsed time (00:00:02.666)
+        #
+        # The number of vertical bars varies and indicates levels of nesting.
+        # For now we ignore the timestamp, and just pick out the description
+        # and the elapsed time.
+        #
+
+        try:
+            f = open(self.ULOGFileName)
+            previousItemNumber = []
+            messageNumberStr = None
+            messageText = None
+            for line in f:
+                #originalLine = line
+                line = line.rstrip('\n')  # get rid of trailing return character
+                index = line.find('] ')
+                if index >= 0:
+                    line = line[index+2:] # strip off leading timestamp part
+                if line.startswith(':'):
+                    line = line[1:]  # strip off colon
+                    level = 0
+                    while line.startswith('|  '):
+                        level = level + 1
+                        line = line[3:]
+                    if line.startswith('BEGIN '):
+                        description = line[6:]  # strip off BEGIN; description is what's left
+                        # create a BeginEnd interval and add to stack
+                        beginEndInterval = BeginEndInterval(description,level,previousItemNumber)
+                        previousItemNumber = list(beginEndInterval.itemNumber)
+                        self.beginEndIntervals.append(beginEndInterval)
+                    elif line.startswith('END   '):
+                        index = line.find(' elapsed time (')
+                        if index >= 0:
+                            description = line[6:index]
+                            elapsedTime = line[index+15:]
+                            elapsedTime = elapsedTime.rstrip(')')
+                            # pop the last BeginEnd interval from the stack
+                            beginEndInterval = self.beginEndIntervals.pop()
+                            beginEndInterval.setEnd(description,elapsedTime)
+                            beginEndInterval.generateData()
+                            previousItemNumber = list(beginEndInterval.itemNumber)
+                            del beginEndInterval                 
+            f.close()
+         
+        except IOError as detail:
+            print "Could not open " + self.ULOGFileName
+            print detail        
+        
+
+
+
+
+# beginning of main
+
+
+# process command line arguments
+
+parser = argparse.ArgumentParser(
+    description='This script parses out interesting data from a ULOG.')
+parser.add_argument("ULOGFileName", help='The name of the ULOG file you wish to parse.')
+
+args = parser.parse_args()  # exits and prints help if args are incorrect
+
+exitCode = 0
+
+ULOGparser = ParseULOG(args.ULOGFileName)
+
+ULOGparser.parseULOG()
+
+exit(exitCode)   
+
+

--- a/core/sql/common/wstr.cpp
+++ b/core/sql/common/wstr.cpp
@@ -64,6 +64,47 @@ int iswspace (NAWchar wc)
 }
 */
 
+// Compares two Wchar strings using SQL blank-padding semantics.
+// Returns +ve if the first string is greater, 0 if equal, -ve if
+// the second string is greater.
+Int32 compareWcharWithBlankPadding(const NAWchar *wstr1, UInt32 len1,
+                                   const NAWchar *wstr2, UInt32 len2)
+{
+  UInt32 shorterLen = (len1 < len2 ? len1 : len2);
+  Int32 rc = memcmp(wstr1,wstr2,shorterLen*sizeof(NAWchar));
+  if (rc == 0)
+    {
+      if (len1 < len2)
+        {
+          // compare the rest of wstr2 with blanks
+          while ((shorterLen < len2) && (wstr2[shorterLen] == L' '))
+            shorterLen++;
+
+          if (shorterLen < len2)
+            {
+              if (wstr2[shorterLen] > L' ')
+                rc = -1;
+              else
+                rc = 1;
+            }
+        }
+      else if (len1 > len2)
+        {
+          // compare the rest of wstr1 with blanks
+          while ((shorterLen < len1) && (wstr1[shorterLen] == L' '))
+            shorterLen++;
+
+          if (shorterLen < len1)
+            {
+              if (wstr1[shorterLen] > L' ')
+                rc = 1;
+              else
+                rc = -1;
+            }
+        }            
+    }
+  return rc;
+}
 
 // Do a char-by-char comparison (including nulls) up to the length of the
 // shorter string or the first difference. If the strings are equal up to the

--- a/core/sql/common/wstr.h
+++ b/core/sql/common/wstr.h
@@ -45,6 +45,17 @@
 #include "unicode_char_set.h"
 
 // -----------------------------------------------------------------------
+// Compare w-strings <left> and <right> (using unsigned comparison and
+// SQL blank-padding semantics)
+// for <length> characters.
+// Return a negative value if left < right,
+// return 0 if left == right,
+// return a positive value if left > right.
+// -----------------------------------------------------------------------
+Int32 compareWcharWithBlankPadding(const NAWchar *wstr1, UInt32 len1,
+                                   const NAWchar *wstr2, UInt32 len2);
+
+// -----------------------------------------------------------------------
 // Compare strings <left> and <right> (using unsigned comparison).
 // for <length> characters.
 // Return a negative value if left < right,

--- a/core/sql/sqlcomp/DefaultConstants.h
+++ b/core/sql/sqlcomp/DefaultConstants.h
@@ -677,6 +677,7 @@ enum DefaultConstants
                                          //   salted table when ON EVERY KEY or ON EVERY COLUMN is specified.
   USTAT_ATTEMPT_ESP_PARALLELISM,  // use parallel plans for reading columns to form histograms
   USTAT_CHECK_HIST_ACCURACY,   // After stats collection, examine full table and calculate accuray of hists
+  USTAT_COMPACT_VARCHARS,      // For internal sort, store only the actual # chars used in each value
   USTAT_CLUSTER_SAMPLE_BLOCKS, // number of blocks for cluster sampling
   USTAT_ESTIMATE_HBASE_ROW_COUNT,  // If ON, estimate row count of HBase table instead of count(*), subject
                                    //     to USTAT_MIN_ESTIMATE_FOR_ROWCOUNT setting)

--- a/core/sql/sqlcomp/nadefaults.cpp
+++ b/core/sql/sqlcomp/nadefaults.cpp
@@ -3528,6 +3528,7 @@ XDDkwd__(SUBQUERY_UNNESTING,			"ON"),
 
   DDkwd__(USTAT_COLLECT_MC_SKEW_VALUES,         "OFF"),
 
+  DDkwd__(USTAT_COMPACT_VARCHARS,               "OFF"),  // If on, internal sort does not pad out varchars
   DD_____(USTAT_CQDS_ALLOWED_FOR_SPAWNED_COMPILERS, ""), // list of CQDs that can be pushed to seconday compilers
                                                          // CQDs are delimited by ","
 

--- a/core/sql/ustat/hs_cli.cpp
+++ b/core/sql/ustat/hs_cli.cpp
@@ -2968,7 +2968,12 @@ Lng32 HSCursor::setRowsetPointers(HSColGroupStruct *group, Lng32 maxRows)
       // Character data is written into a different buffer, and the data buffer
       // will consist of pointers to the char values.
       if (DFS2REC::isAnyCharacter(group->ISdatatype))
-        rowset_fields_[j].var_ptr = (void *)group->strNextData;
+        {
+          if (DFS2REC::isSQLVarChar(group->ISdatatype) && group->isCompacted())
+            rowset_fields_[j].var_ptr = (void *)group->varcharFetchBuffer;
+          else
+            rowset_fields_[j].var_ptr = (void *)group->strNextData;
+        }
       else
         rowset_fields_[j].var_ptr = (void *)group->nextData;
       j++;


### PR DESCRIPTION
This pull request submits a performance enhancement to the UPDATE STATISTICS utility. This work is the completion of a prototype originally done by Barry Fritchman (@blfritch).

For the moment, the feature is turned off by default. Use CQD  USTAT_COMPARE_VARCHARS 'ON' to turn on this enhancement.

What this feature does is compact varchars in memory for the internal sort code path in UPDATE STATISTICS. In the old code, varchars are expanded out to their full length. (Actually, we already truncate them at 256 characters -- the setting of CQD USTAT_MAX_CHAR_COL_LENGTH_IN_BYTES -- giving up some accuracy in UEC computation perhaps but improving performance dramatically for very long varchar columns.) In the new code, we estimate the average length of the column, and allocate space assuming the column still adheres to that average. For columns that already have statistics, we use the average varchar length stored in SB_HISTOGRAMS column V2. For columns that don't, we take a guess that the average is one-half the declared length of the column.

The performance gain from using this feature comes from reducing the number of scans of the table or sample table because more columns can fit in memory in each scan.

Also included in this pull request is a tool, analyzeULOG.py, that can be used to scan ULOGs from UPDATE STATISTICS runs to extract timing data. This is useful for determining where time is spent during UPDATE STATISTICS processing.