### PR TITLE
Fix for udr/TEST001 test failure

### DIFF
--- a/core/sql/regress/udr/EXPECTED001
+++ b/core/sql/regress/udr/EXPECTED001
@@ -285,7 +285,8 @@ CREATE TABLE_MAPPING FUNCTION TRAFODION.SCH.SESSIONIZE_JAVA
 +>                                  PARTITION BY 1 ORDER BY 2),
 +>                            'USERID',
 +>                            'TS',
-+>                            60000000));
++>                            60000000))
++>ORDER BY 2, 1, 3;
 
 (EXPR)           USERID                            SESSION_ID            IPADDR
 ---------------  --------------------------------  --------------------  ---------------
@@ -306,7 +307,8 @@ CREATE TABLE_MAPPING FUNCTION TRAFODION.SCH.SESSIONIZE_JAVA
 +>                                  PARTITION BY 1 ORDER BY 2),
 +>                            'USERID',
 +>                            'TS',
-+>                            60000000));
++>                            60000000))
++>ORDER BY 2, 1, 3;
 
 (EXPR)           USERID                            SESSION_ID            IPADDR
 ---------------  --------------------------------  --------------------  ---------------
@@ -324,7 +326,8 @@ CREATE TABLE_MAPPING FUNCTION TRAFODION.SCH.SESSIONIZE_JAVA
 +>                                  PARTITION BY 1 ORDER BY 2),
 +>                            'USERID',
 +>                            'TS',
-+>                            60000000));
++>                            60000000))
++>ORDER BY 2, 1, 3;
 
 (EXPR)           USERID                            SESSION_ID            IPADDR
 ---------------  --------------------------------  --------------------  ---------------
@@ -343,15 +346,16 @@ CREATE TABLE_MAPPING FUNCTION TRAFODION.SCH.SESSIONIZE_JAVA
 +>                                         PARTITION BY ipaddr ORDER BY ts),
 +>                                   'IPADDR',
 +>                                   cast('TS' as char(2)),
-+>                                   60000000)) XO;
++>                                   60000000)) XO
++>ORDER BY ipaddr, session_id, sequence_no;
 
 SESSION_ID            SEQUENCE_NO           USERID                            TS                    IPADDR
 --------------------  --------------------  --------------------------------  --------------------  ---------------
 
-                   1                     1  super-user                          212334861599500000  12.345.567.345 
-                   2                     1  super-user                          212334868799500000  12.345.567.345 
-                   2                     2  super-services                      212334868799500000  12.345.567.345 
-                   2                     3  super-services                      212334868799550000  12.345.567.345 
+                   1                     1  super-user                          212365360799500000  12.345.567.345 
+                   2                     1  super-user                          212365367999500000  12.345.567.345 
+                   2                     2  super-services                      212365367999500000  12.345.567.345 
+                   2                     3  super-services                      212365367999550000  12.345.567.345 
 
 --- 4 row(s) selected.
 >>
@@ -430,7 +434,8 @@ SESSION_ID            SEQUENCE_NO           USERID                            TS
 +>                               PARTITION BY 1 ORDER BY 2),
 +>                         'USERID',
 +>                         'TS',
-+>                         60000000));
++>                         60000000))
++>ORDER BY 2, 1, 3;
 
 (EXPR)           USERID                            SESSION_ID            IPADDR
 ---------------  --------------------------------  --------------------  ---------------
@@ -453,7 +458,8 @@ SESSION_ID            SEQUENCE_NO           USERID                            TS
 +>                         'IPADDR',
 +>                         cast('TS' as char(2)),
 +>                         60000000)) XO
-+>where session_id < 10;
++>where session_id < 10
++>ORDER BY 2, 1, 3;
 
 --- SQL command prepared.
 >>explain options 'f' s;
@@ -461,8 +467,9 @@ SESSION_ID            SEQUENCE_NO           USERID                            TS
 LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 ---- ---- ---- --------------------  --------  --------------------  ---------
 
-5    .    6    root                                                  1.79E+001
-4    .    5    esp_exchange                    1:4(hash2)            5.00E+001
+6    .    7    root                                                  1.79E+001
+5    .    6    esp_exchange                    1:4(hash2) (m)        5.00E+001
+4    .    5    sort                                                  5.00E+001
 3    .    4    tmudf                           XO                    5.00E+001
 2    .    3    sort                                                  1.00E+002
 1    .    2    esp_exchange                    4(hash2):1            1.00E+002

--- a/core/sql/regress/udr/EXPECTED002
+++ b/core/sql/regress/udr/EXPECTED002
@@ -6629,7 +6629,8 @@ LOG_TS                      SEVERITY    COMPONENT                               
 +>                    'VAL1', 'FC',
 +>                    'VAL1', 'LC',
 +>                    'VAL2', 'FC',
-+>                    'VAL2', 'LC'));
++>                    'VAL2', 'LC'))
++>order by p, slice_time;
 
 P            SLICE_TIME                  VAL1_FC      VAL1_LC      VAL2_FC       VAL2_LC
 -----------  --------------------------  -----------  -----------  ------------  ------------
@@ -6693,7 +6694,8 @@ P            SLICE_TIME                  VAL1_FC      VAL1_LC      VAL2_FC      
 +>                    'VAL1', 'FLi',
 +>                    'VAL1', 'LLi',
 +>                    'VAL2', 'FLi',
-+>                    'VAL2', 'LLi'));
++>                    'VAL2', 'LLi'))
++>order by p, slice_time;
 
 P            SLICE_TIME                  VAL1_FCI     VAL1_LCI     VAL2_FCI      VAL2_LCI      VAL1_FL                    VAL1_LL                    VAL2_FL                    VAL2_LL                    VAL1_FLI                   VAL1_LLI                   VAL2_FLI                   VAL2_LLI
 -----------  --------------------------  -----------  -----------  ------------  ------------  -------------------------  -------------------------  -------------------------  -------------------------  -------------------------  -------------------------  -------------------------  -------------------------

--- a/core/sql/regress/udr/TEST001
+++ b/core/sql/regress/udr/TEST001
@@ -247,7 +247,8 @@ FROM UDF(sessionize_dynamic(TABLE(SELECT userid,
                                   PARTITION BY 1 ORDER BY 2),
                             'USERID',
                             'TS',
-                            60000000));
+                            60000000))
+ORDER BY 2, 1, 3;
 
 SELECT cast(CONVERTTIMESTAMP(ts) as TIME(6)), userid, session_id, ipAddr
 FROM UDF(sessionize_dynamic(TABLE(SELECT userid,
@@ -258,7 +259,8 @@ FROM UDF(sessionize_dynamic(TABLE(SELECT userid,
                                   PARTITION BY 1 ORDER BY 2),
                             'USERID',
                             'TS',
-                            60000000));
+                            60000000))
+ORDER BY 2, 1, 3;
 SELECT cast(CONVERTTIMESTAMP(ts) as TIME(6)), userid, session_id, ipAddr
 FROM UDF(sessionize_dynamic(TABLE(SELECT userid,
                                          JULIANTIMESTAMP(ts) as TS,
@@ -268,7 +270,8 @@ FROM UDF(sessionize_dynamic(TABLE(SELECT userid,
                                   PARTITION BY 1 ORDER BY 2),
                             'USERID',
                             'TS',
-                            60000000));
+                            60000000))
+ORDER BY 2, 1, 3;
 
 -- call sessionize_dynamic_shared, sharing the same DLL
 SELECT *
@@ -279,7 +282,8 @@ FROM UDF(sessionize_dynamic_shared(TABLE(SELECT userid,
                                          PARTITION BY ipaddr ORDER BY ts),
                                    'IPADDR',
                                    cast('TS' as char(2)),
-                                   60000000)) XO;
+                                   60000000)) XO
+ORDER BY ipaddr, session_id, sequence_no;
 
 -- uniqueness constraint avoids a groupby
 explain options 'f'
@@ -324,7 +328,8 @@ FROM UDF(sessionize_java(TABLE(SELECT userid,
                                PARTITION BY 1 ORDER BY 2),
                          'USERID',
                          'TS',
-                         60000000));
+                         60000000))
+ORDER BY 2, 1, 3;
 
 -- uniqueness constraint avoids a groupby
 prepare s from
@@ -337,7 +342,8 @@ FROM UDF(sessionize_java(TABLE(SELECT userid,
                          'IPADDR',
                          cast('TS' as char(2)),
                          60000000)) XO
-where session_id < 10;
+where session_id < 10
+ORDER BY 2, 1, 3;
 explain options 'f' s;
 execute s;
 

--- a/core/sql/regress/udr/TEST002
+++ b/core/sql/regress/udr/TEST002
@@ -209,7 +209,8 @@ from udf(timeseries(table(select * from t002_Timeseries
                     'VAL1', 'FC',
                     'VAL1', 'LC',
                     'VAL2', 'FC',
-                    'VAL2', 'LC'));
+                    'VAL2', 'LC'))
+order by p, slice_time;
 
 select *
 from udf(timeseries(table(select * from t002_Timeseries
@@ -228,7 +229,8 @@ from udf(timeseries(table(select * from t002_Timeseries
                     'VAL1', 'FLi',
                     'VAL1', 'LLi',
                     'VAL2', 'FLi',
-                    'VAL2', 'LLi'));
+                    'VAL2', 'LLi'))
+order by p, slice_time;
 
 -- JDBC queries through a TMUDF. Note that this requires the Trafodion T4
 -- driver jar to exist in $TRAF_HOME/udr/external_libs.


### PR DESCRIPTION
My earlier change for TRAFODION-2637 (PR #1141) caused a
non-deterministic failure of test udr/TEST001 and probably also
TEST002.

I added code that enables more parallel execution for TMUDFs.  The
tests have SELECT statements for these UDFs in them. Normally, the
logsort program sorts the output of these queries, so random
differences caused by parallel queries are ignored. However, some UDF
query have the keywords ORDER BY in them, not for the main query, but
for the inner query that is the child of the UDF. That suppressed
sorting and caused a difference.

The fix is to add an ORDER BY for the main query when we could expect
a non-deterministic order and when the child query of the UDF uses
ORDER BY.

@DaveBirdsall  suggested that we could also change the logsort program to
recognize different types of ORDER BY, but this is probably not needed
right now.