### PR TITLE
Multiple fixes: REPLACE func maxlen, hbase unregister, DDLExpr cleanup

### DIFF
--- a/core/sql/generator/GenPreCode.cpp
+++ b/core/sql/generator/GenPreCode.cpp
@@ -2804,12 +2804,12 @@ short DDLExpr::ddlXnsInfo(NABoolean &isDDLxn, NABoolean &xnCanBeStarted)
   if (NOT ddlXns()) 
   { 
      if ((dropHbase()) ||
-       (purgedataHbase()) ||
+       (purgedata()) ||
        (initHbase()) ||
        (createMDViews()) ||
        (dropMDViews()) ||
-       (initAuthorization()) ||
-       (dropAuthorization()) ||
+       (initAuth()) ||
+       (dropAuth()) ||
        (createRepos()) ||
        (dropRepos()) ||
        (upgradeRepos()) ||
@@ -2845,7 +2845,7 @@ short DDLExpr::ddlXnsInfo(NABoolean &isDDLxn, NABoolean &xnCanBeStarted)
         ddlNode->castToStmtDDLNode()->ddlXns())
      isDDLxn = TRUE;
 
-     if (purgedataHbase() || upgradeRepos())
+     if (purgedata() || upgradeRepos())
         // transaction will be started and commited in called methods.
         xnCanBeStarted = FALSE;
      if ((ddlNode && ddlNode->castToStmtDDLNode() &&
@@ -2878,7 +2878,7 @@ RelExpr * DDLExpr::preCodeGen(Generator * generator,
     return NULL;
   
   if ((specialDDL()) ||
-      (initHbase_))
+      (initHbase()))
     {
       generator->setAqrEnabled(FALSE);
     }

--- a/core/sql/generator/GenRelExeUtil.cpp
+++ b/core/sql/generator/GenRelExeUtil.cpp
@@ -541,7 +541,7 @@ short ExeUtilDisplayExplainComplex::codeGen(Generator * generator)
   if (getExprNode()->getOperatorType() == REL_DDL)
     {
       DDLExpr * ddlExpr = (DDLExpr*)getExprNode()->castToRelExpr();
-      if (ddlExpr->forShowddlExplain())
+      if (ddlExpr->showddlExplain())
 	{
 	  exe_util_tdb->setIsShowddl(TRUE);
 	  

--- a/core/sql/optimizer/RelExeUtil.cpp
+++ b/core/sql/optimizer/RelExeUtil.cpp
@@ -229,8 +229,8 @@ RelExpr * DDLExpr::copyTopNode(RelExpr *derivedNode, CollHeap* outHeap)
   if (derivedNode == NULL)
     result = new (outHeap) DDLExpr(getDDLNode(), // ExprNode * ddlNode
                                    (char *)NULL, // char * ddlStmtText
-                                   CharInfo::UnknownCharSet, // CharInfo::CharSet ddlStmtTextCharSet
-                                   FALSE, FALSE, FALSE, NULL, 0, outHeap);
+                                   CharInfo::UnknownCharSet,
+                                   outHeap);
   else
     result = (DDLExpr *) derivedNode;
 
@@ -238,9 +238,6 @@ RelExpr * DDLExpr::copyTopNode(RelExpr *derivedNode, CollHeap* outHeap)
 
   result->ddlObjNATable_ = ddlObjNATable_;
 
-  result->forShowddlExplain_ = forShowddlExplain_;
-  result->internalShowddlExplain_ = internalShowddlExplain_;
-  result->noLabelStats_ = noLabelStats_;
   result->explObjName_ = explObjName_;
   result->numExplRows_ = numExplRows_;
 
@@ -265,11 +262,6 @@ RelExpr * DDLExpr::copyTopNode(RelExpr *derivedNode, CollHeap* outHeap)
   result->isHbase_ = isHbase_;
   result->isNative_ = isNative_;
   result->hbaseDDLNoUserXn_ = hbaseDDLNoUserXn_;
-  result->initHbase_ = initHbase_;
-  result->dropHbase_ = dropHbase_;
-  result->updateVersion_ = updateVersion_;
-  result->purgedataHbase_ = purgedataHbase_;
-  result->addSchemaObjects_ = addSchemaObjects_;
 
   result->returnStatus_ = returnStatus_;
 
@@ -4052,12 +4044,12 @@ RelExpr * DDLExpr::bindNode(BindWA *bindWA)
       return boundExpr;
       //      isHbase_ = TRUE;
     }
-  else if (initAuthorization() || dropAuthorization() || cleanupAuth())
+  else if (initAuth() || dropAuth() || cleanupAuth())
   {
     isHbase_ = TRUE;
     hbaseDDLNoUserXn_ = TRUE;
   }
-  else if (initHbase_ || dropHbase_ || createMDViews() || dropMDViews() ||
+  else if (initHbase() || dropHbase() || createMDViews() || dropMDViews() ||
       addSchemaObjects() || updateVersion())
   {
     isHbase_ = TRUE;
@@ -4073,7 +4065,7 @@ RelExpr * DDLExpr::bindNode(BindWA *bindWA)
       isHbase_ = TRUE;
       hbaseDDLNoUserXn_ = TRUE;
     }
-  else if (purgedataHbase_)
+  else if (purgedata())
   {
     isHbase_ = TRUE;
     hbaseDDLNoUserXn_ = TRUE;      
@@ -4515,7 +4507,7 @@ RelExpr * DDLExpr::bindNode(BindWA *bindWA)
 
     if ((isCreateSchema || isDropSchema || isAlterSchema) || isRegister ||
         ((isTable_ || isIndex_ || isView_ || isRoutine_ || isLibrary_ || isSeq) &&
-         (isCreate_ || isDrop_ || purgedataHbase_ || 
+         (isCreate_ || isDrop_ || purgedata() || 
           (isAlter_ && (alterAddCol || alterDropCol || alterDisableIndex || alterEnableIndex || 
 			alterAddConstr || alterDropConstr || alterRenameTable ||
                         alterStoredDesc ||
@@ -5193,10 +5185,13 @@ RelExpr * ExeUtilFastDelete::bindNode(BindWA *bindWA)
       return NULL;
     }
   
-  DDLExpr * ddlExpr = new(bindWA->wHeap()) DDLExpr(TRUE,
-                                                   getTableName(),
+  DDLExpr * ddlExpr = new(bindWA->wHeap()) DDLExpr(NULL,
                                                    getStmtText(),
-                                                   CharInfo::UnknownCharSet);
+                                                   CharInfo::UnknownCharSet,
+                                                   CmpCommon::statementHeap());
+  ddlExpr->setPurgedata(TRUE);
+  ddlExpr->setPurgedataTableName(getTableName());
+
   RelExpr * boundExpr = ddlExpr->bindNode(bindWA);
 
   return boundExpr;

--- a/core/sql/optimizer/RelExeUtil.h
+++ b/core/sql/optimizer/RelExeUtil.h
@@ -215,120 +215,22 @@ public:
   DDLExpr(ExprNode * ddlNode,
 	  char * ddlStmtText,
 	  CharInfo::CharSet ddlStmtTextCharSet,
-	  NABoolean forShowddlExplain = FALSE,
-	  NABoolean internalShowddlExplain = FALSE,
-	  NABoolean noLabelStats = FALSE,
-	  QualifiedName * explObjName = NULL,
-	  double numExplRows = 0,
-	  CollHeap *oHeap = CmpCommon::statementHeap())
-    : GenericUtilExpr(ddlStmtText, ddlStmtTextCharSet, ddlNode, NULL, REL_DDL, oHeap),
-    specialDDL_(FALSE),
-    ddlObjNATable_(NULL),
-    forShowddlExplain_(forShowddlExplain),
-    internalShowddlExplain_(internalShowddlExplain),
-    noLabelStats_(noLabelStats),
-    numExplRows_(numExplRows),
-    isCreate_(FALSE), isCreateLike_(FALSE), isVolatile_(FALSE), 
-    isDrop_(FALSE), isAlter_(FALSE), isCleanup_(FALSE),
-    isTable_(FALSE), isIndex_(FALSE), isMV_(FALSE), isView_(FALSE),
-    isSchema_(FALSE),
-    isLibrary_(FALSE), isRoutine_(FALSE),
-    isUstat_(FALSE),
-    isHbase_(FALSE),
-    isNative_(FALSE),
-    initHbase_(FALSE),
-    dropHbase_(FALSE),
-    updateVersion_(FALSE),
-    purgedataHbase_(FALSE),
-    initAuthorization_(FALSE),
-    dropAuthorization_(FALSE),
-    addSchemaObjects_(FALSE),
-    minimal_(FALSE),
-    returnStatus_(FALSE),
-    flags_(0)
+	  CollHeap *oHeap)
+       : GenericUtilExpr(ddlStmtText, ddlStmtTextCharSet, ddlNode, NULL, 
+                         REL_DDL, oHeap),
+         specialDDL_(FALSE),
+         ddlObjNATable_(NULL),
+         numExplRows_(0),
+         isCreate_(FALSE), isCreateLike_(FALSE), isVolatile_(FALSE), 
+         isDrop_(FALSE), isAlter_(FALSE), isCleanup_(FALSE),
+         isTable_(FALSE), isIndex_(FALSE), isMV_(FALSE), isView_(FALSE),
+         isSchema_(FALSE), isLibrary_(FALSE), isRoutine_(FALSE),
+         isUstat_(FALSE),
+         isHbase_(FALSE),
+         isNative_(FALSE),
+         returnStatus_(FALSE),
+         flags_(0)
   {
-    if (explObjName)
-      explObjName_ = *explObjName;
-
-    setDDLXns(TRUE);
-  };
-
- DDLExpr(NABoolean initHbase, NABoolean dropHbase,
-	 NABoolean createMDviews, NABoolean dropMDviews,
-         NABoolean initAuthorization, NABoolean dropAuthorization,
-	 NABoolean /* formerly addSeqTable */ dummy, NABoolean updateVersion, NABoolean addSchemaObjects,
-         NABoolean minimal,
-	 char * ddlStmtText,
-	 CharInfo::CharSet ddlStmtTextCharSet,
-	  CollHeap *oHeap = CmpCommon::statementHeap())
-   : GenericUtilExpr(ddlStmtText, ddlStmtTextCharSet, NULL, NULL, REL_DDL, oHeap),
-    specialDDL_(FALSE),
-    ddlObjNATable_(NULL),
-    forShowddlExplain_(FALSE),
-    internalShowddlExplain_(FALSE),
-    noLabelStats_(FALSE),
-    numExplRows_(0),
-    isCreate_(FALSE), isCreateLike_(FALSE), isVolatile_(FALSE), 
-    isDrop_(FALSE), isAlter_(FALSE), isCleanup_(FALSE),
-    isTable_(FALSE), isIndex_(FALSE), isMV_(FALSE), isView_(FALSE),
-    isSchema_(FALSE),
-    isLibrary_(FALSE), isRoutine_(FALSE),
-    isUstat_(FALSE),
-    isHbase_(FALSE),
-    isNative_(FALSE),
-    initHbase_(initHbase), 
-    dropHbase_(dropHbase),
-    updateVersion_(updateVersion),
-    purgedataHbase_(FALSE),
-    initAuthorization_(initAuthorization),
-    dropAuthorization_(dropAuthorization),
-    addSchemaObjects_(addSchemaObjects),
-    minimal_(minimal),
-    returnStatus_(FALSE),
-    flags_(0)
-  {
-    if (createMDviews)
-      setCreateMDViews(TRUE);
-    
-    if (dropMDviews)
-      setDropMDViews(TRUE);
-
-    setDDLXns(TRUE);
-  };
-
- DDLExpr(NABoolean purgedataHbase,
-	 CorrName &purgedataTableName,
-	 char * ddlStmtText,
-	 CharInfo::CharSet ddlStmtTextCharSet,
-	 CollHeap *oHeap = CmpCommon::statementHeap())
-   : GenericUtilExpr(ddlStmtText, ddlStmtTextCharSet, NULL, NULL, REL_DDL, oHeap),
-    specialDDL_(FALSE),
-    ddlObjNATable_(NULL),
-    forShowddlExplain_(FALSE),
-    internalShowddlExplain_(FALSE),
-    noLabelStats_(FALSE),
-    numExplRows_(0),
-    isCreate_(FALSE), isCreateLike_(FALSE), isVolatile_(FALSE), 
-    isDrop_(FALSE), isAlter_(FALSE), isCleanup_(FALSE),
-    isTable_(FALSE), isIndex_(FALSE), isMV_(FALSE), isView_(FALSE),
-    isSchema_(FALSE),
-    isUstat_(FALSE),
-    isHbase_(FALSE),
-    isNative_(FALSE),
-    initHbase_(FALSE), 
-    dropHbase_(FALSE),
-    updateVersion_(FALSE),
-    purgedataHbase_(purgedataHbase),
-    initAuthorization_(FALSE),
-    dropAuthorization_(FALSE),
-    addSchemaObjects_(FALSE),
-    minimal_(FALSE),
-    returnStatus_(FALSE),
-    flags_(0)
-  {
-    purgedataTableName_ = purgedataTableName;
-    qualObjName_ = purgedataTableName.getQualifiedNameObj();
-
     setDDLXns(TRUE);
   };
 
@@ -371,30 +273,23 @@ public:
   }
 
   CorrName &purgedataTableName() { return purgedataTableName_; }
+  void setPurgedataTableName(CorrName &cn) 
+  { 
+    purgedataTableName_ = cn; 
+    qualObjName_ = cn.getQualifiedNameObj();
+  }
 
   NABoolean &specialDDL() { return specialDDL_;}
   NABoolean &isUstat() { return isUstat_; }
 
-  NABoolean forShowddlExplain() { return forShowddlExplain_; }
-  NABoolean internalShowddlExplain() { return internalShowddlExplain_; }
-  NABoolean noLabelStats() { return noLabelStats_; }
-  void setNoLabelStats(NABoolean v) { noLabelStats_ = v; }
-
   QualifiedName &explObjName() { return explObjName_; }
+  void setExplObjName(QualifiedName &qn) { explObjName_ = qn; }
 
   double numExplRows() { return numExplRows_; }
+  void setNumExplRows(double nr) { numExplRows_ = nr; }
 
   virtual NABoolean dontUseCache() 
-  { return (forShowddlExplain() ? FALSE : TRUE); }
-
-  NABoolean initHbase() { return initHbase_; }
-  NABoolean dropHbase() { return dropHbase_; }
-  NABoolean updateVersion() { return updateVersion_; }
-  NABoolean purgedataHbase() { return purgedataHbase_; }
-  NABoolean initAuthorization() { return initAuthorization_; }
-  NABoolean dropAuthorization() { return dropAuthorization_; }
-  NABoolean addSchemaObjects() { return addSchemaObjects_; }
-  NABoolean minimal() { return minimal_; }
+  { return (showddlExplain() ? FALSE : TRUE); }
 
   short ddlXnsInfo(NABoolean &ddlXns, NABoolean &xnCanBeStarted);
 
@@ -440,21 +335,80 @@ public:
   {(v ? flags_ |= CLEANUP_AUTH : flags_ &= ~CLEANUP_AUTH); }
   NABoolean cleanupAuth() { return (flags_ & CLEANUP_AUTH) != 0;}
 
+  void setInitHbase(NABoolean v)
+  {(v ? flags_ |= INIT_HBASE : flags_ &= ~INIT_HBASE); }
+  NABoolean initHbase() { return (flags_ & INIT_HBASE) != 0;}
+
+  void setDropHbase(NABoolean v)
+  {(v ? flags_ |= DROP_HBASE : flags_ &= ~DROP_HBASE); }
+  NABoolean dropHbase() { return (flags_ & DROP_HBASE) != 0;}
+
+  void setInitAuth(NABoolean v)
+  {(v ? flags_ |= INIT_AUTH : flags_ &= ~INIT_AUTH); }
+  NABoolean initAuth() { return (flags_ & INIT_AUTH) != 0;}
+
+  void setDropAuth(NABoolean v)
+  {(v ? flags_ |= DROP_AUTH : flags_ &= ~DROP_AUTH); }
+  NABoolean dropAuth() { return (flags_ & DROP_AUTH) != 0;}
+
+  void setUpdateVersion(NABoolean v)
+  {(v ? flags_ |= UPDATE_VERSION : flags_ &= ~UPDATE_VERSION); }
+  NABoolean updateVersion() { return (flags_ & UPDATE_VERSION) != 0;}
+
+  void setAddSchemaObjects(NABoolean v)
+  {(v ? flags_ |= ADD_SCH_OBJS : flags_ &= ~ADD_SCH_OBJS); }
+  NABoolean addSchemaObjects() { return (flags_ & ADD_SCH_OBJS) != 0;}
+
+  // minimal: meaningful only when initHbase_ is true; if this is true,
+  // means create the metadata tables only (and not repository etc.)
+  void setMinimal(NABoolean v)
+  {(v ? flags_ |= MINIMAL : flags_ &= ~MINIMAL); }
+  NABoolean minimal() { return (flags_ & MINIMAL) != 0;}
+
+  void setPurgedata(NABoolean v)
+  {(v ? flags_ |= PURGEDATA : flags_ &= ~PURGEDATA); }
+  NABoolean purgedata() { return (flags_ & PURGEDATA) != 0;}
+
+  // this ddlexpr is created for 'showddl <obj>, explain' to
+  // explain the object explObjName.
+  void setShowddlExplain(NABoolean v)
+  {(v ? flags_ |= SHOWDDL_EXPLAIN : flags_ &= ~SHOWDDL_EXPLAIN); }
+  NABoolean showddlExplain() { return (flags_ & SHOWDDL_EXPLAIN) != 0;}
+
+  void setShowddlExplainInt(NABoolean v)
+  {(v ? flags_ |= SHOWDDL_EXPLAIN_INT : flags_ &= ~SHOWDDL_EXPLAIN_INT); }
+  NABoolean showddlExplainInt() { return (flags_ & SHOWDDL_EXPLAIN_INT) != 0;}
+
+  void setNoLabelStats(NABoolean v)
+  {(v ? flags_ |= NO_LABEL_STATS : flags_ &= ~NO_LABEL_STATS); }
+  NABoolean noLabelStats() { return (flags_ & NO_LABEL_STATS) != 0;}
+
   NABoolean ddlXns() { return ddlXns_; }
 
  protected:
   enum Flags
   {
-    CREATE_MD_VIEWS         = 0x0001,
-    DROP_MD_VIEWS           = 0x0002,
-    GET_MD_VERSION          = 0x0004,
-    CREATE_REPOS            = 0x0008,
-    DROP_REPOS              = 0x0010,
-    UPGRADE_REPOS           = 0x0020,
-    CLEANUP_AUTH            = 0X0040,
-    CREATE_LIBMGR           = 0x0080,
-    DROP_LIBMGR             = 0x0100,
-    UPGRADE_LIBMGR          = 0x0200
+    CREATE_MD_VIEWS         = 0x000001,
+    DROP_MD_VIEWS           = 0x000002,
+    GET_MD_VERSION          = 0x000004,
+    CREATE_REPOS            = 0x000008,
+    DROP_REPOS              = 0x000010,
+    UPGRADE_REPOS           = 0x000020,
+    CLEANUP_AUTH            = 0X000040,
+    CREATE_LIBMGR           = 0x000080,
+    DROP_LIBMGR             = 0x000100,
+    UPGRADE_LIBMGR          = 0x000200,
+    INIT_HBASE              = 0x000400,
+    DROP_HBASE              = 0x000800,
+    INIT_AUTH               = 0x001000,
+    DROP_AUTH               = 0x002000,
+    UPDATE_VERSION          = 0x004000,
+    ADD_SCH_OBJS            = 0x008000,
+    MINIMAL                 = 0x010000,
+    PURGEDATA               = 0x020000,
+    SHOWDDL_EXPLAIN         = 0x040000,
+    SHOWDDL_EXPLAIN_INT     = 0x080000,
+    NO_LABEL_STATS          = 0x100000,
   };
 
   // see method processSpecialDDL in sqlcomp/parser.cpp
@@ -464,11 +418,6 @@ public:
   // Set during bindNode phase.
   NATable * ddlObjNATable_;
 
-  // this ddlexpr is created for 'showddl <obj>, explain' to
-  // explain the object explObjName.
-  NABoolean forShowddlExplain_;
-  NABoolean internalShowddlExplain_;
-  NABoolean noLabelStats_;
   QualifiedName explObjName_;
   double numExplRows_;  // number of rows specified by user or actual count
 
@@ -486,19 +435,10 @@ public:
 
   NABoolean isHbase_; // a trafodion or hbase operation
   NABoolean isNative_; // an operation directly on a native hbase table, like
-                                  // creating an hbase table from trafodion interface.
-  NABoolean initHbase_;	  
-  NABoolean dropHbase_;	
-  NABoolean updateVersion_;
-  NABoolean purgedataHbase_;
-  NABoolean initAuthorization_;
-  NABoolean dropAuthorization_;
-  NABoolean addSchemaObjects_;
-  NABoolean minimal_;  // meaningful only when initHbase_ is true; if this is true,
-                       // means create the metadata tables only (and not repository etc.)
+                       // creating an hbase table from trafodion interface.
 
-  // if set, this ddl cannot run under a user transaction. It must run in autocommit
-  // mode.
+  // if set, this ddl cannot run under a user transaction. 
+  // It must run in autocommit mode.
   NABoolean hbaseDDLNoUserXn_;
 
   // set for create table index/MV only. Used during InMemory table
@@ -821,7 +761,7 @@ public:
 			      char * stmtText,
 			      CharInfo::CharSet stmtTextCharSet,
 			      CollHeap *oHeap = CmpCommon::statementHeap())
-       : DDLExpr(exprNode, stmtText, stmtTextCharSet, FALSE, FALSE, FALSE, NULL, 0, oHeap),
+       : DDLExpr(exprNode, stmtText, stmtTextCharSet, oHeap),
 	 isCreate_(FALSE),
 	 isTable_(FALSE),
 	 isIndex_(FALSE),
@@ -862,7 +802,7 @@ public:
 			       char * stmtText,
 			       CharInfo::CharSet stmtTextCharSet,
 			       CollHeap *oHeap = CmpCommon::statementHeap())
-       : DDLExpr(exprNode, stmtText, stmtTextCharSet, FALSE, FALSE, FALSE, NULL, 0, oHeap)
+       : DDLExpr(exprNode, stmtText, stmtTextCharSet, oHeap)
   {
   };
 

--- a/core/sql/optimizer/SynthType.cpp
+++ b/core/sql/optimizer/SynthType.cpp
@@ -4052,6 +4052,7 @@ const NAType *Replace::synthesizeType()
   const NAType *typ2 = &(child(1)->getValueId().getType());
   const NAType *typ3 = &(child(2)->getValueId().getType());
 
+
   /* Soln-10-050426-7137 begin */
 
   NAString defVal;
@@ -4155,9 +4156,13 @@ const NAType *Replace::synthesizeType()
      }
   }
 
-  if ( size_in_chars > CONST_32K ) size_in_chars = CONST_32K ;
-  if ( size_in_bytes > CONST_32K ) size_in_bytes = CONST_32K ;
-
+  Int32 maxLenInBytes = CmpCommon::getDefaultNumeric(TRAF_MAX_CHARACTER_COL_LENGTH);
+  if (size_in_bytes > maxLenInBytes)
+    {
+      size_in_bytes = maxLenInBytes;
+      size_in_chars = size_in_bytes / CharInfo::minBytesPerChar(ctyp1->getCharSet());
+    }
+ 
   CharLenInfo CLInfo( size_in_chars, size_in_bytes );
 
   NAType *result =

--- a/core/sql/parser/sqlparser.y
+++ b/core/sql/parser/sqlparser.y
@@ -14793,7 +14793,8 @@ interactive_query_expression:
 		  else
 		    {
 		      $$ = finalize(new (PARSERHEAP())
-				    DDLExpr($1, (char*)stmt->data(), stmtCharSet));
+				    DDLExpr($1, (char*)stmt->data(), 
+                                            stmtCharSet, PARSERHEAP()));
 		    }
 
                   delete stmt;
@@ -16456,12 +16457,14 @@ exe_util_init_hbase : TOK_INITIALIZE TOK_TRAFODION
 						   , PARSERHEAP() 
 	                                       );
 
-		 DDLExpr * de = new(PARSERHEAP()) DDLExpr(TRUE, FALSE, TRUE, FALSE,
-                                                          FALSE, FALSE,
-							  FALSE, FALSE, FALSE, FALSE,
-							  (char*)stmt->data(),
-							  stmtCharSet,
-							  PARSERHEAP());
+                 DDLExpr * de = new(PARSERHEAP()) DDLExpr
+                   (NULL,
+                    (char*)stmt->data(), 
+                    stmtCharSet,
+                    PARSERHEAP());
+
+                 de->setInitHbase(TRUE);
+                 de->setCreateMDViews(TRUE);
 
 		 $$ = de;
 	       }
@@ -16473,12 +16476,15 @@ exe_util_init_hbase : TOK_INITIALIZE TOK_TRAFODION
 						   , PARSERHEAP() 
 	                                       );
 
-		 DDLExpr * de = new(PARSERHEAP()) DDLExpr(TRUE, FALSE, TRUE, FALSE,
-                                                          FALSE, FALSE,
-							  FALSE, FALSE, FALSE, TRUE /* minimal */,
-							  (char*)stmt->data(),
-							  stmtCharSet,
-							  PARSERHEAP());
+                 DDLExpr * de = new(PARSERHEAP()) DDLExpr
+                   (NULL,
+                    (char*)stmt->data(), 
+                    stmtCharSet,
+                    PARSERHEAP());
+
+                 de->setInitHbase(TRUE);
+                 de->setCreateMDViews(TRUE);
+                 de->setMinimal(TRUE);
 
 		 $$ = de;                
                }
@@ -16490,12 +16496,14 @@ exe_util_init_hbase : TOK_INITIALIZE TOK_TRAFODION
 						   , PARSERHEAP() 
 	                                       );
 
-		 DDLExpr * de = new(PARSERHEAP()) DDLExpr(TRUE, FALSE, FALSE, FALSE,
-                                                          FALSE, FALSE,
-							  FALSE, FALSE, FALSE, FALSE,
-							  (char*)stmt->data(),
-							  stmtCharSet,
-							  PARSERHEAP());
+
+                 DDLExpr * de = new(PARSERHEAP()) DDLExpr
+                   (NULL,
+                    (char*)stmt->data(), 
+                    stmtCharSet,
+                    PARSERHEAP());
+
+                 de->setInitHbase(TRUE);
 
 		 $$ = de;
 	       }
@@ -16507,12 +16515,14 @@ exe_util_init_hbase : TOK_INITIALIZE TOK_TRAFODION
 						   , PARSERHEAP() 
 	                                       );
 
-		 DDLExpr * de = new(PARSERHEAP()) DDLExpr(FALSE, TRUE, FALSE, TRUE,
-                                                          FALSE, FALSE,
-							  FALSE, FALSE, FALSE, FALSE,
-							  (char*)stmt->data(),
-							  stmtCharSet,
-							  PARSERHEAP());
+                 DDLExpr * de = new(PARSERHEAP()) DDLExpr
+                   (NULL,
+                    (char*)stmt->data(), 
+                    stmtCharSet,
+                    PARSERHEAP());
+
+                 de->setDropHbase(TRUE);
+                 de->setDropMDViews(TRUE);
 
 		 $$ = de;
 	       }
@@ -16524,12 +16534,13 @@ exe_util_init_hbase : TOK_INITIALIZE TOK_TRAFODION
 						   , PARSERHEAP() 
 	                                       );
 
-		 DDLExpr * de = new(PARSERHEAP()) DDLExpr(FALSE, FALSE, TRUE, FALSE,
-                                                          FALSE, FALSE,
-							  FALSE, FALSE, FALSE, FALSE,
-							  (char*)stmt->data(),
-							  stmtCharSet,
-							  PARSERHEAP());
+                 DDLExpr * de = new(PARSERHEAP()) DDLExpr
+                   (NULL,
+                    (char*)stmt->data(), 
+                    stmtCharSet,
+                    PARSERHEAP());
+
+                 de->setCreateMDViews(TRUE);
 
 		 $$ = de;
 	       }
@@ -16541,12 +16552,13 @@ exe_util_init_hbase : TOK_INITIALIZE TOK_TRAFODION
 						   , PARSERHEAP() 
 	                                       );
 
-		 DDLExpr * de = new(PARSERHEAP()) DDLExpr(FALSE, FALSE, FALSE, TRUE,
-                                                          FALSE, FALSE,
-							  FALSE, FALSE, FALSE, FALSE,
-							  (char*)stmt->data(),
-							  stmtCharSet,
-							  PARSERHEAP());
+                 DDLExpr * de = new(PARSERHEAP()) DDLExpr
+                   (NULL,
+                    (char*)stmt->data(), 
+                    stmtCharSet,
+                    PARSERHEAP());
+
+                 de->setDropMDViews(TRUE);
 
 		 $$ = de;
 	       }
@@ -16565,12 +16577,13 @@ exe_util_init_hbase : TOK_INITIALIZE TOK_TRAFODION
 						   , PARSERHEAP() 
 	                                       );
 
-		 DDLExpr * de = new(PARSERHEAP()) DDLExpr(FALSE, FALSE, FALSE, FALSE,
-                                                          FALSE, FALSE,
-							  FALSE, FALSE,	TRUE, FALSE,
-							  (char*)stmt->data(),
-							  stmtCharSet,
-							  PARSERHEAP());
+                 DDLExpr * de = new(PARSERHEAP()) DDLExpr
+                   (NULL,
+                    (char*)stmt->data(), 
+                    stmtCharSet,
+                    PARSERHEAP());
+
+                 de->setAddSchemaObjects(TRUE);
 
                  $$ = de;
 
@@ -16585,8 +16598,8 @@ exe_util_init_hbase : TOK_INITIALIZE TOK_TRAFODION
 
 		 DDLExpr * de = new(PARSERHEAP()) DDLExpr(NULL,
                                                           (char*)stmt->data(),
-                                                           stmtCharSet);
-
+                                                          stmtCharSet,
+                                                          PARSERHEAP());
                  de->setCreateLibmgr(TRUE);
 
                  $$ = de;
@@ -16602,7 +16615,8 @@ exe_util_init_hbase : TOK_INITIALIZE TOK_TRAFODION
 
                  DDLExpr * de = new(PARSERHEAP()) DDLExpr(NULL,
                                                           (char*)stmt->data(),
-                                                          stmtCharSet);
+                                                          stmtCharSet,
+                                                          PARSERHEAP());
 
                  de->setDropLibmgr(TRUE);
 
@@ -16619,7 +16633,8 @@ exe_util_init_hbase : TOK_INITIALIZE TOK_TRAFODION
 
                  DDLExpr * de = new(PARSERHEAP()) DDLExpr(NULL,
                                                           (char*)stmt->data(),
-                                                          stmtCharSet);
+                                                          stmtCharSet,
+                                                          PARSERHEAP());
 
                  de->setUpgradeLibmgr(TRUE);
 
@@ -16636,7 +16651,8 @@ exe_util_init_hbase : TOK_INITIALIZE TOK_TRAFODION
 
 		 DDLExpr * de = new(PARSERHEAP()) DDLExpr(NULL,
 							  (char*)stmt->data(),
-							  stmtCharSet);
+							  stmtCharSet,
+                                                          PARSERHEAP());
 
                  de->setCreateRepos(TRUE);
 
@@ -16652,7 +16668,8 @@ exe_util_init_hbase : TOK_INITIALIZE TOK_TRAFODION
 
 		 DDLExpr * de = new(PARSERHEAP()) DDLExpr(NULL,
 							  (char*)stmt->data(),
-							  stmtCharSet);
+							  stmtCharSet,
+                                                          PARSERHEAP());
 
                  de->setDropRepos(TRUE);
 
@@ -16668,7 +16685,8 @@ exe_util_init_hbase : TOK_INITIALIZE TOK_TRAFODION
 
 		 DDLExpr * de = new(PARSERHEAP()) DDLExpr(NULL,
 							  (char*)stmt->data(),
-							  stmtCharSet);
+							  stmtCharSet,
+                                                          PARSERHEAP());
 
                  de->setUpgradeRepos(TRUE);
 
@@ -16681,13 +16699,16 @@ exe_util_init_hbase : TOK_INITIALIZE TOK_TRAFODION
 		 NAString * stmt = getSqlStmtStr ( stmtCharSet  // out - CharInfo::CharSet &
 						   , PARSERHEAP() 
 	                                       );
-		 DDLExpr * ia = new(PARSERHEAP()) DDLExpr(FALSE, FALSE, FALSE, FALSE,
-                                                          TRUE, FALSE,
-							  FALSE, FALSE, FALSE, FALSE,
-							  (char*)stmt->data(),
-							  stmtCharSet,
-							  PARSERHEAP());
-                 $$ = ia;
+
+                 DDLExpr * de = new(PARSERHEAP()) DDLExpr
+                   (NULL,
+                    (char*)stmt->data(), 
+                    stmtCharSet,
+                    PARSERHEAP());
+
+                 de->setInitAuth(TRUE);
+
+                 $$ = de;
 
                }
 
@@ -16700,7 +16721,8 @@ exe_util_init_hbase : TOK_INITIALIZE TOK_TRAFODION
 
 		 DDLExpr * de = new(PARSERHEAP()) DDLExpr(NULL,
 							  (char*)stmt->data(),
-							  stmtCharSet);
+							  stmtCharSet,
+                                                          PARSERHEAP());
 
                  de->setCleanupAuth(TRUE);
                  $$ = de;
@@ -16714,14 +16736,13 @@ exe_util_init_hbase : TOK_INITIALIZE TOK_TRAFODION
 						   , PARSERHEAP() 
 	                                       );
 
-		 DDLExpr * ia = new(PARSERHEAP()) DDLExpr(FALSE, FALSE, FALSE, FALSE,
-                                                          FALSE, TRUE,
-							  FALSE, FALSE, FALSE, FALSE,
+		 DDLExpr * de = new(PARSERHEAP()) DDLExpr(NULL,
 							  (char*)stmt->data(),
 							  stmtCharSet,
-							  PARSERHEAP());
+                                                          PARSERHEAP());
+                 de->setDropAuth(TRUE);
 
-                 $$ = ia;
+                 $$ = de;
 
                }
 
@@ -16732,12 +16753,11 @@ exe_util_init_hbase : TOK_INITIALIZE TOK_TRAFODION
 						   , PARSERHEAP() 
 	                                       );
 
-		 DDLExpr * de = new(PARSERHEAP()) DDLExpr(FALSE, FALSE, FALSE, FALSE,
-                                                          FALSE, FALSE,
-							  FALSE, TRUE, FALSE, FALSE,
+		 DDLExpr * de = new(PARSERHEAP()) DDLExpr(NULL,
 							  (char*)stmt->data(),
 							  stmtCharSet,
-							  PARSERHEAP());
+                                                          PARSERHEAP());
+                 de->setUpdateVersion(TRUE);
 
 		 $$ = de;
 	       }
@@ -17001,8 +17021,8 @@ exe_util_display_explain: explain_starting_tokens interactive_query_expression d
 			ddlExpr = (DDLExpr*)$2;
 		      else
 			ddlExpr = (DDLExpr*)($2->castToRelExpr()->child(0)->castToRelExpr());
-		      if ((ddlExpr->forShowddlExplain()) &&
-			  (NOT ddlExpr->internalShowddlExplain()))
+		      if ((ddlExpr->showddlExplain()) &&
+			  (NOT ddlExpr->showddlExplainInt()))
 			{
 			  complexExplain = TRUE;
 			  nodeToExplainComplex = ddlExpr;
@@ -22477,25 +22497,31 @@ show_statement:
 	     }
 	   | TOK_SHOWDDL table_name ',' TOK_EXPLAIN
 	     {
+               // this option is not supported and causes a crash.
+               // It either need to fixed or removed.
+               *SqlParser_Diags <<  DgSqlCode(-3131);
+               YYERROR;
+
                CharInfo::CharSet stmtCharSet = CharInfo::UnknownCharSet;
 	       NAString * stmt = getSqlStmtStr ( stmtCharSet  // out - CharInfo::CharSet &
 	                                       , PARSERHEAP() // in  - NAMemory * heapUsedForOutputBuffers
 	                                       );
 	       // If we can not get a variable-width multi-byte or single-byte string here, report error 
 	       if ( stmt == NULL )
-	       {
-	         *SqlParser_Diags <<  DgSqlCode(-3406);
-	         YYERROR;
-	       }
-	       DDLExpr * de = 
-		 new (PARSERHEAP()) DDLExpr(NULL,
-					    (char*)stmt->data(),
-					    stmtCharSet,
-					    TRUE, // for explain
-					    FALSE,
-					    FALSE,
-					    &$2->getQualifiedNameObj());
-	       
+                 {
+                   *SqlParser_Diags <<  DgSqlCode(-3406);
+                   YYERROR;
+                 }
+
+               DDLExpr * de = new(PARSERHEAP()) DDLExpr
+                 (NULL,
+                  (char*)stmt->data(), 
+                  stmtCharSet,
+                  PARSERHEAP());
+               
+               de->setShowddlExplain(TRUE);
+               de->setExplObjName($2->getQualifiedNameObj());
+
 	       ExeUtilDisplayExplainComplex * eue =
 		 new (PARSERHEAP()) 
 		 ExeUtilDisplayExplainComplex((char*)stmt->data(),
@@ -22508,6 +22534,11 @@ show_statement:
 	     }
 	   | TOK_SHOWDDL table_name ',' TOK_EXPLAIN ',' TOK_NO TOK_LABEL TOK_STATISTICS
 	     {
+               // this option is not supported and causes a crash.
+               // It either need to fixed or removed.
+               *SqlParser_Diags <<  DgSqlCode(-3131);
+               YYERROR;
+
 	       CharInfo::CharSet stmtCharSet = CharInfo::UnknownCharSet;
 	       NAString  * stmt = getSqlStmtStr ( stmtCharSet  // out - CharInfo::CharSet &
 						, PARSERHEAP() // in  - NAMemory * heapUsedForOutputBuffers
@@ -22518,15 +22549,17 @@ show_statement:
 	         *SqlParser_Diags <<  DgSqlCode(-3406);
 	         YYERROR;
 	       }
-	       DDLExpr * de = 
-		 new (PARSERHEAP()) DDLExpr(NULL,
-					    (char*)stmt->data(),
-					    stmtCharSet,
-					    TRUE, // for explain
-					    FALSE,
-					    TRUE,
-					    &$2->getQualifiedNameObj());
-	       
+
+               DDLExpr * de = new(PARSERHEAP()) DDLExpr
+                 (NULL,
+                  (char*)stmt->data(), 
+                  stmtCharSet,
+                  PARSERHEAP());
+               
+               de->setShowddlExplain(TRUE);
+               de->setNoLabelStats(TRUE);
+               de->setExplObjName($2->getQualifiedNameObj());
+
 	       ExeUtilDisplayExplainComplex * eue =
 		 new (PARSERHEAP()) 
 		 ExeUtilDisplayExplainComplex((char*)stmt->data(),
@@ -22550,16 +22583,17 @@ show_statement:
 	         *SqlParser_Diags <<  DgSqlCode(-3406);
 	         YYERROR;
 	       }
-	       DDLExpr * de = 
-		 new (PARSERHEAP()) DDLExpr(NULL, 
-					    (char*)stmt->data(),
-					    stmtCharSet,
-					    TRUE, // for explain
-					    TRUE, // internal explain
-					    FALSE,
-					    &$2->getQualifiedNameObj(),
-					    numRows);
-	       
+               DDLExpr * de = new(PARSERHEAP()) DDLExpr
+                 (NULL,
+                  (char*)stmt->data(), 
+                  stmtCharSet,
+                  PARSERHEAP());
+               
+               de->setShowddlExplain(TRUE);
+               de->setShowddlExplainInt(TRUE);
+               de->setNumExplRows(numRows);
+               de->setExplObjName($2->getQualifiedNameObj());
+
 	       $$ = de;
 	     }
            | TOK_SHOWDDL table_name optional_showddl_object_options_list

--- a/core/sql/sqlcomp/CmpDescribe.cpp
+++ b/core/sql/sqlcomp/CmpDescribe.cpp
@@ -2275,11 +2275,6 @@ short CmpDescribeHiveTable (
   if (NOT naTable->isHiveTable())
     return -1;
 
-#ifdef __ignore
-  if (NOT ((type == 1) || (type == 2)))
-    return -1;
-#endif
-
   char * buf = new (heap) char[15000];
   CMPASSERT(buf);
 

--- a/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
@@ -9011,7 +9011,7 @@ short CmpSeabaseDDL::executeSeabaseDDL(DDLExpr * ddlExpr, ExprNode * ddlNode,
     {
       dropSeabaseMDviews();
     }
-  else if (ddlExpr->initAuthorization())
+  else if (ddlExpr->initAuth())
     {
       std::vector<std::string> tablesCreated;
       std::vector<std::string> tablesUpgraded;
@@ -9044,7 +9044,7 @@ short CmpSeabaseDDL::executeSeabaseDDL(DDLExpr * ddlExpr, ExprNode * ddlNode,
       cout << msgBuf.data() << endl;
 #endif
     }
-  else if (ddlExpr->dropAuthorization())
+  else if (ddlExpr->dropAuth())
     {
       dropSeabaseAuthorization(&cliInterface, FALSE);
     }
@@ -9072,7 +9072,7 @@ short CmpSeabaseDDL::executeSeabaseDDL(DDLExpr * ddlExpr, ExprNode * ddlNode,
     {
       updateVersion();
     }
-  else if (ddlExpr->purgedataHbase())
+  else if (ddlExpr->purgedata())
     {
       purgedataHbaseTable(ddlExpr, currCatName, currSchName);
     }

--- a/core/sql/sqlcomp/CmpSeabaseDDLindex.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLindex.cpp
@@ -897,14 +897,6 @@ void CmpSeabaseDDL::createSeabaseIndex( StmtDDLCreateIndex * createIndexNode,
   tableInfo->objOwnerID = naTable->getOwner(); 
   tableInfo->schemaOwnerID = naTable->getSchemaOwner();
 
-#ifdef __ignore
-  if (NOT createIndexNode->isNoPopulateOptionSpecified())
-    // if index is to be populated during create index, then initially create it as an
-    // unaudited index. That would avoid any transactional inserts.
-    // After the index has been populated, make it audited.
-    tableInfo->isAudited = 0;
-  else
-#endif
   tableInfo->isAudited = (nafs->isAudited() ? 1 : 0);
 
   tableInfo->validDef = 0;

--- a/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
@@ -10709,7 +10709,8 @@ void CmpSeabaseDDL::regOrUnregNativeObject(
   // make sure that underlying hive/hbase object exists
   BindWA bindWA(ActiveSchemaDB(), CmpCommon::context(), FALSE/*inDDL*/);
   CorrName cn(objectNamePart, STMTHEAP, 
-              (isHBase? HBASE_CELL_SCHEMA : schemaNamePart),
+              ((isHBase && (schemaNamePart == HBASE_SYSTEM_SCHEMA))
+               ? HBASE_CELL_SCHEMA : schemaNamePart),
               catalogNamePart);
   if (isHive && regOrUnregObject->objType() == COM_SHARED_SCHEMA_OBJECT)
     cn.setSpecialType(ExtendedQualName::SCHEMA_TABLE);

--- a/core/sql/sqlcomp/parser.cpp
+++ b/core/sql/sqlcomp/parser.cpp
@@ -1529,7 +1529,8 @@ NABoolean Parser::processSpecialDDL(const char* inputStr, size_t inputStrLen, Ch
     {
       *node = NULL;
       DDLExpr * ddlExpr = new(CmpCommon::statementHeap()) 
-	DDLExpr(NULL, (char *)ns.data(), inputStrCharSet);
+	DDLExpr(NULL, (char *)ns.data(), inputStrCharSet, 
+                CmpCommon::statementHeap());
       RelExpr *queryExpr = new(CmpCommon::statementHeap())
 	RelRoot(ddlExpr);
 


### PR DESCRIPTION
-- REPLACE function max length is no longer limited to 32K
-- HBase object unregister was not working correctly. That is fixed.
-- class DDLExpr has been cleaned up to have one constructor for all cases.
   All options are now set using flags instead of constructor params.
-- "showddl <tab>, explain " command now returns an error instead of crash.