### PR TITLE
[TRAFODION-2702]Fix wrong offset when the charset type is ucs2 in SQLTOC

### DIFF
--- a/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/sqltocconv.cpp
+++ b/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/sqltocconv.cpp
@@ -421,7 +421,7 @@ unsigned long ODBC::ConvertSQLToC(SQLINTEGER	ODBCAppVersion,
                 break;
             }
 		case SQL_WCHAR:
-			charlength = srcLength-1;
+			charlength = srcLength - 1;
 			if (charlength == 0)
 			{
 				if (targetStrLenPtr != NULL)
@@ -3557,7 +3557,10 @@ unsigned long ODBC::ConvertSQLToC(SQLINTEGER	ODBCAppVersion,
 			{
 				if(CDataType == SQL_C_CHAR)
 				{
-					DataLen = charlength-Offset;
+			                if(srcCharSet == SQLCHARSETCODE_UCS2)
+					    DataLen = charlength / 2 - Offset;
+					else
+					    DataLen = charlength  - Offset;
 					if (DataLen >= targetLength)
 					{
 						DataLenTruncated = DataLen;


### PR DESCRIPTION
The offset will record the number of the chars returned,which have been translated from ucs2 to SQL_C_CHAR. When the function is called again to get the remaining chars, it  use the length of string without translation and the offset translated to calculate the number of the remaining chars.