### PR TITLE
[TRAFODION-2579] installers should allow multiple ldap hosts and ldap UID lines

### DIFF
--- a/install/python-installer/configs/prompt.json
+++ b/install/python-installer/configs/prompt.json
@@ -77,7 +77,7 @@
   },
   "ldap_hosts":
   {
-      "prompt":"Enter list of LDAP Hostnames (comma separated)"
+      "prompt":"Enter list of LDAP Hostnames (comma separated if more than one host)"
   },
   "ldap_port":
   {
@@ -87,7 +87,7 @@
   },
   "ldap_identifiers":
   {
-      "prompt":"Enter all LDAP unique identifiers (blank separated)"
+      "prompt":"Enter all LDAP unique identifiers (semi-colon separated if more than one identifier)"
   },
   "ldap_encrypt":
   {

--- a/install/python-installer/scripts/traf_ldap.py
+++ b/install/python-installer/scripts/traf_ldap.py
@@ -38,11 +38,18 @@ def run():
     traf_auth_config = '%s/sql/scripts/.traf_authentication_config' % traf_home
     traf_auth_template = '%s/sql/scripts/traf_authentication_config' % traf_home
 
+    ldap_hostname = ''
+    for host in dbcfgs['ldap_hosts'].split(','):
+        ldap_hostname += 'LDAPHostName:%s\n' % host
+    unique_identifier = ''
+    for identifier in dbcfgs['ldap_identifiers'].split(';'):
+        unique_identifier += 'UniqueIdentifier:%s\n' % identifier
+
     # set traf_authentication_config file
     change_items = {
-        'LDAPHostName:.*': 'LDAPHostName:%s' % dbcfgs['ldap_hosts'],
+        'LDAPHostName:.*': ldap_hostname.strip(),
         'LDAPPort:.*': 'LDAPPort:%s' % dbcfgs['ldap_port'],
-        'UniqueIdentifier:.*': 'UniqueIdentifier:%s' % dbcfgs['ldap_identifiers'],
+        'UniqueIdentifier:.*': unique_identifier.strip(),
         'LDAPSSL:.*': 'LDAPSSL:%s' % dbcfgs['ldap_encrypt'],
         'TLS_CACERTFilename:.*': 'TLS_CACERTFilename:%s' % dbcfgs['ldap_certpath'],
         'LDAPSearchDN:.*': 'LDAPSearchDN:%s' % dbcfgs['ldap_user'],


### PR DESCRIPTION
changes for pyinstaller part.