### PR TITLE
[TRAFODION-2346] ODB copy incorrect rows when using rowset and parallel

### DIFF
--- a/core/conn/odb/src/odb.c
+++ b/core/conn/odb/src/odb.c
@@ -407,12 +407,14 @@ struct execute {
     size_t fsl;                 /* field separator length */
     size_t r;                   /* initial rowset, 'Z' thread: key section length */
     size_t ar;                  /* "actual" rowset (could be < r at the end) */
+    size_t AlreadyLoadRows;     /* already load rows */
     size_t rbs;                 /* rowset buffer size, Z thread: "actual" rowset for tgt threads */
     size_t s;                   /* rowbuffer length (includes data & indicator) */
     size_t sbl;                 /* allocated splitby buffer length (if !=0 grandfather should free etab[].sb) */
     size_t iobuff;              /* low level io buffer size. */
     size_t buffsz;              /* load: fread buffer size */
     unsigned long mr;           /* max number of records to insert/fetch; 0 = unlimited. Extract returns here tinit. Zthread:#records 'I" */
+    unsigned long TotalMaxRecords;  /* total number of records */
     int mer;                    /* max number of errors */
     int roe;                    /* restart on error */
     unsigned int roedel;        /* delay before restarting on error */
@@ -5463,8 +5465,10 @@ static void etabadd(char type, char *run, int id)
                     }
                 } else {                            /* not a load job */
                     etab[no].k = no;                /* record grandparent for copy/diff ops */
-                    if ( etab[no].ps )
+                    if ( etab[no].ps ){
+                        etab[no].TotalMaxRecords = etab[no].mr;
                         etab[no].mr /= etab[no].ps; /* each thread will get a portion of the max record to fetch */
+                    }
                     strmcpy(tabn, etab[no].src, sizeof(tabn));
                     if ( !SQL_SUCCEEDED(Oret=SQLAllocHandle(SQL_HANDLE_STMT, Oc, &Os))){
                         Oerr(-1, -1, __LINE__, Oc, SQL_HANDLE_DBC);
@@ -5858,6 +5862,8 @@ static void etabadd(char type, char *run, int id)
                                     l = no ;
                                 }
                                 cimutex(&etab[no].pmutex);
+                                if ( etab[or].TotalMaxRecords )
+                                    etab[or].mr += etab[or].TotalMaxRecords%etab[or].ps;
                                 for ( no++, j = 1 ; j < etab[l].ps ; j++ ) {
                                     etabnew ( l );
                                     etab[no].id = no;
@@ -9349,6 +9355,11 @@ static int Oloadbuff(int eid)
             ts += tspdiff ( &tsp1 , &tsp2 ) ;
 #endif
         }
+        if ( (etab[eid].mr - etab[eid].AlreadyLoadRows) < etab[eid].r )
+            /* Reset Rowset size*/
+            if (!SQL_SUCCEEDED(Or=SQLSetStmtAttr(thps[tid].Os,
+                SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)(etab[eid].mr - etab[eid].AlreadyLoadRows), 0)))
+                Oerr(eid, tid, __LINE__, thps[tid].Os, SQL_HANDLE_STMT);
         if ( etab[eid].ar < etab[eid].r )       /* Reset Rowset size */ 
             if (!SQL_SUCCEEDED(Or=SQLSetStmtAttr(thps[tid].Os,
                 SQL_ATTR_PARAMSET_SIZE, (SQLPOINTER)(etab[eid].ar), 0)))
@@ -10670,6 +10681,7 @@ static int Ocopy(int eid)
             etab[i].lstat = 1;                  /* mark loader buffer read_available */
             MutexUnlock(&etab[eid].pmutex);     /* lock shared mutex */
             etab[i].ar = Orespl;                /* inform loader about #rec to insert */
+            etab[i].AlreadyLoadRows += Orespl;
             CondWakeAll(&etab[eid].pcvc);       /* wake-up sleeping loader threads */
 #ifdef ODB_PROFILE
             clock_gettime(CLOCK_MONOTONIC, &tsp2);


### PR DESCRIPTION
fix jira TRAFODION-2346 and TRAFODION-2373 bug as follows:
When using parallel, max rows/ parallel will cause rows cutting because of divisibility.
When using rowset, per thread rows/rowset will cause one more round contained the same rowset.
For example, rows = 5000 ,max = 500000 ,parallel = 6 :
per thread rows(size_t) = max rows / parallel = 500000 / 6 = 83333
round = per thread rows / rowset = 83333 / 5000 = 16 (actually do one more round)
Finally , 5000 * 17 * 6 = 510000 rows will be load and copy