### PR TITLE
[TRAFODION-2622] Left join with other_join_predicate on table alone i…

### DIFF
--- a/core/sql/comexe/ComTdbHashj.cpp
+++ b/core/sql/comexe/ComTdbHashj.cpp
@@ -208,7 +208,8 @@ ComTdbHashj::ComTdbHashj(ComTdb * leftChildTdb,
     minMaxValsAtpIndex_(minMaxValsAtpIndex),
     minMaxRowLength_(minMaxRowLength),
     minMaxExpr_(minMaxExpr),
-    leftDownCriDesc_(leftDownCriDesc)
+    leftDownCriDesc_(leftDownCriDesc),
+    hjFlags2_(0)
 {
       // For now
       hjFlags_ = 0;

--- a/core/sql/comexe/ComTdbHashj.h
+++ b/core/sql/comexe/ComTdbHashj.h
@@ -376,6 +376,12 @@ public:
     {return (hjFlags_ & LEFT_SIDE_IUD_OPERATION) !=0; }; 
   void setLeftSideIUD() { hjFlags_ |= LEFT_SIDE_IUD_OPERATION;};
 
+  NABoolean beforePredOnOuterOnly() const 
+    {return (hjFlags2_ & BEFORE_PRED_OUTER_ONLY) !=0; }; 
+  void setBeforePredOnOuterOnly() { hjFlags2_ |= BEFORE_PRED_OUTER_ONLY;};
+
+  AggrExpr * minMaxExpr() { return (AggrExpr*)((ex_expr*)minMaxExpr_); }
+
 protected:
   
   enum join_flags { SEMI_JOIN = 0x0001, 
@@ -395,6 +401,7 @@ protected:
                     CONSIDER_BUFFER_DEFRAG = 0x4000,
                     LEFT_SIDE_IUD_OPERATION = 0x8000
   };
+  enum join_flags2 { BEFORE_PRED_OUTER_ONLY = 0x0001 };
 
   ComTdbPtr    leftChildTdb_;                       // 00-07
   ComTdbPtr    rightChildTdb_;                      // 08-15
@@ -498,7 +505,8 @@ private:
   // from the parent.  With the min max opt, it has one
   // additional tuple for the min max values.
   ExCriDescPtr leftDownCriDesc_;                    // 352-369
-  char         fillersComTdbHashj_[6];              // 370-375
+  UInt16       hjFlags2_;                           // 370-371
+  char         fillersComTdbHashj_[4];              // 372-375
   
 
 protected:

--- a/core/sql/generator/GenExplain.cpp
+++ b/core/sql/generator/GenExplain.cpp
@@ -1338,6 +1338,9 @@ Join::addSpecificExplainInfo(ExplainTupleMaster *explainTuple,
        } 
  }
 
+ if (beforeJoinPredOnOuterOnly())
+   buffer += "other_join_pred_first: yes ";
+
  explainTuple->setDescription(buffer);
 
  return(explainTuple);

--- a/core/sql/generator/GenRelJoin.cpp
+++ b/core/sql/generator/GenRelJoin.cpp
@@ -1816,6 +1816,9 @@ short HashJoin::codeGen(Generator * generator) {
     }
   }
 
+  if (beforeJoinPredOnOuterOnly())
+    hashj_tdb->setBeforePredOnOuterOnly();
+
   generator->addToTotalOverflowMemory(
                       getEstimatedRunTimeOverflowSize(memQuota)
                                      );

--- a/core/sql/optimizer/RelExpr.cpp
+++ b/core/sql/optimizer/RelExpr.cpp
@@ -5301,6 +5301,8 @@ RelExpr * Join::copyTopNode(RelExpr *derivedNode, CollHeap* outHeap)
 
   result->isForTrafLoadPrep_ = isForTrafLoadPrep_;
 
+  result->beforeJoinPredOnOuterOnly_ = beforeJoinPredOnOuterOnly_;
+
   return RelExpr::copyTopNode(result, outHeap);
 }
 

--- a/core/sql/optimizer/RelJoin.h
+++ b/core/sql/optimizer/RelJoin.h
@@ -157,6 +157,7 @@ public:
   , tsjForSideTreeInsert_(FALSE)
   , enableTransformToSTI_(FALSE)
   , isForTrafLoadPrep_(FALSE)
+  , beforeJoinPredOnOuterOnly_(FALSE)
   { }
 
   // copy ctor
@@ -258,6 +259,11 @@ public:
 
   NABoolean isFloatingJoin() const { return floatingJoin_; }
   void setFloatingJoin() { floatingJoin_ = TRUE; }
+
+
+  NABoolean beforeJoinPredOnOuterOnly() const
+  { return beforeJoinPredOnOuterOnly_; }
+  void setBeforeJoinPredOnOuterOnly() { beforeJoinPredOnOuterOnly_ = TRUE; }
 
   // Accessor method for returning any required order that was specified.
   // If there was a required order, it could only have come from a
@@ -1181,6 +1187,10 @@ private:
 
 
   NABoolean isForTrafLoadPrep_;
+  
+  // used for HJ and MJ (later). Causes beforeJoinPred to be evaluated prior
+  // to equi join pred in work() method.
+  NABoolean beforeJoinPredOnOuterOnly_;
 }; // class Join
 
 // -----------------------------------------------------------------------


### PR DESCRIPTION
…s slow

This change is due to Hans Zeller.
The other join predicate in a hash join is evaluated before the hash join,
so that failing rows can be nulll instantiated directly. This avoids
a temporary join explosion when the join predicate matches most rows but
the other_join_predicate fails most rows. This change will be extended
to merge joins later.