### PR TITLE
[TRAFODION-2559] Fix bug in RIGHT function

### DIFF
--- a/core/sql/optimizer/BindItemExpr.cpp
+++ b/core/sql/optimizer/BindItemExpr.cpp
@@ -11295,7 +11295,12 @@ ItemExpr *ZZZBinderFunction::bindNode(BindWA *bindWA)
         }
 
         if ( getOperatorType() == ITM_RIGHT )
-	  strcpy(buf, "SUBSTRING(@A1 FROM (CHAR_LENGTH(@A1) - CAST(@A2 AS INT UNSIGNED) + 1));");
+	  // The case expression is needed for cases where the length supplied
+          // exceeds the length of the string; in this case we want to return 
+          // the whole string. SUBSTR of a 0 or negative value doesn't do that.
+          strcpy(buf, "SUBSTRING(@A1 FROM "
+                      "CASE WHEN(CHAR_LENGTH(@A1) - CAST(@A2 AS INT UNSIGNED) + 1) > 1 "
+                      "THEN (CHAR_LENGTH(@A1) - CAST(@A2 AS INT UNSIGNED) + 1) ELSE 1 END);");
         else
 	  strcpy(buf, "SUBSTRING(@A1 FROM 1 FOR @A2);"); // LEFT()
 

--- a/core/sql/regress/core/FILTERRTS
+++ b/core/sql/regress/core/FILTERRTS
@@ -43,6 +43,7 @@ s/SQL Space Allocated[ ]*[0-9,]*[ ]*/SQL Space Allocated @SQLSpaceAllocated@/
 s/SQL Space Used[ ]*[0-9,]*[ ]*/SQL Space Used @SQLSpaceUsed@/
 s/SQL Heap Allocated[ ]*[0-9,]*[ ]*/SQL Heap Allocated @SQLHeapAllocated@/
 s/SQL Heap Used[ ]*[0-9,]*[ ]*/SQL Heap Used @SQLHeapUsed@/
+s/SQL Heap WM[ ]*[0-9,]*[ ]*/SQL Heap WM @SQLHeapWM@/
 s/Process Create Time[ ]*[0-9,]*/Process Create Time @ProcessCreateTime@/
 s/Processes Created[ ]*[0-9,]*/Processes Created @ProcessesCreated@/
 s/Opens[ ]*[0-9,]*/Opens @Opens@/


### PR DESCRIPTION
The binder transformation for RIGHT was incorrect in the case where the length parameter exceeds the character length of the string parameter.

Also in this change is a filter tweak to core/TESTRTS due to a new RMS counter, "SQL Heap WM".