### PR TITLE
[TRAFODION-2636] Memory leak in metadata context

### DIFF
--- a/core/sql/common/NAMemory.h
+++ b/core/sql/common/NAMemory.h
@@ -468,6 +468,11 @@ NA_EIDPROC
   NAMemoryType getType() {  return type_; }
 NA_EIDPROC
   NABoolean getUsage(size_t* lastSegSize, size_t* freeSize, size_t* totalSize);
+  // for debugging
+NA_EIDPROC
+  NABoolean containsAddress(void *addr)
+        { return NABlock::blockHolding(firstBlk_, addr) != NULL; }
+
   // #ifdef NA_WINNT
 #ifndef __EID
   NABoolean  getSharedMemory() { return sharedMemory_; }

--- a/core/sql/optimizer/ControlDB.cpp
+++ b/core/sql/optimizer/ControlDB.cpp
@@ -108,7 +108,12 @@ ControlDB::~ControlDB()
 
 void ControlDB::setRequiredShape(ControlQueryShape *shape)
 {
-  delete requiredShape_;
+  if (requiredShape_)
+    {
+      delete requiredShape_->getShape();
+      delete requiredShape_;
+    }
+
   if (!shape
 	  ||
 	  !shape->getShape()


### PR DESCRIPTION
Fixing a memory leak found by Selva. See [[TRAFODION-2636]](https://issues.apache.org/jira/browse/TRAFODION-2636) for details. Also adding a method that helped me in debugging this issue.