### PR TITLE
[TRAFODION-2639] parallelize commmands with randomizes execution order core dumped

### DIFF
--- a/core/conn/odb/src/odb.c
+++ b/core/conn/odb/src/odb.c
@@ -6014,7 +6014,7 @@ static void etabshuffle()
     if ( no ) {                 /* more than one element in etab[] */
         for ( i = 0; i < no - 1 ; i++ ) {
             if ( etab[i].type != 'q' ) {    /* etab[] type 'q' entries are linked to qtab[] */
-                j = (int) ( i + rand() / ( RAND_MAX + 1.0 ) * ( no - i + 1 ) );
+                j = (int) ( i + rand() / ( RAND_MAX + 1.0 ) * ( no - i ) );
                 save = etab[j].run;
                 etab[j].run = etab[i].run;
                 etab[i].run = save;

--- a/core/conn/odb/src/odb.c
+++ b/core/conn/odb/src/odb.c
@@ -6012,7 +6012,7 @@ static void etabshuffle()
     
     srand((unsigned int)time(0));
     if ( no ) {                 /* more than one element in etab[] */
-        for ( i = 0; i < no ; i++ ) {
+        for ( i = 0; i < no - 1 ; i++ ) {
             if ( etab[i].type != 'q' ) {    /* etab[] type 'q' entries are linked to qtab[] */
                 j = (int) ( i + rand() / ( RAND_MAX + 1.0 ) * ( no - i + 1 ) );
                 save = etab[j].run;


### PR DESCRIPTION
root cause: generated random index out of range.
fix by: narrow down random range, and the last element no need to be exchanged.