### PR TITLE
[TRAFODION-2669] Improve error message 8402 - string overflow

### DIFF
--- a/core/sql/exp/ExpError.cpp
+++ b/core/sql/exp/ExpError.cpp
@@ -536,7 +536,8 @@ ComDiagsArea *ExRaiseDetailSqlError(CollHeap* heap,
                                     Int16 tgtType,
                                     UInt32 flags,
                                     Int32 tgtLength,
-                                    Int32 tgtScale)
+                                    Int32 tgtScale,
+                                    Int32 tgtPrecision)
 {
   //if looping situation, no need to proceed further, return back.
   if(flags & CONV_CONTROL_LOOPING)
@@ -593,9 +594,10 @@ ComDiagsArea *ExRaiseDetailSqlError(CollHeap* heap,
   if ((DFS2REC::isAnyCharacter(tgtType)) &&
       (tgtLength >= 0) &&
       (tgtScale > 0))
-    str_sprintf(tgtDatatypeDetail, "%s,%d BYTES,%s", 
+    str_sprintf(tgtDatatypeDetail, "%s,%d %s,%s", 
                 getDatatypeAsString(tgtType, false), 
-                tgtLength,
+                tgtPrecision ? tgtPrecision : tgtLength,
+                tgtPrecision ? "CHARS" : "BYTES",
                 //                tgtLength/CharInfo::bytesPerChar((CharInfo::CharSet)tgtScale),
                 (tgtScale == CharInfo::ISO88591 ? "ISO88591" : "UTF8"));
   else

--- a/core/sql/exp/ExpError.h
+++ b/core/sql/exp/ExpError.h
@@ -139,7 +139,8 @@ ComDiagsArea *ExRaiseDetailSqlError(CollHeap* heap,
                                     Int16 tgtType,
                                     UInt32 flags,
                                     Int32 tgtLength = -1,
-                                    Int32 tgtScale = -1);
+                                    Int32 tgtScale = -1,
+                                    Int32 tgtPrecision = 0);
 NA_EIDPROC
 SQLEXP_LIB_FUNC
 char *stringToHex(char * out, Int32 outLen, char * in, Int32 inLen);

--- a/core/sql/exp/exp_conv.cpp
+++ b/core/sql/exp/exp_conv.cpp
@@ -671,7 +671,8 @@ ex_expr::exp_return_type convInt64ToAscii(char *target,
                           (char*)&source,
                           sizeof(Int64), REC_BIN64_SIGNED, scale, trgType,
                           flags,
-                          targetLen, targetScale);
+                          targetLen, targetScale,
+                          targetPrecision);
     return ex_expr::EXPR_ERROR;   
   } 
   
@@ -11825,7 +11826,8 @@ ex_expr::exp_return_type ex_conv_clause::eval(char *op_data[],
                               tgt->getDatatype(),
                               0,
                               tgt->getLength(),
-                              tgt->getScale());
+                              tgt->getScale(),
+                              tgt->getPrecision());
         retcode = ex_expr::EXPR_ERROR;
       }
       else if (((*diagsArea)->getWarningEntry(warningMark2 - counter + 1))->


### PR DESCRIPTION
Trying to give a better indication in some cases, to show
whether we exceeded the character limit or the byte limit.
The character limit is defined by a "precision" that is
a positive number.