### PR TITLE
[TRAFODION-2681] Repeated execution of prepared SQL select statement …

### DIFF
--- a/core/sql/executor/HBaseClient_JNI.cpp
+++ b/core/sql/executor/HBaseClient_JNI.cpp
@@ -413,8 +413,6 @@ HTableClient_JNI* HBaseClient_JNI::getHTableClient(NAHeap *heap, const char* tab
      releaseHTableClient(htc);
      return NULL;
   }
-  htc->setTableName(tableName);
-  htc->setHbaseStats(hbs);
   jenv_->PopLocalFrame(NULL);
   return htc;
 }

--- a/core/sql/executor/HBaseClient_JNI.h
+++ b/core/sql/executor/HBaseClient_JNI.h
@@ -247,7 +247,7 @@ public:
 
     if (tableName_ != NULL)
     {
-        NADELETEBASIC(tableName_, heap);
+        NADELETEBASIC(tableName_, heap_);
         tableName_ = NULL;
     }
     tableName_ = new (heap_) char[len+1];

--- a/core/sql/executor/HBaseClient_JNI.h
+++ b/core/sql/executor/HBaseClient_JNI.h
@@ -245,6 +245,11 @@ public:
   {
     Int32 len = strlen(tableName);
 
+    if (tableName_ != NULL)
+    {
+        NADELETEBASIC(tableName_, heap);
+        tableName_ = NULL;
+    }
     tableName_ = new (heap_) char[len+1];
     strcpy(tableName_, tableName);
   } 


### PR DESCRIPTION
…causes memory leak

This leak can be seen with the mdam plans when it attempts to do multiple scans
of different key ranges