### PR TITLE
[TRAFODION-2577] Add missing config variables in Ambari install

### DIFF
--- a/install/ambari-installer/traf-mpack/common-services/TRAFODION/2.1/configuration/traf-cluster-env.xml
+++ b/install/ambari-installer/traf-mpack/common-services/TRAFODION/2.1/configuration/traf-cluster-env.xml
@@ -32,6 +32,7 @@
 export NODE_LIST="{{traf_nodes}}"
 export MY_NODES="{{traf_w_nodes}}"
 export node_count="{{traf_node_count}}"
+export CLUSTERNAME="{{cluster_name}}"
 
     </value>
     <value-attributes>

--- a/install/ambari-installer/traf-mpack/common-services/TRAFODION/2.1/configuration/trafodion-env.xml
+++ b/install/ambari-installer/traf-mpack/common-services/TRAFODION/2.1/configuration/trafodion-env.xml
@@ -187,6 +187,10 @@ export DB_ADMIN_USER={{traf_db_admin}}
 export HADOOP_TYPE="hortonworks"
 
 export TRAFODION_ENABLE_AUTHENTICATION={{traf_ldap_enabled}}
+export SECURE_HADOOP={{security_enabled}}
+
+export ZOOKEEPER_NODES={{zookeeper_quorum_hosts}}
+export ZOOKEEPER_PORT={{zookeeper_clientPort}}
   
     </value>
     <value-attributes>

--- a/install/ambari-installer/traf-mpack/common-services/TRAFODION/2.1/package/scripts/params.py
+++ b/install/ambari-installer/traf-mpack/common-services/TRAFODION/2.1/package/scripts/params.py
@@ -27,6 +27,8 @@ config = Script.get_config()
 java_home = config['hostLevelParams']['java_home']
 java_version = int(config['hostLevelParams']['java_version'])
 
+cluster_name = str(config['clusterName'])
+
 dcs_servers = config['configurations']['dcs-env']['dcs.servers']
 dcs_master_port = config['configurations']['dcs-site']['dcs.master.port']
 dcs_info_port = config['configurations']['dcs-site']['dcs.master.info.port']

--- a/install/ambari-installer/traf-mpack/common-services/TRAFODION/2.1/package/scripts/trafodionmaster.py
+++ b/install/ambari-installer/traf-mpack/common-services/TRAFODION/2.1/package/scripts/trafodionmaster.py
@@ -94,7 +94,8 @@ class Master(Script):
          content=InlineTemplate(params.traf_clust_template,
                                 traf_nodes=traf_nodes,
                                 traf_w_nodes=traf_w_nodes,
-                                traf_node_count=traf_node_count),
+                                traf_node_count=traf_node_count,
+                                cluster_name=params.cluster_name),
          mode=0644)
 
     # install cluster-env on all nodes


### PR DESCRIPTION
Based on python-installer, added these to config:
  ZOOKEEPER_NODES
  ZOOKEEPER_PORT
  SECURE_HADOOP
  CLUSTERNAME