### PR TITLE
[TRAFODION-2588] monitor failed to start if part of zookeeper server is down

### DIFF
--- a/core/sqf/monitor/linux/zclient.cxx
+++ b/core/sqf/monitor/linux/zclient.cxx
@@ -53,6 +53,9 @@
 // The monitors register their znodes under the cluster znode
 #define ZCLIENT_CLUSTER_ZNODE               "/cluster"
 
+// zookeeper connection retry count
+#define ZOOKEEPER_RETRY_COUNT                3
+
 using namespace std;
 
 extern char Node_name[MPI_MAX_PROCESSOR_NAME];
@@ -748,8 +751,16 @@ int CZClient::InitializeZClient( void )
     TRACE_ENTRY;
 
     int rc;
+    int retries = 0;
 
     rc = MakeClusterZNodes();
+
+    while ( rc != ZOK and retries < ZOOKEEPER_RETRY_COUNT)
+    {
+        retries++;
+        rc = MakeClusterZNodes();
+    }
+
     if ( rc == ZOK )
     {
         rc = RegisterMyNodeZNode();


### PR DESCRIPTION
retry 3 times when connecting to zookeeper.

@narendragoyal @zcorrea please review.