### PR TITLE
[TRAFODION-2337] odb on windows can not use parameter with absolute path

### DIFF
--- a/core/conn/odb/src/odb.c
+++ b/core/conn/odb/src/odb.c
@@ -13133,7 +13133,11 @@ static int Otcol(int eid, SQLHDBC *Ocn)
                     j++; 
                     q = 1;
                 }
-                for ( l = j ; ( str[j] && str[j] != '\n' ) && ( q || str[j] != ':' ) ; j++) {
+#ifdef _WIN32
+                for (l = j; (str[j] && str[j] != '\n') && (q || str[j] != ':') || str[j + 1] == '/'; j++) {
+#else
+                for (l = j; (str[j] && str[j] != '\n') && (q || str[j] != ':'); j++) {
+#endif
                     if ( q ) {
                         if ( str[j] == ']' && ( str[j+1] == ':' || str[j+1] == 0 || isspace((int)str[j+1]) ) ) {
                             q = 0;


### PR DESCRIPTION
When using absolute path on windows such as src=d:/src.txt , ':' will be used as separator.
So I add judging condition to avoid dividing when ':' and '/' is apart.