### PR TITLE
[TRAAFODION-2568] [TRAFODION-2574]

### DIFF
--- a/core/sql/optimizer/Analyzer.cpp
+++ b/core/sql/optimizer/Analyzer.cpp
@@ -820,12 +820,12 @@ TableAnalysis * QueryAnalysis::newTableAnalysis(RelExpr* tableExpr)
       return NULL;
   }
 
+  const IndexDesc *tableIndexDesc = tableDesc->getClusteringIndex();
   // Record the highest no of partitions for a table among all of the tables 
   // in a query. This is used in opt.cpp to adjust max parallelism.
   if (CmpCommon::getDefault(COMP_BOOL_24) == DF_ON)
   {
     // Get the number of partitions for the table
-    const IndexDesc *tableIndexDesc = tableDesc->getClusteringIndex();
     Lng32 tableNumOfPartns = tableIndexDesc->getNAFileSet()->getCountOfPartitions();
 
     // Check and save highest no of partitions
@@ -859,6 +859,10 @@ TableAnalysis * QueryAnalysis::newTableAnalysis(RelExpr* tableExpr)
   // append columns referenced in the scan required outputs
   tableExpr->getGroupAttr()->getCharacteristicOutputs()
     .findAllReferencedBaseCols(usedCols);
+ // add table's clustering key for index joins
+  ValueIdSet keyAsSet(tableIndexDesc->getIndexKey());
+  keyAsSet.findAllReferencedBaseCols(usedCols) ;
+
 
   const ValueIdSet tableCols(tableDesc->getColumnList());
 

--- a/core/sql/optimizer/NormRelExpr.cpp
+++ b/core/sql/optimizer/NormRelExpr.cpp
@@ -6886,6 +6886,14 @@ RelExpr * GenericUpdate::normalizeNode(NormWA & normWARef)
      }
   }
 
+  /// YYY
+   if (getOperator().match(REL_ANY_UNARY_GEN_UPDATE))
+   {
+      Scan * scan = getLeftmostScanNode();
+      if (scan && scan->requiresHalloweenForUpdateUsingIndexScan())
+        setAvoidHalloween(TRUE);
+   }
+
   if (producedMergeIUDIndicator_ != NULL_VALUE_ID)
     {
       ValueId dummy;

--- a/core/sql/optimizer/RelExpr.cpp
+++ b/core/sql/optimizer/RelExpr.cpp
@@ -8580,9 +8580,10 @@ void Scan::addIndexInfo()
     {
       IndexDesc *idesc = ixlist[indexNo];
 
-
+      NABoolean dummy; // halloweenProtection is decided using updateableIndex
+      // in GU::normalizeNode. Here this parameter is not used.
       // Determine if this index can be used for a scan during an update.
-      if (updatingCol AND NOT updateableIndex(idesc))
+      if (updatingCol AND NOT updateableIndex(idesc, preds, dummy))
         continue;
 
       ValueIdSet indexColumns(idesc->getIndexColumns());
@@ -9055,19 +9056,33 @@ void Scan::setTableAttributes(CANodeId nodeId)
   setBaseCardinality(MIN_ONE (tableDesc->getNATable()->getEstRowCount())) ;
 }
 
-NABoolean Scan::updateableIndex(IndexDesc *idx)
+NABoolean Scan::updateableIndex(IndexDesc *idx, ValueIdSet& preds, 
+                                NABoolean & needsHalloweenProtection)
 {
   //
-  // Returns TRUE if the index (idx) can be used for a scan during 
-  // an UPDATE. Halloween problem is protected with a sort using
-  // Scan::requiresHalloweenForUpdateUsingIndexScan(). 
-  // Returns FALSE only for certain embedded updates now.
+  // Returns TRUE if the index (idx) can be used for a scan during an UPDATE.
+  // Returns TRUE with needsHalloweenProtection also set to TRUE, if the index
+  // needs a blocking sort for Halloween protection
+  // Otherwise, returns FALSE to prevent use of this index. 
+  // Using the index in this case requires Halloween protection, but is likely 
+  // inefficient since there are no useful preds on the index key columns, so
+  // we don't add this index to list of candidates.
   //
 
-  if (!getGroupAttr()->isEmbeddedUpdate())
-    return TRUE ;
+  // The conditions of when this index returns TRUE can also be expressed as
+  // returns true for an index if it is 
+  // a) a unique/clustering index or 
+  // b) has a unique predicate on its key or 
+  // c) has an equals or range predicate on all the index columns that 
+  // get updated. If one of the key columns being updated has a range predicate
+  // then needsHalloweenProtection is set to TRUE.
+  // Note that if a key column is being updated and has no predicate on it then
+  // we return FALSE.
 
+  // preds has predicate in non-RangeSpec form, 
+  // while pred will be in RangeSpec form if feature is enabled.
   ValueIdSet pred = getSelectionPredicates(), dummySet;
+
   SearchKey searchKey(idx->getIndexKey(),
 	              idx->getOrderOfKeyValues(),
 	              getGroupAttr()->getCharacteristicInputs(),
@@ -9076,10 +9091,11 @@ NABoolean Scan::updateableIndex(IndexDesc *idx)
                       dummySet, // needed by the interface but not used here
                       idx
                       );
+
   // Unique index is OK to use.
   if (searchKey.isUnique())
     return TRUE;
-
+  
   const ValueIdList colUpdated = getTableDesc()->getColUpdated();
   const ValueIdList indexKey = idx->getIndexKey();
 
@@ -9093,79 +9109,83 @@ NABoolean Scan::updateableIndex(IndexDesc *idx)
     for (CollIndex j = 0; j < indexKey.entries(); j++)
     {
       ItemExpr *keyCol = indexKey[j].getItemExpr();
-      ItemExpr *baseCol = 
-        ((IndexColumn*)keyCol)->getDefinition().getItemExpr();
+      ItemExpr *baseCol = ((IndexColumn*)keyCol)->getDefinition().getItemExpr();
       CMPASSERT(baseCol->getOperatorType() == ITM_BASECOLUMN);
-      if (((BaseColumn*)updateCol)->getColNumber() ==
-          ((BaseColumn*)baseCol)->getColNumber())
-        return FALSE;
-    }
-  }
+      if (getGroupAttr()->isEmbeddedUpdate()){
+        if (((BaseColumn*)updateCol)->getColNumber() ==
+            ((BaseColumn*)baseCol)->getColNumber())
+          return FALSE;
+      }
+      if ((NOT(idx->isUniqueIndex() || idx->isClusteringIndex()) && 
+           (CmpCommon::getDefault(UPDATE_CLUSTERING_OR_UNIQUE_INDEX_KEY) != DF_AGGRESSIVE))
+          ||
+	  (CmpCommon::getDefault(UPDATE_CLUSTERING_OR_UNIQUE_INDEX_KEY) == DF_OFF))
+      {
+        if (((BaseColumn*)updateCol)->getColNumber() ==
+            ((BaseColumn*)baseCol)->getColNumber()) 
+        {
+          if (preds.containsAsEquiLocalPred(baseCol->getValueId()))
+            continue;
+          else if (preds.containsAsRangeLocalPred(baseCol->getValueId()))
+            needsHalloweenProtection = TRUE;
+          else {
+            needsHalloweenProtection = FALSE;
+            return FALSE;
+          }
+        } // index key col is being updated
+      } // not a clustering or unique index
+    } // loop over index key cols
+  } // loop over cols being updated
+
   return TRUE;
 } // Scan::updateableIndex
 
 NABoolean Scan::requiresHalloweenForUpdateUsingIndexScan()
-{
-
-  // Returns TRUE if any non clustering index can be used for a scan 
-  // during an UPDATE and a key column of that index is in the SET
-  // clause of the update. If this method returns TRUE we will use a 
-  // sort node to prevent the "Halloween Update Problem".
-  //
+{ 
+  // Returns TRUE if any index that is in the list of indexes that will be 
+  // added later in addIndexInfo() to drive the scan for an UPDATE requires 
+  // Halloween protection. This is decided by using Scan::updateableIndex(). 
+  // If this method returns TRUE we will use a sort node to prevent the 
+  // "Halloween Update Problem".
 
   // preds are in RangeSpec form
   ValueIdSet preds = getSelectionPredicates();
-  const ValueIdList colUpdated = getTableDesc()->getColUpdated();
+  const ValueIdList & colUpdated = getTableDesc()->getColUpdated();
   const LIST(IndexDesc *) & ixlist = getTableDesc()->getIndexes();
-
+  
   if ((colUpdated.entries() == 0) || (preds.entries() == 0) ||
       (ixlist.entries() == 1) || // this is the clustering index
       (CmpCommon::getDefault(UPDATE_CLUSTERING_OR_UNIQUE_INDEX_KEY) 
        == DF_AGGRESSIVE)) // this setting means no Halloween protection
     return FALSE;
-
-   if (CmpCommon::getDefault(RANGESPEC_TRANSFORMATION) == DF_ON)
-   {
-     ValueIdList selectionPredList(preds);
-     ItemExpr *inputItemExprTree = 
-       selectionPredList.rebuildExprTree(ITM_AND,FALSE,FALSE);
-     ItemExpr * resultOld = revertBackToOldTree(STMTHEAP, 
-                                                inputItemExprTree);
-     preds.clear();
-     resultOld->convertToValueIdSet(preds, NULL, ITM_AND);
-     doNotReplaceAnItemExpressionForLikePredicates(resultOld,preds,
-                                                   resultOld);
-   }
-
+ 
+  if (CmpCommon::getDefault(RANGESPEC_TRANSFORMATION) == DF_ON)
+  {
+    ValueIdList selectionPredList(preds);
+    ItemExpr *inputItemExprTree = 
+      selectionPredList.rebuildExprTree(ITM_AND,FALSE,FALSE);
+    ItemExpr * resultOld = revertBackToOldTree(STMTHEAP, 
+                                               inputItemExprTree);
+    preds.clear();
+    resultOld->convertToValueIdSet(preds, NULL, ITM_AND);
+    doNotReplaceAnItemExpressionForLikePredicates(resultOld,preds,
+                                                  resultOld);
+  }
+  
+  NABoolean needsHalloweenProtection ;
   for (CollIndex indexNo = 0; indexNo < ixlist.entries(); indexNo++)
   {
     IndexDesc *idx = ixlist[indexNo];
     if (idx->isClusteringIndex() || 
         (idx->isUniqueIndex() && 
-        (CmpCommon::getDefault(UPDATE_CLUSTERING_OR_UNIQUE_INDEX_KEY) 
-         == DF_ON)))
+         (CmpCommon::getDefault(UPDATE_CLUSTERING_OR_UNIQUE_INDEX_KEY) 
+          == DF_ON)))
       continue ; // skip this idesc
-
-    const ValueIdList indexKey = idx->getIndexKey();
-    // Determine if the columns being updated are key columns. Each key
-    // column being updated must have an associated equality clause in
-    // the WHERE clause of the UPDATE for it to be used.
-    for (CollIndex i = 0; i < colUpdated.entries(); i++)
-    {
-      ItemExpr *updateCol = colUpdated[i].getItemExpr();
-      CMPASSERT(updateCol->getOperatorType() == ITM_BASECOLUMN);
-      for (CollIndex j = 0; j < indexKey.entries(); j++)
-      {
-        ItemExpr *keyCol = indexKey[j].getItemExpr();
-        ItemExpr *baseCol = 
-          ((IndexColumn*)keyCol)->getDefinition().getItemExpr();
-        CMPASSERT(baseCol->getOperatorType() == ITM_BASECOLUMN);
-        if (((BaseColumn*)updateCol)->getColNumber() ==
-            ((BaseColumn*)baseCol)->getColNumber() AND
-            NOT preds.containsAsEquiLocalPred(baseCol->getValueId()))
-          return TRUE;
-      }
-    }
+    
+    needsHalloweenProtection = FALSE;
+    if(updateableIndex(idx, preds, needsHalloweenProtection) && 
+       needsHalloweenProtection)
+      return TRUE; // if even one index requires Halloween, then we add the sort
   }
   return FALSE;
 }

--- a/core/sql/optimizer/RelScan.h
+++ b/core/sql/optimizer/RelScan.h
@@ -431,7 +431,8 @@ public:
 
   // find out which indexes on the base table are usable for this scan
   void addIndexInfo();
-  NABoolean updateableIndex(IndexDesc*);
+  NABoolean updateableIndex(IndexDesc*, ValueIdSet& preds, 
+                            NABoolean & needsHalloweenProtection);
   NABoolean requiresHalloweenForUpdateUsingIndexScan();
 
   // iterate over the usable indexes (index-only and index joins)

--- a/core/sql/optimizer/RelScan.h
+++ b/core/sql/optimizer/RelScan.h
@@ -431,8 +431,8 @@ public:
 
   // find out which indexes on the base table are usable for this scan
   void addIndexInfo();
-  NABoolean equalityPredOnCol(ItemExpr*);
   NABoolean updateableIndex(IndexDesc*);
+  NABoolean requiresHalloweenForUpdateUsingIndexScan();
 
   // iterate over the usable indexes (index-only and index joins)
   CollIndex numUsableIndexes();

--- a/core/sql/optimizer/ScmCostMethod.cpp
+++ b/core/sql/optimizer/ScmCostMethod.cpp
@@ -3783,9 +3783,10 @@ void CostMethodHbaseUpdateOrDelete::computeIOCostsForCursorOperation(
   ) const
 {
   const CostScalar & kbPerBlock = CIDesc->getBlockSizeInKb();
+  // if rowsize is bigger than blocksize, rowsPerBlock will be 1.
   const CostScalar rowsPerBlock =
     ((kbPerBlock * csOneKiloBytes) /
-     CIDesc->getNAFileSet()->getRecordLength()).getFloor();
+     CIDesc->getNAFileSet()->getRecordLength()).getCeiling();
   CostScalar totalIndexBlocks(csZero);
 
   if (probesInOrder)

--- a/core/sql/optimizer/SearchKey.cpp
+++ b/core/sql/optimizer/SearchKey.cpp
@@ -2656,6 +2656,7 @@ HbaseSearchKey::HbaseSearchKey(const ValueIdList & keyColumns,
 
    requiredOutputColumns_ = keyColumns_;
    requiredOutputColumns_.insert(nonKeyColumns_);
+   isFalsePred_ = FALSE;
 }
 
 

--- a/core/sql/optimizer/SearchKey.h
+++ b/core/sql/optimizer/SearchKey.h
@@ -1027,6 +1027,9 @@ public:
   //
   NABoolean isEqualTo(const HbaseSearchKey* other) const;
 
+  NABoolean isFalsePred() {return isFalsePred_ ;}
+  void setIsFalsePred(NABoolean val) {isFalsePred_ = val ;}
+
   // -----------------------------------------------------------------------
 
 protected:
@@ -1042,6 +1045,10 @@ protected:
    ValueIdSet requiredOutputColumns_;
 
    ValueIdSet nonKeyPreds_;
+
+   // is a constant folded pred that returns FALSE always. SK has 
+   // min/max for begin/end reversed.
+   NABoolean isFalsePred_;
 };
 
 #endif /* SEARCHKEY_H */

--- a/core/sql/optimizer/ValueDesc.cpp
+++ b/core/sql/optimizer/ValueDesc.cpp
@@ -4480,6 +4480,33 @@ NABoolean ValueIdSet::containsAnyTrue(ValueId &refAnyTrue ) const
    return FALSE;
 } // ValueIdSet::containsAnyTrue
 
+NABoolean ValueIdSet::containsFalseConstant(ValueId &falseConstant ) const
+{
+
+   for ( ValueId vid = init(); next(vid); advance(vid))
+   {
+     OperatorTypeEnum OpType = vid.getItemExpr()->getOperatorType();
+     
+     if( OpType == ITM_RETURN_FALSE )
+     {
+       falseConstant = vid;
+       return TRUE;
+     }
+     else if ( OpType == ITM_CONSTANT )
+     {
+       NABoolean negate;
+       ConstValue *cv = vid.getItemExpr()->castToConstValue(negate);
+       if( cv && cv->isAFalseConstant())
+       {
+         falseConstant = vid;
+         return TRUE;
+       }
+     }
+   }
+   return FALSE;
+
+} // ValueIdSet::containsFalseConstant
+
 // -----------------------------------------------------------------------
 // Methods used for debugging and display.
 // -----------------------------------------------------------------------

--- a/core/sql/optimizer/ValueDesc.cpp
+++ b/core/sql/optimizer/ValueDesc.cpp
@@ -2764,6 +2764,54 @@ NABoolean ValueIdSet::containsAsEquiLocalPred(ValueId x) const
 
 } // ValueIdSet::containsAsEquiPred()
 
+NABoolean ValueIdSet::containsAsRangeLocalPred(ValueId x) const
+{
+  NABoolean result = FALSE; // until proven otherwise
+  if (entries() <= 0)
+    return result; // has no predicates at all
+  ItemExpr* constExpr = NULL;
+  NABoolean found = FALSE;
+
+  for (ValueId vid = init(); next(vid); advance(vid))
+  {
+    ItemExpr *expr = vid.getItemExpr();
+    switch (expr->getOperatorType())
+    {      
+    case ITM_LESS:
+    case ITM_LESS_EQ:
+    case ITM_LESS_OR_LE:
+    case ITM_GREATER:
+    case ITM_GREATER_EQ:
+    case ITM_GREATER_OR_GE:
+      
+      // consider range-predicate "a<1", "1>a", "a>1" or "1<xa" 
+      for (CollIndex i=0; i<2; i++ ) {
+        if ( expr->child(i)->getOperatorType() == ITM_VEG_REFERENCE ) 
+        {
+          ItemExpr* childExpr = expr->child(i);
+          found = ((VEGReference*)(childExpr))->getVEG()
+            ->getAllValues().contains(x);
+        } else
+          found = (expr->child(i) == x);
+        
+        if (found) {
+          CollIndex j = (i==0) ? 1 : 0;
+          ValueIdSet vset(expr->child(j));
+          if ( vset.entries() == 1 &&
+               vset.referencesAConstExpr(&constExpr) == TRUE )
+            return TRUE;
+        }
+      }      
+      break;
+      
+    default:
+      return FALSE;
+    }
+  }
+  return result;
+
+} // ValueIdSet::containsAsRangeLocalPred()
+
 
 void ValueIdSet::insertList(const ValueIdList &other)
 {

--- a/core/sql/optimizer/ValueDesc.h
+++ b/core/sql/optimizer/ValueDesc.h
@@ -984,6 +984,9 @@ public:
   // vegPredicate or the equal predicate.
   NABoolean containsAsEquiLocalPred(ValueId x) const;
 
+  // return TRUE iff x appears in this in a vegRef and is part of a 
+  // range predicate (<.<=,>,>=) whee the other side is a constant
+  NABoolean containsAsRangeLocalPred(ValueId x) const;
 
   // --------------------------------------------------------------------
   // ValueIdSet::getVEGesWithMultipleConsts()
@@ -1483,7 +1486,7 @@ public:
 
   // ---------------------------------------------------------------------
   // Returns a boolean to indicate if this vid set has a vid that 
-  // corresponds to a FlaseConstant. Such a constant is generated 
+  // corresponds to a FalseConstant. Such a constant is generated 
   // during constant folding. For example a user given predicate such as 
   // 1 = 0 will cause constant folding to generate such a Constant. 
   // The reference to a ValueId given is initialized to the ValueID 

--- a/core/sql/optimizer/ValueDesc.h
+++ b/core/sql/optimizer/ValueDesc.h
@@ -1481,6 +1481,16 @@ public:
   // ---------------------------------------------------------------------
   NABoolean containsAnyTrue(ValueId &refAnyTrue ) const;
 
+  // ---------------------------------------------------------------------
+  // Returns a boolean to indicate if this vid set has a vid that 
+  // corresponds to a FlaseConstant. Such a constant is generated 
+  // during constant folding. For example a user given predicate such as 
+  // 1 = 0 will cause constant folding to generate such a Constant. 
+  // The reference to a ValueId given is initialized to the ValueID 
+  // of the FalseConstant.
+  // ---------------------------------------------------------------------
+  NABoolean containsFalseConstant(ValueId &falseConstant ) const;
+
   // for each OLAP LEAD function cotnained in this, add the equivalent
   // OLAP LEAD function for each element (as the child of LEAD) in input, 
   // and save the new function in result


### PR DESCRIPTION
2568 - Predicates that are always false at compile time will cause their scan to have begin and end keys reversed. No rows will be scanned. Idea due to Hans.
Files : ValueDesc.h/.cpp, SearchKey.h/.cpp and GenPreCode.cpp
2574 - Update on table with an index in which SET and WHERE clause contain an index key column can now get a index driven scan. Thank you Qifan and Hans for your help.
Files : NormRelExpr.cpp, RelExpr.cpp and RelScan.h
Two other minor changes that will help get index plans. I am not able to get reproducible test cases to open JIRAs on them. Thank you Eric and Dave for your help.
Files : ScmCostMethod.cpp and Analyzer.cpp
Thank you Ming for finding all these issues.