### PR TITLE
[TRAFODION-2569] Improve handling of index hints

### DIFF
--- a/core/sql/bin/SqlciErrors.txt
+++ b/core/sql/bin/SqlciErrors.txt
@@ -1364,9 +1364,9 @@ $1~String1 --------------------------------
 4366 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Invalid Select list index.
 4367 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Using rank function and sequence functions together in the same query scope is not supported.
 4368 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Nesting rank functions is not supported.
-4369 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Paramaters and outer references are not supported with rank function.
+4369 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Parameters and outer references are not supported with rank function.
 4370 ZZZZZ 99999 BEGINNER MAJOR DBADMIN -- Unused ----
-4371 ZZZZZ 99999 BEGINNER MAJOR DBADMIN -- Unused ----
+4371 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Only $0~Int0 of the $1~Int1 indexes in the hint match actual indexes of the table $2~TableName.
 4372 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Snapshot scan cannot be used with table $0~String0 because $1~String1.
 4373 ZZZZZ 99999 BEGINNER MAJOR DBADMIN The base temporary location for snapshot scan cannot be an empty string and needs to end with the character /.
 4374 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Invalid escape sequence specified as BULK UNLOAD field delimiter or record separator. Only the following escape sequences are allowed: \\a, \\b, \\f, \\n, \\r, \\t, or \\v.
@@ -1381,7 +1381,7 @@ $1~String1 --------------------------------
 4383 ZZZZZ 99999 BEGINNER MINOR DBADMIN A float value cannot be inserted into a numeric data type column $0~ColumnName, if the column is part of the partitioning key.
 4384 ZZZZZ 99999 BEGINNER MINOR DBADMIN GROUP BY ROLLUP clause not allowed for this statement. Reason: $0~String0
 4390 ZZZZZ 99999 BEGINNER MAJOR DBADMIN The OLAP History row size exceeds the limit of $0~Int0 bytes
-4391 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Paramaters and outer references in the PARTITION BY or ORDER BY clause of a window function are not supported.
+4391 ZZZZZ 99999 BEGINNER MAJOR DBADMIN Parameters and outer references in the PARTITION BY or ORDER BY clause of a window function are not supported.
 4392 ZZZZZ 99999 BEGINNER MAJOR DBADMIN The REGEXP predicate only supports the default collating sequence.
 4400 ZZZZZ 99999 BEGINNER MAJOR LOGONLY Internal error
 4401 ZZZZZ 99999 BEGINNER MAJOR LOGONLY No Privileged Segment

--- a/core/sql/optimizer/IndexDesc.h
+++ b/core/sql/optimizer/IndexDesc.h
@@ -141,8 +141,8 @@ public:
   // mutator functions
   void markAsClusteringIndex()        { clusteringIndexFlag_ = TRUE; }
 
-  // Is it recommended by user hint
-  NABoolean isHintIndex() const;
+  // Is it recommended by user hint, and what delta to use
+  int indexHintPriorityDelta() const;
 
   // On return:
   //   the amount of data that the local predicate will produce, when 

--- a/core/sql/optimizer/OptHints.h
+++ b/core/sql/optimizer/OptHints.h
@@ -61,6 +61,9 @@ class Hint : public NABasicObject
 
   Hint* setSelectivity(double s) { selectivity_ = s; return this; }
 
+  void replaceIndexHint(CollIndex x, const NAString &newIndexName)
+                                    { indexes_[x] = newIndexName; }
+
   // accessors
   NABoolean hasIndexHint(const NAString &xName); 
   CollIndex indexCnt() const { return indexes_.entries(); }

--- a/core/sql/optimizer/OptLogRelExpr.cpp
+++ b/core/sql/optimizer/OptLogRelExpr.cpp
@@ -451,8 +451,8 @@ RelExpr::synthEstLogPropForUnaryLeafOp (const EstLogPropSharedPtr& inputEstLogPr
   if (opType == REL_SCAN)
   {
     Scan * scanExpr = (Scan *)this;
-    selHint = scanExpr->getTableDesc()->getSelectivityHint();
-    cardHint = scanExpr->getTableDesc()->getCardinalityHint();
+    selHint = scanExpr->getSelectivityHint();
+    cardHint = scanExpr->getCardinalityHint();
 
     ColStatDescList columnStatsForMaxSel(CmpCommon::statementHeap());
     columnStatsForMaxSel.makeDeepCopy (columnStats) ;
@@ -5335,7 +5335,7 @@ Scan::finishSynthEstLogProp()
       CardinalityHint * cardHint = tableDesc->cardinalityHint();
       SelectivityHint * selHint = tableDesc->selectivityHint();
 
-      if (cardHint || selHint)
+      if ((cardHint || selHint) && !suppressHints_)
       {
 		if ((cardHint && ( cardHint->getBaseScanSelectivityFactor() == -1.0 ) ) ||
 			(selHint && ( selHint->getBaseScanSelectivityFactor() == -1.0 ) ) )

--- a/core/sql/optimizer/RelScan.h
+++ b/core/sql/optimizer/RelScan.h
@@ -228,9 +228,8 @@ public:
           // QSTUFF
          stream_ (stream),
          embeddedUpdateOrDelete_ (FALSE),
-	 selectivityFactor_(-1.0),
-	 cardinalityHint_(-1.0),
 	 forcedIndexInfo_(FALSE),
+         suppressHints_(FALSE),
          baseCardinality_(0),
           // QSTUFF
          isRewrittenMV_(FALSE),
@@ -257,9 +256,8 @@ public:
                  // QSTUFF
          stream_ (stream),
          embeddedUpdateOrDelete_ (FALSE),
-	 selectivityFactor_(-1.0),
-	 cardinalityHint_(-1.0),
 	 forcedIndexInfo_(FALSE),
+         suppressHints_(FALSE),
          baseCardinality_(0),
           // QSTUFF
          isRewrittenMV_(FALSE),
@@ -289,9 +287,8 @@ public:
                  // QSTUFF
          stream_ (stream),
          embeddedUpdateOrDelete_ (FALSE),
-	 selectivityFactor_(-1.0),
-	 cardinalityHint_(-1.0),
 	 forcedIndexInfo_(FALSE),
+         suppressHints_(FALSE),
          baseCardinality_(0),
           // QSTUFF
          isRewrittenMV_(FALSE),
@@ -319,9 +316,8 @@ public:
                  // QSTUFF
 	 stream_ (FALSE),
          embeddedUpdateOrDelete_ (FALSE),
-	 selectivityFactor_(-1.0),
-	 cardinalityHint_(-1.0),
 	 forcedIndexInfo_(FALSE),
+         suppressHints_(FALSE),
          baseCardinality_(0),
          // QSTUFF
          isRewrittenMV_(FALSE),
@@ -488,6 +484,11 @@ public:
   const StmtLevelAccessOptions  accessOptions() const { return accessOptions_; }
         StmtLevelAccessOptions &accessOptions()       { return accessOptions_; }
 
+  const SelectivityHint * getSelectivityHint() const
+              { return (suppressHints_ ? NULL : tabId_->getSelectivityHint()); }
+  const CardinalityHint * getCardinalityHint() const 
+              { return (suppressHints_ ? NULL : tabId_->getCardinalityHint()); }
+
   // ---------------------------------------------------------------------
   // Scan::normalizeNode()
   // Invokes ItemExpr::normalizeNode() & then performs mdamBuildDisjuncts
@@ -518,6 +519,10 @@ public:
   void setForceIndexInfo() { forcedIndexInfo_ = TRUE; }
   void resetForceIndexInfo() { forcedIndexInfo_ = FALSE; }
   NABoolean isIndexInfoForced() const { return forcedIndexInfo_; }
+
+  void setSuppressHints(NABoolean x = TRUE)            { suppressHints_ = x; }
+  NABoolean areHintsSuppressed() const              { return suppressHints_; }
+
   // ---------------------------------------------------------------------
   // Vertical Partitioning related methods
   // ---------------------------------------------------------------------
@@ -550,12 +555,6 @@ public:
 
   Float32 samplePercent() const               { return samplePercent_; };
   void samplePercent(Float32 sp)              { samplePercent_ = sp; };
-
-  CostScalar getScanSelectivityFactor() const     { return selectivityFactor_ ; };
-  void setScanSelectivityFactor(CostScalar sf) { selectivityFactor_ = sf; };
-
-  CostScalar getScanCardinalityHint() const       { return cardinalityHint_ ; };
-  void setScanCardinalityHint(CostScalar ch)   { cardinalityHint_ = ch; };
 
   NABoolean checkForCardRange(const ValueIdSet & setOfPredicates,
                         CostScalar & newRowCount /* in and out */);
@@ -767,12 +766,11 @@ private:
   // scan produces a continuous stream without returning an end-of-data
   NABoolean stream_;
 
-  // is this scan created by FilterRule0
+  // is this scan created by a rule that wants to force a specific index?
   NABoolean forcedIndexInfo_;
 
-  // selectivity hint from user. Set in the parser. Set if > 0, set -1 otherwise
-  CostScalar selectivityFactor_;
-  CostScalar cardinalityHint_;
+  // do not apply hints (e.g. used for inner table of index join)
+  NABoolean suppressHints_;
 
   // hbase options. Like: number of trafodion row versions to retrieve from hbase.
   HbaseAccessOptions *hbaseAccessOptions_;
@@ -1006,8 +1004,6 @@ public:
   // -----------------------------------------------------
   virtual short generateShape(CollHeap * space, char * buf, NAString * shapeStr = NULL);
 
-
-  NABoolean isRecommendedByHints();
   inline const CostScalar getEstRowsAccessed() const 
     { return estRowsAccessed_; }
   inline void setEstRowsAccessed(CostScalar r)  { estRowsAccessed_ = r; }

--- a/core/sql/optimizer/SimpleScanOptimizer.cpp
+++ b/core/sql/optimizer/SimpleScanOptimizer.cpp
@@ -304,8 +304,8 @@ SimpleFileScanOptimizer::computeSingleSubsetSize()
       IndexDescHistograms innerHistograms(*getIndexDesc(),
                                           singleSubsetPrefixColumn + 1);
 
-      const SelectivityHint * selHint = getIndexDesc()->getPrimaryTableDesc()->getSelectivityHint();
-      const CardinalityHint * cardHint = getIndexDesc()->getPrimaryTableDesc()->getCardinalityHint();
+      const SelectivityHint * selHint = getFileScan().getSelectivityHint();
+      const CardinalityHint * cardHint = getFileScan().getCardinalityHint();
 
       // Exclude the added computed predicates since they do not contribute
       // to the cardinality. 
@@ -2400,8 +2400,8 @@ SimpleFileScanOptimizer::estimateEffTotalRowCount(
   //
   if( hasAtleastOneConstExpr )
     {
-      const SelectivityHint * selHint = getIndexDesc()->getPrimaryTableDesc()->getSelectivityHint();
-      const CardinalityHint * cardHint = getIndexDesc()->getPrimaryTableDesc()->getCardinalityHint();
+      const SelectivityHint * selHint = getFileScan().getSelectivityHint();
+      const CardinalityHint * cardHint = getFileScan().getCardinalityHint();
 
       innerHistograms.applyPredicates(totalPreds, getRelExpr(), selHint, cardHint, REL_SCAN);
 

--- a/core/sql/optimizer/TableDesc.h
+++ b/core/sql/optimizer/TableDesc.h
@@ -122,7 +122,7 @@ public:
   const LIST(IndexDesc *) &getVerticalPartitions() const { return vertParts_; }
   const IndexDesc * getClusteringIndex() const     { return clusteringIndex_; }
 
-  const LIST(IndexDesc *) &getHintIndexes() const      { return hintIndexes_; }
+  const LIST(const IndexDesc *) &getHintIndexes() const{ return hintIndexes_; }
   NABoolean hasHintIndexes() const       { return hintIndexes_.entries() > 0; }
 
   const ValueIdList &getColUpdated() const              { return colUpdated_; }
@@ -166,7 +166,7 @@ public:
   void addIndex(IndexDesc *idesc)                  { indexes_.insert(idesc); }
   void addUniqueIndex(IndexDesc *idesc)		   { uniqueIndexes_.insert(idesc); }
   void addVerticalPartition(IndexDesc *idesc)    { vertParts_.insert(idesc); }
-  void addHintIndex(IndexDesc *idesc)          { hintIndexes_.insert(idesc); }
+  void addHintIndex(const IndexDesc *idesc)    { hintIndexes_.insert(idesc); }
   void setClusteringIndex(IndexDesc *idesc)      { clusteringIndex_ = idesc; }
   void setCorrName(const CorrName &corrName)	     { corrName_ = corrName; }
   void setLocationName(const NAString &locName) {corrName_.setLocationName(locName);}
@@ -276,7 +276,7 @@ private:
   // ---------------------------------------------------------------------
   // List of recommended indexes by user hints
   // ---------------------------------------------------------------------
-  LIST(IndexDesc *) hintIndexes_;
+  LIST(const IndexDesc *) hintIndexes_;
 
   // ---------------------------------------------------------------------
   // List of available column statistics

--- a/core/sql/optimizer/TransRule.cpp
+++ b/core/sql/optimizer/TransRule.cpp
@@ -1452,6 +1452,7 @@ RelExpr * IndexJoinRule1::makeSubstituteFromIndexInfo(Scan *bef,
   Scan *rightScan = new (CmpCommon::statementHeap())
     Scan(bef->getTableName(),bef->getTableDesc());
   rightScan->setForceIndexInfo();
+  rightScan->setSuppressHints();
 
   // propagate SqlTableOpen information pointers
   leftScan->setOptStoi(bef->getOptStoi());

--- a/core/sql/optimizer/memo.cpp
+++ b/core/sql/optimizer/memo.cpp
@@ -134,14 +134,9 @@ void CascadesGroup::addLogExpr(RelExpr * expr, RelExpr *src)
   // the indexes of any scan inserted to the group.
   if (expr->getOperatorType() == REL_SCAN)
   {
-	Scan* scanNode = (Scan*) expr;
+    Scan* scanNode = (Scan*) expr;
 
-	// if this scanNode was created by FilterRule0 and this expression is
-	// not an duplicate then we must have some properties that requires us
-	// to re-evaluate the indexes and their applicability
-	if(scanNode->isIndexInfoForced() == FALSE) scanNode->removeIndexInfo();
-
-	scanNode->addIndexInfo();
+    scanNode->addIndexInfo();
     getGroupAttr()->addToAvailableBtreeIndexes(scanNode->deriveIndexOnlyIndexDesc());
     getGroupAttr()->addToAvailableBtreeIndexes(scanNode->deriveIndexJoinIndexDesc());
   }

--- a/core/sql/optimizer/opt.h
+++ b/core/sql/optimizer/opt.h
@@ -1824,8 +1824,8 @@ public:
   // ---------------------------------------------------------------------
   Context* getChildContext(Lng32 childIndex, Lng32 planNumber = 0) const;
 
-  // Is this plan's right leaf a scan?
-  NABoolean getRightLeaf(Lng32 planNumber, FileScan **rLeaf) const;
+  // Is this plan's n-th child a scan?
+  NABoolean getScanLeaf(int childNumber, int planNumber, FileScan *&scanLeaf) const;
 
   // -----------------------------------------------------------------------
   // Erase the latest context.

--- a/core/sql/regress/compGeneral/EXPECTED006.SB
+++ b/core/sql/regress/compGeneral/EXPECTED006.SB
@@ -39,6 +39,23 @@
 
 --- SQL operation complete.
 >>
+>>-- used for index hints
+>>create table t006t9 (a int not null primary key, b int, c int) salt using 2 partitions ;
+
+--- SQL operation complete.
+>>create index t006t9ix1 on t006t9(b) ;
+
+--- SQL operation complete.
+>>create index t006t9ix2 on t006t9(c) ;
+
+--- SQL operation complete.
+>>create index t006t9ix3 on t006t9(b) salt like table;
+
+--- SQL operation complete.
+>>create index t006t9ix4 on t006t9(c) salt like table;
+
+--- SQL operation complete.
+>>
 >>-- used for large scope rules
 >>create table x1 (a int not null, b int not null primary key);
 
@@ -681,7 +698,7 @@
 >>-- Error 4391
 >>prepare xx from select variance(a) over (order by ?p) from t006t2;
 
-*** ERROR[4391] Paramaters and outer references in the PARTITION BY or ORDER BY clause of a window function are not supported.
+*** ERROR[4391] Parameters and outer references in the PARTITION BY or ORDER BY clause of a window function are not supported.
 
 *** ERROR[8822] The statement was not prepared.
 
@@ -1871,8 +1888,8 @@ bc0050f3ff7a540c74a42664c53a7f9fd485622374a43eb4a62cd84e48f483237bed50f6562f8c6e
 >>-- TEST aes_encrypt/aes_decrypt
 >>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
 
-(EXPR)
-----------
+(EXPR)                                                          
+----------------------------------------------------------------
 
 EC10187492EB7FB319E09AFF8806B1CA4F1382B41D23C00B118B3DDD9A9CFA02
 
@@ -1881,28 +1898,28 @@ EC10187492EB7FB319E09AFF8806B1CA4F1382B41D23C00B118B3DDD9A9CFA02
 
 *** WARNING[8956] IV option ignored
 
-(EXPR)
-----------
+(EXPR)                                                          
+----------------------------------------------------------------
 
 EC10187492EB7FB319E09AFF8806B1CA4F1382B41D23C00B118B3DDD9A9CFA02
 
 --- 1 row(s) selected.
 >>select aes_decrypt(X'EC10187492EB7FB319E09AFF8806B1CA4F1382B41D23C00B118B3DDD9A9CFA02', '1234567812345678') from dual;
 
-(EXPR)
-----------
+(EXPR)                          
+--------------------------------
 
-abcdedfhijklmnopqrstuvwxyz
+abcdedfhijklmnopqrstuvwxyz      
 
 --- 1 row(s) selected.
 >>select aes_decrypt(X'EC10187492EB7FB319E09AFF8806B1CA4F1382B41D23C00B118B3DDD9A9CFA02', '1234567812345678', '1234567812345678') from dual;
 
 *** WARNING[8956] IV option ignored
 
-(EXPR)
-----------
+(EXPR)                          
+--------------------------------
 
-abcdedfhijklmnopqrstuvwxyz
+abcdedfhijklmnopqrstuvwxyz      
 
 --- 1 row(s) selected.
 >>
@@ -1911,8 +1928,8 @@ abcdedfhijklmnopqrstuvwxyz
 --- SQL operation complete.
 >>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
 
-(EXPR)
-----------
+(EXPR)                                                          
+----------------------------------------------------------------
 
 0D9C1230E4B129757607D2E7C10805C9483C239A6A760FD1CECD8FC4D159E76F
 
@@ -1921,28 +1938,28 @@ abcdedfhijklmnopqrstuvwxyz
 
 *** WARNING[8956] IV option ignored
 
-(EXPR)
-----------
+(EXPR)                                                          
+----------------------------------------------------------------
 
 0D9C1230E4B129757607D2E7C10805C9483C239A6A760FD1CECD8FC4D159E76F
 
 --- 1 row(s) selected.
 >>select aes_decrypt(X'0D9C1230E4B129757607D2E7C10805C9483C239A6A760FD1CECD8FC4D159E76F', '1234567812345678') from dual;
 
-(EXPR)
-----------
+(EXPR)                          
+--------------------------------
 
-abcdedfhijklmnopqrstuvwxyz
+abcdedfhijklmnopqrstuvwxyz      
 
 --- 1 row(s) selected.
 >>select aes_decrypt(X'0D9C1230E4B129757607D2E7C10805C9483C239A6A760FD1CECD8FC4D159E76F', '1234567812345678', '1234567812345678') from dual;
 
 *** WARNING[8956] IV option ignored
 
-(EXPR)
-----------
+(EXPR)                          
+--------------------------------
 
-abcdedfhijklmnopqrstuvwxyz
+abcdedfhijklmnopqrstuvwxyz      
 
 --- 1 row(s) selected.
 >>
@@ -1951,8 +1968,8 @@ abcdedfhijklmnopqrstuvwxyz
 --- SQL operation complete.
 >>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678')) from dual;
 
-(EXPR)
-----------
+(EXPR)                                                          
+----------------------------------------------------------------
 
 EFB4059C8975543222830627F7433861A173BECA31B8902540174253476CA985
 
@@ -1961,28 +1978,28 @@ EFB4059C8975543222830627F7433861A173BECA31B8902540174253476CA985
 
 *** WARNING[8956] IV option ignored
 
-(EXPR)
-----------
+(EXPR)                                                          
+----------------------------------------------------------------
 
 EFB4059C8975543222830627F7433861A173BECA31B8902540174253476CA985
 
 --- 1 row(s) selected.
 >>select aes_decrypt(X'EFB4059C8975543222830627F7433861A173BECA31B8902540174253476CA985', '1234567812345678') from dual;
 
-(EXPR)
-----------
+(EXPR)                          
+--------------------------------
 
-abcdedfhijklmnopqrstuvwxyz
+abcdedfhijklmnopqrstuvwxyz      
 
 --- 1 row(s) selected.
 >>select aes_decrypt(X'EFB4059C8975543222830627F7433861A173BECA31B8902540174253476CA985', '1234567812345678', '1234567812345678') from dual;
 
 *** WARNING[8956] IV option ignored
 
-(EXPR)
-----------
+(EXPR)                          
+--------------------------------
 
-abcdedfhijklmnopqrstuvwxyz
+abcdedfhijklmnopqrstuvwxyz      
 
 --- 1 row(s) selected.
 >>
@@ -1996,8 +2013,8 @@ abcdedfhijklmnopqrstuvwxyz
 --- 0 row(s) selected.
 >>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
 
-(EXPR)
-----------
+(EXPR)                                                          
+----------------------------------------------------------------
 
 12FF81AF2AB65E82DEFAE32D2CF0E7E5C14F90BAA80DF073608CE6ED0C47737F
 
@@ -2009,10 +2026,10 @@ abcdedfhijklmnopqrstuvwxyz
 --- 0 row(s) selected.
 >>select aes_decrypt(X'12FF81AF2AB65E82DEFAE32D2CF0E7E5C14F90BAA80DF073608CE6ED0C47737F', '1234567812345678', '1234567812345678') from dual;
 
-(EXPR)
-----------
+(EXPR)                          
+--------------------------------
 
-abcdedfhijklmnopqrstuvwxyz
+abcdedfhijklmnopqrstuvwxyz      
 
 --- 1 row(s) selected.
 >>
@@ -2026,8 +2043,8 @@ abcdedfhijklmnopqrstuvwxyz
 --- 0 row(s) selected.
 >>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
 
-(EXPR)
-----------
+(EXPR)                                                          
+----------------------------------------------------------------
 
 1A1332592C987A79374609C89BB53F89A8F0B0A2B71E06B824894D1B95E1D953
 
@@ -2039,10 +2056,10 @@ abcdedfhijklmnopqrstuvwxyz
 --- 0 row(s) selected.
 >>select aes_decrypt(X'1A1332592C987A79374609C89BB53F89A8F0B0A2B71E06B824894D1B95E1D953', '1234567812345678', '1234567812345678') from dual;
 
-(EXPR)
-----------
+(EXPR)                          
+--------------------------------
 
-abcdedfhijklmnopqrstuvwxyz
+abcdedfhijklmnopqrstuvwxyz      
 
 --- 1 row(s) selected.
 >>
@@ -2056,8 +2073,8 @@ abcdedfhijklmnopqrstuvwxyz
 --- 0 row(s) selected.
 >>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
 
-(EXPR)
-----------
+(EXPR)                                                          
+----------------------------------------------------------------
 
 E22114AB552C8613622ADD34B3FEDCE840A18C84FDEA9D6394F57A14F6DB2497
 
@@ -2069,10 +2086,10 @@ E22114AB552C8613622ADD34B3FEDCE840A18C84FDEA9D6394F57A14F6DB2497
 --- 0 row(s) selected.
 >>select aes_decrypt(X'E22114AB552C8613622ADD34B3FEDCE840A18C84FDEA9D6394F57A14F6DB2497', '1234567812345678', '1234567812345678') from dual;
 
-(EXPR)
-----------
+(EXPR)                          
+--------------------------------
 
-abcdedfhijklmnopqrstuvwxyz
+abcdedfhijklmnopqrstuvwxyz      
 
 --- 1 row(s) selected.
 >>
@@ -2086,10 +2103,10 @@ abcdedfhijklmnopqrstuvwxyz
 --- 0 row(s) selected.
 >>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
 
-(EXPR)
-----------
+(EXPR)                                                          
+----------------------------------------------------------------
 
-2A23CC234BC4175E6AE90793BFBD03E4D7F2921AC6032E45D1C0
+2A23CC234BC4175E6AE90793BFBD03E4D7F2921AC6032E45D1C0            
 
 --- 1 row(s) selected.
 >>select aes_decrypt(X'2A23CC234BC4175E6AE90793BFBD03E4D7F2921AC6032E45D1C0', '1234567812345678') from dual;
@@ -2099,8 +2116,8 @@ abcdedfhijklmnopqrstuvwxyz
 --- 0 row(s) selected.
 >>select aes_decrypt(X'2A23CC234BC4175E6AE90793BFBD03E4D7F2921AC6032E45D1C0', '1234567812345678', '1234567812345678') from dual;
 
-(EXPR)
-----------
+(EXPR)                    
+--------------------------
 
 abcdedfhijklmnopqrstuvwxyz
 
@@ -2116,10 +2133,10 @@ abcdedfhijklmnopqrstuvwxyz
 --- 0 row(s) selected.
 >>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
 
-(EXPR)
-----------
+(EXPR)                                                          
+----------------------------------------------------------------
 
-09389E6E99083B18F50D2B4D14106CFCF9F9EEAD004929940C17
+09389E6E99083B18F50D2B4D14106CFCF9F9EEAD004929940C17            
 
 --- 1 row(s) selected.
 >>select aes_decrypt(X'09389E6E99083B18F50D2B4D14106CFCF9F9EEAD004929940C17', '1234567812345678') from dual;
@@ -2129,8 +2146,8 @@ abcdedfhijklmnopqrstuvwxyz
 --- 0 row(s) selected.
 >>select aes_decrypt(X'09389E6E99083B18F50D2B4D14106CFCF9F9EEAD004929940C17', '1234567812345678', '1234567812345678') from dual;
 
-(EXPR)
-----------
+(EXPR)                    
+--------------------------
 
 abcdedfhijklmnopqrstuvwxyz
 
@@ -2146,10 +2163,10 @@ abcdedfhijklmnopqrstuvwxyz
 --- 0 row(s) selected.
 >>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
 
-(EXPR)
-----------
+(EXPR)                                                          
+----------------------------------------------------------------
 
-209F05F9B3E25391258A434F6FA9663F14886E9FF7E6C2CF5EF9
+209F05F9B3E25391258A434F6FA9663F14886E9FF7E6C2CF5EF9            
 
 --- 1 row(s) selected.
 >>select aes_decrypt(X'209F05F9B3E25391258A434F6FA9663F14886E9FF7E6C2CF5EF9', '1234567812345678') from dual;
@@ -2159,8 +2176,8 @@ abcdedfhijklmnopqrstuvwxyz
 --- 0 row(s) selected.
 >>select aes_decrypt(X'209F05F9B3E25391258A434F6FA9663F14886E9FF7E6C2CF5EF9', '1234567812345678', '1234567812345678') from dual;
 
-(EXPR)
-----------
+(EXPR)                    
+--------------------------
 
 abcdedfhijklmnopqrstuvwxyz
 
@@ -2176,10 +2193,10 @@ abcdedfhijklmnopqrstuvwxyz
 --- 0 row(s) selected.
 >>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
 
-(EXPR)
-----------
+(EXPR)                                                          
+----------------------------------------------------------------
 
-0C45C8DB6AE2F87AE36420AE711AC1121576FEECB26BD9B246AB
+0C45C8DB6AE2F87AE36420AE711AC1121576FEECB26BD9B246AB            
 
 --- 1 row(s) selected.
 >>select aes_decrypt(X'0C45C8DB6AE2F87AE36420AE711AC1121576FEECB26BD9B246AB', '1234567812345678') from dual;
@@ -2189,8 +2206,8 @@ abcdedfhijklmnopqrstuvwxyz
 --- 0 row(s) selected.
 >>select aes_decrypt(X'0C45C8DB6AE2F87AE36420AE711AC1121576FEECB26BD9B246AB', '1234567812345678', '1234567812345678') from dual;
 
-(EXPR)
-----------
+(EXPR)                    
+--------------------------
 
 abcdedfhijklmnopqrstuvwxyz
 
@@ -2206,10 +2223,10 @@ abcdedfhijklmnopqrstuvwxyz
 --- 0 row(s) selected.
 >>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
 
-(EXPR)
-----------
+(EXPR)                                                          
+----------------------------------------------------------------
 
-2C39ACEEBF859846261D8B1B712BBC7965F64889293C26CDFE61
+2C39ACEEBF859846261D8B1B712BBC7965F64889293C26CDFE61            
 
 --- 1 row(s) selected.
 >>select aes_decrypt(X'2C39ACEEBF859846261D8B1B712BBC7965F64889293C26CDFE61', '1234567812345678') from dual;
@@ -2219,8 +2236,8 @@ abcdedfhijklmnopqrstuvwxyz
 --- 0 row(s) selected.
 >>select aes_decrypt(X'2C39ACEEBF859846261D8B1B712BBC7965F64889293C26CDFE61', '1234567812345678', '1234567812345678') from dual;
 
-(EXPR)
-----------
+(EXPR)                    
+--------------------------
 
 abcdedfhijklmnopqrstuvwxyz
 
@@ -2236,10 +2253,10 @@ abcdedfhijklmnopqrstuvwxyz
 --- 0 row(s) selected.
 >>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
 
-(EXPR)
-----------
+(EXPR)                                                          
+----------------------------------------------------------------
 
-6A3C1001A693B34DD2619B066413995BDEC5259A73E1E6D2DEBC
+6A3C1001A693B34DD2619B066413995BDEC5259A73E1E6D2DEBC            
 
 --- 1 row(s) selected.
 >>select aes_decrypt(X'6A3C1001A693B34DD2619B066413995BDEC5259A73E1E6D2DEBC', '1234567812345678') from dual;
@@ -2249,8 +2266,8 @@ abcdedfhijklmnopqrstuvwxyz
 --- 0 row(s) selected.
 >>select aes_decrypt(X'6A3C1001A693B34DD2619B066413995BDEC5259A73E1E6D2DEBC', '1234567812345678', '1234567812345678') from dual;
 
-(EXPR)
-----------
+(EXPR)                    
+--------------------------
 
 abcdedfhijklmnopqrstuvwxyz
 
@@ -2266,10 +2283,10 @@ abcdedfhijklmnopqrstuvwxyz
 --- 0 row(s) selected.
 >>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
 
-(EXPR)
-----------
+(EXPR)                                                          
+----------------------------------------------------------------
 
-0CCE7F3282239C8853A5E704FC8A47901D8036903B6603DF43E5
+0CCE7F3282239C8853A5E704FC8A47901D8036903B6603DF43E5            
 
 --- 1 row(s) selected.
 >>select aes_decrypt(X'0CCE7F3282239C8853A5E704FC8A47901D8036903B6603DF43E5', '1234567812345678') from dual;
@@ -2279,8 +2296,8 @@ abcdedfhijklmnopqrstuvwxyz
 --- 0 row(s) selected.
 >>select aes_decrypt(X'0CCE7F3282239C8853A5E704FC8A47901D8036903B6603DF43E5', '1234567812345678', '1234567812345678') from dual;
 
-(EXPR)
-----------
+(EXPR)                    
+--------------------------
 
 abcdedfhijklmnopqrstuvwxyz
 
@@ -2296,10 +2313,10 @@ abcdedfhijklmnopqrstuvwxyz
 --- 0 row(s) selected.
 >>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
 
-(EXPR)
-----------
+(EXPR)                                                          
+----------------------------------------------------------------
 
-2C6B7A87519F9E95E0F46EDA774152245E8DD142FC6CD57D57E2
+2C6B7A87519F9E95E0F46EDA774152245E8DD142FC6CD57D57E2            
 
 --- 1 row(s) selected.
 >>select aes_decrypt(X'2C6B7A87519F9E95E0F46EDA774152245E8DD142FC6CD57D57E2', '1234567812345678') from dual;
@@ -2309,8 +2326,8 @@ abcdedfhijklmnopqrstuvwxyz
 --- 0 row(s) selected.
 >>select aes_decrypt(X'2C6B7A87519F9E95E0F46EDA774152245E8DD142FC6CD57D57E2', '1234567812345678', '1234567812345678') from dual;
 
-(EXPR)
-----------
+(EXPR)                    
+--------------------------
 
 abcdedfhijklmnopqrstuvwxyz
 
@@ -2326,10 +2343,10 @@ abcdedfhijklmnopqrstuvwxyz
 --- 0 row(s) selected.
 >>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
 
-(EXPR)
-----------
+(EXPR)                                                          
+----------------------------------------------------------------
 
-6A0D74250CB7E54F4690801A7AD9CDB07435157353DAE7BC6203
+6A0D74250CB7E54F4690801A7AD9CDB07435157353DAE7BC6203            
 
 --- 1 row(s) selected.
 >>select aes_decrypt(X'6A0D74250CB7E54F4690801A7AD9CDB07435157353DAE7BC6203', '1234567812345678') from dual;
@@ -2339,8 +2356,8 @@ abcdedfhijklmnopqrstuvwxyz
 --- 0 row(s) selected.
 >>select aes_decrypt(X'6A0D74250CB7E54F4690801A7AD9CDB07435157353DAE7BC6203', '1234567812345678', '1234567812345678') from dual;
 
-(EXPR)
-----------
+(EXPR)                    
+--------------------------
 
 abcdedfhijklmnopqrstuvwxyz
 
@@ -2356,10 +2373,10 @@ abcdedfhijklmnopqrstuvwxyz
 --- 0 row(s) selected.
 >>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
 
-(EXPR)
-----------
+(EXPR)                                                          
+----------------------------------------------------------------
 
-0CCE7F3282239C8853A5E704FC8A4790B5D857207B417EFB52D8
+0CCE7F3282239C8853A5E704FC8A4790B5D857207B417EFB52D8            
 
 --- 1 row(s) selected.
 >>select aes_decrypt(X'0CCE7F3282239C8853A5E704FC8A4790B5D857207B417EFB52D8', '1234567812345678') from dual;
@@ -2369,8 +2386,8 @@ abcdedfhijklmnopqrstuvwxyz
 --- 0 row(s) selected.
 >>select aes_decrypt(X'0CCE7F3282239C8853A5E704FC8A4790B5D857207B417EFB52D8', '1234567812345678', '1234567812345678') from dual;
 
-(EXPR)
-----------
+(EXPR)                    
+--------------------------
 
 abcdedfhijklmnopqrstuvwxyz
 
@@ -2386,10 +2403,10 @@ abcdedfhijklmnopqrstuvwxyz
 --- 0 row(s) selected.
 >>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
 
-(EXPR)
-----------
+(EXPR)                                                          
+----------------------------------------------------------------
 
-2C6B7A87519F9E95E0F46EDA774152244B6E78427EC604C84868
+2C6B7A87519F9E95E0F46EDA774152244B6E78427EC604C84868            
 
 --- 1 row(s) selected.
 >>select aes_decrypt(X'2C6B7A87519F9E95E0F46EDA774152244B6E78427EC604C84868', '1234567812345678') from dual;
@@ -2399,8 +2416,8 @@ abcdedfhijklmnopqrstuvwxyz
 --- 0 row(s) selected.
 >>select aes_decrypt(X'2C6B7A87519F9E95E0F46EDA774152244B6E78427EC604C84868', '1234567812345678', '1234567812345678') from dual;
 
-(EXPR)
-----------
+(EXPR)                    
+--------------------------
 
 abcdedfhijklmnopqrstuvwxyz
 
@@ -2416,10 +2433,10 @@ abcdedfhijklmnopqrstuvwxyz
 --- 0 row(s) selected.
 >>select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
 
-(EXPR)
-----------
+(EXPR)                                                          
+----------------------------------------------------------------
 
-6A0D74250CB7E54F4690801A7AD9CDB053213B2F461EA174E128
+6A0D74250CB7E54F4690801A7AD9CDB053213B2F461EA174E128            
 
 --- 1 row(s) selected.
 >>select aes_decrypt(X'6A0D74250CB7E54F4690801A7AD9CDB053213B2F461EA174E128', '1234567812345678') from dual;
@@ -2429,10 +2446,342 @@ abcdedfhijklmnopqrstuvwxyz
 --- 0 row(s) selected.
 >>select aes_decrypt(X'6A0D74250CB7E54F4690801A7AD9CDB053213B2F461EA174E128', '1234567812345678', '1234567812345678') from dual;
 
-(EXPR)
-----------
+(EXPR)                    
+--------------------------
 
 abcdedfhijklmnopqrstuvwxyz
+
+--- 1 row(s) selected.
+>>
+>>obey TEST006(optimizer_hints);
+>>
+>>insert into t006t9 values (1,2,3), (10,20,30);
+
+--- 2 row(s) inserted.
+>>prepare expl from
++>select operator, cardinality,
++>       cast(substring(description, position('scan_type: ' in description), position('object_type: ' in description) - position('scan_type: ' in description)) as char(100)) scan_type
++>from table(explain(null, 'S'))
++>where operator like '%SCAN%';
+
+--- SQL command prepared.
+>>
+>>prepare s from
++>select * from t006t9 <<+ index TRAFODION.SCH.T006T9IX1>> where b > 10;
+
+--- SQL command prepared.
+>>execute expl;
+
+OPERATOR                        CARDINALITY      SCAN_TYPE
+------------------------------  ---------------  ----------------------------------------------------------------------------------------------------
+
+TRAFODION_INDEX_SCAN             3.3000000E+001  scan_type: subset scan of index TRAFODION.SCH.T006T9IX1(TRAFODION.SCH.T006T9)                       
+TRAFODION_VSBB_SCAN              1.0000000E+000  scan_type: subset scan of table TRAFODION.SCH.T006T9                                                
+
+--- 2 row(s) selected.
+>>execute s;
+
+A            B            C          
+-----------  -----------  -----------
+
+         10           20           30
+
+--- 1 row(s) selected.
+>>
+>>prepare s from
++>select * from t006t9 <<+ index t006t9ix3>> where b > 10;
+
+--- SQL command prepared.
+>>execute expl;
+
+OPERATOR                        CARDINALITY      SCAN_TYPE
+------------------------------  ---------------  ----------------------------------------------------------------------------------------------------
+
+TRAFODION_INDEX_SCAN             3.3000000E+001  scan_type: subset scan of index TRAFODION.SCH.T006T9IX3(TRAFODION.SCH.T006T9)                       
+TRAFODION_VSBB_SCAN              1.0000000E+000  scan_type: subset scan of table TRAFODION.SCH.T006T9                                                
+
+--- 2 row(s) selected.
+>>execute s;
+
+A            B            C          
+-----------  -----------  -----------
+
+         10           20           30
+
+--- 1 row(s) selected.
+>>
+>>prepare s from
++>select * from t006t9 <<+ index t006t9>> where b > 10;
+
+--- SQL command prepared.
+>>execute expl;
+
+OPERATOR                        CARDINALITY      SCAN_TYPE
+------------------------------  ---------------  ----------------------------------------------------------------------------------------------------
+
+TRAFODION_SCAN                   3.3000000E+001  scan_type: subset scan of table TRAFODION.SCH.T006T9                                                
+
+--- 1 row(s) selected.
+>>execute s;
+
+A            B            C          
+-----------  -----------  -----------
+
+         10           20           30
+
+--- 1 row(s) selected.
+>>
+>>prepare s from
++>select a,b from t006t9 <<+ index TRAFODION.SCH.T006T9IX1>> where b > 10;
+
+--- SQL command prepared.
+>>execute expl;
+
+OPERATOR                        CARDINALITY      SCAN_TYPE
+------------------------------  ---------------  ----------------------------------------------------------------------------------------------------
+
+TRAFODION_INDEX_SCAN             3.3000000E+001  scan_type: subset scan of index TRAFODION.SCH.T006T9IX1(TRAFODION.SCH.T006T9)                       
+
+--- 1 row(s) selected.
+>>execute s;
+
+A            B          
+-----------  -----------
+
+         10           20
+
+--- 1 row(s) selected.
+>>
+>>prepare s from
++>select a,b from t006t9 <<+ index TRAFODION.SCH.T006T9IX3 | cardinality 2000.0>> where b > 10;
+
+--- SQL command prepared.
+>>execute expl;
+
+OPERATOR                        CARDINALITY      SCAN_TYPE
+------------------------------  ---------------  ----------------------------------------------------------------------------------------------------
+
+TRAFODION_INDEX_SCAN             2.0000000E+003  scan_type: subset scan of index TRAFODION.SCH.T006T9IX3(TRAFODION.SCH.T006T9)                       
+
+--- 1 row(s) selected.
+>>execute s;
+
+A            B          
+-----------  -----------
+
+         10           20
+
+--- 1 row(s) selected.
+>>
+>>prepare s from
++>update t006t9 <<+ index TRAFODION.SCH.T006T9IX1>> set c = 5 where b > 10;
+
+--- SQL command prepared.
+>>execute expl;
+
+OPERATOR                        CARDINALITY      SCAN_TYPE
+------------------------------  ---------------  ----------------------------------------------------------------------------------------------------
+
+TRAFODION_INDEX_SCAN             3.3000000E+001  scan_type: subset scan of index TRAFODION.SCH.T006T9IX1(TRAFODION.SCH.T006T9)                       
+TRAFODION_VSBB_SCAN              1.0000000E+000  scan_type: subset scan of table TRAFODION.SCH.T006T9                                                
+
+--- 2 row(s) selected.
+>>execute s;
+
+--- 1 row(s) updated.
+>>
+>>prepare s from
++>update t006t9 <<+ cardinality 2e4 | index sch.T006T9IX1>> as x set c = 5 where b = 10;
+
+--- SQL command prepared.
+>>execute expl;
+
+OPERATOR                        CARDINALITY      SCAN_TYPE
+------------------------------  ---------------  ----------------------------------------------------------------------------------------------------
+
+TRAFODION_INDEX_SCAN             2.0000000E+004  scan_type: subset scan of index TRAFODION.SCH.T006T9IX1(TRAFODION.SCH.T006T9 X)                     
+TRAFODION_VSBB_SCAN              7.1000000E-003  scan_type: subset scan of table TRAFODION.SCH.T006T9 X                                              
+
+--- 2 row(s) selected.
+>>execute s;
+
+--- 0 row(s) updated.
+>>
+>>prepare s from
++>update t006t9 <<+ index TRAFODION.SCH.T006T9IX3 | cardinality 1e7>> set c = 5 where b > 10;
+
+--- SQL command prepared.
+>>execute expl;
+
+OPERATOR                        CARDINALITY      SCAN_TYPE
+------------------------------  ---------------  ----------------------------------------------------------------------------------------------------
+
+TRAFODION_INDEX_SCAN             1.0000000E+007  scan_type: subset scan of index TRAFODION.SCH.T006T9IX3(TRAFODION.SCH.T006T9)                       
+TRAFODION_VSBB_SCAN              1.0000000E+000  scan_type: subset scan of table TRAFODION.SCH.T006T9                                                
+
+--- 2 row(s) selected.
+>>execute s;
+
+--- 1 row(s) updated.
+>>
+>>prepare s from
++>update t006t9 <<+ index TRAFODION.SCH.T006T9IX3>> set c = 5 where b = 10;
+
+--- SQL command prepared.
+>>execute expl;
+
+OPERATOR                        CARDINALITY      SCAN_TYPE
+------------------------------  ---------------  ----------------------------------------------------------------------------------------------------
+
+TRAFODION_INDEX_SCAN             1.0000000E+001  scan_type: subset scan of index TRAFODION.SCH.T006T9IX3(TRAFODION.SCH.T006T9)                       
+TRAFODION_VSBB_SCAN              4.0000000E-001  scan_type: subset scan of table TRAFODION.SCH.T006T9                                                
+
+--- 2 row(s) selected.
+>>execute s;
+
+--- 0 row(s) updated.
+>>
+>>prepare s from
++>delete from t006t9 <<+ index TRAFODION.SCH.T006T9IX2>> where c > 10;
+
+--- SQL command prepared.
+>>execute expl;
+
+OPERATOR                        CARDINALITY      SCAN_TYPE
+------------------------------  ---------------  ----------------------------------------------------------------------------------------------------
+
+TRAFODION_INDEX_SCAN             3.3000000E+001  scan_type: subset scan of index TRAFODION.SCH.T006T9IX2(TRAFODION.SCH.T006T9)                       
+TRAFODION_VSBB_SCAN              1.0000000E+000  scan_type: subset scan of table TRAFODION.SCH.T006T9                                                
+
+--- 2 row(s) selected.
+>>execute s;
+
+--- 0 row(s) deleted.
+>>
+>>prepare s from
++>delete from t006t9 <<+ index TRAFODION.SCH.T006T9IX2 | selectivity 0.03 >> where c = 10;
+
+--- SQL command prepared.
+>>execute expl;
+
+OPERATOR                        CARDINALITY      SCAN_TYPE
+------------------------------  ---------------  ----------------------------------------------------------------------------------------------------
+
+TRAFODION_INDEX_SCAN             3.0000000E+000  scan_type: subset scan of index TRAFODION.SCH.T006T9IX2(TRAFODION.SCH.T006T9)                       
+TRAFODION_VSBB_SCAN              6.6666668E-001  scan_type: subset scan of table TRAFODION.SCH.T006T9                                                
+
+--- 2 row(s) selected.
+>>execute s;
+
+--- 0 row(s) deleted.
+>>
+>>prepare s from
++>delete from t006t9 <<+ index TRAFODION.SCH.T006T9IX4>> where c > 10;
+
+--- SQL command prepared.
+>>execute expl;
+
+OPERATOR                        CARDINALITY      SCAN_TYPE
+------------------------------  ---------------  ----------------------------------------------------------------------------------------------------
+
+TRAFODION_INDEX_SCAN             3.3000000E+001  scan_type: subset scan of index TRAFODION.SCH.T006T9IX4(TRAFODION.SCH.T006T9)                       
+TRAFODION_VSBB_SCAN              1.0000000E+000  scan_type: subset scan of table TRAFODION.SCH.T006T9                                                
+
+--- 2 row(s) selected.
+>>execute s;
+
+--- 0 row(s) deleted.
+>>
+>>prepare s from
++>delete [first 10] from t006t9 <<+ index TRAFODION.SCH.T006T9IX4>> where c = 10;
+
+--- SQL command prepared.
+>>execute expl;
+
+OPERATOR                        CARDINALITY      SCAN_TYPE
+------------------------------  ---------------  ----------------------------------------------------------------------------------------------------
+
+TRAFODION_INDEX_SCAN             1.0000000E+001  scan_type: subset scan of index TRAFODION.SCH.T006T9IX4(TRAFODION.SCH.T006T9)                       
+TRAFODION_VSBB_SCAN              4.0000000E-001  scan_type: subset scan of table TRAFODION.SCH.T006T9                                                
+
+--- 2 row(s) selected.
+>>execute s;
+
+--- 0 row(s) deleted.
+>>
+>>prepare s from
++>delete from t006t9 <<+ index t006t9ix2, t006t9ix4>> where c > 10;
+
+--- SQL command prepared.
+>>-- this can pick either index
+>>with expl as
++>(select operator, cardinality,
++>        cast(substring(description, position('scan_type: ' in description), position('object_type: ' in description) - position('scan_type: ' in description)) as char(100)) scan_type
++> from table(explain(null, 'S'))
++> where operator like '%SCAN%')
++>select count(*) from expl where scan_type like '%T006T9IX2%' or scan_type like '%T006T9IX4%';
+
+(EXPR)              
+--------------------
+
+                   1
+
+--- 1 row(s) selected.
+>>execute s;
+
+--- 0 row(s) deleted.
+>>
+>>prepare s from
++>merge into t006t5
++>  using (select * from t006t9 <<+index SCH.t006t9ix3 | cardinality 1e7>>) as src
++>  on t006t5.a = src.a
++>when matched
++>  then update set b='abc'
++>when not matched
++>  then insert values (src.a, 'cde', date '2000-01-01');
+
+--- SQL command prepared.
+>>execute expl;
+
+OPERATOR                        CARDINALITY      SCAN_TYPE
+------------------------------  ---------------  ----------------------------------------------------------------------------------------------------
+
+TRAFODION_INDEX_SCAN             1.0000000E+007  scan_type: subset scan of index TRAFODION.SCH.T006T9IX3(TRAFODION.SCH.T006T9)                       
+
+--- 1 row(s) selected.
+>>execute s;
+
+--- 2 row(s) updated.
+>>
+>>-- negative tests
+>>prepare s from
++>select * from t006t9 <<+ index nosuchindex>> where b > 10;
+
+*** WARNING[4371] Only 0 of the 1 indexes in the hint match actual indexes of the table TRAFODION.SCH.T006T9.
+
+--- SQL command prepared.
+>>execute s;
+
+A            B            C          
+-----------  -----------  -----------
+
+         10           20            5
+
+--- 1 row(s) selected.
+>>
+>>cqd index_hint_warnings 'off';
+
+--- SQL operation complete.
+>>prepare s from
++>select * from t006t9 <<+ index nosuchindex>> where b > 10;
+
+--- SQL command prepared.
+>>execute s;
+
+A            B            C          
+-----------  -----------  -----------
+
+         10           20            5
 
 --- 1 row(s) selected.
 >>log;

--- a/core/sql/regress/compGeneral/EXPECTEDTOK2
+++ b/core/sql/regress/compGeneral/EXPECTEDTOK2
@@ -1,16 +1,16 @@
-sqlparser.y: warning: 73 shift/reduce conflicts [-Wconflicts-sr]
+sqlparser.y: warning: 72 shift/reduce conflicts [-Wconflicts-sr]
 sqlparser.y: warning: 12 reduce/reduce conflicts [-Wconflicts-rr]
  
 nnnn conflicts: 1 shift/reduce nnnn olap_sequence_function: set_function_specification . TOK_OVER '(' opt_olap_part_clause opt_olap_order_clause ')'
 nnnn conflicts: 1 shift/reduce nnnn value_expression: value_expression_sans_collate . collation_option
 nnnn conflicts: 8 shift/reduce nnnn primary: row_subquery .
 nnnn conflicts: 1 shift/reduce nnnn sql_statement: TOK_BEGIN . TOK_DECLARE TOK_SECTION
-nnnn conflicts: 1 shift/reduce nnnn update_statement_searched: TOK_UPDATE . update_statement_searched_body
 nnnn conflicts: 9 shift/reduce nnnn row_subquery: '(' row_subquery . ')'
 nnnn conflicts: 1 reduce/reduce nnnn row_subquery: rel_subquery .
 nnnn conflicts: 1 reduce/reduce nnnn transaction_statement: TOK_BEGIN .
 nnnn conflicts: 1 shift/reduce nnnn show_statement: TOK_SHOWCONTROL showcontrol_type . optional_control_identifier optional_comma_match_clause
 nnnn conflicts: 1 shift/reduce nnnn extended_label_name: TOK_INDEX . label_name
+nnnn conflicts: 1 shift/reduce nnnn table_as_stream_any: table_as_stream .
 nnnn conflicts: 1 shift/reduce nnnn row_subquery: '(' row_subquery . ')'
 nnnn conflicts: 1 shift/reduce nnnn input_hostvar_expression: HOSTVAR .
 nnnn conflicts: 1 reduce/reduce nnnn primary: row_subquery .
@@ -20,7 +20,6 @@ nnnn conflicts: 1 shift/reduce nnnn primary: row_subquery .
 nnnn conflicts: 1 shift/reduce nnnn control_statement: TOK_CONTROL TOK_QUERY TOK_SHAPE . query_shape_options query_shape_control
 nnnn conflicts: 1 reduce/reduce nnnn procedure_or_function: TOK_PROCEDURES .
 nnnn conflicts: 1 reduce/reduce nnnn procedure_or_function: TOK_FUNCTIONS .
-nnnn conflicts: 1 shift/reduce nnnn table_as_stream_any: table_as_stream .
 nnnn conflicts: 1 shift/reduce nnnn drop_catalog_statement: TOK_DROP TOK_CATALOG . catalog_name extension_drop_behavior
 nnnn conflicts: 1 reduce/reduce nnnn procedure_or_function: TOK_TABLE_MAPPING TOK_FUNCTIONS .
 nnnn conflicts: 13 shift/reduce nnnn query_spec_body: query_select_list table_expression . access_type optional_lock_mode
@@ -35,7 +34,7 @@ nnnn conflicts: 1 shift/reduce nnnn query_spec_body: query_select_list table_exp
 nnnn conflicts: 1 shift/reduce nnnn mv_definition: create_mv_keywords ddl_qualified_name optional_view_column_list refresh_type . create_mv_attribute_table_lists mv_initialization_clause optional_query_rewrite optional_create_mv_file_options optional_in_memory_clause as_token query_expression
 nnnn conflicts: 1 shift/reduce nnnn table_name_and_hint: table_name . optimizer_hint hbase_access_options
 nnnn conflicts: 1 shift/reduce nnnn table_reference: table_as_procedure .
-nnnn conflicts: 1 shift/reduce nnnn table_reference: table_as_stream_any . optimizer_hint
+nnnn conflicts: 1 shift/reduce nnnn table_reference: table_as_stream_any .
 nnnn conflicts: 1 shift/reduce nnnn table_reference: table_as_tmudf_function .
 nnnn conflicts: 1 shift/reduce nnnn table_reference: rel_subquery .
 nnnn conflicts: 1 shift/reduce nnnn query_spec_body: query_select_list into_clause table_expression access_type . optional_lock_mode

--- a/core/sql/regress/compGeneral/TEST006
+++ b/core/sql/regress/compGeneral/TEST006
@@ -36,6 +36,7 @@ obey TEST006(defaults_tests);
 obey TEST006(misc_tests);
 obey TEST006(mode_special_tests);
 obey TEST006(olap_functions);
+obey TEST006(optimizer_hints);
 log;
 obey TEST006(clean_up);
 
@@ -51,6 +52,7 @@ drop table t006t5;
 drop table t006t6;
 drop table t006t7;
 drop table t006t8;
+drop table t006t9;
 drop schema $$TEST_CATALOG$$.TEST_PUBLIC_SCHEMA cascade;
 -- used for large scrope rules tests
 drop table x1 cascade;
@@ -86,6 +88,13 @@ create view t006t1_v as select a from t006t1;
 create table t006t7 (a float);
 
 create table t006t8 (a time);
+
+-- used for index hints
+create table t006t9 (a int not null primary key, b int, c int) salt using 2 partitions ;
+create index t006t9ix1 on t006t9(b) ;
+create index t006t9ix2 on t006t9(c) ;
+create index t006t9ix3 on t006t9(b) salt like table;
+create index t006t9ix4 on t006t9(c) salt like table;
 
 -- used for large scope rules
 create table x1 (a int not null, b int not null primary key);
@@ -794,3 +803,109 @@ select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678'
 select converttohex(aes_encrypt('abcdedfhijklmnopqrstuvwxyz', '1234567812345678', '1234567812345678')) from dual;
 select aes_decrypt(X'6A0D74250CB7E54F4690801A7AD9CDB053213B2F461EA174E128', '1234567812345678') from dual;
 select aes_decrypt(X'6A0D74250CB7E54F4690801A7AD9CDB053213B2F461EA174E128', '1234567812345678', '1234567812345678') from dual;
+
+?section optimizer_hints
+
+insert into t006t9 values (1,2,3), (10,20,30);
+prepare expl from
+select operator, cardinality,
+       cast(substring(description, position('scan_type: ' in description), position('object_type: ' in description) - position('scan_type: ' in description)) as char(100)) scan_type
+from table(explain(null, 'S'))
+where operator like '%SCAN%';
+
+prepare s from
+select * from t006t9 <<+ index TRAFODION.SCH.T006T9IX1>> where b > 10;
+execute expl;
+execute s;
+
+prepare s from
+select * from t006t9 <<+ index t006t9ix3>> where b > 10;
+execute expl;
+execute s;
+
+prepare s from
+select * from t006t9 <<+ index t006t9>> where b > 10;
+execute expl;
+execute s;
+
+prepare s from
+select a,b from t006t9 <<+ index TRAFODION.SCH.T006T9IX1>> where b > 10;
+execute expl;
+execute s;
+
+prepare s from
+select a,b from t006t9 <<+ index TRAFODION.SCH.T006T9IX3 | cardinality 2000.0>> where b > 10;
+execute expl;
+execute s;
+
+prepare s from
+update t006t9 <<+ index TRAFODION.SCH.T006T9IX1>> set c = 5 where b > 10;
+execute expl;
+execute s;
+
+prepare s from
+update t006t9 <<+ cardinality 2e4 | index sch.T006T9IX1>> as x set c = 5 where b = 10;
+execute expl;
+execute s;
+
+prepare s from
+update t006t9 <<+ index TRAFODION.SCH.T006T9IX3 | cardinality 1e7>> set c = 5 where b > 10;
+execute expl;
+execute s;
+
+prepare s from
+update t006t9 <<+ index TRAFODION.SCH.T006T9IX3>> set c = 5 where b = 10;
+execute expl;
+execute s;
+
+prepare s from
+delete from t006t9 <<+ index TRAFODION.SCH.T006T9IX2>> where c > 10;
+execute expl;
+execute s;
+
+prepare s from
+delete from t006t9 <<+ index TRAFODION.SCH.T006T9IX2 | selectivity 0.03 >> where c = 10;
+execute expl;
+execute s;
+
+prepare s from
+delete from t006t9 <<+ index TRAFODION.SCH.T006T9IX4>> where c > 10;
+execute expl;
+execute s;
+
+prepare s from
+delete [first 10] from t006t9 <<+ index TRAFODION.SCH.T006T9IX4>> where c = 10;
+execute expl;
+execute s;
+
+prepare s from
+delete from t006t9 <<+ index t006t9ix2, t006t9ix4>> where c > 10;
+-- this can pick either index
+with expl as
+(select operator, cardinality,
+        cast(substring(description, position('scan_type: ' in description), position('object_type: ' in description) - position('scan_type: ' in description)) as char(100)) scan_type
+ from table(explain(null, 'S'))
+ where operator like '%SCAN%')
+select count(*) from expl where scan_type like '%T006T9IX2%' or scan_type like '%T006T9IX4%';
+execute s;
+
+prepare s from
+merge into t006t5
+  using (select * from t006t9 <<+index SCH.t006t9ix3 | cardinality 1e7>>) as src
+  on t006t5.a = src.a
+when matched
+  then update set b='abc'
+when not matched
+  then insert values (src.a, 'cde', date '2000-01-01');
+execute expl;
+execute s;
+
+-- negative tests
+prepare s from
+select * from t006t9 <<+ index nosuchindex>> where b > 10;
+execute s;
+
+cqd index_hint_warnings 'off';
+prepare s from
+select * from t006t9 <<+ index nosuchindex>> where b > 10;
+execute s;

--- a/core/sql/regress/executor/EXPECTED063
+++ b/core/sql/regress/executor/EXPECTED063
@@ -10185,7 +10185,7 @@ M           23000                    10
 >>set param ?p 2;
 >>select rank(annualsalary + ?p) from tdemployee;
 
-*** ERROR[4369] Paramaters and outer references are not supported with rank function.
+*** ERROR[4369] Parameters and outer references are not supported with rank function.
 
 *** ERROR[8822] The statement was not prepared.
 
@@ -10194,7 +10194,7 @@ M           23000                    10
 >>select num,( select rank(o.num) from tdemployee i where i.num=1)
 +>from tdemployee o;
 
-*** ERROR[4369] Paramaters and outer references are not supported with rank function.
+*** ERROR[4369] Parameters and outer references are not supported with rank function.
 
 *** ERROR[8822] The statement was not prepared.
 

--- a/core/sql/sqlcomp/DefaultConstants.h
+++ b/core/sql/sqlcomp/DefaultConstants.h
@@ -3900,6 +3900,7 @@ enum DefaultConstants
 
   TRANSLATE_ERROR,
   TRANSLATE_ERROR_UNICODE_TO_UNICODE,
+  INDEX_HINT_WARNINGS,
 
   // This enum constant must be the LAST one in the list; it's a count,
   // not an Attribute (it's not IN DefaultDefaults; it's the SIZE of it)!

--- a/core/sql/sqlcomp/nadefaults.cpp
+++ b/core/sql/sqlcomp/nadefaults.cpp
@@ -2020,6 +2020,7 @@ SDDkwd__(EXE_DIAGNOSTIC_EVENTS,		"OFF"),
   DDkwd__(INCORPORATE_SKEW_IN_COSTING,		  "ON"),
   DDkwd__(INDEX_ELIMINATION_LEVEL,              "AGGRESSIVE"),
   DDui1__(INDEX_ELIMINATION_THRESHOLD,          "50"),
+  DDkwd__(INDEX_HINT_WARNINGS,                  "ON"),
  SDDkwd__(INFER_CHARSET,			"OFF"),
 
   // UDF initial row cost CQDs


### PR DESCRIPTION
Allowing hints in update and delete statements - they apply to the
scan of the table. Also making sure that heuristics to eliminate
indexes don't apply to indexes listed in a hint. Excluding the right
child of an index join when giving priority to plans that satisfy the
hint. Otherwise, an index join (index - base table) could be chosen
when the hint lists the base table.

Also removed some unused interfaces:
- no_log option in grammar, since it made changing the update syntax harder.
  If we decide to implement incremental MVs in the future, we should use
  a better parser or a different syntax for the no log feature.
- Some obsolete parser rules.
- Another set of hints in the scan node, in addition to those in the RelExpr.