### PR TITLE
[TRAFODION-2661] Improve MDAM costing for RangeSpecs

### DIFF
--- a/core/sql/common/str.cpp
+++ b/core/sql/common/str.cpp
@@ -1620,9 +1620,11 @@ Int32 str_convertToHexAscii(const char * src,               // in
 //    char * dataPointer = getDataPointer();
 //    Lng32 len = tupp_.getAllocatedSize();
 //
-//    printBrief(dataPointer, len) 
+//    printBrief(dataPointer, len) if you want an end of line
+//
+//    printBrief(dataPointer, len, FALSE) if you don't 
 //    
-void printBrief(char* dataPointer, Lng32 len) 
+void printBrief(char* dataPointer, Lng32 len, NABoolean endLine) 
 {
    // We don't know what the data type is, but we do know how
    // long the field is. So we will guess the data type.
@@ -1771,7 +1773,7 @@ void printBrief(char* dataPointer, Lng32 len)
        }
      }    
    cout << local;
-   // cout << *(Lng32 *)dataPointer;
-   // End test change
+   if (endLine)
+     cout << endl;
  }
 

--- a/core/sql/common/str.h
+++ b/core/sql/common/str.h
@@ -461,8 +461,10 @@ Int32 str_convertToHexAscii(const char * src,                   // in
 //    char * dataPointer = getDataPointer();
 //    Lng32 len = tupp_.getAllocatedSize();
 //
-//    printBrief(dataPointer, len) 
+//    printBrief(dataPointer, len) if you want an end of line
+//
+//    printBrief(dataPointer, len, FALSE) if you don't 
 //    
 NA_EIDPROC
-void printBrief(char* dataPointer, Lng32 keyLen); 
+void printBrief(char* dataPointer, Lng32 keyLen, NABoolean endLine = TRUE); 
 #endif // STR_H

--- a/core/sql/executor/MdamPoint.cpp
+++ b/core/sql/executor/MdamPoint.cpp
@@ -138,6 +138,6 @@ void MdamPoint::printBrief() const
   char * dataPointer = getDataPointer();
   Lng32 keyLen = tupp_.getAllocatedSize();
 
-  printBrief(dataPointer, keyLen);
+  ::printBrief(dataPointer, keyLen, FALSE /* no end of line wanted */);
 }
 #endif

--- a/core/sql/executor/MdamPoint.h
+++ b/core/sql/executor/MdamPoint.h
@@ -103,9 +103,6 @@ public:
   NA_EIDPROC void printBrief() const;
   #endif /* NA_MDAM_EXECUTOR_DEBUG */
   
-  #ifdef _DEBUG
-  NA_EIDPROC static void printBrief(char* ptr, Lng32 len) ;
-  #endif 
 private:
 
   // The point's value.

--- a/core/sql/executor/ex_mdam.cpp
+++ b/core/sql/executor/ex_mdam.cpp
@@ -762,6 +762,8 @@ while ((predIterator.positionToNextOr(&currentPred_)) &&
                                             columnGenInfo_->getLength(),
                                             mdamIntervalHeap,
                                             mdamRefListEntryHeap);
+                or_temp1.deleteAllIntervals(mdamIntervalHeap,
+                                            mdamRefListEntryHeap);
               }
           }
       }

--- a/core/sql/nskgmake/Makerules.linux
+++ b/core/sql/nskgmake/Makerules.linux
@@ -216,6 +216,9 @@ ifeq ($(FLAVOR),debug)
    SYS_CXXFLAGS += -O0
    SYS_DEFS += -D_DEBUG
 
+   # uncomment the next line if you want the MDAM run-time debugging code
+   #SYS_CXXFLAGS += -DNA_MDAM_EXECUTOR_DEBUG
+
    # for coverage checking support
    ifeq ($(SQ_COVERAGE),1)
       SYS_CXXFLAGS += --coverage

--- a/core/sql/optimizer/mdam.cpp
+++ b/core/sql/optimizer/mdam.cpp
@@ -1680,20 +1680,28 @@ void MdamKey::preCodeGen(ValueIdSet& executorPredicates,
   // might have wanted).  This code *does not* print any
   // *official* warnings (but it prints a warning to the console).
   // --------------------------------------------------------------------
-  // if the mdamkey has more than one disjunct and if one
-  // disjunct does not have key  predicates:
 
-  // Now, tell each element of the columnOrderListArray up to
-  // which column they contain valid key predicates:
+  // Note: The "for" loop below does two very important things:
+  // 1. Detects empty disjuncts (as discussed above) 
+  //
+  // and, while it is doing that,
+  //
+  // 2. Sets the stop column for each disjunct.
+  //
+  // Note that if we don't set the stop column, then MDAM will traverse
+  // *all* of the key columns, whether they have predicates or not, and
+  // performance will be terrible.
+
   NABoolean isEmpty = FALSE;
-  if (!partKeyPredsAdded)
+
     for (i=0; i < curDisjuncts->entries(); i++)
       {
         (*columnOrderListPtrArrayPtr_)[i]->setStopColumn(getStopColumn(i));
 
         // Find out if the disjunct has key preds:
         const ColumnOrderList& coList= *((*columnOrderListPtrArrayPtr_)[i]);
-        isEmpty = TRUE; // assume it is empty
+        if (!partKeyPredsAdded)
+          isEmpty = TRUE; // assume it is empty
         for (CollIndex j=0; j < coList.entries(); j++)
           {
             if (coList[j] AND (NOT coList[j]->isEmpty()))
@@ -1707,7 +1715,7 @@ void MdamKey::preCodeGen(ValueIdSet& executorPredicates,
             FSOWARNING("Empty disjunct");
             break;
           }
-      } // find out whether there is an empty disjunct
+      } // set stop columns and also find out whether there is an empty disjunct
 
   if (isEmpty)
     {


### PR DESCRIPTION
JIRA TRAFODION-1641 fixed an issue with MDAM costing, where MDAM costing was not accounting for the cost of recursion. That is, it was not accounting for the accumulated costs of probes as we recurse through a set of key columns. When analyzing that JIRA, I uncovered an issue with RangeSpec costing which I partially fixed.

JIRA TRAFODION-2655 tuned the above fix further, increasing the weight of the cost of accumulated probes. So for plans lacking RangeSpecs, or plans whose RangeSpecs lack ORs, MDAM costing should now be doing a much better job of picking prefixes when it should.

This fix addresses the last bit of the problem by addressing RangeSpecs. There was some code that was forcing MDAM plans to traverse all key columns when a RangeSpec containing an OR was present. I have simply deleted that code.

I do not know why that code was originally there. It does predate the fixes noted above. I will speculate that before that change, we were picking MDAM in some cases where we should not, and adding that bit of code increased the total cost of MDAM to such a point that we no longer did.