### PR TITLE
[TRAFODION-2679] odb crash when extracting data to xml file

### DIFF
--- a/core/conn/odb/src/odb.c
+++ b/core/conn/odb/src/odb.c
@@ -9901,16 +9901,7 @@ static void Oextract(int eid)
                 nr += etab[i].nr;
             }
         }
-        /* close single outut file */
-        if ( !(etab[eid].flg & 01000) ) {   /* non multiparted output */
-#ifdef HDFS
-            if ( etab[eid].fho )
-                (*hdfsclose)(hfs, etab[eid].fho);
-#endif
-            if ( etab[eid].fo && etab[eid].fo != stdout ) 
-                fclose ( etab[eid].fo );
-        }
-        /* Print stats */
+
         if ( etab[eid].flg2 & 04000000 ) {  /* initialize XML output buffer */
             xbuffl = snprintf(xbuff, xbuffl, "\n<%s>\n",
                 etab[eid].src ? etab[eid].src : "select" );
@@ -9926,6 +9917,18 @@ static void Oextract(int eid)
             (void)fwrite ( xbuff, 1, xbuffl, etab[eid].fo );
 #endif
         }
+
+        /* close single outut file */
+        if (!(etab[eid].flg & 01000)) {   /* non multiparted output */
+#ifdef HDFS
+            if (etab[eid].fho)
+                (*hdfsclose)(hfs, etab[eid].fho);
+#endif
+            if (etab[eid].fo && etab[eid].fo != stdout)
+                fclose(etab[eid].fo);
+        }
+
+        /* Print stats */
         fprintf(stderr,"[%d] %s Extract statistics:\n", ptid, odbid);
         if ( etab[eid].flg2 & 0100000 )     /* print custom SQL file name */
             fprintf(stderr,"\t[%d] Source (SQL file): %s\n", ptid, etab[eid].cols);


### PR DESCRIPTION
root cause: write tag to file which had been closed.
fix by: don't close file until tag writing finished.