### PR TITLE
[TRAFODION-2676]rm log redirection lines

### DIFF
--- a/core/sql/src/main/java/org/trafodion/sql/HBaseClient.java
+++ b/core/sql/src/main/java/org/trafodion/sql/HBaseClient.java
@@ -149,23 +149,6 @@ public class HBaseClient {
     public HBaseClient() {
     }
 
-    static {
-    	//Some clients of this class e.g., DcsServer/JdbcT2 
-    	//want to use use their own log4j.properties file instead
-    	//of the lo4j.hdf.config so they can see their
-    	//log events in their own log files or console.
-    	//So, check for alternate log4j.properties otherwise
-    	//use the default HBaseClient config.
-    	String confFile = System.getProperty("trafodion.log4j.configFile");
-    	if (confFile == null) {
-    		System.setProperty("trafodion.sql.log", System.getenv("TRAF_HOME") + "/logs/trafodion.sql.java.log");
-    		confFile = System.getenv("TRAF_CONF") + "/log4j.sql.config";
-    	}
-    	PropertyConfigurator.configure(confFile);
-        config = TrafConfiguration.create(TrafConfiguration.HBASE_CONF);
-    }
-
-    
     static public Connection getConnection() throws IOException {
         if (connection == null) 
               connection = ConnectionFactory.createConnection(config);


### PR DESCRIPTION
When the user is using T2, the lines of the log before getConnection will be printed on console, while after getConnection the lines redirected into trafodion.sql.java.log. In another word, the caller should take responsibility of the direction of logs in stead of redirecting by default. Usually, it's on console by default, or the caller will specify the log file themselves( here the logs in HBaseClient.java even could be printing out) .  