### PR TITLE
[TRAFODION-2596] Improve the log4j and log4cxx infrastructure in Traf…

### DIFF
--- a/core/sqf/conf/log4cxx.monitor.mon.config
+++ b/core/sqf/conf/log4cxx.monitor.mon.config
@@ -28,10 +28,6 @@ trafodion.log.filename.suffix=${TRAFODION_LOG_FILENAME_SUFFIX}
 # Logging Threshold
 log4j.threshhold=ALL
 
-# Define the root logger to the system property "trafodion.root.logger".
-trafodion.root.logger=INFO, monAppender
-log4j.rootLogger=${trafodion.root.logger}
-
 # Rolling File Appender
 #
 log4j.appender.monAppender=org.apache.log4j.RollingFileAppender
@@ -46,4 +42,4 @@ log4j.appender.monAppender.Append=true
 log4j.additivity.monAppender=false 
 
 # Foundation Monitor
-log4j.logger.MON=INFO
+log4j.logger.MON=INFO,monAppender

--- a/core/sqf/conf/log4cxx.trafodion.masterexe.config
+++ b/core/sqf/conf/log4cxx.trafodion.masterexe.config
@@ -28,25 +28,22 @@ trafodion.log.filename.suffix=${TRAFODION_LOG_FILENAME_SUFFIX}
 # Logging Threshold
 log4j.threshhold=ALL
 
-# Define the root logger to the system property "trafodion.root.logger".
-trafodion.root.logger=INFO, mxoAppender
-log4j.rootLogger=${trafodion.root.logger}
 
 # Rolling File Appender
 #
-log4j.appender.mxoAppender=org.apache.log4j.RollingFileAppender
-log4j.appender.mxoAppender.file=${trafodion.log.dir}/master_exec${trafodion.log.filename.suffix}
-log4j.appender.mxoAppender.maxFileSize=100000000
-log4j.appender.mxoAppender.maxBackupIndex=1
-log4j.appender.mxoAppender.addPid=false
-log4j.appender.mxoAppender.layout=org.apache.log4j.PatternLayout
-log4j.appender.mxoAppender.layout.ConversionPattern=%d, %p, %c, %m%n
+log4j.appender.sqlAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.sqlAppender.file=${trafodion.log.dir}/master_exec${trafodion.log.filename.suffix}
+log4j.appender.sqlAppender.maxFileSize=100000000
+log4j.appender.sqlAppender.maxBackupIndex=1
+log4j.appender.sqlAppender.addPid=false
+log4j.appender.sqlAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.sqlAppender.layout.ConversionPattern=%d, %p, %c, %m%n
 
-log4j.additive.mxoAppender=false 
+log4j.additive.sqlAppender=false 
 
 #MXOSRVR
-log4j.logger.MXOSRVR=ERROR
+log4j.logger.MXOSRVR=ERROR,sqlAppender
 
 # SQL
-log4j.logger.SQL=INFO
+log4j.logger.SQL=INFO,sqlAppender
 

--- a/core/sqf/conf/log4cxx.trafodion.sql.config
+++ b/core/sqf/conf/log4cxx.trafodion.sql.config
@@ -28,24 +28,19 @@ trafodion.log.filename.suffix=${TRAFODION_LOG_FILENAME_SUFFIX}
 # Logging Threshold
 log4j.threshhold=ALL
 
-# Define the root logger to the system property "trafodion.root.logger".
-trafodion.root.logger=INFO, mxoAppender
-log4j.rootLogger=${trafodion.root.logger}
-
 # Rolling File Appender
 #
-log4j.appender.mxoAppender=org.apache.log4j.RollingFileAppender
-log4j.appender.mxoAppender.file=${trafodion.log.dir}/trafodion.sql${trafodion.log.filename.suffix}
-log4j.appender.mxoAppender.maxFileSize=100000000
-log4j.appender.mxoAppender.maxBackupIndex=1
-log4j.appender.mxoAppender.addPid=false
-log4j.appender.mxoAppender.layout=org.apache.log4j.PatternLayout
-log4j.appender.mxoAppender.layout.ConversionPattern=%d, %p, %c, %m%n
+log4j.appender.sqlAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.sqlAppender.file=${trafodion.log.dir}/trafodion.sql${trafodion.log.filename.suffix}
+log4j.appender.sqlAppender.maxFileSize=100000000
+log4j.appender.sqlAppender.maxBackupIndex=1
+log4j.appender.sqlAppender.addPid=false
+log4j.appender.sqlAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.sqlAppender.layout.ConversionPattern=%d, %p, %c, %m%n
+log4j.appender.sqlAppender.immediateFlush=true
+log4j.additive.sqlAppender=false 
 
-log4j.additive.mxoAppender=false 
-
-#MXOSRVR
-log4j.logger.MXOSRVR=ERROR
+log4j.logger.MXOSRVR=ERROR,sqlAppender
 
 # SQL
-log4j.logger.SQL=INFO
+log4j.logger.SQL=INFO,sqlAppender

--- a/core/sqf/conf/log4cxx.trafodion.ssmp.config
+++ b/core/sqf/conf/log4cxx.trafodion.ssmp.config
@@ -28,10 +28,6 @@ trafodion.log.filename.suffix=${TRAFODION_LOG_FILENAME_SUFFIX}
 # Logging Threshold
 log4j.threshhold=ALL
 
-# Define the root logger to the system property "trafodion.root.logger".
-trafodion.root.logger=INFO, ssmpAppender
-log4j.rootLogger=${trafodion.root.logger}
-
 # Rolling File Appender
 #
 log4j.appender.ssmpAppender=org.apache.log4j.RollingFileAppender
@@ -41,9 +37,10 @@ log4j.appender.ssmpAppender.maxBackupIndex=1
 log4j.appender.ssmpAppender.addPid=false
 log4j.appender.ssmpAppender.layout=org.apache.log4j.PatternLayout
 log4j.appender.ssmpAppender.layout.ConversionPattern=%d, %p, %c, %m%n
+log4j.appender.ssmpAppender.immediateFlush=true
 log4j.appender.ssmpAppender.Append=true
 
 log4j.additivity.ssmpAppender=false 
 
 #SSMP
-log4j.logger.SQL.SSMP=INFO
+log4j.logger.SQL.SSMP=INFO,ssmpAppender

--- a/core/sqf/conf/log4cxx.trafodion.tm.config
+++ b/core/sqf/conf/log4cxx.trafodion.tm.config
@@ -22,7 +22,8 @@
 #
 
 # Define some default values that can be overridden by system properties
-trafodion.log.dir=${TRAF_HOME}/logs
+#trafodion.log.dir=${TRAF_HOME}/logs
+trafodion.log.dir=/home/centos/incubator-trafodion/core/sqf/logs
 trafodion.log.filename.suffix=${TRAFODION_LOG_FILENAME_SUFFIX}
 
 # Define the root logger to the system property "trafodion.root.logger".

--- a/core/sqf/conf/log4cxx.trafodion.tm.config
+++ b/core/sqf/conf/log4cxx.trafodion.tm.config
@@ -22,8 +22,7 @@
 #
 
 # Define some default values that can be overridden by system properties
-#trafodion.log.dir=${TRAF_HOME}/logs
-trafodion.log.dir=/home/centos/incubator-trafodion/core/sqf/logs
+trafodion.log.dir=${TRAF_HOME}/logs
 trafodion.log.filename.suffix=${TRAFODION_LOG_FILENAME_SUFFIX}
 
 # Define the root logger to the system property "trafodion.root.logger".

--- a/core/sqf/conf/log4j.dtm.config
+++ b/core/sqf/conf/log4j.dtm.config
@@ -22,36 +22,28 @@
 #
 
 # Define some default values that can be overridden by system properties
-hbase.root.logger=INFO,hbaseclient
-#hbase.log.dir=.
-hbase.log.dir=${trafodion.root}/logs
-hbase.log.file=trafodion.dtm.log
-
-# Define the root logger to the system property "hbase.root.logger".
-log4j.rootLogger=${hbase.root.logger}
+dtm.log.dir=${trafodion.root}/logs
+dtm.log.file=trafodion.dtm.log
 
 # Logging Threshold
 log4j.threshhold=ALL
 
 #
 # Rolling File Appender
-# Uncomment the 'DailyRollingFile Appender to roll the logs daily
-# (based on the DatePattern)
-log4j.appender.hbaseclient=org.apache.log4j.RollingFileAppender
-#log4j.appender.hbaseclient=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.hbaseclient.File=${hbase.log.dir}/trafodion.dtm.log
-log4j.appender.hbaseclient.MaxFileSize=64MB
-log4j.appender.hbaseclient.MaxBackupIndex=20
-log4j.appender.hbaseclient.layout=org.apache.log4j.PatternLayout
-log4j.appender.hbaseclient.layout.ConversionPattern=%d{ISO8601} %p %c{2}: %m%n
-log4j.appender.hbaseclient.immediateFlush=true
-log4j.appender.hbaseclient.Append=true
-#log4j.appender.hbaseclient.DatePattern='.'yyyy-MM-dd 
+#
+log4j.appender.dtmAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.dtmAppender.File=${dtm.log.dir}/${dtm.log.file}
+log4j.appender.dtmAppender.MaxFileSize=64MB
+log4j.appender.dtmAppender.MaxBackupIndex=20
+log4j.appender.dtmAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.dtmAppender.layout.ConversionPattern=%d{ISO8601} %p %c{2}: %m%n
+log4j.appender.dtmAppender.immediateFlush=true
+log4j.appender.dtmAppender.Append=true
+#log4j.appender.dtmAppender.DatePattern='.'yyyy-MM-dd 
 
 # Custom Logging levels
 
-log4j.logger.org.apache.zookeeper=ERROR
-log4j.logger.org.apache.hadoop.hbase=ERROR
-log4j.logger.org.trafodion.dtm=INFO
-#log4j.logger.org.apache.hadoop.hbase.client.transactional=TRACE
+log4j.logger.org.apache.zookeeper=ERROR,dtmAppender
+log4j.logger.org.apache.hadoop.hbase=ERROR,dtmAppender
+log4j.logger.org.trafodion.dtm=INFO,dtmAppender
 

--- a/core/sqf/conf/log4j.sql.config
+++ b/core/sqf/conf/log4j.sql.config
@@ -22,28 +22,22 @@
 #
 
 # Define some default values that can be overridden by system properties
-trafodion.root.logger=INFO,hbaseclient
-trafodion.log.file=trafodion.sql.java.log
+trafodion.sql.log=${trafodion.root}/logs/trafodion.sql.java.log
 
 # Logging Threshold
 log4j.threshhold=ALL
 
-# Define the root logger to the system property 
-log4j.rootLogger=${trafodion.root.logger}
-
-
 # Rolling File Appender
 #
-log4j.appender.DRFA=org.apache.log4j.DailyRollingFileAppender
-log4j.appender.hbaseclient=org.apache.log4j.RollingFileAppender
-log4j.appender.hbaseclient.file=${trafodion.sql.log}
-log4j.appender.hbaseclient.layout=org.apache.log4j.PatternLayout
-log4j.appender.hbaseclient.layout.ConversionPattern=%d{ISO8601} %p %c{2}: %m%n
-log4j.appender.hbaseclient.immediateFlush=true
-log4j.appender.hbaseclient.MaxFileSize=64MB
-log4j.appender.hbaseclient.MaxBackupIndex=20
+log4j.appender.sqlAppender=org.apache.log4j.RollingFileAppender
+log4j.appender.sqlAppender.file=${trafodion.sql.log}
+log4j.appender.sqlAppender.layout=org.apache.log4j.PatternLayout
+log4j.appender.sqlAppender.layout.ConversionPattern=%d{ISO8601} %p %c{2}: %m%n
+log4j.appender.sqlAppender.immediateFlush=true
+log4j.appender.sqlAppender.MaxFileSize=64MB
+log4j.appender.sqlAppender.MaxBackupIndex=20
 
 # Custom Logging levels
 
-log4j.logger.org.apache=ERROR
-log4j.logger.org.trafodion.sql=INFO
+log4j.logger.org.apache=ERROR,sqlAppender
+log4j.logger.org.trafodion.sql=INFO,sqlAppender

--- a/core/sql/qmscommon/QRLogger.cpp
+++ b/core/sql/qmscommon/QRLogger.cpp
@@ -167,9 +167,6 @@ void getMyNidSuffix(char stringNidSuffix[])
 // **************************************************************************
 NABoolean QRLogger::initLog4cxx(const char* configFileName)
 {
-  if (gv_QRLoggerInitialized_)
-     return TRUE;
-
   NAString logFileName;
 
   if (gv_QRLoggerInitialized_)
@@ -213,54 +210,6 @@ NABoolean QRLogger::initLog4cxx(const char* configFileName)
     gv_QRLoggerInitialized_ = TRUE;
     return TRUE;
   }
-
-/* This code is kept around for the old QMS kind of logging
-   This can be deleted. But keeeping it around if we need
-   to do use the catgory later */
-
-/*
-
-  logFileName += "sql_events";
-  logFileName += logFileSuffix;
-  
-  log4cxx::PatternLayout *fileLayout = new log4cxx::PatternLayout();
-  fileLayout->setConversionPattern("%d, %p, %c, %m%n");
-  fileAppender_ = new log4cxx::RollingFileAppender(fileLayout, logFileName.data());
-
-  // Top level categories
-  initCategory(CAT_SQL_QMP, log4cxx::Level::getError());
-  initCategory(CAT_SQL_QMM, log4cxx::Level::getError());
-  initCategory(CAT_SQL_COMP_QR_COMMON, log4cxx::Level::getError());
-  initCategory(CAT_SQL_QMS, log4cxx::Level::getError());
-
-  initCategory(CAT_SQL, log4cxx::Level::getError());
-  switch (module_)
-  {
-    case QRL_NONE:
-    case QRL_MXCMP:
-      initCategory(CAT_SQL_COMP, log4cxx::Level::ERROR_INT);
-      log4cxx::Logger::getLogger(CAT_SQL_COMP)->setLevel(log4cxx::Level::getInfo());
-      log4cxx::Logger::getLogger(CAT_SQL_COMP)->setAdditivity(false);
-      break;
-
-    case QRL_ESP:
-      initCategory(CAT_SQL_ESP, log4cxx::Level::ERROR_INT);
-      log4cxx::Logger::getLogger(CAT_SQL_ESP)->setLevel(log4cxx::Level::getInfo());
-      log4cxx::Logger::getLogger(CAT_SQL_ESP)->setAdditivity(false);
-      break;
-
-    case QRL_MXEXE:
-      initCategory(CAT_SQL_EXE, log4cxx::Level::ERROR_INT);
-      log4cxx::Logger::getLogger(CAT_SQL_EXE)->setLevel(log4cxx::Level::getInfo());
-      log4cxx::Logger::getLogger(CAT_SQL_EXE)->setAdditivity(false);
-      break;
-      
-  }
-
-  introduceSelf();
-
-  // initialize sub categories here - they were removed since they are not currently being used
-*/
   return FALSE;
 }
 

--- a/core/sql/src/main/java/org/trafodion/sql/HBaseClient.java
+++ b/core/sql/src/main/java/org/trafodion/sql/HBaseClient.java
@@ -150,16 +150,10 @@ public class HBaseClient {
     }
 
     static {
-    	//Some clients of this class e.g., DcsServer/JdbcT2 
-    	//want to use use their own log4j.properties file instead
-    	//of the lo4j.hdf.config so they can see their
-    	//log events in their own log files or console.
-    	//So, check for alternate log4j.properties otherwise
-    	//use the default HBaseClient config.
     	String confFile = System.getProperty("trafodion.log4j.configFile");
+        System.setProperty("trafodion.root", System.getenv("TRAF_HOME"));
     	if (confFile == null) {
-    		System.setProperty("trafodion.sql.log", System.getenv("TRAF_HOME") + "/logs/trafodion.sql.java.log");
-    		confFile = System.getenv("TRAF_CONF") + "/log4j.sql.config";
+           confFile = System.getenv("TRAF_CONF") + "/log4j.sql.config";
     	}
     	PropertyConfigurator.configure(confFile);
         config = TrafConfiguration.create(TrafConfiguration.HBASE_CONF);


### PR DESCRIPTION
…odion

Removed setting the root logger to be the appender logger in most of
the configuration files. This would allow T2 driver applications
to have control over the logging in their layer to its preferred way.
But, the logging in SQL engine layer will be controlled by the Trafodion
engine itself.

Changed the code so that the logging location and the file name is
picked up from the config file.