### PR TITLE
[TRAFODION-2652] run cmd “./odb64luo -l src=nofile:tgt=ldata:map=map:max=300000:rows=K1:parallel=16” core dumped

### DIFF
--- a/core/conn/odb/src/odb.c
+++ b/core/conn/odb/src/odb.c
@@ -3474,8 +3474,7 @@ Please note the fixed length '6' in strmicmp: SELECT/UPDATET/DELETE/INSERT have 
         etab[eid].r = etab[eid].rbs / rsds;
         if ( etab[eid].mr && etab[eid].r > etab[eid].mr )   /* if # records to fetch < rowset ... */
             etab[eid].r = etab[eid].mr;                     /* make rowset = records to fetch */
-        if (etab[eid].r < 1)
-            etab[eid].r = 1;
+        etab[eid].r = etab[eid].r < 1 ? 1 : etab[eid].r;    /* at least one record at a time  */
     }
 
     /* Set output buffer length */
@@ -7021,8 +7020,7 @@ static void Oload(int eid)
         etab[eid].r = etab[eid].rbs / etab[eid].s;
         if ( etab[eid].mr && etab[eid].r > etab[eid].mr )   /* if # records to fetch < rowset ... */
             etab[eid].r = etab[eid].mr;                     /* make rowset = records to fetch */
-        if (etab[eid].r < 1)                                /* at least one record at a time */
-            etab[eid].r = 1;
+        etab[eid].r = etab[eid].r < 1 ? 1 : etab[eid].r;    /* at least one record at a time  */
     }
     if ( etab[eid].flg2 & 0001 )    /* commit as multiplier */
         etab[eid].cmt *= (int)etab[eid].r ;
@@ -8114,6 +8112,7 @@ static void Oload2(int eid)
     /* Calculate rowset if buffer size is set */
     if ( etab[eid].rbs ) {
         etab[eid].r = etab[eid].rbs / etab[eid].s;
+        etab[eid].r = etab[eid].r < 1 ? 1 : etab[eid].r;    /* at least one record at a time  */
     }
     if ( etab[eid].flg2 & 0001 )    /* commit as multiplier */
         etab[eid].cmt *= (int)etab[eid].r ;
@@ -8791,6 +8790,7 @@ static void OloadX(int eid)
     /* Calculate rowset if buffer size is set */
     if ( etab[eid].rbs ) {
         etab[eid].r = etab[eid].rbs / etab[eid].s;
+        etab[eid].r = etab[eid].r < 1 ? 1 : etab[eid].r;    /* at least one record at a time  */
     }
     if ( etab[eid].flg2 & 0001 )    /* commit as multiplier */
         etab[eid].cmt *= (int)etab[eid].r ;
@@ -10380,6 +10380,7 @@ static int Ocopy(int eid)
     /* Calculate rowset if buffer size is set */
     if ( etab[eid].rbs ) {
         etab[eid].r = etab[eid].rbs / etab[eid].s;
+        etab[eid].r = etab[eid].r < 1 ? 1 : etab[eid].r;    /* at least one record at a time  */
         if ( etab[eid].mr && etab[eid].r > etab[eid].mr )   /* if # records to fetch < rowset ... */
             etab[eid].r = etab[eid].mr;                     /* make rowset = records to fetch */
         for ( i = echild ; i < echild + nchild ; i++ )
@@ -11075,8 +11076,11 @@ static void Odiff(int eid)
     }
 
     /* Calculate rowset if buffer size is set */
-    if ( etab[eid].rbs )
+    if (etab[eid].rbs)
+    {
         etab[eid].r = etab[eid].rbs / etab[eid].s;
+        etab[eid].r = etab[eid].r < 1 ? 1 : etab[eid].r; // at least one record at a time
+    }
 
     /* Allocate memory for result set from source */
     rbl = etab[eid].r * etab[eid].s ;

--- a/core/conn/odb/src/odb.c
+++ b/core/conn/odb/src/odb.c
@@ -3474,6 +3474,8 @@ Please note the fixed length '6' in strmicmp: SELECT/UPDATET/DELETE/INSERT have 
         etab[eid].r = etab[eid].rbs / rsds;
         if ( etab[eid].mr && etab[eid].r > etab[eid].mr )   /* if # records to fetch < rowset ... */
             etab[eid].r = etab[eid].mr;                     /* make rowset = records to fetch */
+        if (etab[eid].r < 1)
+            etab[eid].r = 1;
     }
 
     /* Set output buffer length */
@@ -7019,6 +7021,8 @@ static void Oload(int eid)
         etab[eid].r = etab[eid].rbs / etab[eid].s;
         if ( etab[eid].mr && etab[eid].r > etab[eid].mr )   /* if # records to fetch < rowset ... */
             etab[eid].r = etab[eid].mr;                     /* make rowset = records to fetch */
+        if (etab[eid].r < 1)                                /* at least one record at a time */
+            etab[eid].r = 1;
     }
     if ( etab[eid].flg2 & 0001 )    /* commit as multiplier */
         etab[eid].cmt *= (int)etab[eid].r ;

--- a/core/conn/odb/src/odb.c
+++ b/core/conn/odb/src/odb.c
@@ -11076,7 +11076,7 @@ static void Odiff(int eid)
     }
 
     /* Calculate rowset if buffer size is set */
-    if (etab[eid].rbs)
+    if ( etab[eid].rbs )
     {
         etab[eid].r = etab[eid].rbs / etab[eid].s;
         etab[eid].r = etab[eid].r < 1 ? 1 : etab[eid].r; // at least one record at a time


### PR DESCRIPTION
root cause: "etab[eid].r = etab[eid].rbs / etab[eid].s" may be zero, this value will use for memory allocation and loop condition. so etab[eid].r = 0 is unreasonable, at least one.
fixed by: if etab[eid].r < 0 let it be 1.