### PR TITLE
TRAFODION - 2632 Performing update statistics on metadata tables caus…

### DIFF
--- a/core/sql/sqlcomp/CmpSeabaseDDL.h
+++ b/core/sql/sqlcomp/CmpSeabaseDDL.h
@@ -168,9 +168,13 @@ class CmpSeabaseDDL
 			       const NAString &schName,
 			       const NAString &objName);
  
+  static ComBoolean isSeabaseMD(const ComObjectName &name);
+
   static NABoolean isSeabasePrivMgrMD(const NAString &catName,
 			              const NAString &schName);
  
+  static ComBoolean isSeabasePrivMgrMD(const ComObjectName &name);
+
   static NABoolean isUserUpdatableSeabaseMD(const NAString &catName,
 			       const NAString &schName,
 			       const NAString &objName);
@@ -465,10 +469,6 @@ protected:
   inline const char * getMDSchema() {return seabaseMDSchema_.data();};
 
   const char * getSystemCatalog();
-
-  ComBoolean isSeabaseMD(const ComObjectName &name);
-
-  ComBoolean isSeabasePrivMgrMD(const ComObjectName &name);
 
   ComBoolean isSeabaseReservedSchema(const ComObjectName &name);
 

--- a/core/sql/ustat/hs_globals.cpp
+++ b/core/sql/ustat/hs_globals.cpp
@@ -3776,7 +3776,7 @@ NABoolean HSGlobalsClass::isAuthorized(NABoolean isShowStats)
        if (privs == NULL)
          {
            *CmpCommon::diags() << DgSqlCode(-1034);
-            authorized = FALSE;
+            return FALSE;
          }
 
        // Requester must have at least select privilege
@@ -3788,7 +3788,7 @@ NABoolean HSGlobalsClass::isAuthorized(NABoolean isShowStats)
             << DgSqlCode( -4481 )
             << DgString0( "SELECT or MANAGE_STATISTICS" )
             << DgString1( objDef->getNATable()->getTableName().getQualifiedNameAsAnsiString() );
-            authorized = FALSE;
+            return FALSE;
           }
        }
 

--- a/core/sql/ustat/hs_globals.cpp
+++ b/core/sql/ustat/hs_globals.cpp
@@ -3776,11 +3776,11 @@ NABoolean HSGlobalsClass::isAuthorized(NABoolean isShowStats)
        if (privs == NULL)
          {
            *CmpCommon::diags() << DgSqlCode(-1034);
-            return FALSE;
+            authorized = FALSE;
          }
 
        // Requester must have at least select privilege
-       if ( privs->hasSelectPriv() )
+       else if ( privs->hasSelectPriv() )
          authorized = TRUE;
        else
          {
@@ -3788,7 +3788,7 @@ NABoolean HSGlobalsClass::isAuthorized(NABoolean isShowStats)
             << DgSqlCode( -4481 )
             << DgString0( "SELECT or MANAGE_STATISTICS" )
             << DgString1( objDef->getNATable()->getTableName().getQualifiedNameAsAnsiString() );
-            return FALSE;
+            authorized = FALSE;
           }
        }
 

--- a/core/sql/ustat/hs_globals.h
+++ b/core/sql/ustat/hs_globals.h
@@ -44,6 +44,7 @@
 #include "nawstring.h"
 #include "Collections.h"
 #include "ComVersionDefs.h" 	
+#include "ComSmallDefs.h"
 #include "NABitVector.h"
 #include <exp_function.h>
 
@@ -1457,15 +1458,10 @@ public:
       return (isNativeHbaseCat(catName) || isHiveCat(catName));
     }
 
-
-    static NABoolean isHBaseMeta(const NAString& schName)
-    { return (schName == "_MD_" || schName == "_PRIVMGR_MD_"); }
-
-    //static NABoolean isHBaseSchema(const NAString& schName)
-    //{ return (schName == "HBASE"); }
-
     static NABoolean isTrafodionCatalog(const NAString& catName)
-    { return (catName == "TRAFODION"); }
+    { 
+      return (catName == TRAFODION_SYSCAT_LIT); 
+    }
 
     static NABoolean isHBaseUMDHistogram(const NAString& tableName)
     { return (tableName == HBASE_HIST_NAME || 

--- a/core/sql/ustat/hs_util.cpp
+++ b/core/sql/ustat/hs_util.cpp
@@ -50,6 +50,7 @@
 #include "ComCextdecs.h"                        // NA_JulianTimestamp()
 #include "NAHeap.h"                             // For NADELETEARRAY.
 #include "CmpContext.h"
+#include "CmpSeabaseDDL.h"
 
 
 #include "ComSmallDefs.h"
@@ -99,9 +100,8 @@ NABoolean isHBaseUmdHistograms(const ComObjectName& objectName)
 NABoolean isHBaseMeta(const ComObjectName& objectName)
 {
     return
-    ( HSGlobalsClass::isHBaseMeta(
-               objectName.getSchemaNamePart().getInternalName()
-                                     ) ||
+    ( CmpSeabaseDDL::isSeabaseMD (objectName) || 
+      CmpSeabaseDDL::isSeabasePrivMgrMD(objectName) ||
       isHBaseUmdHistograms(objectName)
     );
 }
@@ -109,9 +109,7 @@ NABoolean isHBaseMeta(const ComObjectName& objectName)
 NABoolean isHBaseMeta(const QualifiedName& qualifiedName)
 {
     return
-    ( HSGlobalsClass::isHBaseMeta(
-           qualifiedName.getUnqualifiedSchemaNameAsAnsiString()
-                                 ) ||
+    ( qualifiedName.isSeabaseMD() || qualifiedName.isSeabasePrivMgrMD() ||
       isHBaseUmdHistograms(qualifiedName)
     );
 }


### PR DESCRIPTION
…es issues

Added code to return error and cleanup code a bit:
*** ERROR[9205] UPDATE STATISTICS is not supported for object <metadata table>

Also fixed a problem where privileges on Hive tables that included external
table gave false "no priv" error for the SHOWDDL <hive table> command.