### PR TITLE
[TRAFODION-2725] SQL types are REAL, FLOAT, and DOUBLE. Some values are inserted, a stack overflow occurs when SQLGetData is executed

### DIFF
--- a/win-odbc64/odbcclient/drvr35/sqltocconv.cpp
+++ b/win-odbc64/odbcclient/drvr35/sqltocconv.cpp
@@ -594,7 +594,7 @@ unsigned long ODBC::ConvertSQLToC(SQLINTEGER	ODBCAppVersion,
 							dTmp)  != SQL_SUCCESS)
 					return IDS_07_006;
 //				_gcvt(dTmp, DBL_DIG, cTmpBuf);
-				if (!double_to_char (dTmp, DBL_DIG, cTmpBuf, targetLength))
+				if (!double_to_char (dTmp, DBL_DIG, cTmpBuf, sizeof(cTmpBuf)))
 					return IDS_22_001;
 			
 			}
@@ -603,13 +603,13 @@ unsigned long ODBC::ConvertSQLToC(SQLINTEGER	ODBCAppVersion,
 				if (ODBCDataType == SQL_REAL) {
 					dTmp = (double)(*(float *)srcDataPtr);
 //					_gcvt(dTmp, FLT_DIG + 1, cTmpBuf);
-					if (!double_to_char (dTmp, FLT_DIG + 1, cTmpBuf, targetLength))
+					if (!double_to_char (dTmp, FLT_DIG + 1, cTmpBuf, sizeof(cTmpBuf)))
 						return IDS_22_001;
 				}
 				else {
 					dTmp = *(double *)srcDataPtr;
 //					_gcvt(dTmp, DBL_DIG, cTmpBuf);
-					if (!double_to_char (dTmp, DBL_DIG + 1, cTmpBuf, targetLength))
+					if (!double_to_char (dTmp, DBL_DIG + 1, cTmpBuf, sizeof(cTmpBuf)))
 						return IDS_22_001;
 				}
 			}


### PR DESCRIPTION
root cause: write stack variable out of range.
unsigned long ODBC::ConvertSQLToC(...., targetLength) {
    ...
    CHAR		cTmpBuf[132];
    ...
    double_to_char (dTmp, FLT_DIG + 1, cTmpBuf, targetLength)  **// when targetLength > 132, the stack will be broken.** 
    ...
}
fixed by:limit the max size to sizeof(cTmpBuf)