### PR TITLE
[TRAFODION-2716] Query compilation gets stuck at listSnapshots() at t…

### DIFF
--- a/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
@@ -12681,7 +12681,9 @@ TrafDesc * CmpSeabaseDDL::getSeabaseTableDesc(const NAString &catName,
         }
       else
         {
-          Int32 ctlFlags = GET_SNAPSHOTS; // get snapshot
+          Int32 ctlFlags = 0;
+          if (CmpCommon::getDefault(TRAF_TABLE_SNAPSHOT_SCAN) != DF_NONE)
+             ctlFlags = GET_SNAPSHOTS; // get snapshot
           if ((CmpCommon::getDefault(TRAF_READ_OBJECT_DESC) == DF_ON) &&
               (!Get_SqlParser_Flags(INTERNAL_QUERY_FROM_EXEUTIL)) &&
               (NOT includeInvalidDefs))


### PR DESCRIPTION
…imes

To reduce the impact on the compilation when there are many snapshots,
call Admin.listSnapshots  only when cqd TRAF_TABLE_SNAPSHOT_SCAN is set to
LATEST or SUFFIX.