### PR TITLE
[TRAFODION-2294] Add known diffs file for executor/TEST140

### DIFF
--- a/core/sql/regress/executor/DIFF140.KNOWN
+++ b/core/sql/regress/executor/DIFF140.KNOWN
@@ -1,0 +1,4 @@
+442d441
+<  input_variables ........ %(200)
+642d640
+<  input_variables ........ %(201)


### PR DESCRIPTION
It turns out the fix for this JIRA has a flaw. Not caching a query plan actually changes the plan! This shows up in executor/TEST140. This pull request provides a DIFFs file for that test. A permanent fix will be done later via JIRA TRAFODION-2605.