### PR TITLE
[TRAFODION-2579] Allow multiple LDAP values in ambari-installer

### DIFF
--- a/install/ambari-installer/mpack.json
+++ b/install/ambari-installer/mpack.json
@@ -21,13 +21,13 @@
             "service_version" : "2.1"
         },
         {  
-           "name" : "TRAFODION-2.1",
+           "name" : "TRAFODION-2.2",
            "type" : "stack-addon-service-definitions",
            "source_dir": "custom-services",
            "service_versions_map": [
              {
               "service_name" : "TRAFODION",
-              "service_version" : "2.1",
+              "service_version" : "MPACK_VERSION",
               "applicable_stacks" : [
                   {
                      "stack_name" : "HDP", "stack_version" : "2.3"

--- a/install/ambari-installer/traf-mpack/common-services/TRAFODION/2.1/configuration/trafodion-env.xml
+++ b/install/ambari-installer/traf-mpack/common-services/TRAFODION/2.1/configuration/trafodion-env.xml
@@ -95,7 +95,7 @@
     <name>traf.ldap.identifiers</name>
     <display-name>LDAP unique identifiers</display-name>
     <value></value>
-    <description>All LDAP unique identifiers (blank separated)</description>
+    <description>All LDAP unique identifiers (semi-colon separated)</description>
     <value-attributes>
       <type>string</type>
       <empty-value-valid>true</empty-value-valid>
@@ -217,13 +217,13 @@ SECTION: local
 
 # One or more identically configured hosts must be specified here,
 # one name: value pair for each host.
-  LdapHostname: {{ ldap_hosts }}
+{{ ldap_hosts }}
 
 # Default is port 389, change if using 636 or any other port
   LdapPort: {{ ldap_port }}
 
 # Must specify one or more unique identifiers, one name: value pair for each
-  UniqueIdentifier: {{ ldap_identifiers }}
+{{ ldap_identifiers }}
 
 # If the configured LDAP server requires a username and password to
 # to perform name lookup, provide those here.

--- a/install/ambari-installer/traf-mpack/common-services/TRAFODION/2.1/package/scripts/params.py
+++ b/install/ambari-installer/traf-mpack/common-services/TRAFODION/2.1/package/scripts/params.py
@@ -62,9 +62,13 @@ traf_scratch = config['configurations']['trafodion-env']['traf.node.dir']
 
 traf_ldap_template = config['configurations']['trafodion-env']['ldap_content']
 traf_ldap_enabled = config['configurations']['trafodion-env']['traf.ldap.enabled']
-ldap_hosts = config['configurations']['trafodion-env']['traf.ldap.hosts']
+ldap_hosts = ''
+for host in config['configurations']['trafodion-env']['traf.ldap.hosts'].split(','):
+  ldap_hosts += '  LDAPHostName: %s\n' % host
 ldap_port = config['configurations']['trafodion-env']['traf.ldap.port']
-ldap_identifiers = config['configurations']['trafodion-env']['traf.ldap.identifiers']
+ldap_identifiers = ''
+for identifier in config['configurations']['trafodion-env']['traf.ldap.identifiers'].split(';'):
+  ldap_identifiers += '  UniqueIdentifier: %s\n' % identifier
 ldap_user = config['configurations']['trafodion-env']['traf.ldap.user']
 ldap_pwd = config['configurations']['trafodion-env']['traf.ldap.pwd']
 ldap_encrypt = config['configurations']['trafodion-env']['traf.ldap.encrypt']


### PR DESCRIPTION
Also updates service number to match release number on master branch.
Common services remain as 2.1, since they work for 2.1+ releases.

This version of ambari installer specifies trafodion 2.2 for all
three HDP stacks.  If it becomes incompatible, then we should specify
2.1 for the older stacks.