### PR TITLE
[TRAFODION-2602] Update Trafodion web site with new 2.1.0 release

### DIFF
--- a/docs/src/site/markdown/documentation.md
+++ b/docs/src/site/markdown/documentation.md
@@ -24,7 +24,7 @@ Trafodion Code Examples                               | [wiki](https://cwiki.apa
 Trafodion Command Interface Guide                     | [Web Book](docs/command_interface/index.html),  [PDF](docs/command_interface/Trafodion_Command_Interface_Guide.pdf)
 Trafodion Control Query Default (CQD) Reference Guide | [Web Book](docs/cqd_reference/index.html),      [PDF](docs/cqd_interface/Trafodion_CQD_Reference_Guide.pdf)
 Trafodion Database Connectivity Services Guide        | [Web Book](docs/dcs_reference/index.html),      [API](docs/dcs_reference/apidocs/index.html)
-Trafodion JDBC Type 4 Programmer Reference Guide      | [Web Book](docs/jdbct4ref_guide/index.html),     [PDF](docs/jdbct4ref_guide/Trafodion_JDBCT4_Reference_Guide.pdf)
+Trafodion JDBC Type 4 Programmer Reference Guide      | [Web Book](docs/jdbct4ref_guide/index.html),    [PDF](docs/jdbct4ref_guide/Trafodion_JDBCT4_Reference_Guide.pdf)
 Trafodion Load and Transform Guide                    | [Web Book](docs/load_transform/index.html),     [PDF](docs/load_transform/Trafodion_Load_Transform_Guide.pdf)
 Trafodion Messages Guide                              | [Web Book](docs/messages_guide/index.html),     [PDF](docs/messages_guide/Trafodion_Messages_Guide.pdf)
 Trafodion Manageability                               | [wiki](https://cwiki.apache.org/confluence/display/TRAFODION/Trafodion+Manageability)
@@ -33,6 +33,27 @@ Trafodion Provisioning Guide                          | [Web Book](docs/provisio
 Trafodion REST Server Reference Guide                 | [Web Book](docs/rest_reference/index.html),     [API](docs/rest_reference/apidocs/index.html)
 Trafodion SQL Reference Manual                        | [Web Book](docs/sql_reference/index.html),      [PDF](docs/sql_reference/Trafodion_SQL_Reference_Manual.pdf)
 Trafodion Stored Procedures in Java (SPJ) Guide       | [Web Book](docs/spj_guide/index.html),          [PDF](docs/spj_guide/Trafodion_SPJ_Guide.pdf)
+UDF Tutorial                                          | [wiki](https://cwiki.apache.org/confluence/display/TRAFODION/Tutorial%3A+The+object-oriented+UDF+interface)
+
+## 2.1.0 Release
+
+Document                                              | Formats
+------------------------------------------------------|-----------------------------------
+Scalar UDFs in C                                      | [wiki](https://cwiki.apache.org/confluence/display/TRAFODION/Scalar+UDFs+-+In+C)
+Trafodion Client Installation Guide                   | [Web Book](docs/2.1.0/client_install/index.html),     [PDF](docs/2.1.0/client_install/Trafodion_Client_Installation_Guide.pdf)
+Trafodion Code Examples                               | [wiki](https://cwiki.apache.org/confluence/display/TRAFODION/Trafodion+Code+Examples)
+Trafodion Command Interface Guide                     | [Web Book](docs/2.1.0/command_interface/index.html),  [PDF](docs/2.1.0/command_interface/Trafodion_Command_Interface_Guide.pdf)
+Trafodion Control Query Default (CQD) Reference Guide | [Web Book](docs/2.1.0/cqd_reference/index.html),      [PDF](docs/2.1.0/cqd_interface/Trafodion_CQD_Reference_Guide.pdf)
+Trafodion Database Connectivity Services Guide        | [Web Book](docs/2.1.0/dcs_reference/index.html),      [API](docs/2.1.0/dcs_reference/apidocs/2.1.0/index.html)
+Trafodion JDBC Type 4 Programmer Reference Guide      | [Web Book](docs/2.1.0/jdbct4ref_guide/index.html),     [PDF](docs/2.1.0/jdbct4ref_guide/Trafodion_JDBCT4_Reference_Guide.pdf)
+Trafodion Load and Transform Guide                    | [Web Book](docs/2.1.0/load_transform/index.html),     [PDF](docs/2.1.0/load_transform/Trafodion_Load_Transform_Guide.pdf)
+Trafodion Messages Guide                              | [Web Book](docs/2.1.0/messages_guide/index.html),     [PDF](docs/2.1.0/messages_guide/Trafodion_Messages_Guide.pdf)
+Trafodion Manageability                               | [wiki](https://cwiki.apache.org/confluence/display/TRAFODION/Trafodion+Manageability)
+Trafodion odb User Guide                              | [Web Book](docs/2.1.0/odb/index.html),                [PDF](docs/2.1.0/odb/Trafodion_odb_User_Guide.pdf)
+Trafodion Provisioning Guide                          | [Web Book](docs/2.1.0/provisioning_guide/index.html), [PDF](docs/2.1.0/provisioning_guide/Trafodion_Provisioning_Guide.pdf)
+Trafodion REST Server Reference Guide                 | [Web Book](docs/2.1.0/rest_reference/index.html),     [API](docs/2.1.0/rest_reference/apidocs/2.1.0/index.html)
+Trafodion SQL Reference Manual                        | [Web Book](docs/2.1.0/sql_reference/index.html),      [PDF](docs/2.1.0/sql_reference/Trafodion_SQL_Reference_Manual.pdf)
+Trafodion Stored Procedures in Java (SPJ) Guide       | [Web Book](docs/2.1.0/spj_guide/index.html),          [PDF](docs/2.1.0/spj_guide/Trafodion_SPJ_Guide.pdf)
 UDF Tutorial                                          | [wiki](https://cwiki.apache.org/confluence/display/TRAFODION/Tutorial%3A+The+object-oriented+UDF+interface)
 
 ## 2.0.x Releases

--- a/docs/src/site/markdown/documentation.md
+++ b/docs/src/site/markdown/documentation.md
@@ -45,7 +45,7 @@ Trafodion Code Examples                               | [wiki](https://cwiki.apa
 Trafodion Command Interface Guide                     | [Web Book](docs/2.1.0/command_interface/index.html),  [PDF](docs/2.1.0/command_interface/Trafodion_Command_Interface_Guide.pdf)
 Trafodion Control Query Default (CQD) Reference Guide | [Web Book](docs/2.1.0/cqd_reference/index.html),      [PDF](docs/2.1.0/cqd_interface/Trafodion_CQD_Reference_Guide.pdf)
 Trafodion Database Connectivity Services Guide        | [Web Book](docs/2.1.0/dcs_reference/index.html),      [API](docs/2.1.0/dcs_reference/apidocs/2.1.0/index.html)
-Trafodion JDBC Type 4 Programmer Reference Guide      | [Web Book](docs/2.1.0/jdbct4ref_guide/index.html),     [PDF](docs/2.1.0/jdbct4ref_guide/Trafodion_JDBCT4_Reference_Guide.pdf)
+Trafodion JDBC Type 4 Programmer Reference Guide      | [Web Book](docs/2.1.0/jdbct4ref_guide/index.html),    [PDF](docs/2.1.0/jdbct4ref_guide/Trafodion_JDBCT4_Reference_Guide.pdf)
 Trafodion Load and Transform Guide                    | [Web Book](docs/2.1.0/load_transform/index.html),     [PDF](docs/2.1.0/load_transform/Trafodion_Load_Transform_Guide.pdf)
 Trafodion Messages Guide                              | [Web Book](docs/2.1.0/messages_guide/index.html),     [PDF](docs/2.1.0/messages_guide/Trafodion_Messages_Guide.pdf)
 Trafodion Manageability                               | [wiki](https://cwiki.apache.org/confluence/display/TRAFODION/Trafodion+Manageability)

--- a/docs/src/site/markdown/download.md
+++ b/docs/src/site/markdown/download.md
@@ -24,7 +24,49 @@ To build Trafodion from source code, see the [Trafodion Contributor Guide](https
 
 # Download
 
-## 2.0.1
+## 2.1.0 (May 2017)
+
+* [Release Notes](release-notes-2-1-0.html)
+* [Source Code Release][src210]  -  [PGP][pgp210] [MD5][md5210] [SHA1][sha210]
+* Convenience Binaries
+    * [bash Installer][ins210]  -  [PGP][inpgp210] [MD5][inmd5210] [SHA1][insha210]
+    * [Python Installer][pins210]  -  [PGP][pinpgp210] [MD5][pinmd5210] [SHA1][pinsha210]
+    * [Server][ser210]  -  [PGP][sepgp210] [MD5][semd5210] [SHA1][sesha210]
+    * [Clients][cl210]  -  [PGP][clpgp210] [MD5][clmd5210] [SHA1][clsha210]
+    * [Ambari RPMs][ar210]  -  [PGP][arpgp210] [MD5][armd5210] [SHA1][arsha210]
+    * [Ambari Plugin][ap210]  -  [PGP][appgp210] [MD5][apmd5210] [SHA1][apsha210]
+* [Documentation](documentation.html#210_Release)
+
+[src210]: http://www.apache.org/dyn/closer.lua/incubator/trafodion/apache-trafodion-2.1.0-incubating/apache-trafodion-2.1.0-incubating-src.tar.gz
+[pgp210]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.1.0-incubating/src/apache-trafodion-2.1.0-incubating-src.tar.gz.asc
+[md5210]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.1.0-incubating/src/apache-trafodion-2.1.0-incubating-src.tar.gz.md5
+[sha210]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.1.0-incubating/src/apache-trafodion-2.1.0-incubating-src.tar.gz.sha
+[ins210]: http://www.apache.org/dyn/closer.lua/incubator/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_installer-2.1.0-incubating.tar.gz
+[inpgp210]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_installer-2.1.0-incubating.tar.gz.asc
+[inmd5210]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_installer-2.1.0-incubating.tar.gz.md5
+[insha210]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_installer-2.1.0-incubating.tar.gz.sha
+[pins210]: http://www.apache.org/dyn/closer.lua/incubator/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_pyinstaller-2.1.0-incubating.tar.gz
+[pinpgp210]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_pyinstaller-2.1.0-incubating.tar.gz.asc
+[pinmd5210]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_pyinstaller-2.1.0-incubating.tar.gz.md5
+[pinsha210]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_pyinstaller-2.1.0-incubating.tar.gz.sha
+[ser210]: http://www.apache.org/dyn/closer.lua/incubator/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_server-2.1.0-RH6-x86_64-incubating.tar.gz
+[sepgp210]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_server-2.1.0-RH6-x86_64-incubating.tar.gz.asc
+[semd5210]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_server-2.1.0-RH6-x86_64-incubating.tar.gz.md5
+[sesha210]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_server-2.1.0-RH6-x86_64-incubating.tar.gz.sha
+[cl210]: http://www.apache.org/dyn/closer.lua/incubator/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_clients-2.1.0-RH6-x86_64-incubating.tar.gz
+[clpgp210]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_clients-2.1.0-RH6-x86_64-incubating.tar.gz.asc
+[clmd5210]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_clients-2.1.0-RH6-x86_64-incubating.tar.gz.md5
+[clsha210]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.1.0-incubating/bin/apache-trafodion_clients-2.1.0-RH6-x86_64-incubating.tar.gz.sha
+[ar210]: http://www.apache.org/dyn/closer.lua/incubator/trafodion/apache-trafodion-2.1.0-incubating/bin/traf_ambari_rpms/apache-trafodion_server-2.1.0-1.x86_64.rpm
+[arpgp210]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.1.0-incubating/bin/traf_ambari_rpms/apache-trafodion_server-2.1.0-1.x86_64.rpm.asc
+[armd5210]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.1.0-incubating/bin/traf_ambari_rpms/apache-trafodion_server-2.1.0-1.x86_64.rpm.md5
+[arsha210]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.1.0-incubating/bin/traf_ambari_rpms/apache-trafodion_server-2.1.0-1.x86_64.rpm.sha
+[ap210]: http://www.apache.org/dyn/closer.lua/incubator/trafodion/apache-trafodion-2.1.0-incubating/bin/traf_ambari_rpms/traf_ambari-2.1.0-1.noarch.rpm
+[appgp210]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.1.0-incubating/bin/traf_ambari_rpms/traf_ambari-2.1.0-1.noarch.rpm.asc
+[apmd5210]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.1.0-incubating/bin/traf_ambari_rpms/traf_ambari-2.1.0-1.noarch.rpm.md5
+[apsha210]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.1.0-incubating/bin/traf_ambari_rpms/traf_ambari-2.1.0-1.noarch.rpm.sha
+
+## 2.0.1 (June 2016)
 
 * [Release Notes](release-notes-2-0-1.html)
 * [Source Code Release][src201]  -  [PGP][pgp201] [MD5][md5201] [SHA1][sha201]
@@ -51,7 +93,7 @@ To build Trafodion from source code, see the [Trafodion Contributor Guide](https
 [clmd5201]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.0.1-incubating/apache-trafodion_clients-2.0.1-incubating.tar.gz.md5
 [clsha201]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.0.1-incubating/apache-trafodion_clients-2.0.1-incubating.tar.gz.sha
 
-## 2.0.0
+## 2.0.0 (June 2016)
 
 * [Release Notes](release-notes-2-0-0.html)
 * [Source Code Release][src200]  -  [PGP][pgp200] [MD5][md5200] [SHA1][sha200]
@@ -74,7 +116,7 @@ To build Trafodion from source code, see the [Trafodion Contributor Guide](https
 [semd5200]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion_server-2.0.0-incubating.tar.gz.md5
 [sesha200]: http://www.apache.org/dist/incubator/trafodion/apache-trafodion-2.0.0-incubating/apache-trafodion_server-2.0.0-incubating.tar.gz.sha
 
-## 1.3.0
+## 1.3.0 (January 2016)
 
 * [Release Notes](release-notes-1-3-0.html)
 * [Source Code Release](http://www.apache.org/dyn/closer.lua/incubator/trafodion/apache-trafodion-1.3.0-incubating/apache-trafodion-1.3.0-incubating-src.tar.gz) -  [PGP](https://www.apache.org/dist/incubator/trafodion/trafodion-1.3.0-incubating/apache-trafodion-1.3.0-incubating-src.tar.gz.asc) [MD5](http://www.apache.org/dist/incubator/trafodion/apache-trafodion-1.3.0-incubating/apache-trafodion-1.3.0-incubating-src.tar.gz.md5) [SHA1](http://www.apache.org/dist/incubator/trafodion/apache-trafodion-1.3.0-incubating/apache-trafodion-1.3.0-incubating-src.tar.gz.sha)

--- a/docs/src/site/markdown/index.md
+++ b/docs/src/site/markdown/index.md
@@ -42,8 +42,10 @@ Trafodion provides SQL access to structured, semi-structured, and unstructured d
 
 
 <table><tr><td>
-  <p><h5>We're working on release 2.1!</h5></p> 
+  <p><h5>We're working on release 2.2!</h5></p> 
   <p>Check out the <a href="https://cwiki.apache.org/confluence/display/TRAFODION/Roadmap">Roadmap</a> page for planned content.</p>
+  <p><h5>Apache Trafodion 2.1.0-incubating was released on May 1, 2017</h5></p> 
+  <p>Check it out on the <a href="http://trafodion.incubator.apache.org/download.html">Download</a> page.</p>
   <p><h5>Want to disucss Trafodion in Chinese? Join the Trafodion discussion on Tencent QQ!</h5></p> 
   <p><a href="http://im.qq.com/">QQ</a> Group ID: 176011868.</p>
 </td></tr></table>

--- a/docs/src/site/markdown/release-notes-2-1-0.md
+++ b/docs/src/site/markdown/release-notes-2-1-0.md
@@ -1,0 +1,164 @@
+<!--
+  Licensed under the Apache License, Version 2.0 (the "License");
+  you may not use this file except in compliance with the License.
+  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+  Unless required by applicable law or agreed to in writing, software
+  distributed under the License is distributed on an "AS IS" BASIS,
+  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+  See the License for the specific language governing permissions and
+  limitations under the License.
+-->
+
+# 2.1.0-incubating Release Notes
+
+This is the third release of the Apache Trafodion (incubating) project.
+
+Build instructions are available in the [Trafodion Contributor Guide](https://cwiki.apache.org/confluence/display/TRAFODION/Create+Build+Environment).
+
+## New Features
+
+<span>
+  <table>
+    <tr>
+      <th>Feature</th>
+      <th>Jira ID</th>
+    </tr>
+    <tr>
+      <td>Hashing functions added to Trafodion</td>
+      <td>[TRAFODION-2229](https://issues.apache.org/jira/browse/TRAFODION-2229)</td>
+    </tr>
+    <tr>
+      <td>Support for Hbase1.1 and CDH5.5-5.7</td>
+      <td>[TRAFODION-2016](https://issues.apache.org/jira/browse/TRAFODION-2016)</td>
+    </tr>
+    <tr>
+      <td>Better java exception handling in the java layer of Trafodion</td>
+      <td>[TRAFODION-1988](https://issues.apache.org/jira/browse/TRAFODION-1988)</td>
+    </tr>
+    <tr>
+      <td>TopN Sort operator</td>
+      <td>[TRAFODION-2259](https://issues.apache.org/jira/browse/TRAFODION-2259)</td>
+    </tr>
+    <tr>
+      <td>Runtime statistics enhancements</td>
+      <td>[TRAFODION-2420](https://issues.apache.org/jira/browse/TRAFODION-2420)</td>
+    </tr>
+    <tr>
+      <td>RegExp operator support</td>
+      <td>[TRAFODION-2353](https://issues.apache.org/jira/browse/TRAFODION-2353)</td>
+    </tr>
+    <tr>
+      <td>Support for LAG and LEAD OLAP functions</td>
+      <td>[TRAFODION-2214](https://issues.apache.org/jira/browse/TRAFODION-2214)</td>
+    </tr>
+    <tr>
+      <td>Bulk load enhancements to log errors</td>
+      <td>[TRAFODION-2351](https://issues.apache.org/jira/browse/TRAFODION-2351)</td>
+    </tr>
+    <tr>
+      <td>ODB tool support for Windows</td>
+      <td>[TRAFODION-1931](https://issues.apache.org/jira/browse/TRAFODION-1931)</td>
+    </tr>
+    <tr>
+      <td>Support for GROUP BY ROLLUP feature</td>
+      <td>[TRAFODION-2246](https://issues.apache.org/jira/browse/TRAFODION-2246)</td>
+    </tr>
+    <tr>
+      <td>Support ORDER BY clause in GROUP_CONCAT</td>
+      <td>[TRAFODION-2270](https://issues.apache.org/jira/browse/TRAFODION-2270)</td>
+    </tr>
+    <tr>
+      <td>Support for boolean datatype</td>
+      <td>[TRAFODION-2099](https://issues.apache.org/jira/browse/TRAFODION-2099)</td>
+    </tr>
+    <tr>
+      <td>Added encryption functions for Trafodion</td>
+      <td>[TRAFODION-2228](https://issues.apache.org/jira/browse/TRAFODION-2228)</td>
+    </tr>
+    <tr>
+      <td>Support of SQL extension 'EXCEPT'</td>
+      <td>[TRAFODION-2117](https://issues.apache.org/jira/browse/TRAFODION-2117)</td>
+    </tr>
+    <tr>
+      <td>Support for tinyint,largeint,unsinged datatype in SQL</td>
+      <td>[TRAFODION-2086](https://issues.apache.org/jira/browse/TRAFODION-2086)</td>
+    </tr>
+    <tr>
+      <td>SQL syntax to support INTERSECT</td>
+      <td>[TRAFODION-2047](https://issues.apache.org/jira/browse/TRAFODION-2047)</td>
+    </tr>
+    <tr>
+      <td>Enable support for various non-ansi sql syntax/functionality</td>
+      <td>[TRAFODION-2180](https://issues.apache.org/jira/browse/TRAFODION-2180)</td>
+    </tr>
+    <tr>
+      <td>Use of CQD to set scratch directory locations</td>
+      <td>[TRAFODION2146](https://issues.apache.org/jira/browse/TRAFODION2146)</td>
+    </tr>
+  </table>
+</span>
+
+## Improvements
+
+<span>
+  <table>
+    <tr>
+      <th>Feature</th>
+      <th>Jira ID</th>
+    </tr>
+    <tr>
+      <td>Improve query compilation time</td>
+      <td>[TRAFODION-2137](https://issues.apache.org/jira/browse/TRAFODION-2137)</td>
+    </tr>
+    <tr>
+      <td>Improve upsert performance for table with indexes</td>
+      <td>[TRAFODION-1546](https://issues.apache.org/jira/browse/TRAFODION-1546)</td>
+    </tr>
+    <tr>
+      <td>Improve concurrency during DDL operations</td>
+      <td>[TRAFODION-2037](https://issues.apache.org/jira/browse/TRAFODION-2037)</td>
+    </tr>
+  </table>
+</span>
+
+## Install and Configuration Changes
+
+* Ambari Integration ([TRAFODION-2291](https://issues.apache.org/jira/browse/TRAFODION-2291))<br/>
+Integration with Ambari cluster manager ambari interface/integration. The Ambari integration provides support for Hortonworks Hadoop distributions, while the command-line Trafodion Installer supports Cloudera and Hortonworks Hadoop distributions, and for select vanilla Hadoop installations.
+* Python Installer ([TRAFODION-1839](https://issues.apache.org/jira/browse/TRAFODION-1839))<br/>
+Trafodion Installer Evolution The command-line installer has been replaced for the 2.1.0 release. Written in python, it replaces the legacy bash-script installer. The bash command-line installer is deprecated as of 2.1.0, but is still provided, just in case you experience any problems with the new installer. If so, please report those problems to the project team, since the legacy installer will soon be obsoleted.
+* Trafodion Configuration File ([TRAFODION-2306](https://issues.apache.org/jira/browse/TRAFODION-2306))<br/>  
+Introducing a configuration file traf-site.xml specific to Trafodion similar to hbase configuration file hbase-site.xml.  This configuration file extends the properties inherited from the standard hbase-site.xml.
+* The environment variable MY_SQROOT has been renamed to TRAF_HOME.
+
+## Fixes
+
+This release contains fixes for 300+ JIRAs. Here is a [list of resolved JIRAs in Release 2.1](https://issues.apache.org/jira/issues/?jql=project%20%3D%20%22Apache%20Trafodion%22%20and%20fixVersion%20%3D%202.1-incubating%20order%20by%20updated%20desc).
+
+## Documentation Updates
+
+Several updates have been made to the SQL Reference Manual to reflect the new functions added in 2.1. Some have not been done but have JIRas outstading and will be completed by the next release. Provisioning Guide has been updated to reflect instructions for using hte new Ambari Installer or the python installation script. 
+
+## Supported Platforms
+
+<span>
+  <table>
+    <tr>
+      <td>**Operating Systems**</td>
+      <td>RedHat / CentOS 6.5 -- 6.8</td>
+    </tr>
+    <tr>
+      <td>**Hadoop Distributions**</td>
+      <td>Cloudera distributions CDH 5.4 -- 5.6<br/>
+          Hortonworks distributions HDP 2.3 -- 2.4<br/>
+          Apache Hadoop with Apache HBase 1.0 -- 1.1</td>
+     </tr>
+    <tr>
+      <td>**Java Version**</td>
+      <td>JDK 1.7.0_67 or newer</td>
+    </tr>
+  </table>
+</span>

--- a/docs/src/site/markdown/release-notes-2-1-0.md
+++ b/docs/src/site/markdown/release-notes-2-1-0.md
@@ -130,7 +130,7 @@ Build instructions are available in the [Trafodion Contributor Guide](https://cw
 Integration with Ambari cluster manager ambari interface/integration. The Ambari integration provides support for Hortonworks Hadoop distributions, while the command-line Trafodion Installer supports Cloudera and Hortonworks Hadoop distributions, and for select vanilla Hadoop installations.
 * Python Installer ([TRAFODION-1839](https://issues.apache.org/jira/browse/TRAFODION-1839))<br/>
 Trafodion Installer Evolution The command-line installer has been replaced for the 2.1.0 release. Written in python, it replaces the legacy bash-script installer. The bash command-line installer is deprecated as of 2.1.0, but is still provided, just in case you experience any problems with the new installer. If so, please report those problems to the project team, since the legacy installer will soon be obsoleted.
-* Trafodion Configuration File ([TRAFODION-2306](https://issues.apache.org/jira/browse/TRAFODION-2306))<br/>  
+* Trafodion Configuration File ([TRAFODION-2306](https://issues.apache.org/jira/browse/TRAFODION-2306))<br/>
 Introducing a configuration file traf-site.xml specific to Trafodion similar to hbase configuration file hbase-site.xml.  This configuration file extends the properties inherited from the standard hbase-site.xml.
 * The environment variable MY_SQROOT has been renamed to TRAF_HOME.
 

--- a/docs/src/site/markdown/release-notes-2-1-0.md
+++ b/docs/src/site/markdown/release-notes-2-1-0.md
@@ -129,7 +129,7 @@ Build instructions are available in the [Trafodion Contributor Guide](https://cw
 * Ambari Integration ([TRAFODION-2291](https://issues.apache.org/jira/browse/TRAFODION-2291))<br/>
 Integration with Ambari cluster manager ambari interface/integration. The Ambari integration provides support for Hortonworks Hadoop distributions, while the command-line Trafodion Installer supports Cloudera and Hortonworks Hadoop distributions, and for select vanilla Hadoop installations.
 * Python Installer ([TRAFODION-1839](https://issues.apache.org/jira/browse/TRAFODION-1839))<br/>
-Trafodion Installer Evolution The command-line installer has been replaced for the 2.1.0 release. Written in python, it replaces the legacy bash-script installer. The bash command-line installer is deprecated as of 2.1.0, but is still provided, just in case you experience any problems with the new installer. If so, please report those problems to the project team, since the legacy installer will soon be obsoleted.
+Trafodion Installer Evolution. The command-line installer has been replaced for the 2.1.0 release. Written in python, it replaces the legacy bash-script installer. The bash command-line installer is deprecated as of 2.1.0, but is still provided, just in case you experience any problems with the new installer. If so, please report those problems to the project team, since the legacy installer will soon be obsolete.
 * Trafodion Configuration File ([TRAFODION-2306](https://issues.apache.org/jira/browse/TRAFODION-2306))<br/>
 Introducing a configuration file traf-site.xml specific to Trafodion similar to hbase configuration file hbase-site.xml.  This configuration file extends the properties inherited from the standard hbase-site.xml.
 * The environment variable MY_SQROOT has been renamed to TRAF_HOME.
@@ -140,7 +140,7 @@ This release contains fixes for 300+ JIRAs. Here is a [list of resolved JIRAs in
 
 ## Documentation Updates
 
-Several updates have been made to the SQL Reference Manual to reflect the new functions added in 2.1. Some have not been done but have JIRas outstading and will be completed by the next release. Provisioning Guide has been updated to reflect instructions for using hte new Ambari Installer or the python installation script. 
+Several updates have been made to the SQL Reference Manual to reflect the new functions added in 2.1. Some functions have not been documented yet but have JIRAs outstading and will be completed by the next release. Provisioning Guide has been updated to reflect instructions for using hte new Ambari Installer or the python installation script. 
 
 ## Supported Platforms
 

--- a/docs/src/site/markdown/release-notes-2-1-0.md
+++ b/docs/src/site/markdown/release-notes-2-1-0.md
@@ -140,7 +140,7 @@ This release contains fixes for 300+ JIRAs. Here is a [list of resolved JIRAs in
 
 ## Documentation Updates
 
-Several updates have been made to the SQL Reference Manual to reflect the new functions added in 2.1. Some functions have not been documented yet but have JIRAs outstading and will be completed by the next release. Provisioning Guide has been updated to reflect instructions for using hte new Ambari Installer or the python installation script. 
+Several updates have been made to the SQL Reference Manual to reflect the new functions added in 2.1. Some functions have not been documented yet but have JIRAs outstanding and will be completed by the next release. Provisioning Guide has been updated to reflect instructions for using hte new Ambari Installer or the python installation script. 
 
 ## Supported Platforms
 

--- a/docs/src/site/markdown/release-notes.md
+++ b/docs/src/site/markdown/release-notes.md
@@ -16,6 +16,7 @@ The following releases have been created for Trafodion.
 
 Release                               | Description                                                           | Date
 --------------------------------------|-----------------------------------------------------------------------|--------------
+**[2.1.0](release-notes-2-1-0.html)** | Major feature enhancements.                                           | May 2017
 **[2.0.1](release-notes-2-0-1.html)** | Patch release. Client package added to convenience binaries.          | June 2016
 **[2.0.0](release-notes-2-0-0.html)** | Major feature enhancements.                                           | June 2016
 **[1.3.0](release-notes-1-3-0.html)** | First Apache (incubating) release.                                    | January 2016


### PR DESCRIPTION
* Added new section to download page. Note: Right now these artifacts are not yet available on the mirror site, hopefully they will show up soon. Steve told me this usually takes a day or two.
* Added new section for 2.1.0 on the documentation page. Note: The links will not work if you build the site yourself, but should work when deployed on the actual site, since the site already has the 2.1.0 manuals in a docs/2.1.0 directory.
* Transferred release notes from wiki https://cwiki.apache.org/confluence/display/TRAFODION/Release+2.1 to the web site. Once the site is up I'll remove the text from the wiki and replace it with a link.
* Minor changes to main site.