### PR TITLE
[TRAFODION-2680] Add CSV_FORMAT function to Trafodion SQL

### DIFF
--- a/core/sql/bin/SqlciErrors.txt
+++ b/core/sql/bin/SqlciErrors.txt
@@ -1087,7 +1087,7 @@ $1~String1 --------------------------------
 4015 42000 99999 BEGINNER MAJOR DBADMIN Aggregate functions are placed incorrectly: $0~string0.
 4016 42000 99999 BEGINNER MAJOR DBADMIN The number of derived columns ($0~int0) must equal the degree of the derived table ($1~int1).
 4017 42000 99999 BEGINNER MAJOR DBADMIN Derived column name $0~ColumnName was specified more than once.
-4018 42000 99999 BEGINNER MAJOR DBADMIN -- unused --
+4018 42000 99999 BEGINNER MAJOR DBADMIN Function $0~string0 does not support operands of type $1~String1.
 4019 42000 99999 BEGINNER MAJOR DBADMIN The select list of a subquery in a select list must be scalar (degree of one).
 4020 42000 99999 BEGINNER MAJOR DBADMIN Arithmetic operations on row value constructors are not allowed.
 4021 42000 99999 BEGINNER MAJOR DBADMIN The select list contains a nongrouping non-aggregated column, $0~ColumnName.

--- a/core/sql/common/OperTypeEnum.h
+++ b/core/sql/common/OperTypeEnum.h
@@ -807,6 +807,9 @@ enum OperatorTypeEnum {
                         ITM_AES_ENCRYPT = 2641,
                         ITM_AES_DECRYPT = 2642,
 
+                        // More miscellaneous functions
+                        ITM_CSV_FORMAT = 2900,
+
                         // Items for needed for Translating to UCS2 output strings
                         ITM_DATEFMT     = 2990,
                         ITM_CURRNT_USER = 2991,

--- a/core/sql/optimizer/BindItemExpr.cpp
+++ b/core/sql/optimizer/BindItemExpr.cpp
@@ -10851,6 +10851,96 @@ ItemExpr *ZZZBinderFunction::bindNode(BindWA *bindWA)
       }
     break;
 
+    case ITM_CSV_FORMAT:
+      {
+	bindChildren(bindWA);
+	if (bindWA->errStatus()) 
+	  return this;
+
+        // The way the arguments of CSV_FORMAT are represented in
+        // the parse tree is as a tree of ItemList nodes; so
+        // CSV_FORMAT(a,b,c,d) is represented as
+        //
+        //    this
+        //    /  \
+        //   a   ItemList
+        //         /  \
+        //        b   ItemList
+        //              /  \
+        //             c    d
+        //
+        // The code below traverses accordingly.
+       
+        ItemExpr * next = child(0)->castToItemExpr();     
+        ItemExpr * resultBoundTree = NULL;
+        while (next)  // while arguments remain to process
+          {
+            ItemExpr * childk = NULL;
+            if (next->getOperatorType() == ITM_ITEM_LIST)
+              {
+                childk = next->child(0);
+                next = next->child(1);
+              }
+            else
+              {
+                childk = next;
+                next = NULL;
+              }
+           
+            const NAType &type = childk->getValueId().getType();
+            switch (type.getTypeQualifier())
+              {
+                case NA_BOOLEAN_TYPE:
+                case NA_DATETIME_TYPE:
+                case NA_INTERVAL_TYPE:
+                case NA_NUMERIC_TYPE:
+                  {
+                    // TODO: Is VARCHAR(100) big enough? Consider bignums, for example. We could
+                    // probably be smarter about the length. E.g. VARCHAR(6) is big enough for SMALLINT.
+                    strcpy(buf,"CAST(@A1 AS VARCHAR(100))");
+                    parseTree = parser.getItemExprTree(buf, strlen(buf), BINDITEMEXPR_STMTCHARSET, 1, childk);
+                    boundTree = parseTree->bindNode(bindWA);
+                    if (bindWA->errStatus()) 
+                      return this;
+                    break;
+                  }
+                case NA_CHARACTER_TYPE:
+                  {
+                    boundTree = childk;
+                    break;
+                  }
+                default:
+                  {
+                    // operand has an unsupported data type
+                    *CmpCommon::diags() << DgSqlCode(-4018)
+                                        << DgString0("CSV_FORMAT")
+                                        << DgString1(type.getTypeName().data());
+                    bindWA->setErrStatus();
+                    return this;
+                  }
+              }
+
+            strcpy(buf,"CASE WHEN POSITION(',' IN @A1) > 0 THEN '\"' || @A1 || '\"' ELSE @A1 END");
+            parseTree = parser.getItemExprTree(buf, strlen(buf), BINDITEMEXPR_STMTCHARSET, 1, boundTree);
+            boundTree = parseTree->bindNode(bindWA);
+            if (bindWA->errStatus()) 
+              return this;
+
+            if (resultBoundTree)
+              {
+                strcpy(buf,"@A1 || ',' || @A2");
+                parseTree = parser.getItemExprTree(buf, strlen(buf), BINDITEMEXPR_STMTCHARSET, 2, resultBoundTree, boundTree);
+                boundTree = parseTree->bindNode(bindWA);
+                if (bindWA->errStatus()) 
+                  return this;
+              }
+            resultBoundTree = boundTree;
+          }
+
+        return resultBoundTree;    
+      }
+    break;
+
     case ITM_DAYNAME:
       {
 	// find the nullability of child

--- a/core/sql/optimizer/ItemExpr.cpp
+++ b/core/sql/optimizer/ItemExpr.cpp
@@ -7527,6 +7527,8 @@ const NAString BuiltinFunction::getText() const
       return "CONVERTTOBITS";
     case ITM_CONVERTTIMESTAMP:
       return "converttimestamp";
+    case ITM_CSV_FORMAT:
+      return "csv_format";
     case ITM_CURRENT_TIMESTAMP:
       return "current_timestamp";
     case ITM_CURRENT_TIMESTAMP_RUNNING:

--- a/core/sql/parser/ParKeyWords.cpp
+++ b/core/sql/parser/ParKeyWords.cpp
@@ -272,6 +272,7 @@ ParKeyWord ParKeyWords::keyWords_[] = {
   ParKeyWord("CREATE_SYNONYM",     TOK_CREATE_SYNONYM, NONRESTOKEN_),
   ParKeyWord("CREATE_VIEW",        TOK_CREATE_VIEW, NONRESTOKEN_),
   ParKeyWord("CROSS",              TOK_CROSS,       ANS_|RESWORD_),
+  ParKeyWord("CSV_FORMAT",         TOK_CSV_FORMAT,  NONRESTOKEN_),
   ParKeyWord("CUBE",               TOK_CUBE,        COMPAQ_|RESWORD_),
   ParKeyWord("CURDATE",            TOK_CURDATE,     NONRESTOKEN_),
   ParKeyWord("CURRENT",            TOK_CURRENT,     ANS_|RESWORD_|MPWORD_),

--- a/core/sql/parser/sqlparser.y
+++ b/core/sql/parser/sqlparser.y
@@ -561,6 +561,7 @@ static void enableMakeQuotedStringISO88591Mechanism()
 %token <tokval> TOK_CRC32
 %token <tokval> TOK_CQD
 %token <tokval> TOK_CROSS
+%token <tokval> TOK_CSV_FORMAT          /* Trafodion extension */
 %token <tokval> TOK_CURDATE             /* ODBC extension  */ 
 %token <tokval> TOK_CURRENT
 %token <tokval> TOK_CURRENT_DATE
@@ -8960,6 +8961,11 @@ string_function :
         {
 
 	  $$ = new (PARSERHEAP()) ZZZBinderFunction(ITM_DECODE,$3);
+        }
+
+     | TOK_CSV_FORMAT '(' value_expression_list ')'
+        {
+          $$ = new (PARSERHEAP()) ZZZBinderFunction(ITM_CSV_FORMAT,$3);
         }
 
      | TOK_INSERT '(' value_expression ',' value_expression ',' 
@@ -34086,6 +34092,7 @@ nonreserved_func_word:  TOK_ABS
                       | TOK_CONVERTTOHX_INTN
                       | TOK_COS
                       | TOK_COSH
+                      | TOK_CSV_FORMAT
                       | TOK_CURDATE
                       | TOK_CURTIME
                       | TOK_D_RANK 


### PR DESCRIPTION
This change adds a new function, CSV_FORMAT, to Trafodion SQL.

Syntax: CSV_FORMAT(argument1, ... ,argumentn)

Semantics: The result of CSV_FORMAT is a VARCHAR string consisting of a comma-separated list of the argument values. If the argument itself contains a comma, it is surrounded with double quotes.

This is a prototype for evaluation. For example, it does not escape double quotes within a double quoted string; the need for that is to be determined. Also, a regression test for this needs to be added.