### PR TITLE
[TRAFODION-2616] Nested join regression after fix for TRAFODION-2569

### DIFF
--- a/core/sql/optimizer/RelExpr.cpp
+++ b/core/sql/optimizer/RelExpr.cpp
@@ -8348,6 +8348,7 @@ void Scan::copyIndexInfo(RelExpr *derivedNode)
       indexOnlyIndexes_.insert(ixDescs[j]);
     }
   }
+  generatedCCPreds_ = scan->generatedCCPreds_;
 }
 
 void Scan::removeIndexInfo()
@@ -8355,6 +8356,7 @@ void Scan::removeIndexInfo()
 	possibleIndexJoins_.clear();
 	indexOnlyIndexes_.clear();
         indexJoinScans_.clear();
+        generatedCCPreds_.clear();
 	forcedIndexInfo_ = FALSE;
 }
 

--- a/core/sql/optimizer/TransRule.cpp
+++ b/core/sql/optimizer/TransRule.cpp
@@ -3494,15 +3494,13 @@ RelExpr * FilterRule0::nextSubstitute(RelExpr * before,
   // copy the tree underneath the filter
   result = getSubstitute()->copyTree(CmpCommon::statementHeap());
 
-  // if the original child of the filter is a scan, then also copy
-  // index information to prevent enumerating potential index joins again.
-  if ((leafNode->getOperatorType() == REL_SCAN))
-    ((Scan *)result)->copyIndexInfo(leafNode);
-
   // now set the group attributes of the result's top node
   result->setGroupAttr(before->getGroupAttr());
 
   result->selectionPred() += bef->selectionPred();
+
+  if ((leafNode->getOperatorType() == REL_SCAN))
+    ((Scan *)result)->addIndexInfo();
 
   return result;
 }

--- a/core/sql/udrserv/udrserv.cpp
+++ b/core/sql/udrserv/udrserv.cpp
@@ -2850,6 +2850,9 @@ Int32 PerformWaitedReplyToClient(UdrGlobals *UdrGlob,
 
   sendDataReply(UdrGlob, msgStream, NULL);
 
+  // cleanup no longer used buffers
+  msgStream.cleanupBuffers();
+
   //Note down the current sp so that we can restore it back
   //once ProcessARequest() call is complete. There are scenarios
   //in ProcessARequest to reset spInfo in udrGlobals once Spinfo


### PR DESCRIPTION
When pushing predicates into a scan node, it is not ok to copy the
index info of the original scan to the new scan node, since the
additional predicates may change the set of qualifying indexes.

Also, the method to copy the index info needs to copy the set of
computed predicates, since these are computed in the addIndexInfo()
method.

Also added a fix for TRAFODION-2625 to this PR. Sorry for combining these,
but it saves me a day in my workflow.