### PR TITLE
[TRAFODION-2217] Error 8026 is shown at times when the query is cance…

### DIFF
--- a/core/sql/executor/ExCancel.cpp
+++ b/core/sql/executor/ExCancel.cpp
@@ -257,8 +257,8 @@ ExWorkProcRetcode ExCancelTcb::work()
                 castToExMasterStmtGlobals()->getStatement()->getContext();
           ExSsmpManager *ssmpManager = context->getSsmpManager(); 
           cbServer_ = ssmpManager->getSsmpServer(
-                                 cliGlobals->myNodeName(), 
-                                 cliGlobals->myCpu(), tempDiagsArea);
+                                 nodeName_,
+                                 cpu_, tempDiagsArea);
           if (cbServer_ == NULL) {
              reportError(tempDiagsArea, true, EXE_CANCEL_PROCESS_NOT_FOUND, 
                           nodeName_, cpu_);


### PR DESCRIPTION
…lled.

control query cancel for qid fails with error *** ERROR[8026] Server
declined cancel request. The query ID of the targeted query was not found.

The query exists and it is in OPEN state and it should have been
cancelled. Cancel query was sending the message to the incorrect ssmp server.