### PR TITLE
[TRAFODION-2701] The maxlength for LargeInt was fixed to 8

### DIFF
--- a/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/sqltocconv.cpp
+++ b/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/sqltocconv.cpp
@@ -587,17 +587,15 @@ unsigned long ODBC::ConvertSQLToC(SQLINTEGER	ODBCAppVersion,
 			break;
 		case SQL_BIGINT:
 #if !defined MXHPUX && !defined MXOSS && !defined MXAIX && !defined MXSUNSPARC
-//			sprintf( cTmpBuf, "%Ld", *((__int64 *)srcDataPtr));
             if (srcUnsigned)
-                snprintf( cTmpBuf, sizeof(unsigned __int64), "%lu", *((unsigned __int64 *)srcDataPtr));
+                sprintf( cTmpBuf, "%lu", *((unsigned __int64 *)srcDataPtr));
             else
-                snprintf( cTmpBuf, sizeof(__int64), "%ld", *((__int64 *)srcDataPtr));
+                sprintf( cTmpBuf, "%ld", *((__int64 *)srcDataPtr));
 #else
-//			sprintf( cTmpBuf, "%lld", *((__int64 *)srcDataPtr));
             if (srcUnsigned)
-                snprintf( cTmpBuf, sizeof(unsigned __int64), "%llu", *((unsigned __int64 *)srcDataPtr));
+                sprintf( cTmpBuf, "%llu", *((unsigned __int64 *)srcDataPtr));
             else
-                snprintf( cTmpBuf, sizeof(__int64), "%lld", *((__int64 *)srcDataPtr));
+                sprintf( cTmpBuf, "%lld", *((__int64 *)srcDataPtr));
 #endif
 			DataLen = strlen(cTmpBuf);
 			if (DataLen > targetLength)

--- a/win-odbc64/odbcclient/drvr35/sqltocconv.cpp
+++ b/win-odbc64/odbcclient/drvr35/sqltocconv.cpp
@@ -539,9 +539,9 @@ unsigned long ODBC::ConvertSQLToC(SQLINTEGER	ODBCAppVersion,
 			break;
 		case SQL_BIGINT:
 			if (srcUnsigned)
-				_snprintf(cTmpBuf, sizeof(__int64), "%I64u", *((unsigned __int64 *)srcDataPtr));
+				sprintf(cTmpBuf, "%I64u", *((unsigned __int64 *)srcDataPtr));
 			else
-				_snprintf(cTmpBuf, sizeof(__int64), "%I64d", *((__int64 *)srcDataPtr));
+				sprintf(cTmpBuf, "%I64d", *((__int64 *)srcDataPtr));
 			DataLen = strlen(cTmpBuf);
 			if (DataLen > targetLength)
 				return IDS_22_003;


### PR DESCRIPTION
Snprintf using sizeof(__int64) to set the max length of binding char to bigint with 8 chars.
It is too short for bigint.
