### PR TITLE
[TRAFODION-2635] Fix two bugs re: HBASE CELL access on Traf objects

### DIFF
--- a/core/sql/common/NAMemory.h
+++ b/core/sql/common/NAMemory.h
@@ -473,6 +473,9 @@ NA_EIDPROC
   NABoolean  getSharedMemory() { return sharedMemory_; }
   void setSharedMemory() { sharedMemory_ = TRUE; }
 #endif
+
+  NABoolean isComSpace(void) { return derivedClass_ == COMSPACE_CLASS; } ;
+
 protected:
 
   // set the name of this memory

--- a/core/sql/generator/GenRelExeUtil.cpp
+++ b/core/sql/generator/GenRelExeUtil.cpp
@@ -284,6 +284,7 @@ TrafDesc *ExeUtilExpr::createVirtualTableDesc()
 {
   TrafDesc * table_desc =
     Generator::createVirtualTableDesc(getVirtualTableName(),
+				      NULL, // let it decide what heap to use
 				      ComTdbExeUtil::getVirtTableNumCols(),
 				      ComTdbExeUtil::getVirtTableColumnInfo(),
 				      ComTdbExeUtil::getVirtTableNumKeys(),
@@ -316,6 +317,7 @@ TrafDesc *ExeUtilDisplayExplain::createVirtualTableDesc()
   TrafDesc * table_desc = 
     Generator::createVirtualTableDesc
     (getVirtualTableName(),
+     NULL, // let it decide what heap to use
      ComTdbExeUtilDisplayExplain::getVirtTableNumCols(),
      vtci,
      ComTdbExeUtil::getVirtTableNumKeys(),
@@ -1225,6 +1227,7 @@ TrafDesc *ExeUtilGetUID::createVirtualTableDesc()
 {
   TrafDesc * table_desc =
     Generator::createVirtualTableDesc(getVirtualTableName(),
+				      NULL, // let it decide what heap to use
 				      ComTdbExeUtilGetUID::getVirtTableNumCols(),
 				      ComTdbExeUtilGetUID::getVirtTableColumnInfo(),
 				      ComTdbExeUtilGetUID::getVirtTableNumKeys(),
@@ -1303,6 +1306,7 @@ TrafDesc *ExeUtilGetQID::createVirtualTableDesc()
 {
   TrafDesc * table_desc =
     Generator::createVirtualTableDesc(getVirtualTableName(),
+				      NULL, // let it decide what heap to use
 				      ComTdbExeUtilGetQID::getVirtTableNumCols(),
 				      ComTdbExeUtilGetQID::getVirtTableColumnInfo(),
 				      ComTdbExeUtilGetQID::getVirtTableNumKeys(),
@@ -3538,6 +3542,7 @@ TrafDesc *ExeUtilRegionStats::createVirtualTableDesc()
   else
     table_desc = Generator::createVirtualTableDesc(
 	 getVirtualTableName(),
+	 NULL, // let it decide what heap to use
 	 rs.getVirtTableNumCols(),
 	 rs.getVirtTableColumnInfo(),
 	 rs.getVirtTableNumKeys(),
@@ -3674,6 +3679,7 @@ TrafDesc *ExeUtilLobInfo::createVirtualTableDesc()
    if (tableFormat_)
     table_desc = Generator::createVirtualTableDesc(
 	 getVirtualTableName(),
+	 NULL, // let it decide what heap to use
 	 ComTdbExeUtilLobInfo::getVirtTableNumCols(),
 	 ComTdbExeUtilLobInfo::getVirtTableColumnInfo(),
 	 ComTdbExeUtilLobInfo::getVirtTableNumKeys(),
@@ -4673,6 +4679,7 @@ TrafDesc *HiveMDaccessFunc::createVirtualTableDesc()
   TrafDesc * table_desc =
     Generator::createVirtualTableDesc(
 				      getVirtualTableName(),
+				      NULL, // let it decide what heap to use
 				      ComTdbExeUtilHiveMDaccess::getVirtTableNumCols((char*)mdType_.data()),
 				      ComTdbExeUtilHiveMDaccess::getVirtTableColumnInfo((char*)mdType_.data()),
 				      ComTdbExeUtilHiveMDaccess::getVirtTableNumKeys((char*)mdType_.data()),

--- a/core/sql/generator/GenRelMisc.cpp
+++ b/core/sql/generator/GenRelMisc.cpp
@@ -373,6 +373,7 @@ TrafDesc *DDLExpr::createVirtualTableDesc()
     {
       table_desc = 
         Generator::createVirtualTableDesc(getVirtualTableName(),
+                                          NULL, // let it decide what heap to use
                                           ComTdbDDL::getVirtTableNumCols(),
                                           ComTdbDDL::getVirtTableColumnInfo(),
                                           ComTdbDDL::getVirtTableNumKeys(),
@@ -5107,6 +5108,7 @@ TrafDesc *StatisticsFunc::createVirtualTableDesc()
 {
   TrafDesc * table_desc =
     Generator::createVirtualTableDesc(getVirtualTableName(),
+				      NULL, // let it decide what heap to use    
 				      ComTdbStats::getVirtTableNumCols(),
 				      ComTdbStats::getVirtTableColumnInfo(),
 				      ComTdbStats::getVirtTableNumKeys(),

--- a/core/sql/generator/GenRelScan.cpp
+++ b/core/sql/generator/GenRelScan.cpp
@@ -1492,7 +1492,7 @@ void populateRangeDescForBeginKey(char* buf, Int32 len, struct TrafDesc* target,
 }
 
 TrafDesc *HbaseAccess::createVirtualTableDesc(const char * name,
-						 NABoolean isRW, NABoolean isCW, NAArray<HbaseStr>* beginKeys)
+  NABoolean isRW, NABoolean isCW, NAArray<HbaseStr>* beginKeys, NAMemory * heap)
 {
   TrafDesc * table_desc = NULL;
 
@@ -1500,6 +1500,7 @@ TrafDesc *HbaseAccess::createVirtualTableDesc(const char * name,
     table_desc =
       Generator::createVirtualTableDesc(
 					name,
+					heap,
 					ComTdbHbaseAccess::getVirtTableRowwiseNumCols(),
 					ComTdbHbaseAccess::getVirtTableRowwiseColumnInfo(),
 					ComTdbHbaseAccess::getVirtTableRowwiseNumKeys(),
@@ -1507,6 +1508,7 @@ TrafDesc *HbaseAccess::createVirtualTableDesc(const char * name,
   else if (isCW)
     table_desc =
       Generator::createVirtualTableDesc(name,
+					heap,
 					ComTdbHbaseAccess::getVirtTableNumCols(),
 					ComTdbHbaseAccess::getVirtTableColumnInfo(),
 					ComTdbHbaseAccess::getVirtTableNumKeys(),
@@ -1514,7 +1516,7 @@ TrafDesc *HbaseAccess::createVirtualTableDesc(const char * name,
 
   if (table_desc)
     {
-      struct TrafDesc* head = Generator::assembleDescs(beginKeys, NULL, NULL);
+      struct TrafDesc* head = Generator::assembleDescs(beginKeys, heap);
 
       table_desc->tableDesc()->hbase_regionkey_desc = head;
 
@@ -1668,6 +1670,7 @@ TrafDesc *HbaseAccess::createVirtualTableDesc(const char * name,
 
    table_desc =
       Generator::createVirtualTableDesc(name,
+					NULL, // let it decide what heap to use
 					numCols, //ComTdbHbaseAccess::getVirtTableNumCols(),
 					colInfoArray, //ComTdbHbaseAccess::getVirtTableColumnInfo(),
 					numKeys, //ComTdbHbaseAccess::getVirtTableNumKeys(),

--- a/core/sql/generator/GenUdr.cpp
+++ b/core/sql/generator/GenUdr.cpp
@@ -1924,6 +1924,7 @@ TrafDesc *TableMappingUDF::createVirtualTableDesc()
   }
   TrafDesc * table_desc =
     Generator::createVirtualTableDesc(getRoutineName().getQualifiedNameAsString().data(),
+                                      NULL, // let it decide what heap to use
                                       numOutputCols,
 				      outColsInfo,
 				      0,

--- a/core/sql/generator/Generator.h
+++ b/core/sql/generator/Generator.h
@@ -1398,26 +1398,27 @@ public:
        ComTdbVirtTableColumnInfo * columnInfo,
        Int16 numCols,
        UInt32 &offset,
-       Space * space);
+       NAMemory * space);
   
   static TrafDesc * createKeyDescs(Int32 numKeys,
-				      const ComTdbVirtTableKeyInfo * keyInfo,
-                                      Space * space);
+                                   const ComTdbVirtTableKeyInfo * keyInfo,
+                                   NAMemory * space);
 
   static TrafDesc * createConstrKeyColsDescs(Int32 numKeys,
-                                                ComTdbVirtTableKeyInfo * keyInfo,
-                                                Space * space);
+                                             ComTdbVirtTableKeyInfo * keyInfo,
+                                             NAMemory * space);
 
   static TrafDesc * createRefConstrDescStructs(
 						  Int32 numConstrs,
 						  ComTdbVirtTableRefConstraints * refConstrs,
-                                                  Space * space);
+						  NAMemory * space);
   
   static TrafDesc * createPrivDescs( const ComTdbVirtTablePrivInfo * privs,
-                                     Space * space);
+                                     NAMemory * space);
 
   static TrafDesc *createVirtualTableDesc(
-       const char * tableName, 
+       const char * tableName,
+       NAMemory * heap,  // in case caller wants a particular heap; if NULL is passed, we decide
        Int32 numCols,
        ComTdbVirtTableColumnInfo * columnInfo,
        Int32 numKeys,
@@ -1439,8 +1440,7 @@ public:
 
   static TrafDesc* assembleDescs(
      NAArray<HbaseStr >* keyArray, 
-     NAMemory* heap,
-     Space * space);
+     NAMemory* space);
 
   static TrafDesc *createVirtualRoutineDesc(
                                   const char *routineName,

--- a/core/sql/optimizer/NATable.cpp
+++ b/core/sql/optimizer/NATable.cpp
@@ -8255,10 +8255,12 @@ NATable * NATableDB::get(CorrName& corrName, BindWA * bindWA,
 
           NAArray<HbaseStr> *keyArray = NATable::getRegionsBeginKey(extHBaseName);
 
+          // create the virtual table descriptor on the same heap that
+          // we are creating the NATable object on
 	  tableDesc = 
 	    HbaseAccess::createVirtualTableDesc
 	    (corrName.getExposedNameAsAnsiString(FALSE, TRUE).data(),
-	     isHbaseRow, isHbaseCell, keyArray);
+	     isHbaseRow, isHbaseCell, keyArray, naTableHeap);
           deleteNAArray(STMTHEAP, keyArray);
 
 	  isSeabase = FALSE;

--- a/core/sql/optimizer/RelScan.h
+++ b/core/sql/optimizer/RelScan.h
@@ -1302,7 +1302,8 @@ public:
   static TrafDesc *createVirtualTableDesc(const char * name,
 					     NABoolean isRW = FALSE,
 					     NABoolean isCW = FALSE, 
-                                             NAArray<HbaseStr> * hbaseKeys = NULL);
+					     NAArray<HbaseStr> * hbaseKeys = NULL,
+					     NAMemory * heap = NULL);
 
   static TrafDesc *createVirtualTableDesc(const char * name,
 					     NAList<char*> &colNameList,

--- a/core/sql/optimizer/ValueDesc.cpp
+++ b/core/sql/optimizer/ValueDesc.cpp
@@ -6794,7 +6794,8 @@ ValueIdList::computeEncodedKey(const TableDesc* tDesc, NABoolean isMaxKey,
    // cast away const since the method may compute and store the length
    keyBufLen = ((NAFileSet*)naf)->getEncodedKeyLength(); 
 
-   if ( naTable->isHbaseCellTable() || naTable->isHbaseRowTable() ) { 
+   if ( (count > 0) && (inputStrings[0]) && 
+        ( naTable->isHbaseCellTable() || naTable->isHbaseRowTable() ) ) { 
       // the encoded key for Native Hbase table is a null-terminated string ('<key>')
       NAString key;
       key.append("(");
@@ -6814,6 +6815,8 @@ ValueIdList::computeEncodedKey(const TableDesc* tDesc, NABoolean isMaxKey,
 
       memcpy(encodedKeyBuffer, key.data(), key.length());
       encodedKeyBuffer[key.length()] = NULL;
+
+      NADELETEARRAY(inputStrings, count, NAStringPtr, STMTHEAP);
 
       return encodedKeyBuffer;
 

--- a/core/sql/sqlcat/TrafDDLdesc.cpp
+++ b/core/sql/sqlcat/TrafDDLdesc.cpp
@@ -29,7 +29,7 @@
 // Allocate one of the primitive structs and initialize to all zeroes.
 // Uses HEAP (StatementHeap) of CmpCommon or space.
 // -----------------------------------------------------------------------
-TrafDesc *TrafAllocateDDLdesc(desc_nodetype nodetype, Space * space)
+TrafDesc *TrafAllocateDDLdesc(desc_nodetype nodetype, NAMemory * space)
 {
   size_t size = 0;
   TrafDesc * desc_ptr = NULL;

--- a/core/sql/sqlcat/TrafDDLdesc.cpp
+++ b/core/sql/sqlcat/TrafDDLdesc.cpp
@@ -106,7 +106,7 @@ TrafDesc *TrafAllocateDDLdesc(desc_nodetype nodetype, NAMemory * space)
 
   // if not being allocated from space, memset all bytes to 0.
   // If allocated from space, it will be set to 0 during space allocation.
-  if (! space)
+  if ((! space) || (!space->isComSpace()))
     memset((char*)desc_ptr+sizeof(TrafDesc), 0, 
            desc_ptr->getClassSize()-sizeof(TrafDesc));
 

--- a/core/sql/sqlcat/TrafDDLdesc.h
+++ b/core/sql/sqlcat/TrafDDLdesc.h
@@ -104,7 +104,7 @@ public:
   enum {CURR_VERSION = 1};
 
   TrafDesc(UInt16 nodeType);
-  TrafDesc() : NAVersionedObject(-1) {}
+  TrafDesc() : NAVersionedObject(-1),descExtension(NULL) {}
 
   // ---------------------------------------------------------------------
   // Redefine virtual functions required for Versioning.
@@ -163,7 +163,7 @@ public:
 
 class TrafCheckConstrntsDesc : public TrafDesc {
 public:
-  TrafCheckConstrntsDesc() : TrafDesc(DESC_CHECK_CONSTRNTS_TYPE)
+  TrafCheckConstrntsDesc() : TrafDesc(DESC_CHECK_CONSTRNTS_TYPE), constrnt_text(NULL)
   {}
 
   // ---------------------------------------------------------------------
@@ -192,7 +192,9 @@ public:
 
 class TrafColumnsDesc : public TrafDesc {
 public:
-  TrafColumnsDesc() : TrafDesc(DESC_COLUMNS_TYPE) 
+  TrafColumnsDesc() : TrafDesc(DESC_COLUMNS_TYPE), colname(NULL),
+    pictureText(NULL), defaultvalue(NULL), heading(NULL),
+    computed_column_text(NULL), hbaseColFam(NULL), hbaseColQual(NULL)
   {};
 
   // ---------------------------------------------------------------------
@@ -305,7 +307,7 @@ public:
 
 class TrafConstrntKeyColsDesc : public TrafDesc {
 public:
-  TrafConstrntKeyColsDesc() : TrafDesc(DESC_CONSTRNT_KEY_COLS_TYPE)
+  TrafConstrntKeyColsDesc() : TrafDesc(DESC_CONSTRNT_KEY_COLS_TYPE), colname(NULL)
   {}
 
   // ---------------------------------------------------------------------
@@ -338,7 +340,8 @@ public:
 
 class TrafConstrntsDesc : public TrafDesc {
 public:
-  TrafConstrntsDesc() : TrafDesc(DESC_CONSTRNTS_TYPE)
+  TrafConstrntsDesc() : TrafDesc(DESC_CONSTRNTS_TYPE),
+    constrntname(NULL), tablename(NULL)
   {}
 
   // ---------------------------------------------------------------------
@@ -432,7 +435,8 @@ public:
 
 class TrafHbaseRegionDesc : public TrafDesc {
 public:
-  TrafHbaseRegionDesc() : TrafDesc(DESC_HBASE_RANGE_REGION_TYPE)
+  TrafHbaseRegionDesc() : TrafDesc(DESC_HBASE_RANGE_REGION_TYPE),
+    beginKey(NULL), endKey(NULL)
   {}
 
   // ---------------------------------------------------------------------
@@ -468,7 +472,8 @@ public:
 
 class TrafHistogramDesc : public TrafDesc {
 public:
-  TrafHistogramDesc() : TrafDesc(DESC_HISTOGRAM_TYPE)
+  TrafHistogramDesc() : TrafDesc(DESC_HISTOGRAM_TYPE),
+    tablename(NULL), histid(NULL), highval(NULL), lowval(NULL)
   {}
 
   // ---------------------------------------------------------------------
@@ -512,7 +517,8 @@ public:
 
 class TrafHistIntervalDesc : public TrafDesc {
 public:
-  TrafHistIntervalDesc() : TrafDesc(DESC_HIST_INTERVAL_TYPE)
+  TrafHistIntervalDesc() : TrafDesc(DESC_HIST_INTERVAL_TYPE),
+    histid(NULL), intboundary(NULL)
   {}
 
   // ---------------------------------------------------------------------
@@ -551,7 +557,9 @@ public:
 
 class TrafIndexesDesc : public TrafDesc {
 public:
-  TrafIndexesDesc() : TrafDesc(DESC_INDEXES_TYPE)
+  TrafIndexesDesc() : TrafDesc(DESC_INDEXES_TYPE), 
+    partitioningScheme_(COM_UNSPECIFIED_PARTITIONING),
+    tablename(NULL), indexname(NULL), hbaseSplitClause(NULL), hbaseCreateOptions(NULL)
   {}
 
   // ---------------------------------------------------------------------
@@ -646,7 +654,8 @@ public:
 
 class TrafKeysDesc : public TrafDesc {
 public:
-  TrafKeysDesc() : TrafDesc(DESC_KEYS_TYPE)
+  TrafKeysDesc() : TrafDesc(DESC_KEYS_TYPE), keyname(NULL),
+    hbaseColFam(NULL), hbaseColQual(NULL)
   {}
 
   // ---------------------------------------------------------------------
@@ -692,7 +701,8 @@ public:
 
 class TrafLibraryDesc : public TrafDesc {
 public:
-  TrafLibraryDesc() : TrafDesc(DESC_LIBRARY_TYPE)
+  TrafLibraryDesc() : TrafDesc(DESC_LIBRARY_TYPE),
+    libraryName(NULL), libraryFilename(NULL)
   {}
 
   // ---------------------------------------------------------------------
@@ -727,7 +737,15 @@ public:
 
 class TrafPartnsDesc : public TrafDesc {
 public:
-  TrafPartnsDesc() : TrafDesc(DESC_PARTNS_TYPE)
+  TrafPartnsDesc() : TrafDesc(DESC_PARTNS_TYPE),
+    tablename(NULL), 
+    partitionname(NULL),
+    logicalpartitionname(NULL),
+    firstkey(NULL),
+    encodedkey(NULL),
+    lowKey(NULL),
+    highKey(NULL),
+    givenname(NULL)
   {}
 
   // ---------------------------------------------------------------------
@@ -769,7 +787,8 @@ public:
 
 class TrafRefConstrntsDesc : public TrafDesc {
 public:
-  TrafRefConstrntsDesc() : TrafDesc(DESC_REF_CONSTRNTS_TYPE)
+  TrafRefConstrntsDesc() : TrafDesc(DESC_REF_CONSTRNTS_TYPE),
+    constrntname(NULL), tablename(NULL)
   {}
 
   // ---------------------------------------------------------------------
@@ -801,7 +820,9 @@ public:
 
 class TrafRoutineDesc : public TrafDesc {
 public:
-  TrafRoutineDesc() : TrafDesc(DESC_ROUTINE_TYPE)
+  TrafRoutineDesc() : TrafDesc(DESC_ROUTINE_TYPE),
+    routineName(NULL), externalName(NULL), librarySqlName(NULL), libraryFileName(NULL),
+    signature(NULL)
   {}
 
   // ---------------------------------------------------------------------
@@ -856,7 +877,8 @@ public:
 
 class TrafSequenceGeneratorDesc : public TrafDesc {
 public:
-  TrafSequenceGeneratorDesc() : TrafDesc(DESC_SEQUENCE_GENERATOR_TYPE)
+  TrafSequenceGeneratorDesc() : TrafDesc(DESC_SEQUENCE_GENERATOR_TYPE),
+    sgLocation(NULL)
   {}
 
   // ---------------------------------------------------------------------
@@ -907,7 +929,8 @@ public:
 
 class TrafTableDesc : public TrafDesc {
 public:
-  TrafTableDesc() : TrafDesc(DESC_TABLE_TYPE)
+  TrafTableDesc() : TrafDesc(DESC_TABLE_TYPE), tablename(NULL),
+    snapshotName(NULL), default_col_fam(NULL), all_col_fams(NULL)
   {}
 
   // ---------------------------------------------------------------------
@@ -1051,7 +1074,7 @@ public:
 
 class TrafUsingMvDesc : public TrafDesc {
 public:
-  TrafUsingMvDesc() : TrafDesc(DESC_USING_MV_TYPE)
+  TrafUsingMvDesc() : TrafDesc(DESC_USING_MV_TYPE), mvName(NULL)
   {}
 
   // ---------------------------------------------------------------------
@@ -1088,7 +1111,9 @@ public:
 
 class TrafViewDesc : public TrafDesc {
 public:
-  TrafViewDesc() : TrafDesc(DESC_VIEW_TYPE)
+  TrafViewDesc() : TrafDesc(DESC_VIEW_TYPE),
+    viewname(NULL), viewfilename(NULL), viewtext(NULL),
+    viewchecktext(NULL), viewcolusages(NULL)
   {}
 
   // ---------------------------------------------------------------------
@@ -1246,9 +1271,9 @@ public:
 };
 // ------------------------- end privilege descriptors -------------------------
 
-// if space is passed in, use it. Otherwise use HEAP of CmpCommon
+// if heap is passed in, use it. Otherwise use HEAP of CmpCommon
 TrafDesc *TrafAllocateDDLdesc(desc_nodetype nodetype, 
-                                 Space *space);
+                              NAMemory * heap);
 
 TrafDesc *TrafMakeColumnDesc
 (
@@ -1260,7 +1285,7 @@ TrafDesc *TrafMakeColumnDesc
      Lng32 &offset,		  // INOUT
      NABoolean null_flag,
      SQLCHARSET_CODE datacharset, // i.e., use CharInfo::DefaultCharSet;
-     Space * space
+     NAMemory * space
  );
 
 #endif

--- a/core/sql/sqlcat/TrafDDLdesc.h
+++ b/core/sql/sqlcat/TrafDDLdesc.h
@@ -34,7 +34,11 @@
 // flatten out and stored in the text table related to object.  When the
 // compiler or DDL subsequently require this information, the flattened DDLDesc 
 // is read from the metadata and expanded. This information can then be used 
-// by the the different components - such as NATable. 
+// by the the different components - such as NATable.
+//
+// Why are there no initializers for most of these classes? The answer is
+// that they are all allocated via the factory function TrafAllocateDDLdesc
+// (declared at the end of this file). That function zeroes everything out.
 // ****************************************************************************
 
 #include "Platform.h"
@@ -104,7 +108,7 @@ public:
   enum {CURR_VERSION = 1};
 
   TrafDesc(UInt16 nodeType);
-  TrafDesc() : NAVersionedObject(-1),descExtension(NULL) {}
+  TrafDesc() : NAVersionedObject(-1) {}
 
   // ---------------------------------------------------------------------
   // Redefine virtual functions required for Versioning.
@@ -163,7 +167,8 @@ public:
 
 class TrafCheckConstrntsDesc : public TrafDesc {
 public:
-  TrafCheckConstrntsDesc() : TrafDesc(DESC_CHECK_CONSTRNTS_TYPE), constrnt_text(NULL)
+  // why almost no initializers? see note at top of file
+  TrafCheckConstrntsDesc() : TrafDesc(DESC_CHECK_CONSTRNTS_TYPE)
   {}
 
   // ---------------------------------------------------------------------
@@ -192,9 +197,8 @@ public:
 
 class TrafColumnsDesc : public TrafDesc {
 public:
-  TrafColumnsDesc() : TrafDesc(DESC_COLUMNS_TYPE), colname(NULL),
-    pictureText(NULL), defaultvalue(NULL), heading(NULL),
-    computed_column_text(NULL), hbaseColFam(NULL), hbaseColQual(NULL)
+  // why almost no initializers? see note at top of file
+  TrafColumnsDesc() : TrafDesc(DESC_COLUMNS_TYPE) 
   {};
 
   // ---------------------------------------------------------------------
@@ -307,7 +311,8 @@ public:
 
 class TrafConstrntKeyColsDesc : public TrafDesc {
 public:
-  TrafConstrntKeyColsDesc() : TrafDesc(DESC_CONSTRNT_KEY_COLS_TYPE), colname(NULL)
+  // why almost no initializers? see note at top of file
+  TrafConstrntKeyColsDesc() : TrafDesc(DESC_CONSTRNT_KEY_COLS_TYPE)
   {}
 
   // ---------------------------------------------------------------------
@@ -340,8 +345,8 @@ public:
 
 class TrafConstrntsDesc : public TrafDesc {
 public:
-  TrafConstrntsDesc() : TrafDesc(DESC_CONSTRNTS_TYPE),
-    constrntname(NULL), tablename(NULL)
+  // why almost no initializers? see note at top of file
+  TrafConstrntsDesc() : TrafDesc(DESC_CONSTRNTS_TYPE)
   {}
 
   // ---------------------------------------------------------------------
@@ -397,6 +402,7 @@ public:
 
 class TrafFilesDesc : public TrafDesc {
 public:
+  // why almost no initializers? see note at top of file
   TrafFilesDesc() : TrafDesc(DESC_FILES_TYPE)
   {}
 
@@ -435,8 +441,8 @@ public:
 
 class TrafHbaseRegionDesc : public TrafDesc {
 public:
-  TrafHbaseRegionDesc() : TrafDesc(DESC_HBASE_RANGE_REGION_TYPE),
-    beginKey(NULL), endKey(NULL)
+  // why almost no initializers? see note at top of file
+  TrafHbaseRegionDesc() : TrafDesc(DESC_HBASE_RANGE_REGION_TYPE)
   {}
 
   // ---------------------------------------------------------------------
@@ -472,8 +478,8 @@ public:
 
 class TrafHistogramDesc : public TrafDesc {
 public:
-  TrafHistogramDesc() : TrafDesc(DESC_HISTOGRAM_TYPE),
-    tablename(NULL), histid(NULL), highval(NULL), lowval(NULL)
+  // why almost no initializers? see note at top of file
+  TrafHistogramDesc() : TrafDesc(DESC_HISTOGRAM_TYPE)
   {}
 
   // ---------------------------------------------------------------------
@@ -517,8 +523,8 @@ public:
 
 class TrafHistIntervalDesc : public TrafDesc {
 public:
-  TrafHistIntervalDesc() : TrafDesc(DESC_HIST_INTERVAL_TYPE),
-    histid(NULL), intboundary(NULL)
+  // why almost no initializers? see note at top of file
+  TrafHistIntervalDesc() : TrafDesc(DESC_HIST_INTERVAL_TYPE)
   {}
 
   // ---------------------------------------------------------------------
@@ -557,9 +563,8 @@ public:
 
 class TrafIndexesDesc : public TrafDesc {
 public:
-  TrafIndexesDesc() : TrafDesc(DESC_INDEXES_TYPE), 
-    partitioningScheme_(COM_UNSPECIFIED_PARTITIONING),
-    tablename(NULL), indexname(NULL), hbaseSplitClause(NULL), hbaseCreateOptions(NULL)
+  // why almost no initializers? see note at top of file
+  TrafIndexesDesc() : TrafDesc(DESC_INDEXES_TYPE)
   {}
 
   // ---------------------------------------------------------------------
@@ -654,8 +659,8 @@ public:
 
 class TrafKeysDesc : public TrafDesc {
 public:
-  TrafKeysDesc() : TrafDesc(DESC_KEYS_TYPE), keyname(NULL),
-    hbaseColFam(NULL), hbaseColQual(NULL)
+  // why almost no initializers? see note at top of file
+  TrafKeysDesc() : TrafDesc(DESC_KEYS_TYPE)
   {}
 
   // ---------------------------------------------------------------------
@@ -701,8 +706,8 @@ public:
 
 class TrafLibraryDesc : public TrafDesc {
 public:
-  TrafLibraryDesc() : TrafDesc(DESC_LIBRARY_TYPE),
-    libraryName(NULL), libraryFilename(NULL)
+  // why almost no initializers? see note at top of file
+  TrafLibraryDesc() : TrafDesc(DESC_LIBRARY_TYPE)
   {}
 
   // ---------------------------------------------------------------------
@@ -737,15 +742,8 @@ public:
 
 class TrafPartnsDesc : public TrafDesc {
 public:
-  TrafPartnsDesc() : TrafDesc(DESC_PARTNS_TYPE),
-    tablename(NULL), 
-    partitionname(NULL),
-    logicalpartitionname(NULL),
-    firstkey(NULL),
-    encodedkey(NULL),
-    lowKey(NULL),
-    highKey(NULL),
-    givenname(NULL)
+  // why almost no initializers? see note at top of file
+  TrafPartnsDesc() : TrafDesc(DESC_PARTNS_TYPE)
   {}
 
   // ---------------------------------------------------------------------
@@ -787,8 +785,8 @@ public:
 
 class TrafRefConstrntsDesc : public TrafDesc {
 public:
-  TrafRefConstrntsDesc() : TrafDesc(DESC_REF_CONSTRNTS_TYPE),
-    constrntname(NULL), tablename(NULL)
+  // why almost no initializers? see note at top of file
+  TrafRefConstrntsDesc() : TrafDesc(DESC_REF_CONSTRNTS_TYPE)
   {}
 
   // ---------------------------------------------------------------------
@@ -820,9 +818,8 @@ public:
 
 class TrafRoutineDesc : public TrafDesc {
 public:
-  TrafRoutineDesc() : TrafDesc(DESC_ROUTINE_TYPE),
-    routineName(NULL), externalName(NULL), librarySqlName(NULL), libraryFileName(NULL),
-    signature(NULL)
+  // why almost no initializers? see note at top of file
+  TrafRoutineDesc() : TrafDesc(DESC_ROUTINE_TYPE)
   {}
 
   // ---------------------------------------------------------------------
@@ -877,8 +874,8 @@ public:
 
 class TrafSequenceGeneratorDesc : public TrafDesc {
 public:
-  TrafSequenceGeneratorDesc() : TrafDesc(DESC_SEQUENCE_GENERATOR_TYPE),
-    sgLocation(NULL)
+  // why almost no initializers? see note at top of file
+  TrafSequenceGeneratorDesc() : TrafDesc(DESC_SEQUENCE_GENERATOR_TYPE)
   {}
 
   // ---------------------------------------------------------------------
@@ -929,8 +926,8 @@ public:
 
 class TrafTableDesc : public TrafDesc {
 public:
-  TrafTableDesc() : TrafDesc(DESC_TABLE_TYPE), tablename(NULL),
-    snapshotName(NULL), default_col_fam(NULL), all_col_fams(NULL)
+  // why almost no initializers? see note at top of file
+  TrafTableDesc() : TrafDesc(DESC_TABLE_TYPE)
   {}
 
   // ---------------------------------------------------------------------
@@ -1074,7 +1071,8 @@ public:
 
 class TrafUsingMvDesc : public TrafDesc {
 public:
-  TrafUsingMvDesc() : TrafDesc(DESC_USING_MV_TYPE), mvName(NULL)
+  // why almost no initializers? see note at top of file
+  TrafUsingMvDesc() : TrafDesc(DESC_USING_MV_TYPE)
   {}
 
   // ---------------------------------------------------------------------
@@ -1111,9 +1109,8 @@ public:
 
 class TrafViewDesc : public TrafDesc {
 public:
-  TrafViewDesc() : TrafDesc(DESC_VIEW_TYPE),
-    viewname(NULL), viewfilename(NULL), viewtext(NULL),
-    viewchecktext(NULL), viewcolusages(NULL)
+  // why almost no initializers? see note at top of file
+  TrafViewDesc() : TrafDesc(DESC_VIEW_TYPE)
   {}
 
   // ---------------------------------------------------------------------
@@ -1181,6 +1178,7 @@ public:
 //   column bits - list of TrafPrivBitmapDesc
 class TrafPrivDesc : public TrafDesc {
 public:
+  // why almost no initializers? see note at top of file
   TrafPrivDesc() : TrafDesc(DESC_PRIV_TYPE)
   {}
 
@@ -1210,6 +1208,7 @@ public:
 
 class TrafPrivGranteeDesc : public TrafDesc {
 public:
+  // why almost no initializers? see note at top of file
   TrafPrivGranteeDesc() : TrafDesc(DESC_PRIV_GRANTEE_TYPE)
   {}
 
@@ -1241,6 +1240,7 @@ public:
 
 class TrafPrivBitmapDesc : public TrafDesc {
 public:
+  // why almost no initializers? see note at top of file
   TrafPrivBitmapDesc() : TrafDesc(DESC_PRIV_BITMAP_TYPE)
   {}
 
@@ -1271,9 +1271,10 @@ public:
 };
 // ------------------------- end privilege descriptors -------------------------
 
-// if heap is passed in, use it. Otherwise use HEAP of CmpCommon
+// If "space" is passed in, use it. (It might be an NAHeap or a ComSpace.)
+// If "space" is null, use the statement heap.
 TrafDesc *TrafAllocateDDLdesc(desc_nodetype nodetype, 
-                              NAMemory * heap);
+                              NAMemory * space);
 
 TrafDesc *TrafMakeColumnDesc
 (

--- a/core/sql/sqlcat/readRealArk.cpp
+++ b/core/sql/sqlcat/readRealArk.cpp
@@ -71,7 +71,7 @@ TrafDesc *TrafMakeColumnDesc(const char *tablename,
                                 Lng32 &offset,	// INOUT
                                 NABoolean null_flag,
                                 SQLCHARSET_CODE datacharset,
-                                Space * space
+                                NAMemory * space
                                 )
 {
   #undef  COLUMN

--- a/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
@@ -11087,6 +11087,7 @@ TrafDesc * CmpSeabaseDDL::getSeabaseMDTableDesc(
   tableDesc =
     Generator::createVirtualTableDesc
     ((char*)extTableName.data(),
+     NULL, // let it decide what heap to use
      colInfoSize,
      (ComTdbVirtTableColumnInfo*)colInfo,
      keyInfoSize,
@@ -11183,6 +11184,7 @@ TrafDesc * CmpSeabaseDDL::getSeabaseHistTableDesc(const NAString &catName,
   tableDesc =
     Generator::createVirtualTableDesc
     ((char*)extTableName.data(),
+     NULL, // let it decide what heap to use
      numCols,
      colInfo,
      numKeys,
@@ -11662,6 +11664,7 @@ TrafDesc * CmpSeabaseDDL::getSeabaseSequenceDesc(const NAString &catName,
   tableDesc =
     Generator::createVirtualTableDesc
     ((char*)extSeqName.data(),
+     NULL, // let it decide what heap to use
      0, NULL, // colInfo
      0, NULL, // keyInfo
      0, NULL,
@@ -12522,6 +12525,7 @@ TrafDesc * CmpSeabaseDDL::getSeabaseUserTableDesc(const NAString &catName,
     Generator::createVirtualTableDesc
     (
      extTableName->data(), //objName,
+     NULL, // let it decide what heap to use
      numCols,
      colInfoArray,
      tableKeyInfo->numEntries(), //keyIndex,


### PR DESCRIPTION
This set of changes fixes two bugs.

1.	In ValueIdList::computeEncodedKey (optimizer/ValueDesc.cpp), if we used HBASE.\”_CELL_\” access for a salted Trafodion table, and we had no begin/end key (e.g. select count(*) from hbase.\”_CELL_\”.\”TRAFODION.SCH.XYZ\”), the code would dereference a null pointer.
2.	In NATableDB::get, if we were creating an NATable object on the NATable cache for an HBASE.\”_CELL_\” access to a Trafodion table, the HBase-related descriptors were allocated on the statement heap instead of the context heap, resulting in a dangling pointer (with unpredictable failure modes) when the object was accessed that way in a second statement.

The change to optimizer/ValueDesc.cpp fixes the first bug.

The remaining changes fix the second bug.

Why so many changes for the second bug?

Partly, it is because routines in generator/Generator.cpp that wrote these descriptors into compiled plans were reused to obtain these descriptors for compile time logic. Unfortunately, the memory models are different: For compiled plans we use ComSpace for heap allocation (as we need the allocations to be contiguous in memory). For compiler access, we use an NAHeap. Before this set of changes, this was hidden in the GENHEAP macro in sqlcat/TrafDDLdesc.h; the code would use a ComSpace object if the space parameter to several methods was non-null, and use the statement heap if the space parameter was null.

The need to (sometimes) use the context heap in NATableDB::get meant that this GENHEAP scheme could no longer work. Since ComSpace and NAHeap inherit from NAMemory, one possibility was to change all relevant descriptor methods to use an NAMemory * parameter instead of ComSpace *. This set of changes attempts this possibility. There is a nuance: The NAMemory class hierarchy does not use virtual methods. So, when there is a need for polymorphism, the calling routines must explicitly cast the NAMemory pointer to the proper class. Fortunately, there was only one place where this was necessary. I’m not completely satisfied with this solution as it seems a dangerous coding practice. No simple alternative seemed to be available however.

After making this change, I encountered numerous test failures due to uninitialized variables in the various descriptors. Perhaps objects on the Statement heap are guaranteed (or vastly more likely) to be zeroed out while those on the Context heap are not. As a result, I added initializers for many of the descriptor members in sqlcat/TrafDDLdesc.h. I am not confident that I got all of the ones needed (I did initialize all pointer members so those are safe).

Please do not merge this until a full regression suite run has passed, which I’m doing on a workstation.

