### PR TITLE
[TRAFODION-2634] Change return type of FLOOR/CEIL to an integer type

### DIFF
--- a/core/sql/common/NumericType.cpp
+++ b/core/sql/common/NumericType.cpp
@@ -1905,6 +1905,7 @@ double SQLNumeric::getMinValue() const
 	    break;
 
 	    case sizeof(short):
+	    case sizeof(Int8):
 	    {
 	       short temp = 0;
 	       Lng32 i=0;
@@ -1969,6 +1970,7 @@ double SQLNumeric::getMaxValue() const
         break;
 
         case sizeof(short):
+        case sizeof(Int8):
         {
 	   short temp = 0;
 	   Lng32 i=0;

--- a/core/sql/exp/exp_conv.cpp
+++ b/core/sql/exp/exp_conv.cpp
@@ -2387,6 +2387,40 @@ ex_expr::exp_return_type convAsciiToDec(char *target,
 };
 
 ///////////////////////////////////////////////////////////////////
+// function to convert a DOUBLE to BIGNUM. 
+///////////////////////////////////////////////////////////////////
+NA_EIDPROC
+ex_expr::exp_return_type convDoubleToBigNum(char *target,
+                                            Lng32 targetLen,
+                                            Lng32 targetType,
+                                            Lng32 targetPrecision,
+                                            Lng32 targetScale,
+                                            double source,
+                                            CollHeap *heap,
+                                            ComDiagsArea** diagsArea)
+{
+  SimpleType sourceAttr(REC_FLOAT64, sizeof(double), 0, 0,
+                        ExpTupleDesc::SQLMX_FORMAT,
+                        8, 0, 0, 0, Attributes::NO_DEFAULT, 0);
+  char * opData[2];
+  opData[0] = target;
+  opData[1] = (char*)&source;
+  NABoolean isSigned = (targetType == REC_NUM_BIG_SIGNED);
+  BigNum bn(targetLen, targetPrecision, (short)targetScale, isSigned);
+  bn.setTempSpaceInfo(ITM_CAST, 0, targetLen);
+  if (bn.castFrom(&sourceAttr, opData, heap, diagsArea) != 0)
+    {
+      ExRaiseDetailSqlError(heap, diagsArea, EXE_NUMERIC_OVERFLOW, 
+                            (char*)&source,
+                            8, REC_FLOAT64, 0, targetType, 0 /* flags */);
+			      
+      return ex_expr::EXPR_ERROR; 
+    }
+
+  return ex_expr::EXPR_OK;
+}
+
+///////////////////////////////////////////////////////////////////
 // function to convert an ASCII string to BIGNUM. 
 // 
 // First convert from ASCII to LARGEDEC, then convert from LARGEDEC

--- a/core/sql/optimizer/ItemFunc.h
+++ b/core/sql/optimizer/ItemFunc.h
@@ -3563,6 +3563,8 @@ public:
   virtual NABoolean calculateMinMaxUecs(ColStatDescList & histograms,
 					       CostScalar & minUec,
 					       CostScalar & maxUec);
+
+  NAType* findReturnTypeForFloorCeil(NABoolean nullable);
 };
 
 class Abs : public MathFunc

--- a/core/sql/regress/core/EXPECTED038.LINUX
+++ b/core/sql/regress/core/EXPECTED038.LINUX
@@ -243,10 +243,10 @@ ORDER_NUM    ORDER_DATE  ORDER_TIME  ORDER_QTY
 -----------  ----------  ----------  -----------
 
         100  1997-01-30    13:40:05         1000
-        200  2016-07-09    05:13:55           99
+        200  2017-06-05    18:32:25           99
         300  1996-08-10    10:20:10         6000
-        400  1997-05-12    05:13:55           99
-        500  2016-07-09    05:13:55           99
+        400  1997-05-12    18:32:25           99
+        500  2017-06-05    18:32:25           99
 
 --- 5 row(s) selected.
 >>
@@ -264,7 +264,7 @@ ORDER_NUM    ORDER_DATE  ORDER_TIME  ORDER_QTY
 T038PART_NUM  ORDER_TIME                
 ------------  --------------------------
 
-         600  2016-07-09 05:13:57.638206
+         600  2017-06-05 18:32:29.319949
 
 --- 1 row(s) selected.
 >>
@@ -661,9 +661,9 @@ GANESAN               DEV                   YOW
 EMPNUM       EMPNAME               DEPTNUM      DEPTNUM      DEPTNAME              MANAGER               UNITNUM      DEPTNUM      REVENVUE
 -----------  --------------------  -----------  -----------  --------------------  --------------------  -----------  -----------  ------------
 
-        100  BHAVE                        6400         6400  DEV                   YOW                           101         6400     10000.000
-        100  RAO                          6500         6500  QA                    DENNIS                          ?            ?             ?
         100  GANESAN                      6400         6400  DEV                   YOW                           101         6400     10000.000
+        100  RAO                          6500         6500  QA                    DENNIS                          ?            ?             ?
+        100  BHAVE                        6400         6400  DEV                   YOW                           101         6400     10000.000
 
 --- 3 row(s) selected.
 >>SELECT *
@@ -675,6 +675,7 @@ EMPNUM       EMPNAME               DEPTNUM      DEPTNUM      DEPTNAME           
 -----------  --------------------  -----------  -----------  --------------------  --------------------  -----------  -----------  ------------
 
         100  BHAVE                        6400         6400  DEV                   YOW                           101         6400     10000.000
+        100  GANESAN                      6400         6400  DEV                   YOW                           101         6400     10000.000
         100  RAO                          6500         6500  QA                    DENNIS                          ?            ?             ?
         100  GANESAN                      6400         6400  DEV                   YOW                           101         6400     10000.000
 
@@ -689,9 +690,9 @@ EMPNUM       EMPNAME               DEPTNUM      DEPTNUM      DEPTNAME           
 EMPNUM       EMPNAME               DEPTNUM      DEPTNUM      DEPTNAME              MANAGER               UNITNUM      DEPTNUM      REVENVUE
 -----------  --------------------  -----------  -----------  --------------------  --------------------  -----------  -----------  ------------
 
-        100  BHAVE                        6400         6400  DEV                   YOW                           101         6400     10000.000
-        100  RAO                          6500         6500  QA                    DENNIS                          ?            ?             ?
         100  GANESAN                      6400         6400  DEV                   YOW                           101         6400     10000.000
+        100  RAO                          6500         6500  QA                    DENNIS                          ?            ?             ?
+        100  BHAVE                        6400         6400  DEV                   YOW                           101         6400     10000.000
 
 --- 3 row(s) selected.
 >>SELECT *
@@ -703,8 +704,8 @@ EMPNUM       EMPNAME               DEPTNUM      DEPTNUM      DEPTNAME           
 -----------  --------------------  -----------  -----------  --------------------  --------------------  -----------  -----------  ------------
 
         100  BHAVE                        6400         6400  DEV                   YOW                           101         6400     10000.000
-        100  RAO                          6500         6500  QA                    DENNIS                          ?            ?             ?
         100  GANESAN                      6400         6400  DEV                   YOW                           101         6400     10000.000
+        100  RAO                          6500         6500  QA                    DENNIS                          ?            ?             ?
 
 --- 3 row(s) selected.
 >>
@@ -744,8 +745,8 @@ EMPNUM       EMPNAME               DEPTNUM      DEPTNUM      DEPTNAME           
 -----------  --------------------  -----------  -----------  --------------------  --------------------  -----------  -----------  ------------
 
         100  GANESAN                      6400         6400  DEV                   YOW                           101         6400     10000.000
-        100  BHAVE                        6400         6400  DEV                   YOW                           101         6400     10000.000
         100  RAO                          6500         6500  QA                    DENNIS                          ?            ?             ?
+        100  BHAVE                        6400         6400  DEV                   YOW                           101         6400     10000.000
 
 --- 3 row(s) selected.
 >>
@@ -4758,6 +4759,55 @@ test      55  trim on non-s
           4
 
 --- 4 row(s) selected.
+>>
+>>
+>>-- floor/ceil function test
+>>create table T038fcl (a int , b decimal(5,2), c numeric (4,1), d largeint, e largeint);
+
+--- SQL operation complete.
+>>insert into T038fcl values
++>(1, 300.10, 202.2, 1, 1), (2, -300.10, -202.2, 2, 2);
+
+--- 2 row(s) inserted.
+>>
+>>select floor(a) floor_a, floor(b) floor_b, floor(c) floor_c, floor(d+e) bignumfloor,
++>       ceil(a) ceil_a, ceil(b) ceil_b, ceil(c) ceil_c, ceil(d+e) bignumceil
++>from T038fcl order by 1;
+
+FLOOR_A      FLOOR_B  FLOOR_C  BIGNUMFLOOR           CEIL_A       CEIL_B  CEIL_C  BIGNUMCEIL
+-----------  -------  -------  --------------------  -----------  ------  ------  --------------------
+
+          1      300      202                     2            1     301     203                     2
+          2     -301     -203                     4            2    -300    -202                     4
+
+--- 2 row(s) selected.
+>>
+>>create table T038fc2 as
++>(
++>select floor(a) floor_a, floor(b) floor_b, floor(c) floor_c, floor(d+e) bignumfloor,
++>       ceil(a) ceil_a, ceil(b) ceil_b, ceil(c) ceil_c, ceil(d+e) bignumceil 
++>from T038fcl
++>);
+
+--- 2 row(s) inserted.
+>>
+>>showddl T038fc2;
+
+CREATE TABLE TRAFODION.SCH.T038FC2
+  (
+    FLOOR_A                          INT DEFAULT NULL
+  , FLOOR_B                          DECIMAL(5, 0) DEFAULT NULL
+  , FLOOR_C                          NUMERIC(4, 0) DEFAULT NULL
+  , BIGNUMFLOOR                      LARGEINT DEFAULT NULL
+  , CEIL_A                           INT DEFAULT NULL
+  , CEIL_B                           DECIMAL(5, 0) DEFAULT NULL
+  , CEIL_C                           NUMERIC(4, 0) DEFAULT NULL
+  , BIGNUMCEIL                       LARGEINT DEFAULT NULL
+  )
+ ATTRIBUTES ALIGNED FORMAT
+;
+
+--- SQL operation complete.
 >>
 >>log;
 >>

--- a/core/sql/regress/core/EXPECTED038.LINUX
+++ b/core/sql/regress/core/EXPECTED038.LINUX
@@ -243,10 +243,10 @@ ORDER_NUM    ORDER_DATE  ORDER_TIME  ORDER_QTY
 -----------  ----------  ----------  -----------
 
         100  1997-01-30    13:40:05         1000
-        200  2017-06-05    18:32:25           99
+        200  2017-06-05    21:43:42           99
         300  1996-08-10    10:20:10         6000
-        400  1997-05-12    18:32:25           99
-        500  2017-06-05    18:32:25           99
+        400  1997-05-12    21:43:42           99
+        500  2017-06-05    21:43:42           99
 
 --- 5 row(s) selected.
 >>
@@ -264,7 +264,7 @@ ORDER_NUM    ORDER_DATE  ORDER_TIME  ORDER_QTY
 T038PART_NUM  ORDER_TIME                
 ------------  --------------------------
 
-         600  2017-06-05 18:32:29.319949
+         600  2017-06-05 21:43:45.699265
 
 --- 1 row(s) selected.
 >>
@@ -661,9 +661,9 @@ GANESAN               DEV                   YOW
 EMPNUM       EMPNAME               DEPTNUM      DEPTNUM      DEPTNAME              MANAGER               UNITNUM      DEPTNUM      REVENVUE
 -----------  --------------------  -----------  -----------  --------------------  --------------------  -----------  -----------  ------------
 
-        100  GANESAN                      6400         6400  DEV                   YOW                           101         6400     10000.000
-        100  RAO                          6500         6500  QA                    DENNIS                          ?            ?             ?
         100  BHAVE                        6400         6400  DEV                   YOW                           101         6400     10000.000
+        100  RAO                          6500         6500  QA                    DENNIS                          ?            ?             ?
+        100  GANESAN                      6400         6400  DEV                   YOW                           101         6400     10000.000
 
 --- 3 row(s) selected.
 >>SELECT *
@@ -674,9 +674,8 @@ EMPNUM       EMPNAME               DEPTNUM      DEPTNUM      DEPTNAME           
 EMPNUM       EMPNAME               DEPTNUM      DEPTNUM      DEPTNAME              MANAGER               UNITNUM      DEPTNUM      REVENVUE
 -----------  --------------------  -----------  -----------  --------------------  --------------------  -----------  -----------  ------------
 
-        100  BHAVE                        6400         6400  DEV                   YOW                           101         6400     10000.000
-        100  GANESAN                      6400         6400  DEV                   YOW                           101         6400     10000.000
         100  RAO                          6500         6500  QA                    DENNIS                          ?            ?             ?
+        100  BHAVE                        6400         6400  DEV                   YOW                           101         6400     10000.000
         100  GANESAN                      6400         6400  DEV                   YOW                           101         6400     10000.000
 
 --- 3 row(s) selected.
@@ -690,8 +689,8 @@ EMPNUM       EMPNAME               DEPTNUM      DEPTNUM      DEPTNAME           
 EMPNUM       EMPNAME               DEPTNUM      DEPTNUM      DEPTNAME              MANAGER               UNITNUM      DEPTNUM      REVENVUE
 -----------  --------------------  -----------  -----------  --------------------  --------------------  -----------  -----------  ------------
 
-        100  GANESAN                      6400         6400  DEV                   YOW                           101         6400     10000.000
         100  RAO                          6500         6500  QA                    DENNIS                          ?            ?             ?
+        100  GANESAN                      6400         6400  DEV                   YOW                           101         6400     10000.000
         100  BHAVE                        6400         6400  DEV                   YOW                           101         6400     10000.000
 
 --- 3 row(s) selected.
@@ -703,9 +702,9 @@ EMPNUM       EMPNAME               DEPTNUM      DEPTNUM      DEPTNAME           
 EMPNUM       EMPNAME               DEPTNUM      DEPTNUM      DEPTNAME              MANAGER               UNITNUM      DEPTNUM      REVENVUE
 -----------  --------------------  -----------  -----------  --------------------  --------------------  -----------  -----------  ------------
 
+        100  RAO                          6500         6500  QA                    DENNIS                          ?            ?             ?
         100  BHAVE                        6400         6400  DEV                   YOW                           101         6400     10000.000
         100  GANESAN                      6400         6400  DEV                   YOW                           101         6400     10000.000
-        100  RAO                          6500         6500  QA                    DENNIS                          ?            ?             ?
 
 --- 3 row(s) selected.
 >>
@@ -732,8 +731,8 @@ EMPNUM       EMPNAME               DEPTNUM      DEPTNUM      DEPTNAME           
 -----------  --------------------  -----------  -----------  --------------------  --------------------  -----------  -----------  ------------
 
         100  BHAVE                        6400         6400  DEV                   YOW                           101         6400     10000.000
-        100  RAO                          6500         6500  QA                    DENNIS                          ?            ?             ?
         100  GANESAN                      6400         6400  DEV                   YOW                           101         6400     10000.000
+        100  RAO                          6500         6500  QA                    DENNIS                          ?            ?             ?
 
 --- 3 row(s) selected.
 >>SELECT *
@@ -744,9 +743,9 @@ EMPNUM       EMPNAME               DEPTNUM      DEPTNUM      DEPTNAME           
 EMPNUM       EMPNAME               DEPTNUM      DEPTNUM      DEPTNAME              MANAGER               UNITNUM      DEPTNUM      REVENVUE
 -----------  --------------------  -----------  -----------  --------------------  --------------------  -----------  -----------  ------------
 
-        100  GANESAN                      6400         6400  DEV                   YOW                           101         6400     10000.000
-        100  RAO                          6500         6500  QA                    DENNIS                          ?            ?             ?
         100  BHAVE                        6400         6400  DEV                   YOW                           101         6400     10000.000
+        100  RAO                          6500         6500  QA                    DENNIS                          ?            ?             ?
+        100  GANESAN                      6400         6400  DEV                   YOW                           101         6400     10000.000
 
 --- 3 row(s) selected.
 >>

--- a/core/sql/regress/core/TEST038
+++ b/core/sql/regress/core/TEST038
@@ -1200,6 +1200,25 @@ create table T038nvl (a int not null, b int, primary key(a));
 insert into T038nvl values (1, null), (2, 2), (3, null), (4, 4);
 select nvl(b,a) from T038nvl;
 
+
+-- floor/ceil function test
+create table T038fcl (a int , b decimal(5,2), c numeric (4,1), d largeint, e largeint);
+insert into T038fcl values
+(1, 300.10, 202.2, 1, 1), (2, -300.10, -202.2, 2, 2);
+
+select floor(a) floor_a, floor(b) floor_b, floor(c) floor_c, floor(d+e) bignumfloor,
+       ceil(a) ceil_a, ceil(b) ceil_b, ceil(c) ceil_c, ceil(d+e) bignumceil
+from T038fcl order by 1;
+
+create table T038fc2 as
+(
+select floor(a) floor_a, floor(b) floor_b, floor(c) floor_c, floor(d+e) bignumfloor,
+       ceil(a) ceil_a, ceil(b) ceil_b, ceil(c) ceil_c, ceil(d+e) bignumceil 
+from T038fcl
+);
+
+showddl T038fc2;
+
 log;
 
 ?section aqr
@@ -1261,5 +1280,7 @@ drop table T038LI;
 drop table T038part;
 drop table T038sf;
 drop table T038nvl;
+drop table T038fcl;
+drop table T038fc2;
 
 


### PR DESCRIPTION
Before this change, the Trafodion FLOOR/CEIL functions returned a floating-point data type. This is counter-intuitive since FLOOR/CEIL return an integer value. This makes it awkward to nest a FLOOR/CEIL call inside some other function (e.g. LEFT) which requires an integer data type.

Other DBMSs return an integer data type for FLOOR/CEIL.

Most of the work for this change is due to @nonstop-qfchen. I added a missing case in ExFunctionMath::eval.