### PR TITLE
[TRAFODION-2702] fix wrong offset while converting sql to c with ucs2

### DIFF
--- a/win-odbc64/odbcclient/drvr35/sqltocconv.cpp
+++ b/win-odbc64/odbcclient/drvr35/sqltocconv.cpp
@@ -3445,7 +3445,10 @@ unsigned long ODBC::ConvertSQLToC(SQLINTEGER	ODBCAppVersion,
 			}
 			else
 			{
-				DataLen = charlength-Offset;
+				if (srcCharSet == SQLCHARSETCODE_UCS2)
+					DataLen = charlength / 2 - Offset;
+				else
+					DataLen = charlength - Offset;
 				if (DataLen >= targetLength)
 				{
 					DataLenTruncated = DataLen;


### PR DESCRIPTION
For last PR , the bug on windows has not been mentioned