### PR TITLE
[TRAFODION-2687] the value of Numeric Struct need not to be changed to BidEndian

### DIFF
--- a/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/sqltocconv.cpp
+++ b/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/sqltocconv.cpp
@@ -4499,8 +4499,8 @@ unsigned long ODBC::ConvertCharToCNumeric( SQL_NUMERIC_STRUCT& numericTmp, CHAR*
 unsigned long ODBC::ConvertCharToBigEndianCNumeric( SQL_NUMERIC_STRUCT& numericTmp, CHAR* cTmpBuf)
 {
 	unsigned long retcode = ConvertCharToCNumeric( numericTmp, cTmpBuf);
-	if (retcode == SQL_SUCCESS)
-		byte_swap((BYTE *)numericTmp.val, SQL_MAX_NUMERIC_LEN);
+/*	if (retcode == SQL_SUCCESS)
+		byte_swap((BYTE *)numericTmp.val, SQL_MAX_NUMERIC_LEN);*/
 
 	return retcode;
 }


### PR DESCRIPTION
When I fetch data from trafodion with SQL_C_NUMERIC and the type in table is int, float and so on.The value will be changed to bigendian.
For example,
data in table is: 1
value fetched is : '\0' * 15 and '1'
