### PR TITLE
[TRAFODION-2566] Reduce the virtual memory allocated in Trafodion pro…

### DIFF
--- a/core/sqf/src/seatrans/tm/hbasetmlib2/javaobjectinterfacetm.cpp
+++ b/core/sqf/src/seatrans/tm/hbasetmlib2/javaobjectinterfacetm.cpp
@@ -34,6 +34,9 @@ jint jniHandleCapacity_ = 0;
 #define DEFAULT_MAX_TM_HEAP_SIZE "2048" 
 #define USE_JVM_DEFAULT_MAX_HEAP_SIZE 0
 #define TRAF_DEFAULT_JNIHANDLE_CAPACITY 32
+#define DEFAULT_COMPRESSED_CLASSSPACE_SIZE 128
+#define DEFAULT_MAX_METASPACE_SIZE 128
+
   
 static const char* const joiErrorEnumStr[] = 
 {
@@ -153,6 +156,28 @@ int JavaObjectInterfaceTM::createJVM()
                                                                        debugPort_,         debugTimeout_);
       jvm_options[numJVMOptions++].optionString = debugOptions;
     }
+
+  char compressedClassSpaceSizeOptions[64];
+  int compressedClassSpaceSize = 0;
+  const char *compressedClassSpaceSizeStr = getenv("JVM_COMPRESSED_CLASS_SPACE_SIZE");
+  if (compressedClassSpaceSizeStr)
+    compressedClassSpaceSize = atoi(compressedClassSpaceSizeStr);
+  if (compressedClassSpaceSize <= 0)
+     compressedClassSpaceSize = DEFAULT_COMPRESSED_CLASSSPACE_SIZE;
+  sprintf(compressedClassSpaceSizeOptions, "-XX:CompressedClassSpaceSize=%dm", compressedClassSpaceSize);
+  jvm_options[numJVMOptions].optionString = compressedClassSpaceSizeOptions;
+  numJVMOptions++;
+
+  char maxMetaspaceSizeOptions[64];
+  int maxMetaspaceSize = 0;
+  const char *maxMetaspaceSizeStr = getenv("JVM_MAX_METASPACE_SIZE");
+  if (maxMetaspaceSizeStr)
+    maxMetaspaceSize = atoi(maxMetaspaceSizeStr);
+  if (maxMetaspaceSize <= 0)
+     maxMetaspaceSize = DEFAULT_MAX_METASPACE_SIZE;
+  sprintf(maxMetaspaceSizeOptions, "-XX:MaxMetaspaceSize=%dm", maxMetaspaceSize);
+  jvm_options[numJVMOptions].optionString = maxMetaspaceSizeOptions;
+  numJVMOptions++;
   
   jvm_args.version            = JNI_VERSION_1_6;
   jvm_args.options            = jvm_options;

--- a/core/sql/langman/LmLangManagerJava.cpp
+++ b/core/sql/langman/LmLangManagerJava.cpp
@@ -361,9 +361,9 @@ void LmLanguageManagerJava::initialize(LmResult &result,
 
     JavaVMInitArgs args;
     args.nOptions = (Lng32) (numUserOpts + numHookOpts);
-    args.version = JNI_VERSION_1_4;
+    args.version = JNI_VERSION_1_6;
     args.options = vmOptions;
-    args.ignoreUnrecognized = JNI_FALSE;
+    args.ignoreUnrecognized = JNI_TRUE;
 
     // Create JVM
     TIMER_ON(jvmTimer)

--- a/core/sql/udrserv/udrserv.cpp
+++ b/core/sql/udrserv/udrserv.cpp
@@ -179,6 +179,8 @@ static Int32 processSingleCommandFromFile(FILE *f, UdrGlobals &glob);
 // Changed the default to 512 to limit java heap size used by SQL processes.
 // Keep this define in sync with executor/JavaObjectInterface.cpp
 #define DEFAULT_JVM_MAX_HEAP_SIZE 512
+#define DEFAULT_COMPRESSED_CLASSSPACE_SIZE 128
+#define DEFAULT_MAX_METASPACE_SIZE 128
 
 static NAString initErrText("");
 /*************************************************************************
@@ -236,7 +238,27 @@ void InitializeJavaOptionsFromEnvironment(LmJavaOptions &javaOptions
    int maxHeapEnvvarMB = DEFAULT_JVM_MAX_HEAP_SIZE;
    sprintf(maxHeapOption, "-Xmx%dm", maxHeapEnvvarMB);
    javaOptions.addOption((const char *)maxHeapOption, TRUE);
-   
+
+   char compressedClassSpaceSizeOptions[64];
+   int compressedClassSpaceSize = 0;
+   const char *compressedClassSpaceSizeStr = getenv("JVM_COMPRESSED_CLASS_SPACE_SIZE");
+   if (compressedClassSpaceSizeStr)
+      compressedClassSpaceSize = atoi(compressedClassSpaceSizeStr);
+   if (compressedClassSpaceSize <= 0)
+      compressedClassSpaceSize = DEFAULT_COMPRESSED_CLASSSPACE_SIZE;
+   sprintf(compressedClassSpaceSizeOptions, "-XX:CompressedClassSpaceSize=%dm", compressedClassSpaceSize);
+   javaOptions.addOption((const char *)compressedClassSpaceSizeOptions, TRUE);
+
+   char maxMetaspaceSizeOptions[64];
+   int maxMetaspaceSize = 0;
+   const char *maxMetaspaceSizeStr = getenv("JVM_MAX_METASPACE_SIZE");
+   if (maxMetaspaceSizeStr)
+      maxMetaspaceSize = atoi(maxMetaspaceSizeStr);
+   if (maxMetaspaceSize <= 0)
+      maxMetaspaceSize = DEFAULT_MAX_METASPACE_SIZE;
+   sprintf(maxMetaspaceSizeOptions, "-XX:MaxMetaspaceSize=%dm", maxMetaspaceSize);
+   javaOptions.addOption((const char *)maxMetaspaceSizeOptions, TRUE);
+
    /* Look for java startup options and envvars in configuration file */
    if (UdrCfgParser::cfgFileIsOpen(initErrText))
    {


### PR DESCRIPTION
…cesses with JDK1.8

Added two new configurable JVM options -XX:CompressedClassSpaceSize=128m and
-XX:MaxMetaSpaceSize=128m.

You can modify the default value of these options using environment variables
JVM_COMPRESSED_CLASS_SPACE_SIZE and JVM_METASPACE_SIZE respectively.

With this change the virtual memory of any SQL processes and tm is reduced by 1GB.

In JDK1.8 this space is used in lieu of permanent generation. Hence, I reduced the
default Java Objects Max heap size for SQL master, ESP and arkcmp processes to 256 MB from 512MB.
The udrserv process continues to have 512MB of java objects space.