### PR TITLE
[TRAFODION-2483] Trafodion treat '\' as NULL in hive table

### DIFF
--- a/core/sql/executor/ExHdfsScan.cpp
+++ b/core/sql/executor/ExHdfsScan.cpp
@@ -1653,7 +1653,7 @@ char * ExHdfsScanTcb::extractAndTransformAsciiSourceToSqlRow(int &err,
                   // for non-varchar, length of zero indicates a null value.
                   // For all datatypes, HIVE_DEFAULT_NULL_STRING('\N') indicates a null value.
                   if (((len == 0) && (tgtAttr && (NOT DFS2REC::isSQLVarChar(tgtAttr->getDatatype())))) ||
-                      ((len > 0) && (memcmp(sourceData, HIVE_DEFAULT_NULL_STRING, len) == 0)))
+                      ((len > 1) && (memcmp(sourceData, HIVE_DEFAULT_NULL_STRING, len) == 0)))
                     {
                       *(short *)&hdfsAsciiSourceData_[attr->getNullIndOffset()] = -1;
                     }

--- a/core/sql/executor/ExHdfsScan.cpp
+++ b/core/sql/executor/ExHdfsScan.cpp
@@ -1653,7 +1653,7 @@ char * ExHdfsScanTcb::extractAndTransformAsciiSourceToSqlRow(int &err,
                   // for non-varchar, length of zero indicates a null value.
                   // For all datatypes, HIVE_DEFAULT_NULL_STRING('\N') indicates a null value.
                   if (((len == 0) && (tgtAttr && (NOT DFS2REC::isSQLVarChar(tgtAttr->getDatatype())))) ||
-                      ((len > 1) && (memcmp(sourceData, HIVE_DEFAULT_NULL_STRING, len) == 0)))
+                      ((len == strlen(HIVE_DEFAULT_NULL_STRING)) && (memcmp(sourceData, HIVE_DEFAULT_NULL_STRING, len) == 0)))
                     {
                       *(short *)&hdfsAsciiSourceData_[attr->getNullIndOffset()] = -1;
                     }


### PR DESCRIPTION
[TRAFODION-2483] fix issue: '\'  is treated as NULL in hive table