### PR TITLE
TRAFODION [2641] User who has MANAGE_STATISTICS privilege can't do up…

### DIFF
--- a/core/sql/executor/ExExeUtil.h
+++ b/core/sql/executor/ExExeUtil.h
@@ -2497,6 +2497,11 @@ private:
     const char *catName,
     const char *schName,
     const char *objName);
+
+  NAString getGrantedPrivCmd(
+    const NAString &roleList,
+    const char * cat);
+
   char * getRoleList(
     const Int32 userID,
     const char *catName,

--- a/core/sql/executor/ExExeUtilGet.cpp
+++ b/core/sql/executor/ExExeUtilGet.cpp
@@ -310,7 +310,7 @@ static const QueryString getTrafTablesInSchemaQuery[] =
   {"   %s.\"%s\".%s "},
   {"  where catalog_name = '%s' and "},
   {"        schema_name = '%s'  and "},
-  {"        object_type = 'BT'  "},
+  {"        object_type = 'BT' %s "},
   {"  order by 1 "},
   {"  ; "}
 };
@@ -321,7 +321,7 @@ static const QueryString getTrafIndexesInSchemaQuery[] =
   {"   %s.\"%s\".%s "},
   {"  where catalog_name = '%s' and "},
   {"        schema_name = '%s'  and "},
-  {"        object_type = 'IX'  "},
+  {"        object_type = 'IX' %s "},
   {"  order by 1 "},
   {"  ; "}
 };
@@ -349,7 +349,7 @@ static const QueryString getTrafProceduresInSchemaQuery[] =
   {"        T.schema_name = '%s'  and "},
   {"        T.object_type = 'UR'  and "},
   {"        T.object_uid = R.udr_uid  and "},
-  {"        R.udr_type = 'P ' "},
+  {"        R.udr_type = 'P ' %s "},
   {"  order by 1 "},
   {"  ; "}
 };
@@ -360,7 +360,7 @@ static const QueryString getTrafLibrariesInSchemaQuery[] =
   {"   %s.\"%s\".%s T "},
   {"  where T.catalog_name = '%s' and "},
   {"        T.schema_name = '%s'  and "},
-  {"        T.object_type = 'LB' "},
+  {"        T.object_type = 'LB' %s "},
   {"  order by 1 "},
   {"  ; "}
 };
@@ -373,7 +373,7 @@ static const QueryString getTrafFunctionsInSchemaQuery[] =
   {"        T.schema_name = '%s'  and "},
   {"        T.object_type = 'UR'  and "},
   {"        T.object_uid = R.udr_uid  and "},
-  {"        R.udr_type = 'F ' "},
+  {"        R.udr_type = 'F ' %s "},
   {"  order by 1 "},
   {"  ; "}
 };
@@ -386,7 +386,7 @@ static const QueryString getTrafTableFunctionsInSchemaQuery[] =
   {"        T.schema_name = '%s'  and "},
   {"        T.object_type = 'UR'  and "},
   {"        T.object_uid = R.udr_uid  and "},
-  {"        R.udr_type = 'T ' "},
+  {"        R.udr_type = 'T ' %s "},
   {"  order by 1 "},
   {"  ; "}
 };
@@ -411,7 +411,7 @@ static const QueryString getTrafSequencesInSchemaQuery[] =
   {"   %s.\"%s\".%s "},
   {"  where catalog_name = '%s' and "},
   {"        schema_name = '%s'  and "},
-  {"        object_type = 'SG' "},
+  {"        object_type = 'SG' %s "},
   {"  order by 1 "},
   {"  ; "}
 };
@@ -421,7 +421,7 @@ static const QueryString getTrafSequencesInCatalogQuery[] =
   {" select trim(schema_name) || '.' || object_name  from "},
   {"   %s.\"%s\".%s "},
   {"  where catalog_name = '%s' and "},
-  {"        object_type = 'SG' "},
+  {"        object_type = 'SG' %s "},
   {"  order by 1 "},
   {"  ; "}
 };
@@ -432,7 +432,7 @@ static const QueryString getTrafViewsInCatalogQuery[] =
   {" object_name from "},
   {"   %s.\"%s\".%s,  %s.\"%s\".%s "},
   {"  where view_uid = object_uid and "},
-  {"            catalog_name = '%s' "},
+  {"            catalog_name = '%s' %s "},
   {" order by 1 "},
   {"  ; "}
 };
@@ -443,7 +443,7 @@ static const QueryString getTrafViewsInSchemaQuery[] =
   {"   %s.\"%s\".%s,  %s.\"%s\".%s "},
   {"  where view_uid = object_uid and "},
   {"             catalog_name = '%s' and "},
-  {"             schema_name = '%s' "},
+  {"             schema_name = '%s' %s "},
   {" order by 1 "},
   {"  ; "}
 };
@@ -484,10 +484,9 @@ static const QueryString getTrafViewsOnObjectQuery[] =
 
 static const QueryString getTrafSchemasInCatalogQuery[] =
 {
-  {" select schema_name "},
+  {" select distinct schema_name "},
   {"   from %s.\"%s\".%s "},
-  {"  where catalog_name = '%s' "},
-  {"        and (object_type = 'PS' or object_type = 'SS') "},
+  {"  where catalog_name = '%s' %s "},
   {" order by 1 "},
   {"  ; "}
 };
@@ -498,7 +497,7 @@ static const QueryString getTrafSchemasForAuthIDQuery[] =
   {"   from %s.\"%s\".%s T, "},
   {"        %s.\"%s\".%s A "},
   {"  where (T.object_type = 'PS' or T.object_type = 'SS') and "},
-  {"         A.auth_db_name = '%s' and T.object_owner = A.auth_id  "},
+  {"         A.auth_db_name = '%s' and T.object_owner = A.auth_id "},
   {" order by 1 "},
   {"  ; "}
 };
@@ -520,6 +519,40 @@ static const QueryString getTrafRoles[] =
   {" union select * from (values ('PUBLIC')) "},
   {" order by 1 "},
   {"  ; "}
+};
+
+static const QueryString getTrafPrivsOnObject[] = 
+{
+  {" select grantee_name, "},
+  {"   case when bitextract(privileges_bitmap,63,1) = 1 then 'S' else '-' end || "},
+  {"   case when bitextract(privileges_bitmap,62,1) = 1 then 'I' else '-' end || "},
+  {"   case when bitextract(privileges_bitmap,61,1) = 1 then 'D' else '-' end || "},
+  {"   case when bitextract(privileges_bitmap,60,1) = 1 then 'U' else '-' end || "},
+  {"   case when bitextract(privileges_bitmap,59,1) = 1 then 'G' else '-' end || "},
+  {"   case when bitextract(privileges_bitmap,58,1) = 1 then 'R' else '-' end || "},
+  {"   case when bitextract(privileges_bitmap,57,1) = 1 then 'E' else '-' end as privs "},
+  {" from %s.\"%s\".%s "},
+  {" where grantor_id <> -2 "},
+  {"  and object_uid = "},
+  {"  (select object_uid from %s.\"%s\".%s "},
+  {"   where catalog_name = '%s' and schema_name = '%s' and object_name = '%s' "},
+  {"     and object_type = '%s') %s "},
+  {"union "},
+  {"(select grantee_name, "},
+  {"  case when bitextract(privileges_bitmap,63,1) = 1 then 'S' else '-' end || "},
+  {"  case when bitextract(privileges_bitmap,62,1) = 1 then 'I' else '-' end || "},
+  {"  case when bitextract(privileges_bitmap,61,1) = 1 then 'D' else '-' end || "},
+  {"  case when bitextract(privileges_bitmap,60,1) = 1 then 'U' else '-' end || "},
+  {"  case when bitextract(privileges_bitmap,59,1) = 1 then 'G' else '-' end || "},
+  {"  case when bitextract(privileges_bitmap,58,1) = 1 then 'R' else '-' end || "},
+  {"  case when bitextract(privileges_bitmap,57,1) = 1 then 'E' else '-' end as privs "},
+  {" from %s.\"%s\".%s "},
+  {" where grantor_id <> -2 "},
+  {"  and object_uid = "},
+  {"  (select object_uid from %s.\"%s\".%s "},
+  {"   where catalog_name = '%s' and schema_name = '%s' and object_name = '%s' "},
+  {"     and object_type = '%s') %s )"},
+  {" ; "}
 };
 
 static const QueryString getHiveRegObjectsInCatalogQuery[] =
@@ -1404,6 +1437,34 @@ Int32 ExExeUtilGetMetadataInfoTcb::getAuthID(
 }
 
 // ----------------------------------------------------------------------------
+// getGrantedPrivCmd
+//
+// Generates syntax that limits the result set to those objects where the 
+// current user has at least one privilege assigned. The syntax unions grantees
+// from object_privileges, column_privileges, and schema_privileges. The 
+// grantee list (authList) includes the current user and the current users 
+// roles.
+// ---------------------------------------------------------------------------- 
+NAString ExExeUtilGetMetadataInfoTcb::getGrantedPrivCmd(
+  const NAString &authList,
+  const char * cat)
+{
+  char buf [authList.length()*3 + MAX_SQL_IDENTIFIER_NAME_LEN*9 + 200];
+  snprintf(buf, sizeof(buf), "and object_uid in (select object_uid from %s.\"%s\".%s "
+                             "where grantee_id in %s union "
+                             "(select object_uid from %s.\"%s\".%s "
+                             " where grantee_id in %s) union "
+                             "(select object_uid from %s.\"%s\".%s "
+                             " where grantee_id in %s))",
+           cat, SEABASE_PRIVMGR_SCHEMA, PRIVMGR_OBJECT_PRIVILEGES, authList.data(),
+           cat, SEABASE_PRIVMGR_SCHEMA, PRIVMGR_COLUMN_PRIVILEGES, authList.data(),
+           cat, SEABASE_PRIVMGR_SCHEMA, PRIVMGR_SCHEMA_PRIVILEGES, authList.data());
+ 
+  NAString cmd(buf); 
+  return cmd;
+}
+
+// ----------------------------------------------------------------------------
 // getRoleList
 //
 // Reads the "_PRIVMGR_MD_".role_usage table to return the list of role IDs
@@ -1753,7 +1814,9 @@ short ExExeUtilGetMetadataInfoTcb::work()
               ||getMItdb().queryType_ == ComTdbExeUtilGetMetadataInfo::USERS_FOR_ROLE_
               ||getMItdb().queryType_ == ComTdbExeUtilGetMetadataInfo::ROLES_FOR_USER_
               ||getMItdb().queryType_ == ComTdbExeUtilGetMetadataInfo::PRIVILEGES_FOR_ROLE_
-              ||getMItdb().queryType_ == ComTdbExeUtilGetMetadataInfo::PRIVILEGES_FOR_USER_)
+              ||getMItdb().queryType_ == ComTdbExeUtilGetMetadataInfo::PRIVILEGES_FOR_USER_
+              ||getMItdb().queryType_ == ComTdbExeUtilGetMetadataInfo::PRIVILEGES_ON_TABLE_
+              ||getMItdb().queryType_ == ComTdbExeUtilGetMetadataInfo::PRIVILEGES_ON_VIEW_)
 	    {
                if (!CmpCommon::context()->isAuthorizationEnabled())
                {
@@ -1779,6 +1842,8 @@ short ExExeUtilGetMetadataInfoTcb::work()
 		  qs = getTrafTablesInSchemaQuery;
 		  sizeOfqs = sizeof(getTrafTablesInSchemaQuery);
 
+                  if (doPrivCheck)
+                    privWhereClause = getGrantedPrivCmd(authList, cat);
                   param_[0] = catSchValue;
                   param_[1] = endQuote;
 		  param_[2] = cat;
@@ -1786,6 +1851,7 @@ short ExExeUtilGetMetadataInfoTcb::work()
 		  param_[4] = tab;
 		  param_[5] = getMItdb().cat_;
 		  param_[6] = getMItdb().sch_;
+                  param_[7] = (char *)privWhereClause.data();
 		}
 	      break;
 	      
@@ -1794,11 +1860,15 @@ short ExExeUtilGetMetadataInfoTcb::work()
 		  qs = getTrafIndexesInSchemaQuery;
 		  sizeOfqs = sizeof(getTrafIndexesInSchemaQuery);
 
+                  if (doPrivCheck)
+                    privWhereClause = getGrantedPrivCmd(authList, cat);
+
 		  param_[0] = cat;
 		  param_[1] = sch;
 		  param_[2] = tab;
 		  param_[3] = getMItdb().cat_;
 		  param_[4] = getMItdb().sch_;
+                  param_[5] = (char *)privWhereClause.data();
 		}
 	      break;
 	      
@@ -1807,6 +1877,9 @@ short ExExeUtilGetMetadataInfoTcb::work()
 		  qs = getTrafViewsInCatalogQuery;
 		  sizeOfqs = sizeof(getTrafViewsInCatalogQuery);
 
+                 if (doPrivCheck)
+                    privWhereClause = getGrantedPrivCmd(authList, cat);
+
 		  param_[0] = cat;
 		  param_[1] = sch;
 		  param_[2] = tab;
@@ -1814,6 +1887,7 @@ short ExExeUtilGetMetadataInfoTcb::work()
 		  param_[4] = sch;
 		  param_[5] = view;
 		  param_[6] = getMItdb().cat_;
+                  param_[7] = (char *)privWhereClause.data();
 		}
 	      break;
 	      
@@ -1898,6 +1972,9 @@ short ExExeUtilGetMetadataInfoTcb::work()
 		  qs = getTrafViewsInSchemaQuery;
 		  sizeOfqs = sizeof(getTrafViewsInSchemaQuery);
 
+                 if (doPrivCheck)
+                    privWhereClause = getGrantedPrivCmd(authList, cat);
+
 		  param_[0] = cat;
 		  param_[1] = sch;
 		  param_[2] = tab;
@@ -1906,6 +1983,7 @@ short ExExeUtilGetMetadataInfoTcb::work()
 		  param_[5] = view;
 		  param_[6] = getMItdb().cat_;
 		  param_[7] = getMItdb().sch_;
+                  param_[8] = (char *)privWhereClause.data();
 		}
 	      break;
 
@@ -1986,10 +2064,14 @@ short ExExeUtilGetMetadataInfoTcb::work()
 		  qs = getTrafSchemasInCatalogQuery;
 		  sizeOfqs = sizeof(getTrafSchemasInCatalogQuery);
 
+                  if (doPrivCheck)
+                    privWhereClause = getGrantedPrivCmd(authList, cat);
+
 		  param_[0] = cat;
 		  param_[1] = sch;
 		  param_[2] = tab;
 		  param_[3] = getMItdb().cat_;
+                  param_[4] = (char *) privWhereClause.data();
 		}
 	      break;
               case ComTdbExeUtilGetMetadataInfo::SCHEMAS_FOR_USER_:
@@ -2029,6 +2111,9 @@ short ExExeUtilGetMetadataInfoTcb::work()
                   qs = getTrafProceduresInSchemaQuery;
                   sizeOfqs = sizeof(getTrafProceduresInSchemaQuery);
 
+                  if (doPrivCheck)
+                    privWhereClause = getGrantedPrivCmd(authList, cat);
+
 		  param_[0] = cat;
 		  param_[1] = sch;
 		  param_[2] = tab;
@@ -2037,6 +2122,7 @@ short ExExeUtilGetMetadataInfoTcb::work()
 		  param_[5] = routine;
 		  param_[6] = getMItdb().cat_;
 		  param_[7] = getMItdb().sch_;
+                  param_[8] = (char *) privWhereClause.data();
                 }
                 break ;
               case ComTdbExeUtilGetMetadataInfo::LIBRARIES_IN_SCHEMA_:
@@ -2044,11 +2130,15 @@ short ExExeUtilGetMetadataInfoTcb::work()
                   qs = getTrafLibrariesInSchemaQuery;
                   sizeOfqs = sizeof(getTrafLibrariesInSchemaQuery);
 
+                  if (doPrivCheck)
+                    privWhereClause = getGrantedPrivCmd(authList, cat);
+
 		  param_[0] = cat;
 		  param_[1] = sch;
 		  param_[2] = tab;
 		  param_[3] = getMItdb().cat_;
 		  param_[4] = getMItdb().sch_;
+                  param_[5] = (char *) privWhereClause.data();
                 }
                 break ;
               case ComTdbExeUtilGetMetadataInfo::FUNCTIONS_IN_SCHEMA_:
@@ -2056,20 +2146,8 @@ short ExExeUtilGetMetadataInfoTcb::work()
                   qs = getTrafFunctionsInSchemaQuery;
                   sizeOfqs = sizeof(getTrafFunctionsInSchemaQuery);
 
-		  param_[0] = cat;
-		  param_[1] = sch;
-		  param_[2] = tab;
-                  param_[3] = cat;
-		  param_[4] = sch;
-		  param_[5] = routine;
-		  param_[6] = getMItdb().cat_;
-		  param_[7] = getMItdb().sch_;
-                }
-                break ;
-	      case ComTdbExeUtilGetMetadataInfo::TABLE_FUNCTIONS_IN_SCHEMA_:
-                {
-                  qs = getTrafTableFunctionsInSchemaQuery;
-                  sizeOfqs = sizeof(getTrafTableFunctionsInSchemaQuery);
+                  if (doPrivCheck)
+                    privWhereClause = getGrantedPrivCmd(authList, cat);
 
 		  param_[0] = cat;
 		  param_[1] = sch;
@@ -2079,6 +2157,26 @@ short ExExeUtilGetMetadataInfoTcb::work()
 		  param_[5] = routine;
 		  param_[6] = getMItdb().cat_;
 		  param_[7] = getMItdb().sch_;
+                  param_[8] = (char *) privWhereClause.data();
+                }
+                break ;
+	      case ComTdbExeUtilGetMetadataInfo::TABLE_FUNCTIONS_IN_SCHEMA_:
+                {
+                  qs = getTrafTableFunctionsInSchemaQuery;
+                  sizeOfqs = sizeof(getTrafTableFunctionsInSchemaQuery);
+
+                  if (doPrivCheck)
+                    privWhereClause = getGrantedPrivCmd(authList, cat);
+
+		  param_[0] = cat;
+		  param_[1] = sch;
+		  param_[2] = tab;
+                  param_[3] = cat;
+		  param_[4] = sch;
+		  param_[5] = routine;
+		  param_[6] = getMItdb().cat_;
+		  param_[7] = getMItdb().sch_;
+                  param_[8] = (char *) privWhereClause.data();
                 }
                 break ;
               case ComTdbExeUtilGetMetadataInfo::PROCEDURES_FOR_LIBRARY_:
@@ -2295,6 +2393,51 @@ short ExExeUtilGetMetadataInfoTcb::work()
                 }
               break;
 
+              case ComTdbExeUtilGetMetadataInfo::PRIVILEGES_ON_TABLE_:
+              case ComTdbExeUtilGetMetadataInfo::PRIVILEGES_ON_VIEW_:
+              {
+                qs = getTrafPrivsOnObject;
+                sizeOfqs = sizeof(getTrafPrivsOnObject);
+
+                NAString objType;
+                if (getMItdb().queryType_ == ComTdbExeUtilGetMetadataInfo::PRIVILEGES_ON_TABLE_)
+                  objType = COM_BASE_TABLE_OBJECT_LIT;
+                else
+                  objType = COM_VIEW_OBJECT_LIT;
+
+                if (doPrivCheck)
+                {
+                   char buf[authList.length() + 100];
+                   str_sprintf(buf, "and grantee_id in %s ", authList.data());
+                   privWhereClause = buf;
+                }
+                param_[0] = cat;
+                param_[1] = pmsch;
+                param_[2] = objPrivs;
+                param_[3] = cat;
+                param_[4] = sch;
+                param_[5] = tab;
+                param_[6] = getMItdb().cat_;
+                param_[7] = getMItdb().sch_;
+                param_[8] = getMItdb().obj_;
+                param_[9] = (char *)objType.data();
+                param_[10] = (char *)privWhereClause.data();
+                param_[11] = cat;
+                param_[12] = pmsch;
+                param_[13] = colPrivs;
+                param_[14] = cat;
+                param_[15] = sch;
+                param_[16] = tab;
+                param_[17] = getMItdb().cat_;
+                param_[18] = getMItdb().sch_;
+                param_[19] = getMItdb().obj_;
+                param_[20] = (char *)objType.data();
+                param_[21] = (char *)privWhereClause.data();
+
+                numOutputEntries_ = 2;
+                break;
+              }
+
               case ComTdbExeUtilGetMetadataInfo::COMPONENTS_:
               {
                 qs = getComponents;
@@ -2418,10 +2561,14 @@ short ExExeUtilGetMetadataInfoTcb::work()
                   qs = getTrafSequencesInCatalogQuery;
                   sizeOfqs = sizeof(getTrafSequencesInCatalogQuery);
 
+                  if (doPrivCheck)
+                    privWhereClause = getGrantedPrivCmd(authList, cat);
+
 		  param_[0] = cat;
 		  param_[1] = sch;
 		  param_[2] = tab;
 		  param_[3] = getMItdb().cat_;
+                  param_[4] = (char *) privWhereClause.data();
                 }
                 break ;
 
@@ -2430,11 +2577,15 @@ short ExExeUtilGetMetadataInfoTcb::work()
                   qs = getTrafSequencesInSchemaQuery;
                   sizeOfqs = sizeof(getTrafSequencesInSchemaQuery);
 
+                  if (doPrivCheck)
+                    privWhereClause = getGrantedPrivCmd(authList, cat);
+
 		  param_[0] = cat;
 		  param_[1] = sch;
 		  param_[2] = tab;
 		  param_[3] = getMItdb().cat_;
 		  param_[4] = getMItdb().sch_;
+                  param_[5] = (char *) privWhereClause.data();
                 }
                 break ;
 
@@ -2517,7 +2668,10 @@ short ExExeUtilGetMetadataInfoTcb::work()
 	    exprRetCode = ex_expr::EXPR_TRUE;
 
             if ((getMItdb().queryType_ == ComTdbExeUtilGetMetadataInfo::PRIVILEGES_FOR_USER_) ||
-                (getMItdb().queryType_ == ComTdbExeUtilGetMetadataInfo::PRIVILEGES_FOR_ROLE_))
+                (getMItdb().queryType_ == ComTdbExeUtilGetMetadataInfo::PRIVILEGES_FOR_ROLE_) ||
+                (getMItdb().queryType_ == ComTdbExeUtilGetMetadataInfo::PRIVILEGES_ON_VIEW_) ||
+                (getMItdb().queryType_ == ComTdbExeUtilGetMetadataInfo::PRIVILEGES_ON_TABLE_))
+
             {
               // output:  privileges<4spaces>object name
               NAString outputStr (vi->get(1));

--- a/core/sql/regress/privs1/EXPECTED125
+++ b/core/sql/regress/privs1/EXPECTED125
@@ -1,0 +1,1335 @@
+>>
+>>obey TEST125(set_up);
+>>create role t125_adminrole;
+
+--- SQL operation complete.
+>>grant role t125_adminrole to sql_user8;
+
+--- SQL operation complete.
+>>create role t125_role1;
+
+--- SQL operation complete.
+>>
+>>-- create schemas
+>>create schema t125sch1;
+
+--- SQL operation complete.
+>>set schema t125sch1;
+
+--- SQL operation complete.
+>>obey TEST125(create_db);
+>>create table teams
++>  (team_number int not null primary key,
++>   team_name char(20) not null,
++>   team_contact varchar(50) not null,
++>   team_contact_number char (10) not null
++>   )
++>  ;
+
+--- SQL operation complete.
+>>
+>>alter table teams add constraint valid_team_no check (team_number > 0);
+
+--- SQL operation complete.
+>>
+>>create table games
++>   ( home_team_number int not null,
++>     visitor_team_number int not null,
++>     game_number int not null primary key,
++>     game_time timestamp not null,
++>     game_location varchar(50) not null)
++>  ;
+
+--- SQL operation complete.
+>>
+>>create table players
++>  (player_number int not null,
++>   player_name varchar (50) not null,
++>   player_team_number int not null,
++>   player_phone_number char (10) not null,
++>   player_details varchar(50),
++>   primary key (player_number, player_team_number))
++>  no partition;
+
+--- SQL operation complete.
+>>
+>>alter table players add constraint players_teams
++>   foreign key (player_team_number) references teams (team_number);
+
+--- SQL operation complete.
+>>
+>>create sequence players_sequence;
+
+--- SQL operation complete.
+>>
+>>create view home_teams_games as
++>  select t.team_number, g.game_number, g.game_time
++>  from "TEAMS" t,
++>       "GAMES" g
++>  where t.team_number = g.home_team_number
++>  order by 1, game_number, game_time;
+
+--- SQL operation complete.
+>>
+>>create view players_on_team as
++>  select player_name, team_name
++>  from teams t, players p
++>  where p.player_team_number = t.team_number
++>  order by t.team_name;
+
+--- SQL operation complete.
+>>
+>>create view games_by_player as
++>  select player_name, game_time
++>  from teams t, games g, players p
++>  where p.player_team_number = t.team_number and
++>        t.team_number = g.home_team_number
++>  order by player_name, team_number;
+
+--- SQL operation complete.
+>>
+>>-- create function to display bitmaps as a bitmap rather than longs
+>>-- set envvar REGRRUNDIR '/mnt/rmarton/gitws/incubator-trafodion/core/sql/regress/rundir/privs1';
+>>-- set envvar REGRTSTDIR '/mnt/rmarton/gitws/incubator-trafodion/core/sql/regress/privs1';
+>>-- set envvar scriptsdir '/mnt/rmarton/gitws/incubator-trafodion/core/sql/regress';
+>>sh rm -f ./etest141.dll;
+>>sh sh $$scriptsdir$$/tools/dll-compile.ksh etest141.cpp
++>  2>&1 | tee LOG125-SECONDARY;
+>>set pattern $$DLL$$ etest141.dll;
+>>set pattern $$QUOTE$$ '''';
+>>
+>>create library t125_l1 file $$QUOTE$$ $$REGRRUNDIR$$/$$DLL$$ $$QUOTE$$ ;
+
+--- SQL operation complete.
+>>create function translateBitmap(bitmap largeint) returns (bitmap_string char (20))
++>language c parameter style sql external name 'translateBitmap'
++>library t125_l1
++>deterministic no sql final call allow any parallelism state area size 1024 ;
+
+--- SQL operation complete.
+>>
+>>sh sh $$scriptsdir$$/tools/java-compile.ksh Utils.java TestHive.java 2> LOG125-SECONDARY | tee -a LOG125;
+------------------------------------------------------------------------------
+-- Compiling Java source files: Utils.java TestHive.java
+-- Executing: $javac -d $REGRRUNDIR $REGRTSTDIR/Utils.java $REGRTSTDIR/TestHive.java
+-- $javac returned 0
+------------------------------------------------------------------------------
+>>sh sh $$scriptsdir$$/tools/java-archive.ksh TEST125_procs.jar TestHive.class Utils.class 2>> LOG125-SECONDARY | tee -a LOG125;
+------------------------------------------------------------------------------
+-- Archiving Java class files:
+--    TestHive.class
+--    Utils.class
+-- Archive will be written to: TEST125_procs.jar
+-- Executing: $jar cMf TEST125_procs.jar TestHive.class Utils.class
+-- $jar returned 0
+------------------------------------------------------------------------------
+>>set pattern $$JARF$$ TEST125_procs.jar;
+>>
+>>create library t125_l2
++>   file $$QUOTE$$ $$REGRRUNDIR$$/$$JARF$$ $$QUOTE$$;
+
+--- SQL operation complete.
+>>
+>>create procedure TestHive(
++>  IN operation char(20),
++>  OUT results varchar(1000))
++>  EXTERNAL NAME 'TestHive.accessHive'
++>  LIBRARY t125_l2
++>  LANGUAGE JAVA
++>  PARAMETER STYLE JAVA
++>  READS SQL DATA
++>  NO TRANSACTION REQUIRED
++>  ISOLATE
++>  ;
+
+--- SQL operation complete.
+>>
+>>
+>>create schema t125sch2;
+
+--- SQL operation complete.
+>>set schema t125sch2;
+
+--- SQL operation complete.
+>>obey TEST125(create_db);
+>>create table teams
++>  (team_number int not null primary key,
++>   team_name char(20) not null,
++>   team_contact varchar(50) not null,
++>   team_contact_number char (10) not null
++>   )
++>  ;
+
+--- SQL operation complete.
+>>
+>>alter table teams add constraint valid_team_no check (team_number > 0);
+
+--- SQL operation complete.
+>>
+>>create table games
++>   ( home_team_number int not null,
++>     visitor_team_number int not null,
++>     game_number int not null primary key,
++>     game_time timestamp not null,
++>     game_location varchar(50) not null)
++>  ;
+
+--- SQL operation complete.
+>>
+>>create table players
++>  (player_number int not null,
++>   player_name varchar (50) not null,
++>   player_team_number int not null,
++>   player_phone_number char (10) not null,
++>   player_details varchar(50),
++>   primary key (player_number, player_team_number))
++>  no partition;
+
+--- SQL operation complete.
+>>
+>>alter table players add constraint players_teams
++>   foreign key (player_team_number) references teams (team_number);
+
+--- SQL operation complete.
+>>
+>>create sequence players_sequence;
+
+--- SQL operation complete.
+>>
+>>create view home_teams_games as
++>  select t.team_number, g.game_number, g.game_time
++>  from "TEAMS" t,
++>       "GAMES" g
++>  where t.team_number = g.home_team_number
++>  order by 1, game_number, game_time;
+
+--- SQL operation complete.
+>>
+>>create view players_on_team as
++>  select player_name, team_name
++>  from teams t, players p
++>  where p.player_team_number = t.team_number
++>  order by t.team_name;
+
+--- SQL operation complete.
+>>
+>>create view games_by_player as
++>  select player_name, game_time
++>  from teams t, games g, players p
++>  where p.player_team_number = t.team_number and
++>        t.team_number = g.home_team_number
++>  order by player_name, team_number;
+
+--- SQL operation complete.
+>>
+>>-- create function to display bitmaps as a bitmap rather than longs
+>>-- set envvar REGRRUNDIR '/mnt/rmarton/gitws/incubator-trafodion/core/sql/regress/rundir/privs1';
+>>-- set envvar REGRTSTDIR '/mnt/rmarton/gitws/incubator-trafodion/core/sql/regress/privs1';
+>>-- set envvar scriptsdir '/mnt/rmarton/gitws/incubator-trafodion/core/sql/regress';
+>>sh rm -f ./etest141.dll;
+>>sh sh $$scriptsdir$$/tools/dll-compile.ksh etest141.cpp
++>  2>&1 | tee LOG125-SECONDARY;
+>>set pattern $$DLL$$ etest141.dll;
+>>set pattern $$QUOTE$$ '''';
+>>
+>>create library t125_l1 file $$QUOTE$$ $$REGRRUNDIR$$/$$DLL$$ $$QUOTE$$ ;
+
+--- SQL operation complete.
+>>create function translateBitmap(bitmap largeint) returns (bitmap_string char (20))
++>language c parameter style sql external name 'translateBitmap'
++>library t125_l1
++>deterministic no sql final call allow any parallelism state area size 1024 ;
+
+--- SQL operation complete.
+>>
+>>sh sh $$scriptsdir$$/tools/java-compile.ksh Utils.java TestHive.java 2> LOG125-SECONDARY | tee -a LOG125;
+------------------------------------------------------------------------------
+-- Compiling Java source files: Utils.java TestHive.java
+-- Executing: $javac -d $REGRRUNDIR $REGRTSTDIR/Utils.java $REGRTSTDIR/TestHive.java
+-- $javac returned 0
+------------------------------------------------------------------------------
+>>sh sh $$scriptsdir$$/tools/java-archive.ksh TEST125_procs.jar TestHive.class Utils.class 2>> LOG125-SECONDARY | tee -a LOG125;
+------------------------------------------------------------------------------
+-- Archiving Java class files:
+--    TestHive.class
+--    Utils.class
+-- Archive will be written to: TEST125_procs.jar
+-- Executing: $jar cMf TEST125_procs.jar TestHive.class Utils.class
+-- $jar returned 0
+------------------------------------------------------------------------------
+>>set pattern $$JARF$$ TEST125_procs.jar;
+>>
+>>create library t125_l2
++>   file $$QUOTE$$ $$REGRRUNDIR$$/$$JARF$$ $$QUOTE$$;
+
+--- SQL operation complete.
+>>
+>>create procedure TestHive(
++>  IN operation char(20),
++>  OUT results varchar(1000))
++>  EXTERNAL NAME 'TestHive.accessHive'
++>  LIBRARY t125_l2
++>  LANGUAGE JAVA
++>  PARAMETER STYLE JAVA
++>  READS SQL DATA
++>  NO TRANSACTION REQUIRED
++>  ISOLATE
++>  ;
+
+--- SQL operation complete.
+>>
+>>
+>>create schema t125sch3 authorization t125_adminrole;
+
+--- SQL operation complete.
+>>set schema t125sch3;
+
+--- SQL operation complete.
+>>obey TEST125(create_db);
+>>create table teams
++>  (team_number int not null primary key,
++>   team_name char(20) not null,
++>   team_contact varchar(50) not null,
++>   team_contact_number char (10) not null
++>   )
++>  ;
+
+--- SQL operation complete.
+>>
+>>alter table teams add constraint valid_team_no check (team_number > 0);
+
+--- SQL operation complete.
+>>
+>>create table games
++>   ( home_team_number int not null,
++>     visitor_team_number int not null,
++>     game_number int not null primary key,
++>     game_time timestamp not null,
++>     game_location varchar(50) not null)
++>  ;
+
+--- SQL operation complete.
+>>
+>>create table players
++>  (player_number int not null,
++>   player_name varchar (50) not null,
++>   player_team_number int not null,
++>   player_phone_number char (10) not null,
++>   player_details varchar(50),
++>   primary key (player_number, player_team_number))
++>  no partition;
+
+--- SQL operation complete.
+>>
+>>alter table players add constraint players_teams
++>   foreign key (player_team_number) references teams (team_number);
+
+--- SQL operation complete.
+>>
+>>create sequence players_sequence;
+
+--- SQL operation complete.
+>>
+>>create view home_teams_games as
++>  select t.team_number, g.game_number, g.game_time
++>  from "TEAMS" t,
++>       "GAMES" g
++>  where t.team_number = g.home_team_number
++>  order by 1, game_number, game_time;
+
+--- SQL operation complete.
+>>
+>>create view players_on_team as
++>  select player_name, team_name
++>  from teams t, players p
++>  where p.player_team_number = t.team_number
++>  order by t.team_name;
+
+--- SQL operation complete.
+>>
+>>create view games_by_player as
++>  select player_name, game_time
++>  from teams t, games g, players p
++>  where p.player_team_number = t.team_number and
++>        t.team_number = g.home_team_number
++>  order by player_name, team_number;
+
+--- SQL operation complete.
+>>
+>>-- create function to display bitmaps as a bitmap rather than longs
+>>-- set envvar REGRRUNDIR '/mnt/rmarton/gitws/incubator-trafodion/core/sql/regress/rundir/privs1';
+>>-- set envvar REGRTSTDIR '/mnt/rmarton/gitws/incubator-trafodion/core/sql/regress/privs1';
+>>-- set envvar scriptsdir '/mnt/rmarton/gitws/incubator-trafodion/core/sql/regress';
+>>sh rm -f ./etest141.dll;
+>>sh sh $$scriptsdir$$/tools/dll-compile.ksh etest141.cpp
++>  2>&1 | tee LOG125-SECONDARY;
+>>set pattern $$DLL$$ etest141.dll;
+>>set pattern $$QUOTE$$ '''';
+>>
+>>create library t125_l1 file $$QUOTE$$ $$REGRRUNDIR$$/$$DLL$$ $$QUOTE$$ ;
+
+--- SQL operation complete.
+>>create function translateBitmap(bitmap largeint) returns (bitmap_string char (20))
++>language c parameter style sql external name 'translateBitmap'
++>library t125_l1
++>deterministic no sql final call allow any parallelism state area size 1024 ;
+
+--- SQL operation complete.
+>>
+>>sh sh $$scriptsdir$$/tools/java-compile.ksh Utils.java TestHive.java 2> LOG125-SECONDARY | tee -a LOG125;
+------------------------------------------------------------------------------
+-- Compiling Java source files: Utils.java TestHive.java
+-- Executing: $javac -d $REGRRUNDIR $REGRTSTDIR/Utils.java $REGRTSTDIR/TestHive.java
+-- $javac returned 0
+------------------------------------------------------------------------------
+>>sh sh $$scriptsdir$$/tools/java-archive.ksh TEST125_procs.jar TestHive.class Utils.class 2>> LOG125-SECONDARY | tee -a LOG125;
+------------------------------------------------------------------------------
+-- Archiving Java class files:
+--    TestHive.class
+--    Utils.class
+-- Archive will be written to: TEST125_procs.jar
+-- Executing: $jar cMf TEST125_procs.jar TestHive.class Utils.class
+-- $jar returned 0
+------------------------------------------------------------------------------
+>>set pattern $$JARF$$ TEST125_procs.jar;
+>>
+>>create library t125_l2
++>   file $$QUOTE$$ $$REGRRUNDIR$$/$$JARF$$ $$QUOTE$$;
+
+--- SQL operation complete.
+>>
+>>create procedure TestHive(
++>  IN operation char(20),
++>  OUT results varchar(1000))
++>  EXTERNAL NAME 'TestHive.accessHive'
++>  LIBRARY t125_l2
++>  LANGUAGE JAVA
++>  PARAMETER STYLE JAVA
++>  READS SQL DATA
++>  NO TRANSACTION REQUIRED
++>  ISOLATE
++>  ;
+
+--- SQL operation complete.
+>>
+>>
+>>-- privileges for role1 (sql_user7)
+>>grant role t125_role1 to sql_user7;
+
+--- SQL operation complete.
+>>grant select(team_number) on t125sch2.teams to t125_role1;
+
+--- SQL operation complete.
+>>grant all on t125sch3.players to t125_role1;
+
+--- SQL operation complete.
+>>grant all on function t125sch3.translateBitmap to t125_role1;
+
+--- SQL operation complete.
+>>
+>>-- privileges for sql_user1
+>>grant insert on t125sch3.games to sql_user1;
+
+--- SQL operation complete.
+>>grant select on t125sch3.games_by_player to sql_user1;
+
+--- SQL operation complete.
+>>grant select (player_name) on t125sch3.games_by_player to sql_user1;
+
+--- SQL operation complete.
+>>grant execute on procedure t125sch2.testhive to sql_user1;
+
+--- SQL operation complete.
+>>grant usage on sequence t125sch2.players_sequence to sql_user1;
+
+--- SQL operation complete.
+>>
+>>-- privileges for sql_user2 + role1
+>>grant role t125_role1 to sql_user2;
+
+--- SQL operation complete.
+>>grant all on t125sch1.games to sql_user2;
+
+--- SQL operation complete.
+>>grant all on t125sch2.games to sql_user2;
+
+--- SQL operation complete.
+>>grant all on t125sch3.games to sql_user2;
+
+--- SQL operation complete.
+>>grant select (game_number) on t125sch2.games to t125_role1;
+
+--- SQL operation complete.
+>>grant select on t125sch1.games_by_player to sql_user2;
+
+--- SQL operation complete.
+>>grant select on t125sch2.games_by_player to sql_user2;
+
+--- SQL operation complete.
+>>grant select on t125sch3.games_by_player to sql_user2;
+
+--- SQL operation complete.
+>>
+>>-- privileges for sql_user8 - all on t125sch3 (owner through role)
+>>
+>>get privileges for role t125_role1;
+
+Privileges for Role T125_ROLE1
+==============================
+
+S------    TRAFODION.T125SCH2.GAMES <Column> GAME_NUMBER
+S------    TRAFODION.T125SCH2.TEAMS <Column> TEAM_NUMBER
+SIDU-R-    TRAFODION.T125SCH3.PLAYERS
+------E    TRAFODION.T125SCH3.TRANSLATEBITMAP
+
+--- SQL operation complete.
+>>get privileges for user sql_user1;
+
+Privileges for User SQL_USER1
+=============================
+
+----G--    TRAFODION.T125SCH2.PLAYERS_SEQUENCE
+------E    TRAFODION.T125SCH2.TESTHIVE
+-I-----    TRAFODION.T125SCH3.GAMES
+S------    TRAFODION.T125SCH3.GAMES_BY_PLAYER
+S------    TRAFODION.T125SCH3.GAMES_BY_PLAYER <Column> PLAYER_NAME
+
+--- SQL operation complete.
+>>get privileges for user sql_user2;
+
+Privileges for User SQL_USER2
+=============================
+
+SIDU-R-    TRAFODION.T125SCH1.GAMES
+S------    TRAFODION.T125SCH1.GAMES_BY_PLAYER
+SIDU-R-    TRAFODION.T125SCH2.GAMES
+S------    TRAFODION.T125SCH2.GAMES <Column> GAME_NUMBER
+S------    TRAFODION.T125SCH2.GAMES_BY_PLAYER
+S------    TRAFODION.T125SCH2.TEAMS <Column> TEAM_NUMBER
+SIDU-R-    TRAFODION.T125SCH3.GAMES
+S------    TRAFODION.T125SCH3.GAMES_BY_PLAYER
+SIDU-R-    TRAFODION.T125SCH3.PLAYERS
+------E    TRAFODION.T125SCH3.TRANSLATEBITMAP
+
+--- SQL operation complete.
+>>get privileges for user sql_user7;
+
+Privileges for User SQL_USER7
+=============================
+
+S------    TRAFODION.T125SCH2.GAMES <Column> GAME_NUMBER
+S------    TRAFODION.T125SCH2.TEAMS <Column> TEAM_NUMBER
+SIDU-R-    TRAFODION.T125SCH3.PLAYERS
+------E    TRAFODION.T125SCH3.TRANSLATEBITMAP
+
+--- SQL operation complete.
+>>get privileges for user sql_user8;
+
+Privileges for User SQL_USER8
+=============================
+
+SIDU-R-    TRAFODION.T125SCH3.GAMES
+S----R-    TRAFODION.T125SCH3.GAMES_BY_PLAYER
+S----R-    TRAFODION.T125SCH3.HOME_TEAMS_GAMES
+SIDU-R-    TRAFODION.T125SCH3.PLAYERS
+S----R-    TRAFODION.T125SCH3.PLAYERS_ON_TEAM
+----G--    TRAFODION.T125SCH3.PLAYERS_SEQUENCE
+SIDU-R-    TRAFODION.T125SCH3.SB_HISTOGRAMS
+SIDU-R-    TRAFODION.T125SCH3.SB_HISTOGRAM_INTERVALS
+SIDU-R-    TRAFODION.T125SCH3.SB_PERSISTENT_SAMPLES
+---UG--    TRAFODION.T125SCH3.T125_L1
+---UG--    TRAFODION.T125SCH3.T125_L2
+SIDU-R-    TRAFODION.T125SCH3.TEAMS
+------E    TRAFODION.T125SCH3.TESTHIVE
+------E    TRAFODION.T125SCH3.TRANSLATEBITMAP
+
+--- SQL operation complete.
+>>
+>>obey TEST125(get_tests);
+>>log LOG125;
+>>cqd SHOWDDL_DISPLAY_PRIVILEGE_GRANTS 'ON';
+
+--- SQL operation complete.
+>>values (user);
+
+(EXPR)
+---------------------------------------------------------------------------------------------------------------------------------
+
+DB__ROOT                                                                                                                         
+
+--- 1 row(s) selected.
+>>obey TEST125(get_statements);
+>>get schemas, match 'T125SCH%';
+
+Schemas in Catalog TRAFODION
+============================
+
+T125SCH1
+T125SCH2
+T125SCH3
+
+--- SQL operation complete.
+>>
+>>set schema t125sch1;
+
+--- SQL operation complete.
+>>get tables;
+
+Tables in Schema TRAFODION.T125SCH1
+===================================
+
+GAMES
+PLAYERS
+SB_HISTOGRAMS
+SB_HISTOGRAM_INTERVALS
+SB_PERSISTENT_SAMPLES
+TEAMS
+
+--- SQL operation complete.
+>>get views;
+
+Views in Schema TRAFODION.T125SCH1
+==================================
+
+GAMES_BY_PLAYER
+HOME_TEAMS_GAMES
+PLAYERS_ON_TEAM
+
+--- SQL operation complete.
+>>get indexes;
+
+Indexes in Schema TRAFODION.T125SCH1
+====================================
+
+PLAYERS_TEAMS
+
+--- SQL operation complete.
+>>get sequences, match 'T125SCH%';
+
+Sequences in catalog TRAFODION
+==============================
+
+T125SCH1.PLAYERS_SEQUENCE
+T125SCH2.PLAYERS_SEQUENCE
+T125SCH3.PLAYERS_SEQUENCE
+
+--- SQL operation complete.
+>>get libraries;
+
+Libraries in Schema TRAFODION.T125SCH1
+======================================
+
+T125_L1
+T125_L2
+
+--- SQL operation complete.
+>>get functions;
+
+Functions in Schema TRAFODION.T125SCH1
+======================================
+
+TRANSLATEBITMAP
+
+--- SQL operation complete.
+>>get procedures;
+
+Procedures in Schema TRAFODION.T125SCH1
+=======================================
+
+TESTHIVE
+
+--- SQL operation complete.
+>>
+>>set schema t125sch2;
+
+--- SQL operation complete.
+>>get tables in schema t125sch2;
+
+Tables in Schema TRAFODION.T125SCH2
+===================================
+
+GAMES
+PLAYERS
+SB_HISTOGRAMS
+SB_HISTOGRAM_INTERVALS
+SB_PERSISTENT_SAMPLES
+TEAMS
+
+--- SQL operation complete.
+>>get views in schema t125sch2;
+
+Views in Schema TRAFODION.T125SCH2
+==================================
+
+GAMES_BY_PLAYER
+HOME_TEAMS_GAMES
+PLAYERS_ON_TEAM
+
+--- SQL operation complete.
+>>get indexes in schema t125sch2;
+
+Indexes in Schema TRAFODION.T125SCH2
+====================================
+
+PLAYERS_TEAMS
+
+--- SQL operation complete.
+>>get sequences in schema t125sch2;
+
+Sequences in schema TRAFODION.T125SCH2
+======================================
+
+PLAYERS_SEQUENCE
+
+--- SQL operation complete.
+>>get libraries in schema t125sch2;
+
+Libraries in Schema TRAFODION.T125SCH2
+======================================
+
+T125_L1
+T125_L2
+
+--- SQL operation complete.
+>>get functions in schema t125sch2;
+
+Functions in Schema TRAFODION.T125SCH2
+======================================
+
+TRANSLATEBITMAP
+
+--- SQL operation complete.
+>>get procedures in schema t125sch2;
+
+Procedures in Schema TRAFODION.T125SCH2
+=======================================
+
+TESTHIVE
+
+--- SQL operation complete.
+>>
+>>set schema t125sch3;
+
+--- SQL operation complete.
+>>get tables;
+
+Tables in Schema TRAFODION.T125SCH3
+===================================
+
+GAMES
+PLAYERS
+SB_HISTOGRAMS
+SB_HISTOGRAM_INTERVALS
+SB_PERSISTENT_SAMPLES
+TEAMS
+
+--- SQL operation complete.
+>>get views in catalog trafodion, match 'T125SCH%';
+
+Views in Catalog TRAFODION
+==========================
+
+T125SCH1.GAMES_BY_PLAYER
+T125SCH1.HOME_TEAMS_GAMES
+T125SCH1.PLAYERS_ON_TEAM
+T125SCH2.GAMES_BY_PLAYER
+T125SCH2.HOME_TEAMS_GAMES
+T125SCH2.PLAYERS_ON_TEAM
+T125SCH3.GAMES_BY_PLAYER
+T125SCH3.HOME_TEAMS_GAMES
+T125SCH3.PLAYERS_ON_TEAM
+
+--- SQL operation complete.
+>>get indexes in schema t125sch3;
+
+Indexes in Schema TRAFODION.T125SCH3
+====================================
+
+PLAYERS_TEAMS
+
+--- SQL operation complete.
+>>get sequences in catalog trafodion, match 'T125SCH%';
+
+Sequences in catalog TRAFODION
+==============================
+
+T125SCH1.PLAYERS_SEQUENCE
+T125SCH2.PLAYERS_SEQUENCE
+T125SCH3.PLAYERS_SEQUENCE
+
+--- SQL operation complete.
+>>get libraries;
+
+Libraries in Schema TRAFODION.T125SCH3
+======================================
+
+T125_L1
+T125_L2
+
+--- SQL operation complete.
+>>get functions in schema t125sch3;
+
+Functions in Schema TRAFODION.T125SCH3
+======================================
+
+TRANSLATEBITMAP
+
+--- SQL operation complete.
+>>get procedures;
+
+Procedures in Schema TRAFODION.T125SCH3
+=======================================
+
+TESTHIVE
+
+--- SQL operation complete.
+>>
+>>
+>>revoke component privilege "SHOW" on sql_operations from "PUBLIC";
+
+--- SQL operation complete.
+>>-- sql_user8 can see all in t125sch3
+>>sh sqlci -i "TEST125(get_tests)" -u sql_user8;
+>>cqd SHOWDDL_DISPLAY_PRIVILEGE_GRANTS 'ON';
+
+--- SQL operation complete.
+>>values (user);
+
+(EXPR)
+---------------------------------------------------------------------------------------------------------------------------------
+
+SQL_USER8                                                                                                                        
+
+--- 1 row(s) selected.
+>>obey TEST125(get_statements);
+>>get schemas, match 'T125SCH%';
+
+Schemas in Catalog TRAFODION
+============================
+
+T125SCH3
+
+--- SQL operation complete.
+>>
+>>set schema t125sch1;
+
+--- SQL operation complete.
+>>get tables;
+
+--- SQL operation complete.
+>>get views;
+
+--- SQL operation complete.
+>>get indexes;
+
+--- SQL operation complete.
+>>get sequences, match 'T125SCH%';
+
+Sequences in catalog TRAFODION
+==============================
+
+T125SCH3.PLAYERS_SEQUENCE
+
+--- SQL operation complete.
+>>get libraries;
+
+--- SQL operation complete.
+>>get functions;
+
+--- SQL operation complete.
+>>get procedures;
+
+--- SQL operation complete.
+>>
+>>set schema t125sch2;
+
+--- SQL operation complete.
+>>get tables in schema t125sch2;
+
+--- SQL operation complete.
+>>get views in schema t125sch2;
+
+--- SQL operation complete.
+>>get indexes in schema t125sch2;
+
+--- SQL operation complete.
+>>get sequences in schema t125sch2;
+
+--- SQL operation complete.
+>>get libraries in schema t125sch2;
+
+--- SQL operation complete.
+>>get functions in schema t125sch2;
+
+--- SQL operation complete.
+>>get procedures in schema t125sch2;
+
+--- SQL operation complete.
+>>
+>>set schema t125sch3;
+
+--- SQL operation complete.
+>>get tables;
+
+Tables in Schema TRAFODION.T125SCH3
+===================================
+
+GAMES
+PLAYERS
+SB_HISTOGRAMS
+SB_HISTOGRAM_INTERVALS
+SB_PERSISTENT_SAMPLES
+TEAMS
+
+--- SQL operation complete.
+>>get views in catalog trafodion, match 'T125SCH%';
+
+Views in Catalog TRAFODION
+==========================
+
+T125SCH3.GAMES_BY_PLAYER
+T125SCH3.HOME_TEAMS_GAMES
+T125SCH3.PLAYERS_ON_TEAM
+
+--- SQL operation complete.
+>>get indexes in schema t125sch3;
+
+--- SQL operation complete.
+>>get sequences in catalog trafodion, match 'T125SCH%';
+
+Sequences in catalog TRAFODION
+==============================
+
+T125SCH3.PLAYERS_SEQUENCE
+
+--- SQL operation complete.
+>>get libraries;
+
+Libraries in Schema TRAFODION.T125SCH3
+======================================
+
+T125_L1
+T125_L2
+
+--- SQL operation complete.
+>>get functions in schema t125sch3;
+
+Functions in Schema TRAFODION.T125SCH3
+======================================
+
+TRANSLATEBITMAP
+
+--- SQL operation complete.
+>>get procedures;
+
+Procedures in Schema TRAFODION.T125SCH3
+=======================================
+
+TESTHIVE
+
+--- SQL operation complete.
+>>
+>>exit;
+
+End of MXCI Session
+
+>>-- sql_user1 sees sch2 testhive, players sequence; sch3 games, games_by_player
+>>sh sqlci -i "TEST125(get_tests)" -u sql_user1;
+>>cqd SHOWDDL_DISPLAY_PRIVILEGE_GRANTS 'ON';
+
+--- SQL operation complete.
+>>values (user);
+
+(EXPR)
+---------------------------------------------------------------------------------------------------------------------------------
+
+SQL_USER1                                                                                                                        
+
+--- 1 row(s) selected.
+>>obey TEST125(get_statements);
+>>get schemas, match 'T125SCH%';
+
+Schemas in Catalog TRAFODION
+============================
+
+T125SCH2
+T125SCH3
+
+--- SQL operation complete.
+>>
+>>set schema t125sch1;
+
+--- SQL operation complete.
+>>get tables;
+
+--- SQL operation complete.
+>>get views;
+
+--- SQL operation complete.
+>>get indexes;
+
+--- SQL operation complete.
+>>get sequences, match 'T125SCH%';
+
+Sequences in catalog TRAFODION
+==============================
+
+T125SCH2.PLAYERS_SEQUENCE
+
+--- SQL operation complete.
+>>get libraries;
+
+--- SQL operation complete.
+>>get functions;
+
+--- SQL operation complete.
+>>get procedures;
+
+--- SQL operation complete.
+>>
+>>set schema t125sch2;
+
+--- SQL operation complete.
+>>get tables in schema t125sch2;
+
+--- SQL operation complete.
+>>get views in schema t125sch2;
+
+--- SQL operation complete.
+>>get indexes in schema t125sch2;
+
+--- SQL operation complete.
+>>get sequences in schema t125sch2;
+
+Sequences in schema TRAFODION.T125SCH2
+======================================
+
+PLAYERS_SEQUENCE
+
+--- SQL operation complete.
+>>get libraries in schema t125sch2;
+
+--- SQL operation complete.
+>>get functions in schema t125sch2;
+
+--- SQL operation complete.
+>>get procedures in schema t125sch2;
+
+Procedures in Schema TRAFODION.T125SCH2
+=======================================
+
+TESTHIVE
+
+--- SQL operation complete.
+>>
+>>set schema t125sch3;
+
+--- SQL operation complete.
+>>get tables;
+
+Tables in Schema TRAFODION.T125SCH3
+===================================
+
+GAMES
+
+--- SQL operation complete.
+>>get views in catalog trafodion, match 'T125SCH%';
+
+Views in Catalog TRAFODION
+==========================
+
+T125SCH3.GAMES_BY_PLAYER
+
+--- SQL operation complete.
+>>get indexes in schema t125sch3;
+
+--- SQL operation complete.
+>>get sequences in catalog trafodion, match 'T125SCH%';
+
+Sequences in catalog TRAFODION
+==============================
+
+T125SCH2.PLAYERS_SEQUENCE
+
+--- SQL operation complete.
+>>get libraries;
+
+--- SQL operation complete.
+>>get functions in schema t125sch3;
+
+--- SQL operation complete.
+>>get procedures;
+
+--- SQL operation complete.
+>>
+>>exit;
+
+End of MXCI Session
+
+>>-- sql_user2 sees same as sql_user7 plus games, games_by_player in all schemas  
+>>sh sqlci -i "TEST125(get_tests)" -u sql_user2;
+>>cqd SHOWDDL_DISPLAY_PRIVILEGE_GRANTS 'ON';
+
+--- SQL operation complete.
+>>values (user);
+
+(EXPR)
+---------------------------------------------------------------------------------------------------------------------------------
+
+SQL_USER2                                                                                                                        
+
+--- 1 row(s) selected.
+>>obey TEST125(get_statements);
+>>get schemas, match 'T125SCH%';
+
+Schemas in Catalog TRAFODION
+============================
+
+T125SCH1
+T125SCH2
+T125SCH3
+
+--- SQL operation complete.
+>>
+>>set schema t125sch1;
+
+--- SQL operation complete.
+>>get tables;
+
+Tables in Schema TRAFODION.T125SCH1
+===================================
+
+GAMES
+
+--- SQL operation complete.
+>>get views;
+
+Views in Schema TRAFODION.T125SCH1
+==================================
+
+GAMES_BY_PLAYER
+
+--- SQL operation complete.
+>>get indexes;
+
+--- SQL operation complete.
+>>get sequences, match 'T125SCH%';
+
+--- SQL operation complete.
+>>get libraries;
+
+--- SQL operation complete.
+>>get functions;
+
+--- SQL operation complete.
+>>get procedures;
+
+--- SQL operation complete.
+>>
+>>set schema t125sch2;
+
+--- SQL operation complete.
+>>get tables in schema t125sch2;
+
+Tables in Schema TRAFODION.T125SCH2
+===================================
+
+GAMES
+TEAMS
+
+--- SQL operation complete.
+>>get views in schema t125sch2;
+
+Views in Schema TRAFODION.T125SCH2
+==================================
+
+GAMES_BY_PLAYER
+
+--- SQL operation complete.
+>>get indexes in schema t125sch2;
+
+--- SQL operation complete.
+>>get sequences in schema t125sch2;
+
+--- SQL operation complete.
+>>get libraries in schema t125sch2;
+
+--- SQL operation complete.
+>>get functions in schema t125sch2;
+
+--- SQL operation complete.
+>>get procedures in schema t125sch2;
+
+--- SQL operation complete.
+>>
+>>set schema t125sch3;
+
+--- SQL operation complete.
+>>get tables;
+
+Tables in Schema TRAFODION.T125SCH3
+===================================
+
+GAMES
+PLAYERS
+
+--- SQL operation complete.
+>>get views in catalog trafodion, match 'T125SCH%';
+
+Views in Catalog TRAFODION
+==========================
+
+T125SCH1.GAMES_BY_PLAYER
+T125SCH2.GAMES_BY_PLAYER
+T125SCH3.GAMES_BY_PLAYER
+
+--- SQL operation complete.
+>>get indexes in schema t125sch3;
+
+--- SQL operation complete.
+>>get sequences in catalog trafodion, match 'T125SCH%';
+
+--- SQL operation complete.
+>>get libraries;
+
+--- SQL operation complete.
+>>get functions in schema t125sch3;
+
+Functions in Schema TRAFODION.T125SCH3
+======================================
+
+TRANSLATEBITMAP
+
+--- SQL operation complete.
+>>get procedures;
+
+--- SQL operation complete.
+>>
+>>exit;
+
+End of MXCI Session
+
+>>-- sql_user7 is based on role1
+>>-- role1 sees sch2 teams; sch3 players and translateBitmap
+>>sh sqlci -i "TEST125(get_tests)" -u sql_user7;
+>>cqd SHOWDDL_DISPLAY_PRIVILEGE_GRANTS 'ON';
+
+--- SQL operation complete.
+>>values (user);
+
+(EXPR)
+---------------------------------------------------------------------------------------------------------------------------------
+
+SQL_USER7                                                                                                                        
+
+--- 1 row(s) selected.
+>>obey TEST125(get_statements);
+>>get schemas, match 'T125SCH%';
+
+Schemas in Catalog TRAFODION
+============================
+
+T125SCH2
+T125SCH3
+
+--- SQL operation complete.
+>>
+>>set schema t125sch1;
+
+--- SQL operation complete.
+>>get tables;
+
+--- SQL operation complete.
+>>get views;
+
+--- SQL operation complete.
+>>get indexes;
+
+--- SQL operation complete.
+>>get sequences, match 'T125SCH%';
+
+--- SQL operation complete.
+>>get libraries;
+
+--- SQL operation complete.
+>>get functions;
+
+--- SQL operation complete.
+>>get procedures;
+
+--- SQL operation complete.
+>>
+>>set schema t125sch2;
+
+--- SQL operation complete.
+>>get tables in schema t125sch2;
+
+Tables in Schema TRAFODION.T125SCH2
+===================================
+
+GAMES
+TEAMS
+
+--- SQL operation complete.
+>>get views in schema t125sch2;
+
+--- SQL operation complete.
+>>get indexes in schema t125sch2;
+
+--- SQL operation complete.
+>>get sequences in schema t125sch2;
+
+--- SQL operation complete.
+>>get libraries in schema t125sch2;
+
+--- SQL operation complete.
+>>get functions in schema t125sch2;
+
+--- SQL operation complete.
+>>get procedures in schema t125sch2;
+
+--- SQL operation complete.
+>>
+>>set schema t125sch3;
+
+--- SQL operation complete.
+>>get tables;
+
+Tables in Schema TRAFODION.T125SCH3
+===================================
+
+PLAYERS
+
+--- SQL operation complete.
+>>get views in catalog trafodion, match 'T125SCH%';
+
+--- SQL operation complete.
+>>get indexes in schema t125sch3;
+
+--- SQL operation complete.
+>>get sequences in catalog trafodion, match 'T125SCH%';
+
+--- SQL operation complete.
+>>get libraries;
+
+--- SQL operation complete.
+>>get functions in schema t125sch3;
+
+Functions in Schema TRAFODION.T125SCH3
+======================================
+
+TRANSLATEBITMAP
+
+--- SQL operation complete.
+>>get procedures;
+
+--- SQL operation complete.
+>>
+>>exit;
+
+End of MXCI Session
+
+>>grant component privilege "SHOW" on sql_operations to "PUBLIC";
+
+--- SQL operation complete.
+>>log;

--- a/core/sql/regress/privs1/TEST125
+++ b/core/sql/regress/privs1/TEST125
@@ -1,0 +1,245 @@
+-- ============================================================================
+-- TEST125 - tests get statements continued
+--
+-- @@@ START COPYRIGHT @@@
+--
+-- Licensed to the Apache Software Foundation (ASF) under one
+-- or more contributor license agreements.  See the NOTICE file
+-- distributed with this work for additional information
+-- regarding copyright ownership.  The ASF licenses this file
+-- to you under the Apache License, Version 2.0 (the
+-- "License"); you may not use this file except in compliance
+-- with the License.  You may obtain a copy of the License at
+--
+--   http://www.apache.org/licenses/LICENSE-2.0
+--
+-- Unless required by applicable law or agreed to in writing,
+-- software distributed under the License is distributed on an
+-- "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+-- KIND, either express or implied.  See the License for the
+-- specific language governing permissions and limitations
+-- under the License.
+--
+-- @@@ END COPYRIGHT @@@
+--
+-- Tests that get statements return only what the user can see
+--  get schemas (in catalog)
+--  get tables (in schemas)
+--  get views (in catalogs)
+--  get views (in schemas)
+--  get indexes (in schemas)
+--  get sequences (in catalog
+--  get sequences (in schema)
+--  get functions, procedures, table mapping functions, libraries (in schema)
+--  get privileges on table
+--  get privileges on view
+--
+-- ============================================================================
+cqd SHOWDDL_DISPLAY_PRIVILEGE_GRANTS 'ON';
+obey TEST125(clean_up);
+log LOG125;
+
+obey TEST125(set_up);
+revoke component privilege "SHOW" on sql_operations from "PUBLIC";
+-- sql_user8 can see all in t125sch3
+sh sqlci -i "TEST125(get_tests)" -u sql_user8;
+-- sql_user1 sees sch2 testhive, players sequence; sch3 games, games_by_player
+sh sqlci -i "TEST125(get_tests)" -u sql_user1;
+-- sql_user2 sees same as sql_user7 plus games, games_by_player in all schemas  
+sh sqlci -i "TEST125(get_tests)" -u sql_user2;
+-- sql_user7 is based on role1
+-- role1 sees sch2 teams; sch3 players and translateBitmap
+sh sqlci -i "TEST125(get_tests)" -u sql_user7;
+grant component privilege "SHOW" on sql_operations to "PUBLIC";
+log;
+obey TEST125(clean_up);
+exit;
+
+?section set_up
+create role t125_adminrole;
+grant role t125_adminrole to sql_user8;
+create role t125_role1;
+
+-- create schemas
+create schema t125sch1; 
+set schema t125sch1;
+obey TEST125(create_db);
+
+create schema t125sch2;
+set schema t125sch2;
+obey TEST125(create_db);
+
+create schema t125sch3 authorization t125_adminrole;
+set schema t125sch3;
+obey TEST125(create_db);
+
+-- privileges for role1 (sql_user7)
+grant role t125_role1 to sql_user7;
+grant select(team_number) on t125sch2.teams to t125_role1;
+grant all on t125sch3.players to t125_role1;
+grant all on function t125sch3.translateBitmap to t125_role1;
+
+-- privileges for sql_user1
+grant insert on t125sch3.games to sql_user1;
+grant select on t125sch3.games_by_player to sql_user1;
+grant select (player_name) on t125sch3.games_by_player to sql_user1;
+grant execute on procedure t125sch2.testhive to sql_user1;
+grant usage on sequence t125sch2.players_sequence to sql_user1;
+
+-- privileges for sql_user2 + role1
+grant role t125_role1 to sql_user2;
+grant all on t125sch1.games to sql_user2;
+grant all on t125sch2.games to sql_user2;
+grant all on t125sch3.games to sql_user2;
+grant select (game_number) on t125sch2.games to t125_role1;
+grant select on t125sch1.games_by_player to sql_user2;
+grant select on t125sch2.games_by_player to sql_user2;
+grant select on t125sch3.games_by_player to sql_user2;
+
+-- privileges for sql_user8 - all on t125sch3 (owner through role)
+
+get privileges for role t125_role1;
+get privileges for user sql_user1;
+get privileges for user sql_user2;
+get privileges for user sql_user7;
+get privileges for user sql_user8;
+
+obey TEST125(get_tests);
+
+?section create_db
+create table teams
+  (team_number int not null primary key,
+   team_name char(20) not null,
+   team_contact varchar(50) not null,
+   team_contact_number char (10) not null
+   )
+  ;
+
+alter table teams add constraint valid_team_no check (team_number > 0);
+
+create table games
+   ( home_team_number int not null,
+     visitor_team_number int not null,
+     game_number int not null primary key,
+     game_time timestamp not null,
+     game_location varchar(50) not null)
+  ;
+
+create table players
+  (player_number int not null,
+   player_name varchar (50) not null,
+   player_team_number int not null,
+   player_phone_number char (10) not null,
+   player_details varchar(50),
+   primary key (player_number, player_team_number))
+  no partition;
+
+alter table players add constraint players_teams
+   foreign key (player_team_number) references teams (team_number);
+
+create sequence players_sequence;
+
+create view home_teams_games as
+  select t.team_number, g.game_number, g.game_time
+  from "TEAMS" t,
+       "GAMES" g
+  where t.team_number = g.home_team_number
+  order by 1, game_number, game_time;
+
+create view players_on_team as
+  select player_name, team_name
+  from teams t, players p
+  where p.player_team_number = t.team_number
+  order by t.team_name;
+
+create view games_by_player as
+  select player_name, game_time
+  from teams t, games g, players p
+  where p.player_team_number = t.team_number and
+        t.team_number = g.home_team_number
+  order by player_name, team_number;
+
+-- create function to display bitmaps as a bitmap rather than longs
+-- set envvar REGRRUNDIR '/mnt/rmarton/gitws/incubator-trafodion/core/sql/regress/rundir/privs1';
+-- set envvar REGRTSTDIR '/mnt/rmarton/gitws/incubator-trafodion/core/sql/regress/privs1';
+-- set envvar scriptsdir '/mnt/rmarton/gitws/incubator-trafodion/core/sql/regress';
+sh rm -f ./etest141.dll;
+sh sh $$scriptsdir$$/tools/dll-compile.ksh etest141.cpp
+  2>&1 | tee LOG125-SECONDARY;
+set pattern $$DLL$$ etest141.dll;
+set pattern $$QUOTE$$ '''';
+
+create library t125_l1 file $$QUOTE$$ $$REGRRUNDIR$$/$$DLL$$ $$QUOTE$$ ;
+create function translateBitmap(bitmap largeint) returns (bitmap_string char (20))
+language c parameter style sql external name 'translateBitmap'
+library t125_l1
+deterministic no sql final call allow any parallelism state area size 1024 ;
+
+sh sh $$scriptsdir$$/tools/java-compile.ksh Utils.java TestHive.java 2> LOG125-SECONDARY | tee -a LOG125;
+sh sh $$scriptsdir$$/tools/java-archive.ksh TEST125_procs.jar TestHive.class Utils.class 2>> LOG125-SECONDARY | tee -a LOG125;
+set pattern $$JARF$$ TEST125_procs.jar;
+
+create library t125_l2
+   file $$QUOTE$$ $$REGRRUNDIR$$/$$JARF$$ $$QUOTE$$;
+
+create procedure TestHive(
+  IN operation char(20),
+  OUT results varchar(1000))
+  EXTERNAL NAME 'TestHive.accessHive'
+  LIBRARY t125_l2
+  LANGUAGE JAVA
+  PARAMETER STYLE JAVA
+  READS SQL DATA
+  NO TRANSACTION REQUIRED
+  ISOLATE
+  ;
+
+?section clean_up
+drop schema t125sch1 cascade;
+drop schema t125sch2 cascade;
+drop schema t125sch3 cascade;
+
+revoke role t125_role1 from sql_user7;
+revoke role t125_role1 from sql_user2;
+
+drop role t125_role1;
+drop role t125_role2;
+
+revoke role t125_adminrole from sql_user8;
+drop role t125_adminrole;
+
+?section get_tests
+log LOG125;
+cqd SHOWDDL_DISPLAY_PRIVILEGE_GRANTS 'ON';
+values (user);
+obey TEST125(get_statements);
+
+?section get_statements
+get schemas, match 'T125SCH%';
+
+set schema t125sch1;
+get tables;
+get views;
+get indexes;
+get sequences, match 'T125SCH%';
+get libraries;
+get functions;
+get procedures;
+
+set schema t125sch2;
+get tables in schema t125sch2;
+get views in schema t125sch2;
+get indexes in schema t125sch2;
+get sequences in schema t125sch2;
+get libraries in schema t125sch2;
+get functions in schema t125sch2;
+get procedures in schema t125sch2;
+
+set schema t125sch3;
+get tables;
+get views in catalog trafodion, match 'T125SCH%';
+get indexes in schema t125sch3;
+get sequences in catalog trafodion, match 'T125SCH%';
+get libraries;
+get functions in schema t125sch3;
+get procedures;

--- a/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
@@ -9756,20 +9756,8 @@ void CmpSeabaseDDL::seabaseGrantRevoke(
   if (objectUID == 0 &&
       naTable && naTable->isHiveTable())
     {
-      // For native hive tables, grantor must be DB__ROOT or belong
-      // to one of the admin roles:  DB__ROOTROLE, DB__HIVEROLE
-      // In hive, you must be an admin, DB__ROOTROLE and DB__HIVEROLE
-      // is the equivalent of an admin.
-      if (!ComUser::isRootUserID() &&
-          !ComUser::currentUserHasRole(ROOT_ROLE_ID) &&
-          !ComUser::currentUserHasRole(HIVE_ROLE_ID)) 
-        {
-          *CmpCommon::diags() << DgSqlCode (-CAT_NOT_AUTHORIZED);
-          processReturn();
-          return;
-        }
-
-      // register this hive table in traf metadata
+      // Register this hive table in traf metadata
+      // Privilege checks performed by register code
       char query[(ComMAX_ANSI_IDENTIFIER_EXTERNAL_LEN*4) + 100];
       snprintf(query, sizeof(query),
                "register internal hive %s if not exists %s.\"%s\".\"%s\"",
@@ -10784,10 +10772,11 @@ void CmpSeabaseDDL::regOrUnregNativeObject(
   // to one of the admin roles:  DB__ROOTROLE, DB__HIVEROLE/DB__HBASEROLE.
   // In hive/hbase, you must be an admin, DB__ROOTROLE,DB__HIVEROLE/HBASEROLE
   // is the equivalent of an admin.
-  if (!ComUser::isRootUserID() &&
-      !ComUser::currentUserHasRole(ROOT_ROLE_ID) &&
-      ((isHive && !ComUser::currentUserHasRole(HIVE_ROLE_ID)) ||
-       (isHBase && !ComUser::currentUserHasRole(HBASE_ROLE_ID))))
+ if (!Get_SqlParser_Flags(INTERNAL_QUERY_FROM_EXEUTIL) &&
+     !ComUser::isRootUserID() &&
+     !ComUser::currentUserHasRole(ROOT_ROLE_ID) &&
+     ((isHive && !ComUser::currentUserHasRole(HIVE_ROLE_ID)) ||
+      (isHBase && !ComUser::currentUserHasRole(HBASE_ROLE_ID))))
     {
       *CmpCommon::diags() << DgSqlCode (-CAT_NOT_AUTHORIZED);
       processReturn();

--- a/core/sql/sqlcomp/PrivMgr.cpp
+++ b/core/sql/sqlcomp/PrivMgr.cpp
@@ -759,7 +759,8 @@ bool PrivMgr::isSQLCreateOperation(SQLOperation operation)
        operation == SQLOperation::CREATE_PROCEDURE ||
        operation == SQLOperation::CREATE_ROUTINE ||
        operation == SQLOperation::CREATE_ROUTINE_ACTION ||
-       operation == SQLOperation::CREATE_SYNONYM)
+       operation == SQLOperation::CREATE_SYNONYM ||
+       operation == SQLOperation::REGISTER_HIVE_OBJECT)
       return true;
       
    return false;
@@ -804,7 +805,8 @@ bool PrivMgr::isSQLDropOperation(SQLOperation operation)
        operation == SQLOperation::DROP_PROCEDURE ||
        operation == SQLOperation::DROP_ROUTINE ||
        operation == SQLOperation::DROP_ROUTINE_ACTION ||
-       operation == SQLOperation::DROP_SYNONYM)
+       operation == SQLOperation::DROP_SYNONYM ||
+       operation == SQLOperation::UNREGISTER_HIVE_OBJECT) 
       return true;
       
    return false;

--- a/core/sql/sqlcomp/PrivMgrComponentPrivileges.cpp
+++ b/core/sql/sqlcomp/PrivMgrComponentPrivileges.cpp
@@ -1125,6 +1125,13 @@ std::string whereClause(" WHERE COMPONENT_UID = 1 AND (OPERATION_CODE = '");
             whereClause += "' OR OPERATION_CODE = '";
             whereClause += PrivMgr::getSQLOperationCode(SQLOperation::ALTER);
          }
+         else
+            if (PrivMgr::isSQLManageOperation(operation))
+            {
+               whereClause += "' OR OPERATION_CODE = '";
+               whereClause += PrivMgr::getSQLOperationCode(SQLOperation::MANAGE);
+            }
+
    
    whereClause += "') AND (GRANTEE_ID = -1 OR GRANTEE_ID = ";
    whereClause += authIDToString(authID);


### PR DESCRIPTION
…date

   statistics on HIVE tables

TRAFODION [2175] a user should only see specific schemas/tables that he has
   privileges to
Updated the following get commands:
  get schemas (in catalog)
  get tables, indexes (in schema)
  get sequences, views (in schema, in catalog)
  get libraries, procedures, functions, table mapping functions

TRAFODION [1573] Additional GET commands for privileges
  get privileges on table
  get privileges on view
New regression test privs1/TEST125

Fixed bug:  user granted MANAGE privilege does not have MANAGE sub-privs
Changed REGISTER_HIVE_OBJECT to be treated as a sub-priv under CREATE
Changed UNREGISTER_HIVE_OBJECT to be treaed as a sub-priv under DROP