### PR TITLE
[TRAFODION-2673] Improve incremental update stats performance

### DIFF
--- a/core/sql/sqlcomp/DefaultConstants.h
+++ b/core/sql/sqlcomp/DefaultConstants.h
@@ -679,6 +679,7 @@ enum DefaultConstants
   USTAT_CHECK_HIST_ACCURACY,   // After stats collection, examine full table and calculate accuray of hists
   USTAT_COMPACT_VARCHARS,      // For internal sort, store only the actual # chars used in each value
   USTAT_CLUSTER_SAMPLE_BLOCKS, // number of blocks for cluster sampling
+  USTAT_DELETE_NO_ROLLBACK,    // If ON, use DELETE WITH NO ROLLBACK in incremental stats when updating sample table
   USTAT_ESTIMATE_HBASE_ROW_COUNT,  // If ON, estimate row count of HBase table instead of count(*), subject
                                    //     to USTAT_MIN_ESTIMATE_FOR_ROWCOUNT setting)
   USTAT_FORCE_TEMP,            // Force temporary table to be used
@@ -2609,8 +2610,7 @@ enum DefaultConstants
   USTAT_SAMPLE_PERCENT_DIFF,   // percentage diff allowed to use old sample in FetchCount().
   USTAT_MAX_SAMPLE_AGE,        // max days before a persistent sample is auto removed.
   USTAT_DEBUG_TEST,            // settings for testing ustat, normally empty.
-  USTAT_DEBUG_FORCE_FETCHCOUNT,// force call to FetchCount() from optimizer if ON.
-
+ 
   // Disallow/Allow left joins in MultiJoin framework
   LEFT_JOINS_SPOIL_JBB,
 

--- a/core/sql/sqlcomp/nadefaults.cpp
+++ b/core/sql/sqlcomp/nadefaults.cpp
@@ -3547,9 +3547,8 @@ XDDkwd__(SUBQUERY_UNNESTING,			"ON"),
   DD_____(USTAT_CQDS_ALLOWED_FOR_SPAWNED_COMPILERS, ""), // list of CQDs that can be pushed to seconday compilers
                                                          // CQDs are delimited by ","
 
-
-  DDkwd__(USTAT_DEBUG_FORCE_FETCHCOUNT,         "OFF"),
   DD_____(USTAT_DEBUG_TEST,                     ""),
+  DDkwd__(USTAT_DELETE_NO_ROLLBACK,             "ON"),   // If ON, use DELETE WITH NO ROLLBACK in IUS when updating sample table
   DDflte_(USTAT_DSHMAX,		                "50.0"),
   DDkwd__(USTAT_ESTIMATE_HBASE_ROW_COUNT,       "ON"),
   DDkwd__(USTAT_FETCHCOUNT_ACTIVE,              "OFF"),

--- a/core/sql/ustat/hs_globals.h
+++ b/core/sql/ustat/hs_globals.h
@@ -1566,7 +1566,7 @@ public:
                                              NABoolean forceToFetch = TRUE);
     Lng32 updatePersistentSampleTableForIUS(NAString& sampleTableName, double sampleRate,
                                             NAString& targetTableName);
-    void generateIUSDeleteQuery(const NAString& smplTable, NAString& queryText);
+    void generateIUSDeleteQuery(const NAString& smplTable, NAString& queryText, NABoolean transactional);
     void generateIUSSelectInsertQuery(const NAString& smplTable,
                                       const NAString& sourceTable,
                                       NAString& queryText);


### PR DESCRIPTION
This change improves the performance of incremental UPDATE STATISTICS by using "WITH NO ROLLBACK" when deleting rows from the persistent sample table.

A CQD, USTAT_DELETE_NO_ROLLBACK, has been added. When set to 'ON' (the default), we use DELETE WITH NO ROLLBACK on the persistent sample table. When set to 'OFF', we do the old behavior, that is, a vanilla transactional DELETE. This CQD is here mostly in order to test and verify the performance improvement. It can be removed later.

While I was at it, I noticed another CQD that is no longer used anywhere and removed it.