### PR TITLE
[TRAFODION-2695] SSMP process ($ZSMxxx) sees too many opens from the …

### DIFF
--- a/core/sql/bin/SqlciErrors.txt
+++ b/core/sql/bin/SqlciErrors.txt
@@ -543,7 +543,7 @@
 2023 ZZZZZ 99999 ADVANCED MAJOR DIALOUT Server process $0~string0 could not be created - $1~string1.
 2024 ZZZZZ 99999 ADVANCED MAJOR DBADMIN Server Process $0~string0 is not running or could not be created. Operating System Error $1~int0 was returned.
 2025 ZZZZZ 99999 ADVANCED MAJOR DBADMIN Server process $0~string0 could not be created - CPU is unavailable; $1~string1.
-2026 ZZZZZ 99999 UUUUUUUU UUUUU UUUUUUU ****Filler for IPC error.
+2026 ZZZZZ 99999 ADVANCED MAJOR DBADMIN Server Process $0~string0 has reached allowed depth for nowait operation from the process $1~int0,$2~int1.
 2027 ZZZZZ 99999 ADVANCED MAJOR DBADMIN Operating system error $0~int0 while sending a startup message to process $1~string0.
 2028 ZZZZZ 99999 ADVANCED MAJOR DIALOUT OSS server process $0~string0 could not be created on $1~string1 - insufficient resources.
 2029 ZZZZZ 99999 BEGINNER MINOR DBADMIN The new min value is greater than the current max value $0~int0.

--- a/core/sql/cli/Context.cpp
+++ b/core/sql/cli/Context.cpp
@@ -158,9 +158,6 @@ ContextCli::ContextCli(CliGlobals *cliGlobals)
     catmanInfo_(NULL),
     flags_(0),
     ssmpManager_(NULL),
-    cbServerClass_(NULL),
-    cbServer_ (NULL),
-    cbServerInUse_(false),
     udrServerList_(NULL),
     udrRuntimeOptions_(NULL),
     udrRuntimeOptionDelimiters_(NULL),
@@ -298,9 +295,6 @@ ContextCli::ContextCli(CliGlobals *cliGlobals)
   if (cliGlobals->getStatsGlobals())
     ssmpManager_ = new(ipcHeap_) ExSsmpManager(env_);
 
-  cbServerClass_ = new(ipcHeap_) IpcServerClass(env_, IPC_SQLSSMP_SERVER,
-    IPC_USE_PROCESS);  // use existing process.
-
   seqGen_ = new(exCollHeap()) SequenceValueGenerator(exCollHeap());
 
   hdfsHandleList_ = new(exCollHeap()) HashQueue(exCollHeap(), 50); // The hfsHandleList_ represents a list of distict hdfs Handles with unique hdfs port numbers and server names. Assume not more than 50 hdfsServers could be connected in the Trafodion setup.  These will get initialized the first time access is made to a particular hdfs server. This list gets cleaned up when the thread exits. 
@@ -426,16 +420,7 @@ void ContextCli::deleteMe()
      NADELETE(udrServerManager_, ExUdrServerManager, ipcHeap_);
   if (ssmpManager_ != NULL)
      NADELETE(ssmpManager_, ExSsmpManager, ipcHeap_);
-  if (cbServer_ != NULL)
-  {
-    cbServer_->release();
-    cbServer_ = NULL;
-  }
-  if (cbServerClass_ != NULL)
-  {
-    NADELETE(cbServerClass_, IpcServerClass, ipcHeap_);
-    cbServerClass_ = NULL;
-  }
+
   if (exeTraceInfo_ != NULL)
   {
     delete exeTraceInfo_;
@@ -4532,10 +4517,10 @@ ExStatisticsArea *ContextCli::getMergedStats(
       (diagsArea_) << DgSqlCode(-EXE_RTS_INVALID_QID) << DgString0(statsReqStr);
       return NULL;
   }
-  ComDiagsArea *tempDisgsArea = &diagsArea_;
+  ComDiagsArea *tempDiagsArea = &diagsArea_;
   ExSsmpManager *ssmpManager = cliGlobals->getSsmpManager();
   IpcServer *ssmpServer = ssmpManager->getSsmpServer(nodeName, 
-           (cpu == -1 ?  cliGlobals->myCpu() : cpu), tempDisgsArea);
+           (cpu == -1 ?  cliGlobals->myCpu() : cpu), tempDiagsArea);
   if (ssmpServer == NULL)
     return NULL; // diags are in diagsArea_
 

--- a/core/sql/cli/Context.h
+++ b/core/sql/cli/Context.h
@@ -479,9 +479,6 @@ private:
   ARRAY(LmRoutine *) trustedRoutines_;
   // SSMP manager for this context.
   ExSsmpManager *ssmpManager_;
-  IpcServerClass *cbServerClass_;
-  IpcServer *cbServer_;
-  bool cbServerInUse_;
   NABoolean dropInProgress_;
 
   // set to true if ddl stmts are issued.
@@ -582,14 +579,6 @@ public:
   inline IpcEnvironment * getEnvironment() { return env_; }
   inline ExEspManager * getEspManager() { return espManager_; }
   inline ExSsmpManager *getSsmpManager() { return ssmpManager_; }
-  inline IpcServerClass * getCbServerClass() { return cbServerClass_; }
-  bool canUseCbServer() { return !(cbServerInUse_ || (cbServer_ == NULL)); }
-  bool hasACbServer() { return cbServer_ != NULL; }
-  void takeCbServer(IpcServer *cbServer) { cbServer_ = cbServer; }
-  void doneWithCbServer() { cbServerInUse_ = false ; }
-  IpcServer * useCbServer() { cbServerInUse_ = true; return cbServer_; }
-  void lostCbServer() { doneWithCbServer(); cbServer_ = NULL; }
-
   inline ExeTraceInfo *getExeTraceInfo() { return exeTraceInfo_; }
   NAHeap *getIpcHeap() { return ipcHeap_; }
   inline ExUdrServerManager *getUdrServerManager() { return udrServerManager_; }

--- a/core/sql/cli/Globals.cpp
+++ b/core/sql/cli/Globals.cpp
@@ -465,11 +465,6 @@ ExSsmpManager *CliGlobals::getSsmpManager()
   return currContext()->getSsmpManager();
 }
 
-IpcServerClass *CliGlobals::getCbServerClass()
-{
-  return currContext()->getCbServerClass();
-}
-
 LmLanguageManager * CliGlobals::getLanguageManager(ComRoutineLanguage language)
 {
   switch (language)

--- a/core/sql/cli/Globals.h
+++ b/core/sql/cli/Globals.h
@@ -414,8 +414,6 @@ inline
   ExeTraceInfo * getExeTraceInfo();
   CLISemaphore *getSemaphore() { return cliSemaphore_; }
 
-  IpcServerClass * getCbServerClass();
-
   // for trusted UDR invocations from executor and compiler
   LmLanguageManager * getLanguageManager(ComRoutineLanguage language);
   LmLanguageManagerC * getLanguageManagerC();

--- a/core/sql/common/Ipc.cpp
+++ b/core/sql/common/Ipc.cpp
@@ -4892,13 +4892,13 @@ IpcServer * IpcServerClass::allocateServerProcess(ComDiagsArea **diags,
     case IPC_SQLSSCP_SERVER:
       className = "sscp";
       lv_usesTransactions = FALSE;
-      lv_maxNowaitRequests =  FS_MAX_NOWAIT_DEPTH-1;   
+      lv_maxNowaitRequests =  FS_MAX_NOWAIT_DEPTH;   
       overridingDefineName = "=_MX_SSCP_PROCESS_PREFIX"; 
       break;
     case IPC_SQLSSMP_SERVER:
       className = "ssmp";
       lv_usesTransactions = FALSE;
-      lv_maxNowaitRequests =  FS_MAX_NOWAIT_DEPTH-1;   
+      lv_maxNowaitRequests =  FS_MAX_NOWAIT_DEPTH;   
       overridingDefineName = "=_MX_SSMP_PROCESS_PREFIX";
       break;
     default:

--- a/core/sql/common/Ipc.h
+++ b/core/sql/common/Ipc.h
@@ -1145,6 +1145,7 @@ public:
 
  inline Int32 getOpenRetries() const { return openRetries_; }
  inline void setOpenRetries(Int32 num) { openRetries_ =  num; }
+ inline unsigned short getNowaitDepth() { return nowaitDepth_; }
  void openRetryCleanup();
 
   // struct is public only to make the compiler happy

--- a/core/sql/executor/ExCancel.h
+++ b/core/sql/executor/ExCancel.h
@@ -31,6 +31,7 @@
 #include "QueueIndex.h"
 #include "Ipc.h"
 #include "rts_msg.h"
+#include "ssmpipc.h"
 
 // -----------------------------------------------------------------------
 // Classes defined in this file
@@ -174,7 +175,8 @@ public:
 
   // constructor
   CancelMsgStream(IpcEnvironment *env, 
-                  ExCancelTcb *cancelTcb)
+                  ExCancelTcb *cancelTcb,
+                  ExSsmpManager *ssmpManager)
 
       : IpcMessageStream(env,
                          IPC_MSG_SSMP_REQUEST,
@@ -186,17 +188,23 @@ public:
 #endif
                          TRUE)
       , cancelTcb_(cancelTcb)
+      , ssmpManager_(ssmpManager)
   {
   }
   
   // method called upon send complete
+  virtual void actOnSend(IpcConnection *conn);
   virtual void actOnSendAllComplete();
  
   // method called upon receive complete
+  virtual void actOnReceive(IpcConnection *conn);
   virtual void actOnReceiveAllComplete();
+
+  void delinkConnection(IpcConnection *conn);
 
 private:
   ExCancelTcb *cancelTcb_;
+  ExSsmpManager *ssmpManager_;
 };
 
 

--- a/core/sql/executor/ex_root.cpp
+++ b/core/sql/executor/ex_root.cpp
@@ -367,7 +367,6 @@ ex_root_tcb::ex_root_tcb(
      queryStartedStream_(NULL),
      queryFinishedStream_(NULL),
      cbServer_(NULL),
-     havePrivateCbServer_(false),
      cbCommStatus_(0),
       mayPinAudit_(false),
       mayLock_(false)
@@ -516,14 +515,6 @@ void ex_root_tcb::freeResources()
     // attempt to correlate retried errors with any particular Statement.
     glob->getIpcEnvironment()->logRetriedMessages();
   }
-
-  if (cbServer_ && havePrivateCbServer_)
-  {
-    cbServer_->release();
-    cbServer_ = NULL;
-    havePrivateCbServer_ = false;
-  }
-
   if (queryStartedStream_)
   {
     queryStartedStream_->removeRootTcb();
@@ -2817,103 +2808,16 @@ void ex_root_tcb::registerCB(ComDiagsArea *&diagsArea)
     }
   }
 
-  // See if an error happened on an earlier execution's finished message.
-  // Temporarily use the cliGlobal's IpcServer to check for error state.
-  if (context->canUseCbServer())
-  {
-    IpcServer * globalCbServer = context->useCbServer();
-    if (globalCbServer && 
-        globalCbServer->getControlConnection()  &&
-        globalCbServer->getControlConnection()->getErrorInfo() != 0)
-    {
-      globalCbServer->release();
-      context->lostCbServer();   // this method also calls doneWithCbServer.
-    }
-    else
-      context->doneWithCbServer();
-  }
-
-  // Also, fix any problem for a private server.
-  if (cbServer_ && 
-      cbServer_->getControlConnection()  &&
-      cbServer_->getControlConnection()->getErrorInfo() != 0)
-  {
-    ex_assert(havePrivateCbServer_, 
-              "Bad cleanup after finishQuery message.");
-    cbServer_->release();
-    cbServer_ = NULL;
-    havePrivateCbServer_ = false;
-
-  }
-
+  ExExeStmtGlobals * exe_glob = getGlobals()->castToExExeStmtGlobals();
+  ComDiagsArea *tempDiagsArea = exe_glob->getDiagsArea();
+  
+  ExSsmpManager *ssmpManager = context->getSsmpManager();
+  cbServer_ = ssmpManager->getSsmpServer(
+                                 cliGlobals->myNodeName(), 
+                                 cliGlobals->myCpu(), tempDiagsArea);
   if (cbServer_ == NULL)
-  {
-    // Use context's IpcServer if it is allocated and not in use.
-    // If context's IpcServer is not allocated, create one, give it to 
-    // globals, and use it. 
-    // If context's IpcServer is allocated, but in use, create a private one,
-    // and remember to release it in ex_root_tcb::freeResources().
+    return ;
 
-    bool fakeAPrivateServer = false;
-#ifdef _DEBUG
-#ifdef NA_LINUX
-   fakeAPrivateServer = (NULL != getenv("CB_PRIVATE"));
-#endif
-#endif
-
-    if ((context->canUseCbServer()) && !fakeAPrivateServer)
-    {
-      cbServer_ = context->useCbServer();
-      havePrivateCbServer_ = false;
-    }
-    else
-    {
-      char nodeName[16];
-      nodeName[0] = '\\';
-      Lng32 nodeNameLen = str_len(cliGlobals->myNodeName()); 
-      str_cpy_all(&nodeName[1], cliGlobals->myNodeName(), nodeNameLen);
-      nodeName[1+nodeNameLen] = '\0';
-
-      IpcServer * cbServer = 
-          context->getCbServerClass()->allocateServerProcess(
-                      &diagsArea, 
-                      context->getIpcHeap(),
-                      nodeName,
-                      cliGlobals->myCpu(),
-                      IPC_PRIORITY_DONT_CARE,
-                      1,      //espLevel (not relevant)
-                      FALSE,  // usesTransactions 
-                      TRUE,   // waitedCreation
-                      3       // maxNowaitRequests -- start+finish+(1 extra).
-                      );
-      if (cbServer == NULL || cbServer->getControlConnection() == NULL)
-      {
-        // We could not get a phandle for the cancel broker.  However,
-        // let the query run (on the assumption that it will not need to 
-        // be canceled) and convert any error conditions to warnings.
-
-        // tbd - figure a way retry registration later, as the query progresses.
-        if (diagsArea != NULL)
-          NegateAllErrors(diagsArea);
-        return;
-      }
-
-      if (context->hasACbServer() || fakeAPrivateServer)
-      {
-        // this statement will use its own CB connection and will release
-        // it when done.
-        cbServer_ = cbServer;
-        havePrivateCbServer_ = true;
-      }
-      else
-      {
-        context->takeCbServer(cbServer);
-        cbServer_ = context->useCbServer();
-        havePrivateCbServer_ = false;
-      }
-
-    }
-  }
   
   // The stream's actOnSend method will delete (or call decrRefCount()) 
   // for this object.
@@ -2937,7 +2841,7 @@ void ex_root_tcb::registerCB(ComDiagsArea *&diagsArea)
   if (queryStartedStream_ == NULL)
   {
     queryStartedStream_  = new (context->getIpcHeap())
-          QueryStartedMsgStream(context->getEnvironment(), this);
+          QueryStartedMsgStream(context->getEnvironment(), this, ssmpManager);
 
     queryStartedStream_->addRecipient(cbServer_->getControlConnection());
   }
@@ -2962,24 +2866,10 @@ void ex_root_tcb::deregisterCB()
   CliGlobals *cliGlobals = glob->getCliGlobals();
   ContextCli *context = cliGlobals->currContext();
 
-#if 0
-  bool allowUnitTestSuspend = false;
-  // This "unit test" has been unit tested but cannot be tested
-  // in the developer regression tests without slowing down 
-  // everybody's run, and also risking false positive due to 
-  // timing issues.  Hence, the use of LCOV. 
-  // LCOV_EXCL_START
-    allowUnitTestSuspend = (NULL != getenv("UNIT_TEST_LATE_SUSPEND"));
-
-  if (allowUnitTestSuspend)
-    DELAY(20*100);
-  // LCOV_EXCL_STOP
-#endif
-
   // Let MXSSMP know this query can no longer be suspended.  Also, here
   // is where we handle one possibilty:  the query can be suspended after
   // the ExScheduler::work method has made its final check of the root
-  // oper stats isSuspended_ flag, but before we get to this code where
+
   // we change ExMasterStats::readyToSuspend_ from READY to NOT_READY.
   // To handle this, the subject master will obtain the Stats semaphore
   // and test ExMasterStats::isSuspended_.  If set to true, it will
@@ -3032,30 +2922,6 @@ void ex_root_tcb::deregisterCB()
                cliGlobals->myPin(),savedPriority, savedStopMode);
   }
 
-  if (context->getCbServerClass() == NULL ||  
-      cbServer_ == NULL ||
-      cbServer_->getControlConnection() == NULL)
-    return;
-
-  if (cbServer_->getControlConnection()->getErrorInfo() != 0)
-  {
-    // Some IPC error happened after we registered.  No need to deregister.
-    if (havePrivateCbServer_)
-    {
-      ; // Private server will be cleanup up in destructor, or when the 
-        // query is re-executed - registerCB.
-    }
-    else
-    {
-      cbServer_ = NULL;
-      // Tell context that we are finished with his cbServer_.
-      // The ipc error will be cleaned up when registerCB is
-      // called next for this query or any other query.
-      context->doneWithCbServer();
-    }
-    return;
-  }
-
   // No started message sent, so no finished message should be sent.
   if (!isCbStartedMessageSent())
     return;
@@ -3090,7 +2956,7 @@ void ex_root_tcb::deregisterCB()
   if (queryFinishedStream_ == NULL)
   {
     queryFinishedStream_  = new (context->getIpcHeap())
-          QueryFinishedMsgStream(context->getEnvironment(), this);
+          QueryFinishedMsgStream(context->getEnvironment(), this, context->getSsmpManager());
 
     queryFinishedStream_->addRecipient(cbServer_->getControlConnection());
   }
@@ -3115,20 +2981,8 @@ void ex_root_tcb::setCbFinishedMessageReplied()
   ContextCli *context = glob->getCliGlobals()->currContext();
 
   cbCommStatus_ &= ~FINISHED_PENDING_; 
-
-  if (havePrivateCbServer_)
-  {
-    // Let my destructor release the server, since we are executing 
-    // from a callback it would not be safe to delete the IpcConnection
-    // object that called us.
-  }
-  else
-  {
-    // Tell context that we are finished with his cbServer_.
-    context->doneWithCbServer();
-    cbServer_ = NULL;
-  }
 }
+
 void ex_root_tcb::cbMessageWait(Int64 waitStartTime)
 {
   ExMasterStmtGlobals *master_glob = getGlobals()->
@@ -3188,6 +3042,12 @@ void ex_root_tcb::dumpCb()
 // Methods for QueryStartedMsgStream. 
 // -----------------------------------------------------------------------
 
+void QueryStartedMsgStream::actOnSend(IpcConnection *conn)
+{
+  if (conn->getErrorInfo() != 0)
+     delinkConnection(conn);
+}
+
 void QueryStartedMsgStream::actOnSendAllComplete()
 {
   clearAllObjects();
@@ -3234,7 +3094,20 @@ void QueryStartedMsgStream::actOnReceive(IpcConnection *connection)
     }
     reply->decrRefCount();
   }
+  else 
+     delinkConnection(connection);
 }
+
+void QueryStartedMsgStream::delinkConnection(IpcConnection *conn)
+{
+  char nodeName[MAX_SEGMENT_NAME_LEN+1];
+  IpcCpuNum cpu;
+
+  conn->getOtherEnd().getNodeName().getNodeNameAsString(nodeName);
+  cpu = conn->getOtherEnd().getCpuNum();
+  ssmpManager_->removeSsmpServer(nodeName, (short)cpu);
+}
+
 
 void QueryStartedMsgStream::actOnReceiveAllComplete()
 {
@@ -3253,6 +3126,12 @@ void QueryStartedMsgStream::actOnReceiveAllComplete()
 // -----------------------------------------------------------------------
 // Methods for QueryFinishedMsgStream. 
 // -----------------------------------------------------------------------
+
+void QueryFinishedMsgStream::actOnSend(IpcConnection *conn)
+{
+  if (conn->getErrorInfo() != 0)
+     delinkConnection(conn);
+}
 
 void QueryFinishedMsgStream::actOnSendAllComplete()
 {
@@ -3280,6 +3159,18 @@ void QueryFinishedMsgStream::actOnReceive(IpcConnection *connection)
 
     reply->decrRefCount();
   }
+  else
+      delinkConnection(connection);
+}
+
+void QueryFinishedMsgStream::delinkConnection(IpcConnection *conn)
+{
+  char nodeName[MAX_SEGMENT_NAME_LEN+1];
+  IpcCpuNum cpu;
+
+  conn->getOtherEnd().getNodeName().getNodeNameAsString(nodeName);
+  cpu = conn->getOtherEnd().getCpuNum();
+  ssmpManager_->removeSsmpServer(nodeName, (short)cpu);
 }
 
 void QueryFinishedMsgStream::actOnReceiveAllComplete()

--- a/core/sql/runtimestats/ssmpipc.cpp
+++ b/core/sql/runtimestats/ssmpipc.cpp
@@ -95,7 +95,20 @@ IpcServer *ExSsmpManager::getSsmpServer(char *nodeName, short cpuNum,
    {
      if (str_cmp(ssmpServer->castToIpcGuardianServer()->getProcessName(),
             tmpProcessName, processNameLen) == 0)
-        return ssmpServer;
+     {
+        GuaConnectionToServer *cbGCTS = ssmpServer->getControlConnection()->castToGuaConnectionToServer();
+
+        // We need to keep 2 entries free - To send QueryFinishedMessage and to get the response for query started message
+       if (cbGCTS->numReceiveCallbacksPending()+2 == cbGCTS->getNowaitDepth())
+       {
+          *diagsArea << DgSqlCode(-2026)
+            << DgString0(tmpProcessName)
+            << DgInt0(GetCliGlobals()->myCpu())
+            << DgInt1(GetCliGlobals()->myPin()); 
+          return NULL;
+       }
+       return ssmpServer;
+     }
      ssmpServer = (IpcServer *) ssmps_->getNext();
    }
 
@@ -119,7 +132,8 @@ IpcServer *ExSsmpManager::getSsmpServer(char *nodeName, short cpuNum,
        ssmpServer = NULL;
      }
    }
-
+   
+   
    return ssmpServer;
 }
 

--- a/core/sql/runtimestats/ssmpipc.h
+++ b/core/sql/runtimestats/ssmpipc.h
@@ -62,6 +62,7 @@ public:
   IpcEnvironment *getIpcEnvironment() { return env_; }
   void removeSsmpServer(char *nodeName, short cpuNum);
   void cleanupDeletedSsmpServers();
+  IpcServerClass *getServerClass() { return ssmpServerClass_; }
 private:
   IpcEnvironment       *env_;
   IpcServerClass       *ssmpServerClass_;


### PR DESCRIPTION
…master process

Mxosrvr/Any master process opens a connection to mxssmp for the following:
1) For get statistics command
   Managed via ssmpManager_ in the context. This can have connections to all the
   ssmps in the cluster

2) To cancel a query
   Was managed via cbServer_ in ExCancelTcb. This connection was expected to go away
   when the cancel is passed on the mxssmp.

3) To Send query started /Query finished message
   Was managed via cbServer_ in ContextCli. If this cbServer_ was taken up already by
   the pending query started message , subsequent statements would have
   created a connection to ssmp and managed via cbServer_ in ex_root_tcb of the query

In a ssmp core there were many opens from a mxosrvr. To avoid many open connections,
all the ssmp connections are now managed via ssmpManager_ in its context.
This connection is shared by multiple message streams by increasing the no-wait depth.