### PR TITLE
[TRAFODION-2035] Not able to copy table where there is column with type timestamp(0), error out with ERROR[8102]

### DIFF
--- a/core/conn/odb/src/odb.c
+++ b/core/conn/odb/src/odb.c
@@ -10289,6 +10289,11 @@ static int Ocopy(int eid)
                 goto ocopy_exit;
             }
             if ( etab[eid].dbt != VERTICA ) { /* Vertica's CHAR field length is in bytes (not chars) */
+                if ( etab[eid].dbt == ORACLE && Odt[j] == SQL_TYPE_TIMESTAMP )
+                /* The precision of Oracle's Timestamp is always 9 */
+                {
+                    Ors[j] = SQL_TIMESTAMP_LEN + 10; /* Display Size of TIMESTAMP(9) */
+                }
                 switch ( Odt[j] ) {
                 case SQL_WCHAR:
                 case SQL_WVARCHAR:


### PR DESCRIPTION
Whatever the precision of oracle timestamp's second is 0-9, the char buffer is like YYYY-MM-DD HH24:MI:SS.FFFFFFFFF.
So data size is always equal the display size of timestamp(9) ( SQL_TIMESTAMP_LEN + '.' + 9 for precision )