### PR TITLE
[TRAFODION-2649] Fixed 'rmscheck' method for obtaining status

### DIFF
--- a/core/sqf/sql/scripts/gensq.pl
+++ b/core/sqf/sql/scripts/gensq.pl
@@ -125,13 +125,6 @@ sub printRMSStopScript{
     }
 }
 
-sub printRMSCheckScript{
-    ($dWhich, @rest) = @_;
-    if ($dWhich == 1) {
-       print RMSC @rest;
-    }
-}
-
 sub printTMScript {
     ($dWhich, @rest) = @_;
     print TM @rest;
@@ -441,20 +434,6 @@ sub generateRMS {
     printRMSStopScript(3, "sqshell -c persist kill SSCP\n");
     printRMSStopScript(3, "exit \$?\n");
    
-
-    printRMSCheckScript(1, "-- Trafodion config/utility file generated @ ",getTime(),"\n");
-    printRMSCheckScript(1, "prepare rms_check from select current_timestamp, \n");
-    printRMSCheckScript(1, "cast('Node' as varchar(5)), \n");
-    printRMSCheckScript(1, "cast(tokenstr('nodeId:', variable_info) as varchar(3)) node, \n");
-    printRMSCheckScript(1, "cast(tokenstr('Status:', variable_info) as varchar(10)) status \n");
-    printRMSCheckScript(1, "from table(statistics(null, ?));\n");
-
-    for ($i=0; $i < $gdNumNodes; $i++) {
-
-        my $l_string =  sprintf("execute rms_check using 'RMS_CHECK=%d' ;\n", $i);
-        printRMSCheckScript(1, $l_string);
-    }
-
     printRMSScript(1, "\n");
 
     printScript(1, "rmsstart\n");
@@ -704,9 +683,6 @@ sub openFiles {
     open (RMSS,">$stopRMS")
         or die("unable to open $stopRMS");
 
-    open (RMSC,">$checkRMS")
-        or die("unable to open $checkRMS");
-
     open (SSMP,">$startSSMP")
         or die("unable to open $startSSMP");
 
@@ -742,7 +718,6 @@ sub endGame {
     print "Generated TM Startup        file: $startTM\n";
     print "Generated RMS Startup       file: $startRMS\n";
     print "Generated RMS Stop          file: $stopRMS\n";
-    print "Generated RMS Check         file: $checkRMS\n";
     print "Generated SSMP Startup      file: $startSSMP\n";
     print "Generated SSMP Stop         file: $stopSSMP\n";
     print "Generated SSCP Startup      file: $startSSCP\n";
@@ -755,7 +730,6 @@ sub endGame {
 
     close(RMS);
     close(RMSS);
-    close(RMSC);
 
     close(SSMP);
     close(SSMPS);
@@ -773,7 +747,6 @@ sub endGame {
 
     chmod 0700, $startRMS;
     chmod 0700, $stopRMS;
-    chmod 0700, $checkRMS;
 
     chmod 0700, $startSSMP;
     chmod 0700, $stopSSMP;
@@ -800,7 +773,6 @@ sub doInit {
     $stopRMS="rmsstop";
     $stopSSMP="ssmpstop";
     $stopSSCP="sscpstop";
-    $checkRMS="rmscheck.sql";
 
 
     $coldscriptFileName=sprintf("%s.cold", $scriptFileName);

--- a/core/sqf/sql/scripts/rmscheck
+++ b/core/sqf/sql/scripts/rmscheck
@@ -22,7 +22,7 @@
 # @@@ END COPYRIGHT @@@
 #
 
-if [ -z $TRAF_HOME ]; then
+if [[ -z $TRAF_HOME ]]; then
     echo
     echo "The TRAF_HOME environment variable does not exist."
     echo "Please ensure sqenv.sh has been sourced."
@@ -38,11 +38,5 @@ if [[ $sq_stat == 255 ]]; then
    exit 1
 fi
 
-# Generate the 'rmscheck.sql' file
-temp_rmscheck_sql=`mktemp -t`
-sqgenrmscheck $temp_rmscheck_sql
-echo temp_rmscheck_sql=$temp_rmscheck_sql
-
 echo "Timestamp                           Id    Status "
-sqlci -i $temp_rmscheck_sql | grep 'Node\|ERROR' | grep -v varchar
-rm -f $temp_rmscheck_sql
+sqgenrmscheck | sqlci | grep 'Node\|ERROR' | grep -v varchar

--- a/core/sqf/sql/scripts/rmscheck
+++ b/core/sqf/sql/scripts/rmscheck
@@ -21,7 +21,28 @@
 #
 # @@@ END COPYRIGHT @@@
 #
-# Most of this was stolen from WMScheck...  which may have started as NDCScheck
+
+if [ -z $TRAF_HOME ]; then
+    echo
+    echo "The TRAF_HOME environment variable does not exist."
+    echo "Please ensure sqenv.sh has been sourced."
+    echo
+    exit 1;
+fi
+
+# Check whether the Trafodion environment up.
+sqcheck -i 1 -d 1 > /dev/null 2>&1
+sq_stat=$?
+if [[ $sq_stat == 255 ]]; then
+   echo "The Trafodion environment is down. Exiting..."
+   exit 1
+fi
+
+# Generate the 'rmscheck.sql' file
+temp_rmscheck_sql=`mktemp -t`
+sqgenrmscheck $temp_rmscheck_sql
+echo temp_rmscheck_sql=$temp_rmscheck_sql
 
 echo "Timestamp                           Id    Status "
-sqlci -i $TRAF_HOME/sql/scripts/rmscheck.sql | grep 'Node\|ERROR' | grep -v varchar
+sqlci -i $temp_rmscheck_sql | grep 'Node\|ERROR' | grep -v varchar
+rm -f $temp_rmscheck_sql

--- a/core/sqf/sql/scripts/sqconfig
+++ b/core/sqf/sql/scripts/sqconfig
@@ -20,7 +20,7 @@
 # @@@ END COPYRIGHT @@@
 
 begin node
-_virtualnodes 2
+_virtualnodes 4
 end node
 
 ###############################################################################

--- a/core/sqf/sql/scripts/sqconfig
+++ b/core/sqf/sql/scripts/sqconfig
@@ -20,7 +20,7 @@
 # @@@ END COPYRIGHT @@@
 
 begin node
-_virtualnodes 4
+_virtualnodes 2
 end node
 
 ###############################################################################

--- a/core/sqf/sql/scripts/sqgenrmscheck
+++ b/core/sqf/sql/scripts/sqgenrmscheck
@@ -1,0 +1,123 @@
+#!/bin/bash
+
+# @@@ START COPYRIGHT @@@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+# @@@ END COPYRIGHT @@@
+#
+# sqgen script - generates various files
+
+function Usage {
+    script_name=`/bin/basename $0`
+    echo
+    echo $script_name generates the Trafodion rmscheck sqlci input file in the $TRAF_HOME/sql/scripts directory.
+    echo
+    echo "Usage: $script_name [ -? | -h ] [<sqlci-in-file>]"
+    echo "  -?    Help"
+    echo "  -h    Help"
+    echo "  <sqlci-in-file> Name of the Trafodion rmscheck sqlci input file (in $TRAF_HOME/sql/scripts directory)(defaults to 'rmscheck.sql')"
+    echo
+    exit 1;
+}
+
+function GenRmsCheckSqlQuery {
+
+GENDATE=`date`
+
+echo "-- 'rmscheck.sql' Generated on $GENDATE"
+echo
+echo "-- Prepare the 'rms_check' query"
+echo "prepare rms_check from select current_timestamp,"
+echo "cast('Node' as varchar(5)),"
+echo "cast(tokenstr('nodeId:', variable_info) as varchar(3)) node,"
+echo "cast(tokenstr('Status:', variable_info) as varchar(10)) status"
+echo "from table(statistics(null, ?));"
+echo
+echo "-- Execute the 'rms_check' query for each node-id"
+
+}
+
+function GenRmsCheckSql {
+
+    # Get Trafodion node-id configuration
+    TempList=`trafconf -node | grep -o 'node-id=.[0-9]*' | cut -d "=" -f 2 | sort -u`
+
+    i=0
+    for NID in $TempList
+    do
+        TrNids[$i]=$NID
+        #echo "-- TrNids[${i}]=${TrNids[$i]}"
+        ((i=i+1))
+    done
+
+    # Check that the <nid>s were correctly added
+    ExNidList=`echo ${TrNids[@]}`
+    if [[ ! -z ${ExNidList[@]} ]]; then
+        GenRmsCheckSqlQuery
+        j=0
+        for Nid in ${TrNids[@]}
+        do
+            Nid=$Nid
+            #echo "j=$j Nid=${Nid}"
+            echo "execute rms_check using 'RMS_CHECK=${Nid}';"
+            ((j=j+1))
+        done
+        exit 0;
+    else
+        echo
+        echo "Could not obtain the Trafodion Configuration from the 'trafconf' utility!"
+        echo "Execute 'trafconf -node' to determine if Trafodion Configuration has been"
+        echo "initialized and can be accessed."
+        echo
+        exit 1;
+    fi
+}
+
+###########################################################
+# MAIN portion of sqgen begins
+###########################################################
+
+SQLCI_IN_FILE=rmscheck.sql
+
+if [ -z $TRAF_HOME ]; then
+    echo
+    echo "The TRAF_HOME environment variable does not exist."
+    echo "Please ensure sqenv.sh has been sourced."
+    echo
+    exit 1;
+fi
+
+rm -f $SQLCI_IN_FILE
+
+cd $TRAF_HOME/sql/scripts
+
+# Assume option is SQLCI_IN_FILE
+while [ $# != 0 ]
+  do
+    flag="$1"
+    case "$flag" in
+        -h)  Usage ;;
+        -?)  Usage ;;
+        *)   SQLCI_IN_FILE=$1 ;;
+    esac
+    shift
+  done
+
+GenRmsCheckSql > $SQLCI_IN_FILE
+

--- a/core/sqf/sql/scripts/sqgenrmscheck
+++ b/core/sqf/sql/scripts/sqgenrmscheck
@@ -26,12 +26,11 @@
 function Usage {
     script_name=`/bin/basename $0`
     echo
-    echo $script_name generates the Trafodion rmscheck sqlci input file in the $TRAF_HOME/sql/scripts directory.
+    echo $script_name displays generated the Trafodion rmscheck sqlci statements
     echo
-    echo "Usage: $script_name [ -? | -h ] [<sqlci-in-file>]"
+    echo "Usage: $script_name [ -? | -h ]"
     echo "  -?    Help"
     echo "  -h    Help"
-    echo "  <sqlci-in-file> Name of the Trafodion rmscheck sqlci input file (in $TRAF_HOME/sql/scripts directory)(defaults to 'rmscheck.sql')"
     echo
     exit 1;
 }
@@ -93,17 +92,13 @@ function GenRmsCheckSql {
 # MAIN portion of sqgen begins
 ###########################################################
 
-SQLCI_IN_FILE=rmscheck.sql
-
-if [ -z $TRAF_HOME ]; then
+if [[ -z $TRAF_HOME ]]; then
     echo
     echo "The TRAF_HOME environment variable does not exist."
     echo "Please ensure sqenv.sh has been sourced."
     echo
     exit 1;
 fi
-
-rm -f $SQLCI_IN_FILE
 
 cd $TRAF_HOME/sql/scripts
 
@@ -114,10 +109,10 @@ while [ $# != 0 ]
     case "$flag" in
         -h)  Usage ;;
         -?)  Usage ;;
-        *)   SQLCI_IN_FILE=$1 ;;
+         *)  Usage ;;
     esac
     shift
   done
 
-GenRmsCheckSql > $SQLCI_IN_FILE
+GenRmsCheckSql
 


### PR DESCRIPTION
It now generates the 'rmscheck.sql' logic in a temporary file which obtains the
node-ids from the 'trafconf' utility. The tempory file is created at 'rmscheck'
invocation.