### PR TITLE
[TRAFODION-25] Temporary code for UPDATE costing

### DIFF
--- a/core/sqf/sql/scripts/analyzeOptimizerTrace.py
+++ b/core/sqf/sql/scripts/analyzeOptimizerTrace.py
@@ -1,0 +1,215 @@
+# @@@ START COPYRIGHT @@@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# @@@ END COPYRIGHT @@@
+#
+#  This script extracts data from an Optimizer trace, created
+#  using the following CQDs:
+#
+#  cqd nsk_dbg_log_file 'optimizerTrace.txt';
+#
+#  cqd NSK_DBG_GENERIC 'ON';
+#  cqd NSK_DBG_PRINT_COST 'ON';
+#  cqd NSK_DBG_PRINT_COST_LIMIT 'ON';
+#  cqd NSK_DBG_PRINT_LOG_PROP 'ON';
+#  cqd NSK_DBG_PRINT_PHYS_PROP 'ON';
+#  cqd NSK_DBG_PRINT_TASK 'ON';
+#  cqd NSK_DBG_PRINT_TASK_STACK 'ON';
+#
+#  cqd NSK_DBG 'ON';
+#
+#  The script extracts completed plans and shows their shape
+#  and costs, along with whether the plan was chosen. The 
+#  goal of the script is to present the trace information in
+#  a simple and high-level way.
+#
+
+import os
+import sys
+import subprocess 
+import sets
+import datetime
+import argparse  # requires Python 2.7
+
+
+
+def indentLevel(line):
+    i = 0
+    while i < len(line) and line[i] == ' ':
+        i = i + 1
+    return i
+
+
+class ParseTrace:
+    #
+
+    def __init__(self, OptimizerTraceFileName):
+        self.OptimizerTraceFileName = OptimizerTraceFileName
+     
+
+    def parseTrace(self):
+        #
+        # The things we are looking for are:
+        #
+        # "Query to optimize:"  
+        # This shows the start of a trace for a particular query
+        #
+        # "Task: 8 ParentTask: 7 Pass: 2 GroupId: 1   7 1 Create plan (0) ..."
+        # Plan fragments show up as a result of "Create plan" tasks being executed.
+        # Plan fragments may result in incomplete plans; we ignore those.
+        #
+        # "*** Qualified plan ***"
+        # This is the beginning of a qualified plan fragment, created by a "Create
+        # plan" task.
+        #
+        # "*** Chosen plan ***" and "*** Non-optimal plan ***"
+        # These indicate the end of a qualified plan fragment, and indicate whether
+        # the particular fragment was chosen for its group.
+        #
+        # "SQL node(<node description>)"
+        # This indicates a node within the plan. The tree structure of the nodes
+        # is indicated by the relative indentation of each of these. Python-like.
+        #
+        # "**** Roll-up Cost ****"
+        # This indicates that cost info for the subtree follows.
+        #
+        # "**** Operator Cost ****"
+        # This indicates that cost info for the node itself follows.
+        #
+        # "elapsed time = <floating point number>"
+        # This gives the cost, reduced to a single number.
+        # 
+        # For now, we ignore the other information in the trace.
+        #
+
+        try:
+            f = open(self.OptimizerTraceFileName)
+            saveSQLNode = ''
+            state = 0
+            for line in f:
+                #print 'state = ' + str(state)
+                line = line.rstrip('\n')  # get rid of trailing return character
+                if state == 0 and line == "Query to optimize:":
+                    print "Trace for the following query:"
+                    state = 1
+                elif state == 1:
+                    if len(line) == 0:
+                        state = 2
+                    else:
+                        print line
+                elif state == 2:
+                    if line == "Query to optimize:":
+                        state = 20  # ignore the rest of the file
+                    tempLine = line.lstrip()
+                    if tempLine.startswith('Task: ') and tempLine.find('Create plan'):
+                        print
+                        print tempLine
+                        print
+                        state = 3
+                elif state == 3:
+                    tempLine = line.lstrip()
+                    if tempLine == "*** Qualified plan ***":
+                        state = 4
+                elif state == 4:
+                    tempLine = line.lstrip()
+                    if tempLine.startswith('SQL node('):
+                        saveSQLNode = line
+                        state = 5
+                elif state == 5:
+                    tempLine = line.lstrip()
+                    if tempLine.startswith('**** Roll-up Cost ****'):
+                        state = 6
+                elif state == 6:
+                    tempLine = line.lstrip()
+                    if tempLine.startswith('elapsed time = '):
+                        planCost = 'Plan cost ' + tempLine
+                        print planCost
+                        print
+                        print saveSQLNode
+                        n = indentLevel(line)
+                        rollupCost = line[0:n] + 'Rollup cost ' + tempLine
+                        print rollupCost
+                        state = 9
+                elif state == 7:
+                    tempLine = line.lstrip()
+                    if tempLine.startswith('**** Roll-up Cost ****'):
+                        state = 8
+                elif state == 8:
+                    tempLine = line.lstrip()
+                    if tempLine.startswith('elapsed time = '):
+                        n = indentLevel(line)
+                        rollupCost = line[0:n] + 'Rollup cost ' + tempLine
+                        print rollupCost
+                        state = 9
+                elif state == 9:
+                    tempLine = line.lstrip()
+                    if tempLine.startswith('**** Operator Cost ****'):
+                        state = 10
+                elif state == 10:
+                    tempLine = line.lstrip()
+                    if tempLine.startswith('elapsed time = '):
+                        n = indentLevel(line)
+                        operatorCost = line[0:n] + 'Operator cost ' + tempLine
+                        print operatorCost
+                        state = 11
+                elif state == 11:
+                    tempLine = line.lstrip()
+                    if tempLine.startswith('SQL node('):
+                        print line
+                        state = 7
+                    elif tempLine.startswith('Task: ') and tempLine.find('Create plan'):
+                        print
+                        print tempLine
+                        print
+                        state = 3
+                    elif tempLine.startswith('*** Chosen plan ***') or tempLine.startswith('*** Non-optimal plan ***'):
+                        print
+                        print line
+                        print
+                        state = 2          
+            f.close()
+         
+        except IOError as detail:
+            print "Could not open " + self.OptimizerTraceFileName
+            print detail        
+        
+
+
+
+
+# beginning of main
+
+
+# process command line arguments
+
+parser = argparse.ArgumentParser(
+    description='This script parses out interesting data from an optimizer debug trace.')
+parser.add_argument("OptimizerTraceFileName", help='The name of the trace file you wish to parse.')
+
+args = parser.parse_args()  # exits and prints help if args are incorrect
+
+exitCode = 0
+
+Traceparser = ParseTrace(args.OptimizerTraceFileName)
+
+Traceparser.parseTrace()
+
+exit(exitCode)   
+
+

--- a/core/sql/optimizer/ScmCostMethod.cpp
+++ b/core/sql/optimizer/ScmCostMethod.cpp
@@ -4162,9 +4162,9 @@ CostMethodHbaseUpdate::scmComputeOperatorCostInternal(RelExpr* op,
 if ( CmpCommon::getDefault( OPTIMIZER_PRINT_COST ) == DF_ON )
     {
       pfp = stdout;
-      fprintf(pfp, "HbaseDelete::scmComputeOperatorCostInternal()\n");
+      fprintf(pfp, "HbaseUpdate::scmComputeOperatorCostInternal()\n");
       updateCost->getScmCplr().print(pfp);
-      fprintf(pfp, "HBase Delete elapsed time: ");
+      fprintf(pfp, "HBase Update elapsed time: ");
       fprintf(pfp,"%f", updateCost->
               convertToElapsedTime(
                    myContext->getReqdPhysicalProperty()).

--- a/core/sql/optimizer/ScmCostMethod.cpp
+++ b/core/sql/optimizer/ScmCostMethod.cpp
@@ -3845,8 +3845,336 @@ CostMethodHbaseUpdate::scmComputeOperatorCostInternal(RelExpr* op,
   const PlanWorkSpace* pws,
   Lng32& countOfStreams)
 {
-  // TODO: Write this method; the line below is a stub
-  return CostMethod::scmComputeOperatorCostInternal(op,pws,countOfStreams);
+  // TODO: Write this method; the code below is a copy of the Delete
+  // method which we'll use for the moment. This is better than just
+  // a simple constant stub; we will get parallel Update plans with
+  // this code, for example, that we won't get with constant cost.
+
+  // The theory of operation of Update is somewhat different (since it
+  // might, for example, do a Delete + an Insert, or might do an Hbase
+  // Update -- is that decided before we get here?), so this code will
+  // underestimate the cost in general.
+
+  const Context * myContext = pws->getContext();
+
+  cacheParameters(op,myContext);
+  estimateDegreeOfParallelism();
+
+  const InputPhysicalProperty* ippForMe =
+    myContext->getInputPhysicalProperty();
+
+  // -----------------------------------------
+  // Save off estimated degree of parallelism.
+  // -----------------------------------------
+  countOfStreams = countOfStreams_;
+
+  HbaseDelete* delOp = (HbaseDelete *)op;   // downcast
+
+  CMPASSERT(partFunc_ != NULL);
+
+  //  Later, if and when we start using NodeMaps to track active regions for 
+  //  Trafodion tables in HBase (or native HBase tables), we can use the
+  //  following to get active partitions.
+  //CostScalar activePartitions =
+  // (CostScalar)
+  //   (((NodeMap *)(partFunc_->getNodeMap()))->getNumActivePartitions());
+  //  But for now, we do the following:
+  CostScalar activePartitions = (CostScalar)(partFunc_->getCountOfPartitions());
+
+  const IndexDesc* CIDesc = delOp->getIndexDesc();
+  const CostScalar & recordSizeInKb = CIDesc->getRecordSizeInKb();
+
+  CostScalar tuplesProcessed(csZero);
+  CostScalar tuplesProduced(csZero);
+  CostScalar tuplesSent(csZero);  // we use tuplesSent to model sending rowIDs to Hbase 
+  CostScalar randomIOs(csZero);
+  CostScalar sequentialIOs(csZero);
+
+  CostScalar countOfAsynchronousStreams = activePartitions;
+
+  // figure out if the probes are in order - if they are, then when
+  // scanning, I/O will tend to be sequential
+
+  NABoolean probesInOrder = FALSE;
+  if (ippForMe != NULL)  // input physical properties exist?
+  {
+    // See if the probes are in order.
+
+    // For delete, a partial order is ok.
+    NABoolean partiallyInOrderOK = TRUE;
+    NABoolean probesForceSynchronousAccess = FALSE;
+    ValueIdList targetSortKey = CIDesc->getOrderOfKeyValues();
+    ValueIdSet sourceCharInputs =
+      delOp->getGroupAttr()->getCharacteristicInputs();
+
+    ValueIdSet targetCharInputs;
+    // The char inputs are still in terms of the source. Map them to the target.
+    // Note: The source char outputs in the ipp have already been mapped to
+    // the target. CharOutputs are a set, meaning they do not have duplicates
+    // But we could have cases where two columns of the target are matched to the
+    // same source column, example: Sol: 10-040416-5166, where we have
+    // INSERT INTO b6table1
+    //		  ( SELECT f, h_to_f, f, 8.4
+    //            FROM btre211
+    //            );
+    // Hence we use lists here instead of sets.
+    // Check to see if there are any duplicates in the source Characteristics inputs
+    // if no, we shall perform set operations, as these are faster
+    ValueIdList bottomValues = delOp->updateToSelectMap().getBottomValues();
+    ValueIdSet bottomValuesSet(bottomValues);
+    NABoolean useListInsteadOfSet = FALSE;
+
+    CascadesGroup* group1 = (*CURRSTMT_OPTGLOBALS->memo)[delOp->getGroupId()];
+
+    GenericUpdate* upOperator = (GenericUpdate *) group1->getFirstLogExpr();
+
+    if (((upOperator->getTableName().getSpecialType() == ExtendedQualName::NORMAL_TABLE ) || (upOperator->getTableName().getSpecialType() == ExtendedQualName::GHOST_TABLE )) &&
+     (bottomValuesSet.entries() != bottomValues.entries() ) )
+    {
+
+      ValueIdList targetInputList;
+      // from here get all the bottom values that appear in the sourceCharInputs
+      bottomValues.findCommonElements(sourceCharInputs );
+      bottomValuesSet = bottomValues;
+
+      // we can use the bottomValues only if these contain some duplicate columns of
+      // characteristics inputs, otherwise we shall use the characteristics inputs.
+      if (bottomValuesSet == sourceCharInputs)
+      {
+        useListInsteadOfSet = TRUE;
+	delOp->updateToSelectMap().rewriteValueIdListUpWithIndex(
+	  targetInputList,
+	  bottomValues);
+	targetCharInputs = targetInputList;
+      }
+    }
+
+    if (!useListInsteadOfSet)
+    {
+      delOp->updateToSelectMap().rewriteValueIdSetUp(
+	targetCharInputs,
+	sourceCharInputs);
+    }
+
+    // If a target key column is covered by a constant on the source side,
+    // then we need to remove that column from the target sort key
+    removeConstantsFromTargetSortKey(&targetSortKey,
+                                   &(delOp->updateToSelectMap()));
+    NABoolean orderedNJ = TRUE;
+    // Don't call ordersMatch if njOuterOrder_ is null.
+    if (ippForMe->getAssumeSortedForCosting())
+      orderedNJ = FALSE;
+    else
+      // if leading keys are not same then don't try ordered NJ.
+      orderedNJ =
+        isOrderedNJFeasible(*(ippForMe->getNjOuterOrder()), targetSortKey);
+
+    if (orderedNJ AND 
+        ordersMatch(ippForMe,
+                    CIDesc,
+                    &targetSortKey,
+                    targetCharInputs,
+                    partiallyInOrderOK,
+                    probesForceSynchronousAccess))
+    {
+      probesInOrder = TRUE;
+      if (probesForceSynchronousAccess)
+      {
+        // The probes form a complete order across all partitions and
+        // the clustering key and partitioning key are the same. So, the
+        // only asynchronous I/O we will see will be due to ESPs. So,
+        // limit the count of streams in DP2 by the count of streams in ESP.
+
+        // Get the logPhysPartitioningFunction, which we will use
+        // to get the logical partitioning function. If it's NULL,
+        // it means the table was not partitioned at all, so we don't
+        // need to limit anything since there already is no asynch I/O.
+
+     // TODO: lppf is always null in Trafodion; figure out what to do instead...
+        const LogPhysPartitioningFunction* lppf =
+            partFunc_->castToLogPhysPartitioningFunction();
+        if (lppf != NULL)
+        {
+          PartitioningFunction* logPartFunc =
+            lppf->getLogPartitioningFunction();
+          // Get the number of ESPs:
+          CostScalar numParts = logPartFunc->getCountOfPartitions();
+
+          countOfAsynchronousStreams = MINOF(numParts,
+                                             countOfAsynchronousStreams);
+        } // lppf != NULL
+      } // probesForceSynchronousAccess
+    } // probes are in order
+  } // if input physical properties exist
+
+  CostScalar currentCpus = 
+    (CostScalar)myContext->getPlan()->getPhysicalProperty()->getCurrentCountOfCPUs();
+  CostScalar activeCpus = MINOF(countOfAsynchronousStreams, currentCpus);
+  CostScalar streamsPerCpu =
+    (countOfAsynchronousStreams / activeCpus).getCeiling();
+
+
+  CostScalar noOfProbesPerPartition(csOne);
+
+  CostScalar numRowsToDelete(csOne);
+  CostScalar numRowsToScan(csOne);
+
+  CostScalar commonComputation;
+
+  // Determine # of rows to scan and to delete
+
+  if (delOp->getSearchKey() && delOp->getSearchKey()->isUnique() && 
+    (noOfProbes_ == 1))
+  {
+    // unique access
+
+    activePartitions = csOne;
+    countOfAsynchronousStreams = csOne;
+    activeCpus = csOne;
+    streamsPerCpu = csOne;
+    numRowsToScan = csOne;
+    // assume the 1 row always satisfies any executor predicates so
+    // we'll always do the Delete
+    numRowsToDelete = csOne;
+  }
+  else
+  {
+    // non-unique access
+
+    numRowsToDelete =
+      ((myRowCount_ / activePartitions).getCeiling()).minCsOne();
+    noOfProbesPerPartition =
+      ((noOfProbes_ / countOfAsynchronousStreams).getCeiling()).minCsOne();
+
+    // need to compute the number of rows that satisfy the key predicates
+    // to compute the I/Os that must be performed
+
+    // need to create a new histogram, since the one from input logical
+    // prop. has the histogram for the table after all executor preds are
+    // applied (i.e. the result cardinality)
+    IndexDescHistograms histograms(*CIDesc,CIDesc->getIndexKey().entries());
+
+    // retrieve all of the key preds in key column order
+    ColumnOrderList keyPredsByCol(CIDesc->getIndexKey());
+    delOp->getSearchKey()->getKeyPredicatesByColumn(keyPredsByCol);
+
+    if ( NOT allKeyColumnsHaveHistogramStatistics( histograms, CIDesc ) )
+    {
+      // All key columns do not have histogram data, the best we can
+      // do is use the number of rows that satisfy all predicates
+      // (i.e. the number of rows we will be updating)
+      numRowsToScan = numRowsToDelete;
+    }
+    else
+    {
+      numRowsToScan = numRowsToScanWhenAllKeyColumnsHaveHistograms(
+	histograms,
+	keyPredsByCol,
+	activePartitions,
+	CIDesc
+	);
+      if (numRowsToScan < numRowsToDelete) // sanity test
+      {
+        // we will scan at least as many rows as we delete
+        numRowsToScan = numRowsToDelete;
+      }
+    }
+  }
+
+  // Notes: At execution time, several different TCBs can be created
+  // for a delete. We can class them three ways: Unique, Subset, and
+  // Rowset. Representative examples of the three classes are:
+  //
+  //   ExHbaseUMDtrafUniqueTaskTcb
+  //   ExHbaseUMDtrafSubsetTaskTcb
+  //   ExHbaseAccessSQRowsetTcb
+  //
+  // The theory of operation of each of these differs somewhat. 
+  //
+  // For the Unique variant, we use an HBase "get" to obtain a row, apply
+  // a predicate to it, then do an HBase "delete" to delete it if the
+  // predicate is true. (If there is no predicate, we'll simply do a
+  // "checkAndDelete" so there would be no "get" cost.) 
+  //
+  // For the Subset variant, we use an HBase "scan" to obtain a sequence
+  // of rows, apply a predicate to each, then do an HBase "delete" on
+  // each row that passes the predicate.
+  //
+  // For the Rowset variant, we simply pass all the input keys to 
+  // HBase in batches in HBase "deleteRows" calls. (In Explain plans,
+  // this TCB shows up as "trafodion_delete_vsbb", while the first two
+  // show up as "trafodion_delete".) There is no "get" cost. In plans
+  // with this TCB, there is a separate Scan TCB to obtain the keys,
+  // which then flow to this Rowset TCB via a tuple flow or nested join.
+  // (Such a separate Scan might exist with the first two TCBs also,
+  // e.g., when an index is used to decide which rows to delete.)
+  // The messaging cost to HBase is also reduced since multiple delete
+  // keys are sent per HBase interaction.
+  //
+  // Unfortunately the decisions as to which TCB will be used are
+  // currently made in the generator code and so aren't easily 
+  // available to us here. For the moment then, we make no attempt 
+  // to distinguish a separate "get" cost, nor do we take into account
+  // possible reduced message cost in the Rowset case. Should this
+  // choice be refactored in the future to push it into the Optimizer,
+  // then we can do a better job here. We did attempt to distinguish
+  // the unique case here from the others, but even there our criteria
+  // are not quite the same as in the generator. So at best, this attempt
+  // simply sharpens the cost estimate in this one particular case.
+
+
+  // Compute the I/O cost
+
+  computeIOCostsForCursorOperation(
+    randomIOs /* out */,
+    sequentialIOs /* out */,
+    CIDesc,
+    numRowsToScan,
+    probesInOrder
+    );
+
+  // Compute the tuple cost
+
+  tuplesProduced = numRowsToDelete;
+  tuplesProcessed = numRowsToScan; 
+  tuplesSent = numRowsToDelete;
+
+  CostScalar rowSize = delOp->getIndexDesc()->getRecordLength();
+  CostScalar rowSizeFactor = scmRowSizeFactor(rowSize); 
+  CostScalar outputRowSize = delOp->getGroupAttr()->getRecordLength();
+  CostScalar outputRowSizeFactor = scmRowSizeFactor(outputRowSize);
+
+  tuplesProcessed *= rowSizeFactor;
+  tuplesSent *= rowSizeFactor;
+  tuplesProduced *= outputRowSizeFactor;
+
+
+  // ---------------------------------------------------------------------
+  // Synthesize and return cost object.
+  // ---------------------------------------------------------------------
+
+  CostScalar probeRowSize = delOp->getIndexDesc()->getKeyLength();
+  Cost * updateCost = 
+    scmCost(tuplesProcessed, tuplesProduced, tuplesSent, randomIOs, sequentialIOs, noOfProbes_,
+	    rowSize, csZero, outputRowSize, probeRowSize);
+
+#ifndef NDEBUG
+if ( CmpCommon::getDefault( OPTIMIZER_PRINT_COST ) == DF_ON )
+    {
+      pfp = stdout;
+      fprintf(pfp, "HbaseDelete::scmComputeOperatorCostInternal()\n");
+      updateCost->getScmCplr().print(pfp);
+      fprintf(pfp, "HBase Delete elapsed time: ");
+      fprintf(pfp,"%f", updateCost->
+              convertToElapsedTime(
+                   myContext->getReqdPhysicalProperty()).
+              value());
+      fprintf(pfp,"\n");
+      fprintf(pfp,"CountOfStreams returned %d\n",countOfStreams);
+    }
+#endif
+
+  return updateCost;
 }
 
 // ----QUICKSEARCH FOR HbaseDelete........................................


### PR DESCRIPTION
This adds some temporary code for UPDATE costing.

The existing code returns a constant value for cost on all UPDATE operations; it is a stub that was put in when the predecessor product was ported to Hadoop and HBase. The temporary code is a copy of the costing code for DELETE. It is being put in because we have an immediate need for parallel UPDATE plans in a particular application, which you don't get with the current stub.

This temporary code, of course, uses the DELETE theory of operation, which understates the costs for UPDATE in general. So it is a stop-gap until better code can be written.

To turn on this code, one must issue CQD HBASE_UPDATE_COSTING 'ON'. Without this CQD, the old stub, a constant cost of 1e32, will be used.