### PR TITLE
[TRAFODION-646] ODBC driver AppUnicodeType setting is not in DSN level

### DIFF
--- a/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/cdatasource.cpp
+++ b/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/cdatasource.cpp
@@ -862,6 +862,22 @@ short CDataSource::readDSValues(char *DSName,CConnect* pConnection)
 							path);
 	}
 
+    // Read AppUnicodeType Value
+    keyValueLength = sizeof(keyValueBuf);
+    len = GetMyPrivateProfileString(
+                        searchKey,
+                        "AppUnicodeType",
+                        "",
+                        keyValueBuf,
+                        keyValueLength,
+                        path);
+	if (len > 0){
+        if( strcmp(keyValueBuf,"utf8") == 0 )
+            gDrvrGlobal.ICUConv.m_AppUnicodeType == APP_UNICODE_TYPE_UTF8;
+        else if( strcmp(keyValueBuf,"utf16") == 0 )
+            gDrvrGlobal.ICUConv.m_AppUnicodeType == APP_UNICODE_TYPE_UTF16;
+    }
+
 
 
 	return ERROR_SUCCESS;

--- a/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/cdatasource_drvr.cpp
+++ b/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/cdatasource_drvr.cpp
@@ -522,6 +522,22 @@ short CDataSource::readDSValues(char *DSName,CConnect* pConnection)
 	else
 		m_DS_UCS2Translation = TRUE;
 
+    // Read AppUnicodeType Value
+    keyValueLength = sizeof(keyValueBuf);
+    len = (gDrvrGlobal.fpSQLGetPrivateProfileString)(
+                        searchKey,
+                        "AppUnicodeType",
+                        "",
+                        keyValueBuf,
+                        keyValueLength,
+                        OdbcIniEnv);
+	if (len > 0)
+	{
+        if( strcmp(keyValueBuf,"utf8") == 0 )
+            gDrvrGlobal.ICUConv.m_AppUnicodeType == APP_UNICODE_TYPE_UTF8;
+        else if( strcmp(keyValueBuf,"utf16") == 0 )
+            gDrvrGlobal.ICUConv.m_AppUnicodeType == APP_UNICODE_TYPE_UTF16;
+    }
 
 	return ERROR_SUCCESS;
 }


### PR DESCRIPTION
Originally, AppUnicodeType is set in [ODBC] section of odbc.ini, by environment variable or default utf8.
This change result in modifing AppUnicodeType on the base of dsn.