### PR TITLE
 [TRAFODION-2727] Memory leak in the compiler part of the code in Trafodion

### DIFF
--- a/core/conn/odbc/src/odbc/nsksrvrcore/sqlinterface.cpp
+++ b/core/conn/odbc/src/odbc/nsksrvrcore/sqlinterface.cpp
@@ -1334,9 +1334,9 @@ SQLRETURN SRVR::BuildSQLDesc(SQLDESC_ID *pDesc,
 					ODBCPrecision, SignType, Nullable, totalMemLen,	SQLCharset, ODBCCharset,
 					IntLeadPrec, ColumnHeading);
 		HANDLE_ERROR(retcode, sqlWarning);
-		if (DataType == SQLTYPECODE_LARGEINT && Precision == 0 && Scale > 0)
-			ODBCDataType = SQL_NUMERIC;
-		
+                if (DataType == SQLTYPECODE_LARGEINT && Precision == 0 && Scale > 0)
+                   ODBCDataType = SQL_NUMERIC;
+
 		implDesc[i-1].charSet = SQLCharset;
 		implDesc[i-1].dataType = DataType;
 		implDesc[i-1].length = Length;
@@ -1457,6 +1457,18 @@ SQLRETURN SRVR::BuildSQLDesc2(SQLDESC_ID *pDesc,
 		delete implDesc;
 		implDesc = NULL;
 	}
+
+	if (SqlDescInfo != NULL)
+	{
+		delete SqlDescInfo;
+		SqlDescInfo = NULL;
+	}
+        
+        if (SQLDesc != NULL)
+        {
+           delete SQLDesc;
+           SQLDesc = NULL;
+        }
 
 	if (numEntries > 0)
 	{
@@ -1742,13 +1754,6 @@ SQLRETURN SRVR::BuildSQLDesc2(SQLDESC_ID *pDesc,
 						implDesc,SqlDescInfo);
 
 	SQLDescLen = totalDescLength;
-/*
-	if (SqlDescInfo != NULL)
-	{
-		delete [] SqlDescInfo;
-		SqlDescInfo = NULL;
-	}
-*/
 //	if (sqlBulkFetchPossible && (sqlQueryType == SQL_SELECT_NON_UNIQUE || sqlQueryType == SQL_SP_RESULT_SET))
 	if (bRWRS)
 	{

--- a/core/sql/common/CharType.cpp
+++ b/core/sql/common/CharType.cpp
@@ -57,7 +57,8 @@ static const NAString LiteralBLOB("BLOB");
 static const NAString LiteralCLOB("CLOB");
 
 // constructor used for CHAR length semantics only
-CharType::CharType( const NAString&  adtName,
+CharType::CharType( NAMemory *h,
+                    const NAString&  adtName,
 		    Lng32            maxLenInBytesOrNAWchars,
 		    short            maxBytesPerChar,
 		    NABoolean        nullTerminated,
@@ -71,7 +72,7 @@ CharType::CharType( const NAString&  adtName,
 		    CharInfo::CharSet      encoding,
 		    Int32 vcIndLen // default is 0
 		  )
-      : NAType( adtName
+      : NAType(h, adtName
 		, NA_CHARACTER_TYPE
 		, (maxLenInBytesOrNAWchars + (nullTerminated ? 1 : 0)) * CharInfo::minBytesPerChar(cs)
 		, allowSQLnull
@@ -110,7 +111,8 @@ CharType::CharType( const NAString&  adtName,
 }
 
 // This constructor supports SJIS and UTF8 
-CharType::CharType( const NAString&  adtName,
+CharType::CharType( NAMemory *h,
+                    const NAString&  adtName,
 		    const CharLenInfo & maxLenInfo,
 		    short            maxBytesPerChar, // is maxBytesPerChar when cs is SJIS or UTF8
 		    NABoolean        nullTerminated,
@@ -123,7 +125,7 @@ CharType::CharType( const NAString&  adtName,
 		    CharInfo::Coercibility ce,
 		    CharInfo::CharSet      encoding
 		  )
-      : NAType( adtName
+      : NAType(h, adtName
 		, NA_CHARACTER_TYPE
 		, (maxLenInfo.getMaxLenInBytes() +
                     (nullTerminated ? CharInfo::minBytesPerChar(cs) : 0))
@@ -509,10 +511,10 @@ const NAType* CharType::synthesizeType(NATypeSynthRuleEnum synthRule,
   if (DFS2REC::isAnyVarChar(op1.getFSDatatype()) OR
       DFS2REC::isAnyVarChar(op2.getFSDatatype()) OR
       makeTypeVarchar)
-    return new(h) SQLVarChar(res_CharLenInfo, null, upshift, caseinsensitive,
+    return new(h) SQLVarChar(h, res_CharLenInfo, null, upshift, caseinsensitive,
 			     op1.getCharSet(), co, ce);
   else
-    return new(h) SQLChar(res_CharLenInfo, null, upshift, caseinsensitive, FALSE,
+    return new(h) SQLChar(h, res_CharLenInfo, null, upshift, caseinsensitive, FALSE,
 			  op1.getCharSet(), co, ce);
 } // synthesizeType()
 
@@ -894,7 +896,8 @@ NABoolean CharType::createSQLLiteral(const char * buf,
 
 
 #pragma nowarn(1506)   // warning elimination
-SQLChar::SQLChar(Lng32 maxLen,
+SQLChar::SQLChar(NAMemory *h,
+                 Lng32 maxLen,
 		 NABoolean allowSQLnull,
 		 NABoolean isUpShifted,
 		 NABoolean isCaseInsensitive,
@@ -904,7 +907,7 @@ SQLChar::SQLChar(Lng32 maxLen,
 		 CharInfo::Coercibility ce,
 		 CharInfo::CharSet encoding
 		 )
-     : CharType(varLenFlag ? LiteralVARCHAR : LiteralCHAR,
+     : CharType(h, varLenFlag ? LiteralVARCHAR : LiteralCHAR,
 		maxLen, CharInfo::maxBytesPerChar(cs),
 		FALSE, allowSQLnull, isUpShifted, isCaseInsensitive,
 		varLenFlag, cs, co, ce,
@@ -913,7 +916,8 @@ SQLChar::SQLChar(Lng32 maxLen,
 #pragma warn(1506)  // warning elimination
 
 #pragma nowarn(1506)   // warning elimination
-SQLChar::SQLChar(const CharLenInfo & maxLenInfo,
+SQLChar::SQLChar(NAMemory *h,
+                 const CharLenInfo & maxLenInfo,
 		 NABoolean allowSQLnull,
 		 NABoolean isUpShifted,
 		 NABoolean isCaseInsensitive,
@@ -923,7 +927,7 @@ SQLChar::SQLChar(const CharLenInfo & maxLenInfo,
 		 CharInfo::Coercibility ce,
 		 CharInfo::CharSet encoding
 		 )
-     : CharType(varLenFlag ? LiteralVARCHAR : LiteralCHAR,
+     : CharType(h, varLenFlag ? LiteralVARCHAR : LiteralCHAR,
 		maxLenInfo, CharInfo::maxBytesPerChar(cs),
 		FALSE, allowSQLnull, isUpShifted, isCaseInsensitive,
 		varLenFlag, cs, co, ce,
@@ -932,7 +936,8 @@ SQLChar::SQLChar(const CharLenInfo & maxLenInfo,
 #pragma warn(1506)  // warning elimination
 
 #pragma nowarn(1506)   // warning elimination
-SQLVarChar::SQLVarChar(Lng32 maxLen,
+SQLVarChar::SQLVarChar(NAMemory *h,
+                       Lng32 maxLen,
 		       NABoolean allowSQLnull,
 		       NABoolean isUpShifted,
 		       NABoolean isCaseInsensitive,
@@ -942,7 +947,7 @@ SQLVarChar::SQLVarChar(Lng32 maxLen,
 		       CharInfo::CharSet encoding,
                        Lng32 vcIndLen
 		      )
-    : CharType(LiteralVARCHAR,
+    : CharType(h, LiteralVARCHAR,
 	       maxLen, CharInfo::maxBytesPerChar(cs),
 	       FALSE, allowSQLnull, isUpShifted, isCaseInsensitive,
 	       TRUE, cs, co, ce,
@@ -953,7 +958,8 @@ SQLVarChar::SQLVarChar(Lng32 maxLen,
 #pragma warn(1506)  // warning elimination
 
 #pragma nowarn(1506)   // warning elimination
-SQLVarChar::SQLVarChar(const CharLenInfo & maxLenInfo,
+SQLVarChar::SQLVarChar(NAMemory *h, 
+                       const CharLenInfo & maxLenInfo,
 		       NABoolean allowSQLnull,
 		       NABoolean isUpShifted,
 		       NABoolean isCaseInsensitive,
@@ -962,7 +968,7 @@ SQLVarChar::SQLVarChar(const CharLenInfo & maxLenInfo,
 		       CharInfo::Coercibility ce,
 		       CharInfo::CharSet encoding
 		      )
-    : CharType(LiteralVARCHAR,
+    : CharType(h, LiteralVARCHAR,
 	       maxLenInfo, CharInfo::maxBytesPerChar(cs),
 	       FALSE, allowSQLnull, isUpShifted, isCaseInsensitive,
 	       TRUE, cs, co, ce,
@@ -1002,7 +1008,8 @@ NABoolean SQLVarChar::operator==(const NAType& other) const
 // in cli + rfork if a CharType is both nul-terminated and has a vc-header.
 // -----------------------------------------------------------------------
 #pragma nowarn(1506)   // warning elimination
-ANSIChar::ANSIChar(Lng32 maxLen,
+ANSIChar::ANSIChar(NAMemory *h,
+                   Lng32 maxLen,
 		   NABoolean allowSQLnull,
 		   NABoolean isUpShifted,
 		   NABoolean varLenFlag,	// *unused*
@@ -1011,7 +1018,7 @@ ANSIChar::ANSIChar(Lng32 maxLen,
 		   CharInfo::Coercibility ce,
 		   CharInfo::CharSet encoding
 		  )
-     : CharType(LiteralCHAR,
+     : CharType(h, LiteralCHAR,
 		maxLen, CharInfo::maxBytesPerChar(cs),
 		TRUE, allowSQLnull, isUpShifted, FALSE, FALSE, cs, co, ce,
 		encoding)
@@ -1129,7 +1136,7 @@ void CharType::generateTextThenSetDisplayDataType ( CharInfo::CharSet cs   // in
 
   if ( charLimit * getBytesPerChar() == sizeInBytes )
   {
-    ddt += LongToNAString(charLimit, (NAHeap *)ddt.heap());
+    ddt += LongToNAString(charLimit);
     if (charLimit EQU 1)
       ddt += " CHAR";
     else
@@ -1137,7 +1144,7 @@ void CharType::generateTextThenSetDisplayDataType ( CharInfo::CharSet cs   // in
   }
   else
   {
-    ddt += LongToNAString(sizeInBytes, (NAHeap *)ddt.heap());
+    ddt += LongToNAString(sizeInBytes);
     if (sizeInBytes EQU 1)
       ddt += " BYTE";
     else
@@ -1148,7 +1155,7 @@ void CharType::generateTextThenSetDisplayDataType ( CharInfo::CharSet cs   // in
 
   ddt += CharInfo::getCharSetName(cs);
 
-  setDisplayDataType(ddt.data());
+  setDisplayDataType(ddt);
 }
 
 // -----------------------------------------------------------------------
@@ -1403,11 +1410,11 @@ CharType::findPushDownCharType(CharInfo::CharSet cs,
 
 const CharType* CharType::desiredCharType(enum CharInfo::CharSet cs)
 {
-  static SQLChar unicodeChar(0, TRUE, FALSE, FALSE, FALSE, CharInfo::UNICODE);
-  static SQLChar latin1Char(0, TRUE, FALSE, FALSE, FALSE, CharInfo::ISO88591);
-  static SQLChar sjisChar(0, TRUE, FALSE, FALSE, FALSE, CharInfo::SJIS /* ... old kludge ... CharInfo::ISO88591 */, CharInfo::DefaultCollation, CharInfo::COERCIBLE, CharInfo::SJIS/*encoding*/);
-  // static SQLChar sjisUnicodeChar(0, TRUE, FALSE, FALSE, FALSE, CharInfo::SJIS, CharInfo::DefaultCollation, CharInfo::COERCIBLE, CharInfo::UNICODE/*encoding*/);
-  static SQLChar utf8Char(0, TRUE, FALSE, FALSE, FALSE, CharInfo::UTF8 /* ... old kludge ... CharInfo::ISO88591 */, CharInfo::DefaultCollation, CharInfo::COERCIBLE, CharInfo::UTF8/*encoding*/);
+  static SQLChar unicodeChar(NULL, 0, TRUE, FALSE, FALSE, FALSE, CharInfo::UNICODE);
+  static SQLChar latin1Char(NULL, 0, TRUE, FALSE, FALSE, FALSE, CharInfo::ISO88591);
+  static SQLChar sjisChar(NULL, 0, TRUE, FALSE, FALSE, FALSE, CharInfo::SJIS /* ... old kludge ... CharInfo::ISO88591 */, CharInfo::DefaultCollation, CharInfo::COERCIBLE, CharInfo::SJIS/*encoding*/);
+  // static SQLChar sjisUnicodeChar(NULL, 0, TRUE, FALSE, FALSE, FALSE, CharInfo::SJIS, CharInfo::DefaultCollation, CharInfo::COERCIBLE, CharInfo::UNICODE/*encoding*/);
+  static SQLChar utf8Char(NULL, 0, TRUE, FALSE, FALSE, FALSE, CharInfo::UTF8 /* ... old kludge ... CharInfo::ISO88591 */, CharInfo::DefaultCollation, CharInfo::COERCIBLE, CharInfo::UTF8/*encoding*/);
 
   switch ( cs ) {
     case CharInfo::UNICODE:
@@ -1458,7 +1465,7 @@ NAType* SQLVarChar::equivalentCharType(NAMemory *h, NABoolean quantizeLen)
   len_in_bytes = quantizeLen ? quantize(getNominalSize()) : getNominalSize() ;
 
   CharLenInfo CLInfo( len_in_chars, len_in_bytes );
-  return new(h) SQLChar(CLInfo, supportsSQLnull(), isUpshifted(),
+  return new(h) SQLChar(h, CLInfo, supportsSQLnull(), isUpshifted(),
                         isCaseinsensitive(), FALSE,
                         getCharSet(), getCollation(), getCoercibility());
 }
@@ -1473,7 +1480,7 @@ NAType* SQLChar::equivalentVarCharType(NAMemory *h, NABoolean quantizeLen)
   len_in_bytes = quantizeLen ? quantize(getNominalSize()) : getNominalSize() ;
 
   CharLenInfo CLInfo( len_in_chars, len_in_bytes );
-  return new(h) SQLVarChar(CLInfo, supportsSQLnull(), isUpshifted(),
+  return new(h) SQLVarChar(h, CLInfo, supportsSQLnull(), isUpshifted(),
 			   isCaseinsensitive(),
 			   getCharSet(), getCollation(), getCoercibility());
 }
@@ -1482,7 +1489,7 @@ NAType* SQLChar::equivalentVarCharType(NAMemory *h, NABoolean quantizeLen)
 NAType* ANSIChar::equivalentVarCharType(NAMemory *h, NABoolean quantizeLen)
 {
   Lng32 len = quantizeLen ? quantize(getStrCharLimit()) : getStrCharLimit();
-  return new(h) SQLVarChar(len, supportsSQLnull(), isUpshifted(),
+  return new(h) SQLVarChar(h, len, supportsSQLnull(), isUpshifted(),
 			   isCaseinsensitive(),
 			   getCharSet(), getCollation(), getCoercibility());
 }
@@ -1504,7 +1511,7 @@ short SQLLongVarChar::getTrueFSDatatype() const
 //////////////////////////////
 // class SQLlob
 //////////////////////////////
-SQLlob::SQLlob( 
+SQLlob::SQLlob(NAMemory *h, 
 	       NABuiltInTypeEnum  ev,
 	       Int64 lobLength, 
 	       LobsStorage ls,
@@ -1513,7 +1520,7 @@ SQLlob::SQLlob(
 	       NABoolean externalFormat,
 	       Lng32 extFormatLen
 		)
-  : NAType( (ev == NA_LOB_TYPE ? LiteralLOB : LiteralLOB)
+  : NAType(h, (ev == NA_LOB_TYPE ? LiteralLOB : LiteralLOB)
 	    , ev
 	    , (externalFormat ? extFormatLen : 512)
 	    , allowSQLnull
@@ -1558,7 +1565,7 @@ NAString SQLlob::getTypeSQLname(NABoolean terse) const
 /////////////////////////////////////
 // class SQLBlob
 /////////////////////////////////////
-SQLBlob::SQLBlob( 
+SQLBlob::SQLBlob(NAMemory *h, 
   Int64 blobLength, 
   LobsStorage lobStorage,
   NABoolean allowSQLnull,
@@ -1566,7 +1573,7 @@ SQLBlob::SQLBlob(
   NABoolean externalFormat,
   Lng32 extFormatLen
 )
-  : SQLlob(NA_LOB_TYPE,
+  : SQLlob(h, NA_LOB_TYPE,
 	   blobLength,
 	   lobStorage,
 	   allowSQLnull,
@@ -1600,7 +1607,7 @@ const NAType* SQLBlob::synthesizeType(NATypeSynthRuleEnum synthRule,
 
   if (synthRule == SYNTH_RULE_UNION)
     {
-      return new(h) SQLBlob(MAXOF(op1.getLobLength(), op2.getLobLength()),
+      return new(h) SQLBlob(h, MAXOF(op1.getLobLength(), op2.getLobLength()),
 			    op1.getLobStorage(),
 			    null);
     }
@@ -1611,7 +1618,7 @@ const NAType* SQLBlob::synthesizeType(NATypeSynthRuleEnum synthRule,
 /////////////////////////////////////
 // class SQLClob
 /////////////////////////////////////
-SQLClob::SQLClob( 
+SQLClob::SQLClob(NAMemory *h, 
   Int64 clobLength, 
   LobsStorage lobStorage,
   NABoolean allowSQLnull,
@@ -1619,7 +1626,7 @@ SQLClob::SQLClob(
   NABoolean externalFormat,
   Lng32 extFormatLen
 )
-  : SQLlob(NA_LOB_TYPE,
+  : SQLlob(h, NA_LOB_TYPE,
 	   clobLength,
 	   lobStorage,
 	   allowSQLnull,
@@ -1653,7 +1660,7 @@ const NAType* SQLClob::synthesizeType(NATypeSynthRuleEnum synthRule,
 
   if (synthRule == SYNTH_RULE_UNION)
     {
-      return new(h) SQLClob(MAXOF(op1.getLobLength(), op2.getLobLength()),
+      return new(h) SQLClob(h, MAXOF(op1.getLobLength(), op2.getLobLength()),
 			    op1.getLobStorage(),
 			    null);
     }

--- a/core/sql/common/CharType.cpp
+++ b/core/sql/common/CharType.cpp
@@ -1129,7 +1129,7 @@ void CharType::generateTextThenSetDisplayDataType ( CharInfo::CharSet cs   // in
 
   if ( charLimit * getBytesPerChar() == sizeInBytes )
   {
-    ddt += LongToNAString(charLimit);
+    ddt += LongToNAString(charLimit, (NAHeap *)ddt.heap());
     if (charLimit EQU 1)
       ddt += " CHAR";
     else
@@ -1137,7 +1137,7 @@ void CharType::generateTextThenSetDisplayDataType ( CharInfo::CharSet cs   // in
   }
   else
   {
-    ddt += LongToNAString(sizeInBytes);
+    ddt += LongToNAString(sizeInBytes, (NAHeap *)ddt.heap());
     if (sizeInBytes EQU 1)
       ddt += " BYTE";
     else

--- a/core/sql/common/CharType.h
+++ b/core/sql/common/CharType.h
@@ -113,7 +113,8 @@ static const NAString LiteralCatalog;
 // ---------------------------------------------------------------------
 // Constructor functions
 // ---------------------------------------------------------------------
-CharType (const NAString&	adtName, 
+CharType (NAMemory *h,
+          const NAString&	adtName, 
 	  Lng32		maxCharStrLen,
 	  short		bytesPerChar = 0,
 	  NABoolean	nullTerminated = FALSE,
@@ -127,7 +128,8 @@ CharType (const NAString&	adtName,
 	  CharInfo::CharSet      encoding = CharInfo::UnknownCharSet,
 	  Lng32 vcIndLen = 0  // not passed in, need to be computed
          );
-CharType (const NAString&  adtName,
+CharType (NAMemory *h,
+          const NAString&  adtName,
           const CharLenInfo & maxLenInfo,
           short            /*max*/bytesPerChar = 0, // is maxBytesPerChar when cs is SJIS or UTF8
           NABoolean        nullTerminated = FALSE,
@@ -430,7 +432,8 @@ public:
 // ---------------------------------------------------------------------
 // Constructor functions 
 // ---------------------------------------------------------------------
-  SQLChar (Lng32 maxLength, 
+  SQLChar (NAMemory *h,
+           Lng32 maxLength, 
 	   NABoolean allowSQLnull	= TRUE,
 	   NABoolean isUpShifted	= FALSE, 
 	   NABoolean     isCaseInsensitive = FALSE,
@@ -440,7 +443,8 @@ public:
 	   CharInfo::Coercibility	= CharInfo::COERCIBLE,
 	   CharInfo::CharSet encoding	= CharInfo::UnknownCharSet
           );
-  SQLChar (const CharLenInfo & maxLenInfo,
+  SQLChar (NAMemory *h,
+           const CharLenInfo & maxLenInfo,
 	   NABoolean allowSQLnull	= TRUE,
 	   NABoolean isUpShifted	= FALSE, 
 	   NABoolean isCaseInsensitive	= FALSE,
@@ -497,7 +501,8 @@ public:
 // ---------------------------------------------------------------------
 // Constructor functions 
 // ---------------------------------------------------------------------
-  SQLVarChar(Lng32 maxLength,
+  SQLVarChar(NAMemory *h,
+             Lng32 maxLength,
  	     NABoolean allowSQLnull	= TRUE,
 	     NABoolean isUpShifted	= FALSE,
 	     NABoolean isCaseInsensitive = FALSE,
@@ -507,7 +512,8 @@ public:
 	     CharInfo::CharSet encoding	= CharInfo::UnknownCharSet,
              Lng32 vcIndLen             = 0
 	    );
-  SQLVarChar(const CharLenInfo & maxLenInfo,
+  SQLVarChar(NAMemory *h,
+             const CharLenInfo & maxLenInfo,
 	     NABoolean allowSQLnull	= TRUE,
 	     NABoolean isUpShifted	= FALSE,
 	     NABoolean isCaseInsensitive = FALSE,
@@ -586,7 +592,8 @@ public:
 // ---------------------------------------------------------------------
 // Constructor functions 
 // ---------------------------------------------------------------------
- ANSIChar (Lng32 maxLength,
+ ANSIChar (NAMemory *h,
+           Lng32 maxLength,
  	   NABoolean allowSQLnull	= TRUE,
 	   NABoolean isUpShifted	= FALSE,
 	   NABoolean varLenFlag		= FALSE,
@@ -604,7 +611,7 @@ NABoolean isExternalType() const 	{ return TRUE; }
 
 NAType * equivalentType(CollHeap* h=0) const
 {
-  return new(h) SQLVarChar(getNominalSize(), supportsSQLnull(),
+  return new(h) SQLVarChar(h, getNominalSize(), supportsSQLnull(),
 			     isUpshifted(), FALSE, getCharSet(), getCollation(),
                            getCoercibility());
 }
@@ -653,7 +660,8 @@ class SQLLongVarChar : public SQLVarChar
 
 public: 
 
- SQLLongVarChar(Lng32 maxLength, 
+ SQLLongVarChar(NAMemory *h,
+                Lng32 maxLength, 
 		NABoolean validLength	   = FALSE, 
 		NABoolean allowSQLnull	   = TRUE,
 		NABoolean isUpShifted	   = FALSE,
@@ -663,13 +671,14 @@ public:
 		CharInfo::Coercibility ce  = CharInfo::COERCIBLE,
 		CharInfo::CharSet encoding = CharInfo::UnknownCharSet
 	       )
-  : SQLVarChar(maxLength, allowSQLnull, isUpShifted, isCaseInsensitive,
+  : SQLVarChar(h, maxLength, allowSQLnull, isUpShifted, isCaseInsensitive,
 	       cs, co, ce)
   {
     setClientDataType("LONG VARCHAR");
     lengthNotSet_ = !validLength;
   }
- SQLLongVarChar(const CharLenInfo & maxLenInfo,
+ SQLLongVarChar(NAMemory *h,
+                const CharLenInfo & maxLenInfo,
 		NABoolean validLength	   = FALSE, 
 		NABoolean allowSQLnull	   = TRUE,
 		NABoolean isUpShifted	   = FALSE,
@@ -679,7 +688,7 @@ public:
 		CharInfo::Coercibility ce  = CharInfo::COERCIBLE,
 		CharInfo::CharSet encoding = CharInfo::UnknownCharSet
 	       )
-  : SQLVarChar(maxLenInfo, allowSQLnull, isUpShifted, isCaseInsensitive,
+  : SQLVarChar(h, maxLenInfo, allowSQLnull, isUpShifted, isCaseInsensitive,
 	       cs, co, ce)
   {
     setClientDataType("LONG VARCHAR");
@@ -724,7 +733,8 @@ class SQLlob : public NAType
 
 public: 
 
-  SQLlob(NABuiltInTypeEnum  ev,
+  SQLlob(NAMemory *h,
+         NABuiltInTypeEnum  ev,
 	 Int64 lobLength, 
 	 LobsStorage lobStorage,
 	 NABoolean allowSQLnull	= TRUE,
@@ -787,7 +797,8 @@ class SQLBlob : public SQLlob
 
 public: 
 
-  SQLBlob(Int64 blobLength, 
+  SQLBlob(NAMemory *h,
+          Int64 blobLength, 
 	  LobsStorage lobStorage = Lob_Invalid_Storage,
 	  NABoolean allowSQLnull	= TRUE,
 	  NABoolean inlineIfPossible = FALSE,
@@ -826,7 +837,8 @@ class SQLClob : public SQLlob
 
 public: 
 
-  SQLClob(Int64 blobLength, 
+  SQLClob(NAMemory *h,
+          Int64 blobLength, 
 	  LobsStorage lobStorage = Lob_Invalid_Storage,
 	  NABoolean allowSQLnull	= TRUE,
 	  NABoolean inlineIfPossible = FALSE,

--- a/core/sql/common/DTICommonType.h
+++ b/core/sql/common/DTICommonType.h
@@ -59,24 +59,22 @@ public:
     UNSUPPORTED_DDL_DATA_TYPE = 1
   };
 
-  DatetimeIntervalCommonType (const NAString & adtName, 
+  DatetimeIntervalCommonType (NAMemory *h, const NAString & adtName, 
                               NABuiltInTypeEnum typeEnum,
                               Lng32 storageSize,
                               NABoolean allowSQLnull,
                               rec_datetime_field startField,
                               rec_datetime_field endField,
                               UInt32 fractionPrecision,
-                              Lng32 dataAlignment = 1 /* no data alignment */,
-                              NAMemory * h=0)
-       : NAType (adtName,
+                              Lng32 dataAlignment = 1 /* no data alignment */)
+       : NAType (h, adtName,
                  typeEnum,
                  storageSize,
                  allowSQLnull,
                  SQL_NULL_HDR_SIZE,
                  FALSE, /* fixed length */
                  0, /* length header size */
-                 dataAlignment,
-                 h),
+                 dataAlignment),
          startField_(startField),
          endField_(endField),
          fractionPrecision_(fractionPrecision)

--- a/core/sql/common/DateTimeType.cpp
+++ b/core/sql/common/DateTimeType.cpp
@@ -83,13 +83,12 @@ static const UInt32 daysInMonth[]   =  { 0, 31, 29, 31, 30, 31, 30, 31, 31, 30, 
 //
 // ***********************************************************************
 
-DatetimeType::DatetimeType (const NAString & adtName,
+DatetimeType::DatetimeType (NAMemory *h, const NAString & adtName,
 			    NABoolean allowSQLnull,
 			    rec_datetime_field startField,
 			    rec_datetime_field endField,
-			    UInt32 fractionPrecision,
-			    NAMemory * h)
-     : DatetimeIntervalCommonType (adtName,
+			    UInt32 fractionPrecision)
+     : DatetimeIntervalCommonType (h, adtName,
 				   NA_DATETIME_TYPE,
 				   getStorageSize(startField,
 						  endField,
@@ -98,8 +97,8 @@ DatetimeType::DatetimeType (const NAString & adtName,
 				   startField,
 				   endField,
 				   fractionPrecision,
-				   1, /* no data alignment */
-				   h)
+				   1 /* no data alignment */
+				   )
        , displayFormat_(h)
 {
   assert(validate(startField, endField, fractionPrecision) != SUBTYPE_ILLEGAL);
@@ -434,15 +433,13 @@ DatetimeType* DatetimeType::constructSubtype(NABoolean allowSQLnull,
 					     NAMemory* h)
 {
   switch (validate(startField, endField, precision)) {
-    case SUBTYPE_SQLDate:       return new (h) SQLDate(allowSQLnull,h);
-    case SUBTYPE_SQLTime:       return new (h) SQLTime(allowSQLnull, precision,h);
-    case SUBTYPE_SQLTimestamp:  return new (h) SQLTimestamp(allowSQLnull, precision, h);
-
-    case SUBTYPE_SQLMPDatetime: return new (h) SQLMPDatetime( startField,
+    case SUBTYPE_SQLDate:       return new (h) SQLDate(h, allowSQLnull);
+    case SUBTYPE_SQLTime:       return new (h) SQLTime(h, allowSQLnull, precision);
+    case SUBTYPE_SQLTimestamp:  return new (h) SQLTimestamp(h, allowSQLnull, precision);
+    case SUBTYPE_SQLMPDatetime: return new (h) SQLMPDatetime(h, startField,
 							      endField,
 							      allowSQLnull,
-							      precision,
-							      h);
+							      precision);
 
     default:		       return NULL;
   }
@@ -607,13 +604,13 @@ const NAType* DatetimeType::synthesizeType(enum NATypeSynthRuleEnum synthRule,
           {
             // this is DATE subtraction in modespecial4.
             // Result is numeric.
-            return new(h) SQLInt(); 
+            return new(h) SQLInt(h); 
           }
         else
           {
-            return new(h) SQLInterval(allowNulls, datetime1->getEndField(),
+            return new(h) SQLInterval(h, allowNulls, datetime1->getEndField(),
                                       12, datetime1->getEndField(),
-                                      fractionPrecision,h);
+                                      fractionPrecision);
           }
       }
     break;
@@ -673,7 +670,7 @@ const NAType* DatetimeType::synthesizeTernary(enum NATypeSynthRuleEnum synthRule
     const DatetimeType& op1 = (DatetimeType&) operand1;
     const DatetimeType& op2 = (DatetimeType&) operand2;
     const IntervalType& op3 = (IntervalType&) operand3;
-    return new(h) SQLInterval(op1.supportsSQLnull() || op2.supportsSQLnull(),
+    return new(h) SQLInterval(h, op1.supportsSQLnull() || op2.supportsSQLnull(),
 			      op3.getStartField(),
 			      op3.getLeadingPrecision(),
 			      op3.getEndField(),
@@ -743,7 +740,6 @@ void DatetimeType::getRepresentableValue(const char* inValueString,
       **stringLiteral += "\'";
       **stringLiteral += valueString;
       **stringLiteral += "\'";
-
 //LCOV_EXCL_START : cnu -- SQ does not support old SQLMP stuff
       if (getSubtype() == SUBTYPE_SQLMPDatetime)
        {
@@ -1303,7 +1299,6 @@ double SQLTimestamp::getMaxValue()  const
 }
 
 
-
 //LCOV_EXCL_START : cnu -- SQ does not support old SQLMP stuff
 double SQLMPDatetime::encode(void *bufPtr) const
 {
@@ -1342,6 +1337,7 @@ NABoolean SQLMPDatetime::isSupportedType(void) const
     return TRUE;
  }
 
+
 // ***********************************************************************
 //
 //  SQLMPDatetime::synthesizeType
@@ -1350,19 +1346,19 @@ NABoolean SQLMPDatetime::isSupportedType(void) const
 
 //LCOV_EXCL_START : cnu -- SQ does not support old SQLMP stuff
 const NAType*SQLMPDatetime::synthesizeType(enum NATypeSynthRuleEnum synthRule,
-					   const NAType& operand1,
-					   const NAType& operand2,
-					   NAMemory* h,
-					   UInt32 *flags) const
+                                          const NAType& operand1,
+                                          const NAType& operand2,
+                                          NAMemory* h,
+                                          UInt32 *flags) const
 {
   if (!operand1.isSupportedType() || !operand2.isSupportedType())
     return NULL;
   else
     return DatetimeType::synthesizeType(synthRule,
-					operand1,
-					operand2,
-					h,
-					flags);
+                                       operand1,
+                                       operand2,
+                                       h,
+                                       flags);
 }
 //LCOV_EXCL_STOP : cnu
 
@@ -1380,6 +1376,7 @@ NABoolean SQLMPDatetime::isCompatible(const NAType& other, UInt32 * flags) const
   else
     return DatetimeType::isCompatible(other, flags);
  }
+
 
 // ***********************************************************************
 //

--- a/core/sql/common/DatetimeType.h
+++ b/core/sql/common/DatetimeType.h
@@ -147,12 +147,11 @@ public:
   // ---------------------------------------------------------------------
   // Constructors
   // ---------------------------------------------------------------------
-  DatetimeType (const NAString & adtName,
+  DatetimeType (NAMemory *h, const NAString & adtName,
                 NABoolean allowSQLnull,
                 rec_datetime_field startField,
                 rec_datetime_field endField,
-                UInt32 fractionPrecision = 0,
-                NAMemory * h=0);
+                UInt32 fractionPrecision = 0);
 
   // copy ctor
   DatetimeType (const DatetimeType & rhs, NAMemory * h=0) :
@@ -296,13 +295,12 @@ public:
   // ---------------------------------------------------------------------
   // Constructor functions 
   // ---------------------------------------------------------------------
-  SQLDate(NABoolean allowSQLnull = TRUE, NAMemory *h=0)
-       : DatetimeType (LiteralDate,
+  SQLDate(NAMemory *h, NABoolean allowSQLnull = TRUE)
+       : DatetimeType (h, LiteralDate,
                        allowSQLnull,
                        REC_DATE_YEAR,
                        REC_DATE_DAY,
-                       0,
-                       h) 
+                       0)
   {}
 
   // copy ctor
@@ -352,15 +350,13 @@ public:
   // ---------------------------------------------------------------------
   // Constructor functions
   // ---------------------------------------------------------------------
-  SQLTime(NABoolean allowSQLnull = TRUE, 
-	  UInt32 fractionPrecision = DEFAULT_FRACTION_PRECISION,
-          NAMemory *h=0)
-       : DatetimeType (LiteralTime,
+  SQLTime(NAMemory *h, NABoolean allowSQLnull = TRUE, 
+	  UInt32 fractionPrecision = DEFAULT_FRACTION_PRECISION)
+       : DatetimeType (h, LiteralTime,
                        allowSQLnull,
                        REC_DATE_HOUR,
                        REC_DATE_SECOND,
-                       fractionPrecision,
-                       h)
+                       fractionPrecision)
   {}
 
   // copy ctor
@@ -420,15 +416,13 @@ public:
   // Constructor functions
   // ---------------------------------------------------------------------
 
-  SQLTimestamp(NABoolean allowSQLnull = TRUE, 
-               UInt32 fractionPrecision = DEFAULT_FRACTION_PRECISION,
-               NAMemory * h=0)
-       : DatetimeType (LiteralTimestamp,
+  SQLTimestamp(NAMemory *h, NABoolean allowSQLnull = TRUE, 
+               UInt32 fractionPrecision = DEFAULT_FRACTION_PRECISION)
+       : DatetimeType (h, LiteralTimestamp,
                        allowSQLnull,
                        REC_DATE_YEAR,
                        REC_DATE_SECOND,
-                       fractionPrecision,
-                       h)
+                       fractionPrecision)
   {}
 
   // copy ctor
@@ -472,7 +466,7 @@ protected:
 private:
   
 }; // class SQLTimestamp
-#pragma warn(1506)  // warning elimination 
+#pragma warn(1506)   // warning elimination
 
 // ***********************************************************************
 //
@@ -484,19 +478,17 @@ class SQLMPDatetime : public DatetimeType
 {
 public:
 
-    SQLMPDatetime(rec_datetime_field startField,
+    SQLMPDatetime(NAMemory *h, rec_datetime_field startField,
                   rec_datetime_field endField,
                   NABoolean allowSQLnull = TRUE, 
-                  UInt32 fractionPrecision = DEFAULT_FRACTION_PRECISION,
-                  NAMemory * h=0)
-  : DatetimeType (LiteralDateTime,
+                  UInt32 fractionPrecision = DEFAULT_FRACTION_PRECISION)
+  : DatetimeType (h, LiteralDateTime,
                   allowSQLnull,
                   startField,
                   endField,
                   ((endField >= REC_DATE_SECOND) ?
                      fractionPrecision : 
-                                                  0),
-                  h)
+                                                  0))
   {}
 
         SQLMPDatetime (const SQLMPDatetime & rhs, NAMemory * h=0)
@@ -507,23 +499,24 @@ public:
         { return new (h) SQLMPDatetime(*this, h); }
 
         virtual double encode (void* bufPtr) const;
-   
-        virtual Lng32 getPrecision() const { return SQLDTCODE_MPDATETIME; } 
  
+        virtual Lng32 getPrecision() const { return SQLDTCODE_MPDATETIME; } 
+
         virtual Lng32 getScale() const { return getFractionPrecision(); }
 
         virtual NABoolean isCompatible(const NAType& other, UInt32 * flags = NULL) const;
   
         virtual const NAType* synthesizeType(enum NATypeSynthRuleEnum synthRule,     // in common\DateTime.cpp
-					     const NAType& operand1,
-					     const NAType& operand2,
-					     NAMemory* h,
-					     UInt32 *flags = NULL
-					     ) const;
+                                            const NAType& operand1,
+                                            const NAType& operand2,
+                                            NAMemory* h,
+                                            UInt32 *flags = NULL
+                                            ) const;
         virtual NABoolean isSupportedType() const;
 
 private:                                          
 };
+ 
 #pragma warn(1506)  // warning elimination 
 // ***********************************************************************
 //

--- a/core/sql/common/IntervalType.cpp
+++ b/core/sql/common/IntervalType.cpp
@@ -425,7 +425,7 @@ const NAType* IntervalType::synthesizeType(enum NATypeSynthRuleEnum synthRule,
                                            fractionPrecision);
     if (totalPrecision > SQLInterval::MAX_LEADING_PRECISION)
       leadingPrecision -= totalPrecision - SQLInterval::MAX_LEADING_PRECISION;
-    return new(h) SQLInterval(
+    return new(h) SQLInterval(h,
 		 op1.supportsSQLnull() || op2.supportsSQLnull(),
 		 startField,
 		 leadingPrecision,
@@ -445,7 +445,7 @@ const NAType* IntervalType::synthesizeType(enum NATypeSynthRuleEnum synthRule,
 
     if ((op1.getLeadingPrecision() < leadingPrecision) ||
        (op2.supportsSQLnull() && !op1.supportsSQLnull()))
-      return new(h) SQLInterval (op1.supportsSQLnull() || op2.supportsSQLnull(),
+      return new(h) SQLInterval (h, op1.supportsSQLnull() || op2.supportsSQLnull(),
                                  op1.getStartField(),
                                  leadingPrecision,
                                  op1.getEndField(),
@@ -481,7 +481,7 @@ const NAType* IntervalType::synthesizeType(enum NATypeSynthRuleEnum synthRule,
                                            intervalOp->getFractionPrecision());
     if (totalPrecision > SQLInterval::MAX_LEADING_PRECISION)
       leadingPrecision -= totalPrecision - SQLInterval::MAX_LEADING_PRECISION;
-    return new(h) SQLInterval(
+    return new(h) SQLInterval(h,
 		 intervalOp->supportsSQLnull() || numericOp->supportsSQLnull(),
 		 intervalOp->getStartField(),
 		 leadingPrecision,
@@ -757,7 +757,7 @@ IntervalValue::IntervalValue
 						  endField,
 						  fractionPrecision);
   if (storageSize == 0) {
-    SQLInterval triggerErrmsg(FALSE,
+    SQLInterval triggerErrmsg(NULL, FALSE,
 			      startField, leadingPrecision,
 			      endField,   fractionPrecision);
     return;

--- a/core/sql/common/IntervalType.h
+++ b/core/sql/common/IntervalType.h
@@ -102,15 +102,14 @@ public:
   // Constructor functions
   // ---------------------------------------------------------------------
   IntervalType
-  ( NABoolean allowSQLnull
+  ( NAMemory *heap, NABoolean allowSQLnull
   , rec_datetime_field startField
   , UInt32 leadingPrec
   , rec_datetime_field endField
   , UInt32 fractionPrec = 0
-  , NAMemory * heap =0
   )
   : DatetimeIntervalCommonType
-  ( LiteralInterval //"INTERVAL"
+  ( heap, LiteralInterval //"INTERVAL"
   , NA_INTERVAL_TYPE
   , getStorageSize(startField, leadingPrec, endField, fractionPrec)
   , allowSQLnull
@@ -118,7 +117,7 @@ public:
   , endField
   , fractionPrec
   , getStorageSize(startField, leadingPrec, endField, fractionPrec)
-  , heap)
+  )
   , leadingPrecision_(leadingPrec)
   {                                         // this could be a valid interval if we change endField to SECOND
     if (endField == REC_DATE_FRACTION_MP && startField != REC_DATE_FRACTION_MP)
@@ -337,15 +336,14 @@ public:
   // Constructor functions
   // ---------------------------------------------------------------------
   SQLInterval
-  ( NABoolean allowSQLnull
+  ( NAMemory *h, NABoolean allowSQLnull
   , rec_datetime_field startField
   , UInt32 leadingPrec
   , rec_datetime_field endField
   , UInt32 fractionPrec = DEFAULT_FRACTION_PRECISION
-  , NAMemory *h=0
   )
-  : IntervalType(allowSQLnull, startField, leadingPrec, endField,
-                 endField >= REC_DATE_SECOND ? fractionPrec : 0, h)
+  : IntervalType(h, allowSQLnull, startField, leadingPrec, endField,
+                 endField >= REC_DATE_SECOND ? fractionPrec : 0)
   {}
 
 // copy ctor
@@ -391,21 +389,19 @@ public:
 
   // Constructors
   IntervalQualifier
-  ( rec_datetime_field startField
+  ( NAMemory *h, rec_datetime_field startField
   , UInt32 leadingPrec = DEFAULT_LEADING_PRECISION
-  , NAMemory *h = 0
   )
-  : SQLInterval(FALSE, startField, leadingPrec, startField, DEFAULT_FRACTION_PRECISION,h)
+  : SQLInterval(h, FALSE, startField, leadingPrec, startField, DEFAULT_FRACTION_PRECISION)
   {}
 
   IntervalQualifier
-  ( rec_datetime_field startField
+  ( NAMemory *h, rec_datetime_field startField
   , UInt32 leadingPrec
   , rec_datetime_field endField
   , UInt32 fractionPrec
-  , NAMemory *h=0
   )
-  : SQLInterval(FALSE, startField, leadingPrec, endField, fractionPrec,h)
+  : SQLInterval(h, FALSE, startField, leadingPrec, endField, fractionPrec)
   {}
 
 private:

--- a/core/sql/common/MiscType.h
+++ b/core/sql/common/MiscType.h
@@ -68,9 +68,8 @@ public:
   // ---------------------------------------------------------------------
   // Constructor functions
   // ---------------------------------------------------------------------
-  SQLBooleanBase(NABoolean allowSQLnull,
-             NABoolean isRelat,
-             NAMemory * heap=0);
+  SQLBooleanBase(NAMemory *heap, NABoolean allowSQLnull,
+             NABoolean isRelat);
 
   // ---------------------------------------------------------------------
   // A method which tells if a conversion error can occur when converting
@@ -93,8 +92,7 @@ public:
   // ---------------------------------------------------------------------
   // Constructor functions
   // ---------------------------------------------------------------------
-  SQLBooleanRelat(NABoolean sqlUnknownFlag = TRUE,
-                  NAMemory * heap=0);
+  SQLBooleanRelat(NAMemory *heap, NABoolean sqlUnknownFlag = TRUE);
   
   // ---------------------------------------------------------------------
   // A virtual function to return a copy of the type.
@@ -138,8 +136,7 @@ public:
   // ---------------------------------------------------------------------
   // Constructor functions
   // ---------------------------------------------------------------------
-  SQLBooleanNative(NABoolean allowSQLnull,
-                  NAMemory * heap=0);
+  SQLBooleanNative(NAMemory *heap, NABoolean allowSQLnull);
   
   // ---------------------------------------------------------------------
   // A virtual function to return a copy of the type.
@@ -192,8 +189,8 @@ public:
   // ---------------------------------------------------------------------
   // Constructor functions
   // ---------------------------------------------------------------------
-  SQLRowset(NAType *elementType, Lng32 maxNumElements, 
-            Lng32 numElements,NAMemory * heap=0);
+  SQLRowset(NAMemory *heap, NAType *elementType, Lng32 maxNumElements, 
+            Lng32 numElements);
   
   // ---------------------------------------------------------------------
   // Are the two types compatible?
@@ -281,9 +278,8 @@ public:
   // ---------------------------------------------------------------------
   // Constructor functions
   // ---------------------------------------------------------------------
-  SQLRecord(const NAType * elementType,
-            const SQLRecord * restOfRecord,
-			NAMemory * heap=0);
+  SQLRecord(NAMemory *heap, const NAType * elementType,
+            const SQLRecord * restOfRecord);
 
   // ---------------------------------------------------------------------
   // A virtual function to return a copy of the type.
@@ -350,8 +346,8 @@ public:
   // ---------------------------------------------------------------------
   // Constructor functions
   // ---------------------------------------------------------------------
-  SQLUnknown(NABoolean supportsSQLnull = FALSE,CollHeap * heap=0)
-  : NAType(LiteralUnknown, NA_UNKNOWN_TYPE, 2, supportsSQLnull, SQL_NULL_HDR_SIZE,FALSE,0,1,heap) {}
+  SQLUnknown(NAMemory *heap, NABoolean supportsSQLnull = FALSE)
+  : NAType(heap, LiteralUnknown, NA_UNKNOWN_TYPE, 2, supportsSQLnull, SQL_NULL_HDR_SIZE,FALSE,0,1) {}
   // copy ctor
   SQLUnknown(const SQLUnknown &unknown,NAMemory * heap=0)
 	  :NAType(unknown,heap)

--- a/core/sql/common/NAString.cpp
+++ b/core/sql/common/NAString.cpp
@@ -265,14 +265,6 @@ NAString LongToNAString(Lng32 l)
   return NAString(resultstr);
 }
 
-NAString LongToNAString(Lng32 l, NAHeap *heap)
-{
-  char resultstr[100];
-  sprintf(resultstr,"%d",l);
-  return NAString(resultstr, heap);
-}
-
-
 NAString UnsignedToNAString(UInt32 u)
 {
   char resultstr[100];

--- a/core/sql/common/NAString.cpp
+++ b/core/sql/common/NAString.cpp
@@ -265,6 +265,13 @@ NAString LongToNAString(Lng32 l)
   return NAString(resultstr);
 }
 
+NAString LongToNAString(Lng32 l, NAHeap *heap)
+{
+  char resultstr[100];
+  sprintf(resultstr,"%d",l);
+  return NAString(resultstr, heap);
+}
+
 
 NAString UnsignedToNAString(UInt32 u)
 {

--- a/core/sql/common/NAString.h
+++ b/core/sql/common/NAString.h
@@ -102,6 +102,7 @@ Lng32      NAStringToLong(const NAString &ns);
 double    NAStringToReal(const NAString &ns);
 UInt32  NAStringToUnsigned(const NAString &ns);
 NAString  LongToNAString(Lng32 l);
+NAString  LongToNAString(Lng32 l, NAHeap *heap);
 NAString  RealToNAString(double d);
 NAString  UnsignedToNAString(UInt32 u);
 NAString  Int64ToNAString(Int64 l);

--- a/core/sql/common/NAString.h
+++ b/core/sql/common/NAString.h
@@ -102,7 +102,6 @@ Lng32      NAStringToLong(const NAString &ns);
 double    NAStringToReal(const NAString &ns);
 UInt32  NAStringToUnsigned(const NAString &ns);
 NAString  LongToNAString(Lng32 l);
-NAString  LongToNAString(Lng32 l, NAHeap *heap);
 NAString  RealToNAString(double d);
 NAString  UnsignedToNAString(UInt32 u);
 NAString  Int64ToNAString(Int64 l);

--- a/core/sql/common/NAType.h
+++ b/core/sql/common/NAType.h
@@ -140,22 +140,21 @@ class NAType : public NABasicObject
 public:
 
   // copy ctor
-  NAType (const NAType & rhs, NAMemory * h=0) ;
+  NAType (const NAType & rhs, NAMemory * h) ;
 
   // ---------------------------------------------------------------------
   // Constructor function (storage size and alignment needs to be
   // specified for data field only, null indicator and variable len
   // field are handled automatically)
   // ---------------------------------------------------------------------
-  NAType (const NAString &   adtName,
+  NAType (NAMemory *h, const NAString &   adtName,
           NABuiltInTypeEnum  ev,
           Lng32               dataStorageSize,
           NABoolean          nullable = FALSE,
           Lng32               SQLnullHdrSize = 0,
           NABoolean          variableLength = FALSE,
           Lng32               lengthHeaderSize = 0,
-          Lng32               dataAlignment = 1,
-          NAMemory *         h=0
+          Lng32               dataAlignment = 1
         );
 
   // ---------------------------------------------------------------------

--- a/core/sql/common/NumericType.h
+++ b/core/sql/common/NumericType.h
@@ -247,22 +247,22 @@ public:
   // A virtual function to return a copy of the type.
   // ---------------------------------------------------------------------
   virtual NAType *newCopy(CollHeap* h=0) const 
-    { return new(h) NumericType(*this,h); }
+    { return new(h) NumericType(*this, h); }
 
 protected:
 
   // ---------------------------------------------------------------------
   // Constructor functions
   // ---------------------------------------------------------------------
-  NumericType ( const NAString&  adtName, 
+  NumericType ( NAMemory *heap,
+                       const NAString&  adtName, 
 	    	       Lng32             dataStorageSize,
 		       Lng32             precision,
 		       Lng32             scale,
 		       Lng32             alignment,
 		       NABoolean        allowNegValues = TRUE,
 		       NABoolean        allowSQLnull = TRUE,
- 		       NABoolean        varLenFlag = FALSE,
-			   CollHeap * heap = 0
+ 		       NABoolean        varLenFlag = FALSE
                      );
    NumericType ( const NumericType& numeric, CollHeap * heap =0);
 
@@ -363,10 +363,9 @@ class SQLBPInt : public NumericType
 {
 public: 
   // Constructor function
-   SQLBPInt (UInt32 declared, 
+   SQLBPInt (NAMemory *heap, UInt32 declared, 
                    NABoolean allowSQLnull = TRUE, 
-                   NABoolean allowNegValues = FALSE,
-				   CollHeap * heap=0
+                   NABoolean allowNegValues = FALSE
                   );
 
   short getFSDatatype () const
@@ -433,7 +432,7 @@ public:
   // ---------------------------------------------------------------------
   virtual NAType *newCopy(CollHeap* h=0) const
   {
-    return new(h) SQLBPInt(declaredSize_, supportsSQLnull(), !isUnsigned(),h);
+    return new(h) SQLBPInt(h, declaredSize_, supportsSQLnull(), !isUnsigned());
   }
 
 private:
@@ -452,10 +451,8 @@ public:
   // ---------------------------------------------------------------------
   // Constructor functions
   // ---------------------------------------------------------------------
-  SQLTiny (NABoolean allowNegValues = TRUE, 
-           NABoolean allowSQLnull = TRUE,
-           CollHeap * heap =0);
-  
+  SQLTiny (NAMemory *heap, NABoolean allowNegValues = TRUE, 
+           NABoolean allowSQLnull = TRUE);
    short getFSDatatype() const
     {
       if (isUnsigned())
@@ -517,8 +514,8 @@ public:
   // ---------------------------------------------------------------------
   virtual NAType *newCopy(CollHeap* h=0) const
   {
-    return new(h) SQLTiny(!isUnsigned()
-                          ,supportsSQLnull(),h
+    return new(h) SQLTiny(h, !isUnsigned()
+                          ,supportsSQLnull()
                           );
   }
 
@@ -545,9 +542,8 @@ public:
   // ---------------------------------------------------------------------
   // Constructor functions
   // ---------------------------------------------------------------------
-  SQLSmall (NABoolean allowNegValues = TRUE, 
-                   NABoolean allowSQLnull = TRUE,
-				   CollHeap * heap =0);
+  SQLSmall (NAMemory *heap, NABoolean allowNegValues = TRUE, 
+                   NABoolean allowSQLnull = TRUE);
 
    short getFSDatatype() const
     {
@@ -610,8 +606,8 @@ public:
   // ---------------------------------------------------------------------
   virtual NAType *newCopy(CollHeap* h=0) const
   {
-    return new(h) SQLSmall(!isUnsigned()
-			   ,supportsSQLnull(),h
+    return new(h) SQLSmall(h, !isUnsigned()
+			   ,supportsSQLnull()
 			   );
   }
 
@@ -638,9 +634,8 @@ public:
   // ---------------------------------------------------------------------
   // Constructor functions
   // ---------------------------------------------------------------------
-  SQLInt (NABoolean allowNegValues = TRUE, 
-		 NABoolean allowSQLnull = TRUE,
-		 CollHeap * heap =0 );
+  SQLInt (NAMemory *heap, NABoolean allowNegValues = TRUE, 
+		 NABoolean allowSQLnull = TRUE);
 
   short getFSDatatype() const
     {
@@ -703,8 +698,8 @@ public:
   // ---------------------------------------------------------------------
   virtual NAType *newCopy(CollHeap* h=0) const
   {
-    return new(h) SQLInt(!isUnsigned()
-			 ,supportsSQLnull(),h
+    return new(h) SQLInt(h, !isUnsigned()
+			 ,supportsSQLnull()
 			 );
   }
 
@@ -733,15 +728,13 @@ public:
   // ---------------------------------------------------------------------
   // Constructor functions
   // ---------------------------------------------------------------------
-  SQLLargeInt (NABoolean allowNegValues = TRUE, 
-	       NABoolean allowSQLnull = TRUE,
-	       CollHeap * heap =0);
+  SQLLargeInt (NAMemory *heap, NABoolean allowNegValues = TRUE, 
+	       NABoolean allowSQLnull = TRUE);
 
-  SQLLargeInt (Lng32 scale,
+  SQLLargeInt (NAMemory *heap, Lng32 scale,
                UInt16 disAmbiguate,  // 64bit
 	       NABoolean allowNegValues = TRUE, 
-	       NABoolean allowSQLnull = TRUE,
-	       CollHeap * heap =0);
+	       NABoolean allowSQLnull = TRUE);
 
   short getFSDatatype() const
     {
@@ -810,11 +803,10 @@ public:
   // ---------------------------------------------------------------------
   virtual NAType *newCopy(CollHeap* h=0) const
   {
-    return new(h) SQLLargeInt(getScale(),
+    return new(h) SQLLargeInt(h, getScale(),
                               (UInt16) 0,
 			      !isUnsigned()
 			      ,supportsSQLnull()
-				  ,h
 			      );
   }
 
@@ -861,18 +853,16 @@ class SQLBigInt : public SQLLargeInt
     
 public: 
       
-  SQLBigInt (NABoolean allowNegValues = TRUE, 
-		      NABoolean allowSQLnull = TRUE,
-			  CollHeap * heap =0);
+  SQLBigInt (NAMemory *heap, NABoolean allowNegValues = TRUE, 
+		      NABoolean allowSQLnull = TRUE);
 
   // ---------------------------------------------------------------------
   // A virtual function to return a copy of the type.
   // ---------------------------------------------------------------------
   virtual NAType *newCopy(CollHeap* h=0) const
   {
-    return new(h) SQLBigInt(!isUnsigned()
+    return new(h) SQLBigInt(h, !isUnsigned()
 			    ,supportsSQLnull()
-				,h
 			    );
   }
 
@@ -894,14 +884,13 @@ public:
   // ---------------------------------------------------------------------
   // Constructor functions
   // ---------------------------------------------------------------------
-  SQLNumeric (Lng32 length, Lng32 precision, Lng32 scale,
+  SQLNumeric (NAMemory *heap, Lng32 length, Lng32 precision, Lng32 scale,
 		     NABoolean allowNegValues = TRUE, 
-		     NABoolean allowSQLnull = TRUE,
-			 CollHeap * heap =0);
+		     NABoolean allowSQLnull = TRUE);
 
    // Note: DisAmbiguate arg added so Compiler can distinguish between
    //       this constructor and the one above....for 64bit project.
-   SQLNumeric (NABoolean allowNegValues,
+   SQLNumeric (NAMemory *heap, NABoolean allowNegValues,
                      Lng32 precision,
                      Lng32 scale,
                      const Int16 DisAmbiguate,
@@ -975,12 +964,11 @@ public:
   // ---------------------------------------------------------------------
   virtual NAType *newCopy(CollHeap* h=0) const
   {
-    return new(h) SQLNumeric(getNominalSize()
+    return new(h) SQLNumeric(h, getNominalSize()
 			     ,getPrecision()
 			     ,getScale()
 			     ,!isUnsigned()
 			     ,supportsSQLnull()
-				 ,h
 			     );
   }
 
@@ -1004,10 +992,9 @@ public:
   // ---------------------------------------------------------------------
   // Constructor functions
   // ---------------------------------------------------------------------
-  SQLDecimal (Lng32 length, Lng32 scale,
+  SQLDecimal (NAMemory *heap, Lng32 length, Lng32 scale,
 		     NABoolean allowNegValues = TRUE, 
-		     NABoolean allowSQLnull = TRUE,
-			 CollHeap * heap =0);
+		     NABoolean allowSQLnull = TRUE);
 
    short getFSDatatype() const
     {
@@ -1051,11 +1038,10 @@ public:
   // ---------------------------------------------------------------------
   virtual NAType *newCopy(CollHeap* h=0) const
   {
-    return new(h) SQLDecimal(getNominalSize()
+    return new(h) SQLDecimal(h, getNominalSize()
 			     ,getScale()
 			     ,!isUnsigned()
 			     ,supportsSQLnull()
-				 ,h
 			     );
   }
 
@@ -1079,11 +1065,10 @@ public:
   // ---------------------------------------------------------------------
   // Constructor functions
   // ---------------------------------------------------------------------
-   SQLBigNum ( Lng32 precision, Lng32 scale,
+   SQLBigNum ( NAMemory *heap, Lng32 precision, Lng32 scale,
 	       NABoolean isARealBigNum, // = TRUE,
 	       NABoolean allowNegValues, // = TRUE, 
-	       NABoolean allowSQLnull, // = TRUE,
-	       CollHeap * heap);
+	       NABoolean allowSQLnull ); // = TRUE);
 
    short getFSDatatype() const
     {
@@ -1159,12 +1144,11 @@ public:
   // ---------------------------------------------------------------------
   virtual NAType *newCopy(CollHeap* h=0) const
   {
-    return new(h) SQLBigNum(getPrecision()
+    return new(h) SQLBigNum(h, getPrecision()
 			    ,getScale()
 			    ,isARealBigNum()
 			    ,!isUnsigned()
 			    ,supportsSQLnull()
-			    , h
 			    );
   }
 
@@ -1194,10 +1178,9 @@ public:
   // ---------------------------------------------------------------------
   // Constructor functions
   // ---------------------------------------------------------------------
-   LSDecimal (Lng32 length,
+   LSDecimal (NAMemory *heap, Lng32 length,
 		    Lng32 scale, 
-		    NABoolean allowSQLnull = TRUE,
-			CollHeap * heap =0);
+		    NABoolean allowSQLnull = TRUE);
 
    short getFSDatatype() const
     {
@@ -1211,7 +1194,7 @@ public:
 
    NAType * equivalentType(CollHeap* h=0) const
     {
-      return new(h) SQLDecimal(getNominalSize() - 1, getScale(),
+      return new(h) SQLDecimal(h, getNominalSize() - 1, getScale(),
 			       TRUE, supportsSQLnull());
     }
 
@@ -1244,10 +1227,9 @@ public:
   // ---------------------------------------------------------------------
   virtual NAType *newCopy(CollHeap* h=0) const
   {
-    return new(h) LSDecimal(getNominalSize()
+    return new(h) LSDecimal(h, getNominalSize()
 			    ,getScale()
 			    ,supportsSQLnull()
-				,h
 			    );
   }
 
@@ -1268,14 +1250,13 @@ public:
   // Constructor functions
   // ---------------------------------------------------------------------
   SQLFloat
-  ( NABoolean allowSQLnull
+  ( NAMemory *heap, NABoolean allowSQLnull
   , Lng32 dataStorageSize
   , Lng32 precision = SQL_FLOAT_PRECISION
   , const NAString& adtName = LiteralFloat
-  , CollHeap * heap =0
   )
   : NumericType
-  ( adtName
+  ( heap, adtName
   , dataStorageSize
   , precision
   , 0
@@ -1283,7 +1264,6 @@ public:
   , TRUE
   , allowSQLnull
   ,FALSE
-  ,heap
   )
   { 
     // Should not assert precision <= SQL_FLOAT_PRECISION. 
@@ -1356,12 +1336,11 @@ public:
   // ---------------------------------------------------------------------
   virtual NAType *newCopy(CollHeap* h=0) const
   {
-    return new(h) SQLFloat(
+    return new(h) SQLFloat(h,
 			   supportsSQLnull(), 
 			   getNominalSize(),
 			   getPrecision(), 
-			   getSimpleTypeName(),
-			   h);
+			   getSimpleTypeName());
   }
 
   virtual double getMaxValue() const { return 1.7976931348623157e+308; }
@@ -1385,9 +1364,9 @@ public:
   // ---------------------------------------------------------------------
   // Constructor functions
   // ---------------------------------------------------------------------
-   SQLReal (NABoolean allowSQLnull = TRUE,CollHeap * heap = 0,
+   SQLReal (NAMemory *heap, NABoolean allowSQLnull = TRUE,
 		  Lng32 precision = 0)
-  : SQLFloat(allowSQLnull, SQL_REAL_SIZE, 0, LiteralReal,heap)
+  : SQLFloat(heap, allowSQLnull, SQL_REAL_SIZE, 0, LiteralReal)
   {}
  
   // The above constructor can mislead callers of getPrecision() into
@@ -1401,7 +1380,7 @@ public:
   // A virtual function to return a copy of the type.
   // ---------------------------------------------------------------------
   virtual NAType *newCopy(CollHeap* h=0) const 
-    { return new(h) SQLReal(supportsSQLnull(),h); }
+    { return new(h) SQLReal(h, supportsSQLnull()); }
 
   virtual double getMaxValue() const { return 3.40282347e+38; }
 
@@ -1422,12 +1401,11 @@ public:
   // ---------------------------------------------------------------------
   // Constructor functions
   // ---------------------------------------------------------------------
-   SQLDoublePrecision (NABoolean allowSQLnull = TRUE,
-                       CollHeap * heap =0,
+   SQLDoublePrecision (NAMemory *heap, NABoolean allowSQLnull = TRUE,
                        Lng32 precision = SQL_DOUBLE_PRECISION,
                        NABoolean fromFloat = FALSE)
-  : SQLFloat(allowSQLnull, SQL_DOUBLE_PRECISION_SIZE, 
-	     precision, LiteralDoublePrecision,heap),
+  : SQLFloat(heap, allowSQLnull, SQL_DOUBLE_PRECISION_SIZE, 
+	     precision, LiteralDoublePrecision),
     fromFloat_(fromFloat),
     origPrecision_(precision)
   {}
@@ -1445,7 +1423,7 @@ public:
   // ---------------------------------------------------------------------
   virtual NAType *newCopy(CollHeap* h=0) const
   {
-    return new(h) SQLDoublePrecision(supportsSQLnull(),h,getPrecision(), fromFloat());
+    return new(h) SQLDoublePrecision(h, supportsSQLnull(),getPrecision(), fromFloat());
   }
 
   // ---------------------------------------------------------------------

--- a/core/sql/export/FBString.h
+++ b/core/sql/export/FBString.h
@@ -984,7 +984,7 @@ public :
   enum Category {
     isSmall = 0,
     //isMedium = sizeof(size_t) == 4 ? 0x80000000 : 0x8000000000000000,
-    isLarge =  sizeof(size_t) == 4 ? 0x40000000 : 0x4000000000000000,
+    isLarge =  sizeof(size_t) == 4 ? 0x80000000 : 0x8000000000000000,
   };
   /* Which categorys string belongs to not always decided by its capacity or size.
    * It is decided when it's constructed and won't change until: 

--- a/core/sql/export/NAStringDef.h
+++ b/core/sql/export/NAStringDef.h
@@ -471,6 +471,8 @@ public:
   
   // useful for supplying hash functions to template hash collection ctors:
   static UInt32       hash(const NAString&);
+
+  NAMemory * heap() const { return fbstring_.heap(); }
 protected:
 
   // Special concatenation constructor:
@@ -492,8 +494,6 @@ private:
 
   void          clone(size_t nc); // Make self a distinct copy w. capacity nc
 
-  NAMemory * heap() const { return fbstring_.heap(); }
-  
   FBString fbstring_;
 friend
 SQLEXPORT_LIB_FUNC 

--- a/core/sql/generator/GenExpGenerator.cpp
+++ b/core/sql/generator/GenExpGenerator.cpp
@@ -862,7 +862,7 @@ short ExpGenerator::handleUnsupportedCast(Cast * castNode)
         {
           const IntervalType &srcInt = (IntervalType&)srcNAType; 
           newType = new (generator->wHeap())
-            SQLNumeric(sizeof(short), srcInt.getTotalPrecision(), 
+            SQLNumeric(generator->wHeap(), sizeof(short), srcInt.getTotalPrecision(), 
                        srcInt.getFractionPrecision(),
                        TRUE, srcNAType.supportsSQLnull());
         }
@@ -870,7 +870,7 @@ short ExpGenerator::handleUnsupportedCast(Cast * castNode)
         {
           const NumericType &srcNum = (NumericType&)srcNAType; 
            newType = new (generator->wHeap())
-             SQLNumeric(sizeof(short), srcNum.getPrecision(), 
+             SQLNumeric(generator->wHeap(), sizeof(short), srcNum.getPrecision(), 
                         srcNum.getScale(),
                         NOT srcNum.isUnsigned(), srcNAType.supportsSQLnull());
         }
@@ -881,11 +881,11 @@ short ExpGenerator::handleUnsupportedCast(Cast * castNode)
           if ((srcNum.getScale() == 0) &&
               (srcNum.binaryPrecision()))
             newType = new (generator->wHeap())
-              SQLSmall(NOT srcNum.isUnsigned(),
+              SQLSmall(generator->wHeap(), NOT srcNum.isUnsigned(),
                        tgtNAType.supportsSQLnull());
           else
             newType = new (generator->wHeap())
-              SQLNumeric(sizeof(short), srcNum.getPrecision(), 
+              SQLNumeric(generator->wHeap(), sizeof(short), srcNum.getPrecision(), 
                          srcNum.getScale(),
                          NOT srcNum.isUnsigned(), 
                          tgtNAType.supportsSQLnull());
@@ -898,11 +898,11 @@ short ExpGenerator::handleUnsupportedCast(Cast * castNode)
           if ((tgtNum.getScale() == 0) &&
               (tgtNum.binaryPrecision()))
             newType = new (generator->wHeap())
-              SQLSmall(NOT tgtNum.isUnsigned(),
+              SQLSmall(generator->wHeap(), NOT tgtNum.isUnsigned(),
                        tgtNAType.supportsSQLnull());
           else
             newType = new (generator->wHeap())
-              SQLNumeric(sizeof(short), tgtNum.getPrecision(), 
+              SQLNumeric(generator->wHeap(), sizeof(short), tgtNum.getPrecision(), 
                          tgtNum.getScale(),
                          NOT tgtNum.isUnsigned(), 
                          tgtNAType.supportsSQLnull());
@@ -931,7 +931,7 @@ short ExpGenerator::handleUnsupportedCast(Cast * castNode)
         new (generator->wHeap())
         Cast(castNode->child(0),
              new (generator->wHeap())
-             SQLLargeInt(numSrc.getScale(), 1,
+             SQLLargeInt(generator->wHeap(), numSrc.getScale(), 1,
                          TRUE,
                          srcNAType.supportsSQLnull()));
       ((Cast*)newChild)->setFlags(castNode->getFlags());
@@ -1150,7 +1150,7 @@ ItemExpr * ExpGenerator::convertIntervalToNumeric(const ValueId & source)
   if (sourceInterval.getStartField() != sourceInterval.getEndField())
     retTree = new(wHeap())
       Cast(retTree, new(wHeap())
-	   SQLInterval(sourceInterval.supportsSQLnull(),
+	   SQLInterval(wHeap(), sourceInterval.supportsSQLnull(),
 		       sourceInterval.getEndField(),
 		       sourceInterval.getTotalPrecision() -
 		       sourceInterval.getFractionPrecision(),
@@ -1162,7 +1162,7 @@ ItemExpr * ExpGenerator::convertIntervalToNumeric(const ValueId & source)
 #pragma nowarn(1506)   // warning elimination
   const Int16 DisAmbiguate = 0;
   retTree = new(wHeap())
-    Cast(retTree, new(wHeap()) SQLNumeric(TRUE, /* signed */
+    Cast(retTree, new(wHeap()) SQLNumeric(wHeap(), TRUE, /* signed */
 				     sourceInterval.getTotalPrecision(),
 				     sourceInterval.getFractionPrecision(),
 				     DisAmbiguate, // added for 64bit proj.
@@ -1198,7 +1198,7 @@ ItemExpr * ExpGenerator::convertNumericToInterval(const ValueId & source,
   //
 
   SQLInterval *interval =
-    new(wHeap()) SQLInterval(targetInterval.supportsSQLnull(),
+    new(wHeap()) SQLInterval(wHeap(), targetInterval.supportsSQLnull(),
                     targetInterval.getEndField(),
                     targetInterval.getTotalPrecision() -
                       targetInterval.getFractionPrecision(),
@@ -2147,7 +2147,7 @@ short ExpGenerator::generateBulkMoveAligned(
     // 5/21/98: Since the tuple is to be moved as a byte array,
     // the current SQLChar constructor should be sufficient.
 
-    NAType * type = new(generator->wHeap()) SQLChar((Int32)tupleLength, FALSE);
+    NAType * type = new(generator->wHeap()) SQLChar(generator->wHeap(), (Int32)tupleLength, FALSE);
     ItemExpr * bulkMoveSrc = new(generator->wHeap()) NATypeToItem(type);
     //ItemExpr * bulkMoveTgt = new(generator->wHeap()) Convert (bulkMoveSrc);
     ItemExpr * bulkMoveTgt = new(generator->wHeap()) Convert (bulkMoveSrc,
@@ -2355,7 +2355,7 @@ short ExpGenerator::generateBulkMove(ValueIdList inValIdList,
 // 5/21/98: Since the tuple is to be moved as a byte array,
 // the current SQLChar constructor should be sufficient.
 
-      NAType * type = new(generator->wHeap()) SQLChar(tupleLength, FALSE);
+      NAType * type = new(generator->wHeap()) SQLChar(generator->wHeap(), tupleLength, FALSE);
       ItemExpr * bulkMoveSrc = new(generator->wHeap()) NATypeToItem(type);
       ItemExpr * bulkMoveTgt = new(generator->wHeap()) Convert (bulkMoveSrc);
       bulkMoveTgt->synthTypeAndValueId();
@@ -3076,7 +3076,7 @@ short ExpGenerator::generateKeyEncodeExpr(const IndexDesc * indexDesc,
 	      col_node = new(wHeap())
 		Cast (col_node,
 		      (new(wHeap())
-		       SQLChar(CharLenInfo(char_t.getStrCharLimit(), char_t.getDataStorageSize()),
+		       SQLChar(wHeap(), CharLenInfo(char_t.getStrCharLimit(), char_t.getDataStorageSize()),
 			       col_node->getValueId().getType().supportsSQLnull(),
 			       FALSE, FALSE, FALSE,
 			       char_t.getCharSet(),
@@ -3307,7 +3307,7 @@ ItemExpr * ExpGenerator::generateKeyCast(const ValueId vid,
                       (keycol->getValueId().getType().getVarLenHdrSize() > 0))
                     {
                       targetType = new(wHeap())
-                        ANSIChar(char_t.getDataStorageSize(),
+                        ANSIChar(wHeap(), char_t.getDataStorageSize(),
                                  keycol->getValueId().getType().supportsSQLnull(),
                                  FALSE,
                                  FALSE,
@@ -3319,7 +3319,7 @@ ItemExpr * ExpGenerator::generateKeyCast(const ValueId vid,
                   else
                     {
                       targetType = new(wHeap())
-                        SQLChar(CharLenInfo(char_t.getStrCharLimit(), char_t.getDataStorageSize()),
+                        SQLChar(wHeap(), CharLenInfo(char_t.getStrCharLimit(), char_t.getDataStorageSize()),
                                 keycol->getValueId().getType().supportsSQLnull(),
                                 FALSE,
                                 ((CharType*)targetType)->isCaseinsensitive(),

--- a/core/sql/generator/GenFastTransport.cpp
+++ b/core/sql/generator/GenFastTransport.cpp
@@ -131,12 +131,12 @@ int CreateAllCharsExpr(const NAType &formalType,
 
   if (formalType.getTypeQualifier() != NA_CHARACTER_TYPE )
   {
-    typ = new (h) SQLVarChar(maxLength);
+    typ = new (h) SQLVarChar(h, maxLength);
   }
   else
   {
     const CharType &cFormalType = (CharType&)formalType;
-    typ = new (h) SQLVarChar( maxLength,
+    typ = new (h) SQLVarChar( h, maxLength,
                               cFormalType.supportsSQLnull(),
                               cFormalType.isUpshifted(),
                               cFormalType.isCaseinsensitive(),

--- a/core/sql/generator/GenItemFunc.cpp
+++ b/core/sql/generator/GenItemFunc.cpp
@@ -2111,7 +2111,7 @@ short RangeLookup::codeGen(Generator * generator)
   copySplitKeys(constKeyArray, keysLen);
 
   constValSplitKeys = new (generator->wHeap()) ConstValue(
-       new (generator->wHeap()) SQLChar(keysLen,FALSE),
+       new (generator->wHeap()) SQLChar(generator->wHeap(), keysLen,FALSE),
        constKeyArray,
        keysLen,
        NULL,
@@ -2306,7 +2306,7 @@ short RandomNum::codeGen(Generator *generator)
       ItemExpr * newChild = 
 	new (generator->wHeap()) 
 	Cast(child(0), 
-	     new (generator->wHeap()) SQLInt(FALSE, FALSE));
+	     new (generator->wHeap()) SQLInt(generator->wHeap(), FALSE, FALSE));
       newChild = newChild->bindNode(generator->getBindWA());
       newChild->preCodeGen(generator);
 

--- a/core/sql/generator/GenKey.cpp
+++ b/core/sql/generator/GenKey.cpp
@@ -97,7 +97,7 @@ short ExpGenerator::buildKeyInfo(keyRangeGen ** keyInfo, // out -- generated obj
 
   ItemExpr * dataConversionErrorFlag = new(generator->wHeap())
     HostVar("_sys_dataConversionErrorFlag",
-            new(generator->wHeap()) SQLInt(TRUE,FALSE), // int not null
+            new(generator->wHeap()) SQLInt(generator->wHeap(), TRUE,FALSE), // int not null
             TRUE);
   ULng32 temp_varb_tupp_len;
 
@@ -275,7 +275,7 @@ short ExpGenerator::buildKeyInfo(keyRangeGen ** keyInfo, // out -- generated obj
                   enode = new(generator->wHeap()) 
                              Cast(enode, 
                                    (new (generator->wHeap())
-                                          SQLChar( CharLenInfo(char_type.getStrCharLimit(),
+                                          SQLChar(generator->wHeap(),  CharLenInfo(char_type.getStrCharLimit(),
                                                    char_type.getDataStorageSize()),
                                           char_type.supportsSQLnull(),
                                           FALSE, FALSE, FALSE,
@@ -357,7 +357,7 @@ short ExpGenerator::buildKeyInfo(keyRangeGen ** keyInfo, // out -- generated obj
               if (!CollationInfo::isSystemCollation(char_type->getCollation()))
                 {
                   targetType = new(generator->wHeap()) 
-                                      SQLChar( CharLenInfo(char_type->getStrCharLimit(),
+                                      SQLChar(generator->wHeap(), CharLenInfo(char_type->getStrCharLimit(),
                                                            char_type->getDataStorageSize()),
                                       char_type -> supportsSQLnull(),
                                       FALSE, FALSE, FALSE,

--- a/core/sql/generator/GenPreCode.cpp
+++ b/core/sql/generator/GenPreCode.cpp
@@ -7336,7 +7336,7 @@ ItemExpr * BuiltinFunction::preCodeGen(Generator * generator)
                 // the executor method assumes an ASCII string for the query id, so
                 // convert the value to a fixed char type in the ISO88591 char set
                 SQLChar * newTyp0 = new(generator->wHeap())
-                  SQLChar(typ0.getCharLimitInUCS2or4chars(),
+                  SQLChar(generator->wHeap(), typ0.getCharLimitInUCS2or4chars(),
                           typ0.supportsSQLnullLogical(),
                           typ0.isUpshifted(),
                           typ0.isCaseinsensitive(),
@@ -7359,7 +7359,7 @@ ItemExpr * BuiltinFunction::preCodeGen(Generator * generator)
                 // the executor method assumes an ASCII string for the query id, so
                 // convert the value to a fixed char type in the ISO88591 char set
                 SQLChar * newTyp1 = new(generator->wHeap())
-                  SQLChar(typ1.getCharLimitInUCS2or4chars(),
+                  SQLChar(generator->wHeap(), typ1.getCharLimitInUCS2or4chars(),
                           typ1.supportsSQLnullLogical(),
                           typ1.isUpshifted(),
                           typ1.isCaseinsensitive(),
@@ -7919,7 +7919,7 @@ ItemExpr * BiArith::preCodeGen(Generator * generator)
         IntervalType *interval = (IntervalType *) result_type;
         const Int16 DisAmbiguate = 0;
         child(1) = new(generator->wHeap()) Cast(child(1),
-                            new(generator->wHeap()) SQLNumeric(TRUE, /* signed */
+                            new(generator->wHeap()) SQLNumeric(generator->wHeap(), TRUE, /* signed */
 #pragma nowarn(1506)   // warning elimination
                                            interval->getTotalPrecision(),
                                            0,
@@ -7968,7 +7968,7 @@ ItemExpr * BiArith::preCodeGen(Generator * generator)
         IntervalType *interval = (IntervalType *) result_type;
         const Int16 DisAmbiguate = 0;
         child(1) = new(generator->wHeap()) Cast(child(1),
-                            new(generator->wHeap()) SQLNumeric(TRUE, /* signed */
+                            new(generator->wHeap()) SQLNumeric(generator->wHeap(), TRUE, /* signed */
 #pragma nowarn(1506)   // warning elimination
                                            interval->getTotalPrecision(),
                                            0,
@@ -8401,7 +8401,7 @@ ItemExpr * BiRelat::preCodeGen(Generator * generator)
 		  if (DFS2REC::isAnyVarChar(cType1.getFSDatatype()))
 		  {
 		    resultType = new (generator->wHeap())
-		      SQLVarChar( CharLenInfo(Prec, len),
+		      SQLVarChar(generator->wHeap(), CharLenInfo(Prec, len),
 				  cType1.supportsSQLnull(), 
 				  cType1.isUpshifted(),
 				  cType1.isCaseinsensitive(),
@@ -8413,7 +8413,7 @@ ItemExpr * BiRelat::preCodeGen(Generator * generator)
 		  else
 		  {
 		    resultType = new (generator->wHeap())
-		      SQLChar( CharLenInfo(Prec, len),
+		      SQLChar(generator->wHeap(), CharLenInfo(Prec, len),
 				  cType1.supportsSQLnull(), 
 				  cType1.isUpshifted(),
 				  cType1.isCaseinsensitive(),
@@ -8432,7 +8432,7 @@ ItemExpr * BiRelat::preCodeGen(Generator * generator)
 		  if (DFS2REC::isAnyVarChar(cType2.getFSDatatype()))
 		  {
 		    resultType = new (generator->wHeap())
-		      SQLVarChar( CharLenInfo(Prec, len),
+		      SQLVarChar(generator->wHeap(), CharLenInfo(Prec, len),
 				  cType2.supportsSQLnull(), 
 				  cType2.isUpshifted(),
 				  cType2.isCaseinsensitive(),
@@ -8444,7 +8444,7 @@ ItemExpr * BiRelat::preCodeGen(Generator * generator)
 		  else
 		  {
 		    resultType = new (generator->wHeap())
-		      SQLChar( CharLenInfo(Prec, len),
+		      SQLChar(generator->wHeap(), CharLenInfo(Prec, len),
 				  cType2.supportsSQLnull(), 
 				  cType2.isUpshifted(),
 				  cType2.isCaseinsensitive(),
@@ -8573,7 +8573,7 @@ ItemExpr * BiRelat::preCodeGen(Generator * generator)
                 new (generator->wHeap())
                 Cast(child(1),
                      new (generator->wHeap())
-                     SQLLargeInt(numOp2.isSigned(),
+                     SQLLargeInt(generator->wHeap(), numOp2.isSigned(),
                                  numOp2.supportsSQLnull()));
               
               newOp2 = newOp2->bindNode(generator->getBindWA());
@@ -8594,7 +8594,7 @@ ItemExpr * BiRelat::preCodeGen(Generator * generator)
                 new (generator->wHeap())
                 Cast(child(0),
                      new (generator->wHeap())
-                     SQLLargeInt(numOp1.isSigned(),
+                     SQLLargeInt(generator->wHeap(), numOp1.isSigned(),
                                  numOp1.supportsSQLnull()));
               
               newOp1 = newOp1->bindNode(generator->getBindWA());
@@ -8820,7 +8820,7 @@ ItemExpr * BitOperFunc::preCodeGen(Generator * generator)
 	      ItemExpr * newChild =
 		new (generator->wHeap()) 
 		Cast(child(i), 
-		     new (generator->wHeap()) SQLInt(FALSE,
+		     new (generator->wHeap()) SQLInt(generator->wHeap(), FALSE,
 						 typ.supportsSQLnullLogical()));
 	      setChild(i, newChild);	
 
@@ -8931,7 +8931,7 @@ ItemExpr * Cast::preCodeGen(Generator * generator)
 	    new (generator->wHeap())
 	    Cast(child(0),
 		 new (generator->wHeap())
-		 SQLLargeInt(TRUE,
+		 SQLLargeInt(generator->wHeap(), TRUE,
 			     child(0)->castToItemExpr()->
 			     getValueId().getType().supportsSQLnull()));
 	  newChild = newChild->bindNode(generator->getBindWA());
@@ -8961,7 +8961,7 @@ ItemExpr * Cast::preCodeGen(Generator * generator)
 	    new (generator->wHeap())
 	    Cast(child(0),
 		 new (generator->wHeap())
-		 SQLLargeInt(TRUE,
+		 SQLLargeInt(generator->wHeap(), TRUE,
 			     child(0)->castToItemExpr()->
 			     getValueId().getType().supportsSQLnull()));
 	  newChild = newChild->bindNode(generator->getBindWA());
@@ -8990,7 +8990,7 @@ ItemExpr * Cast::preCodeGen(Generator * generator)
 	    new (generator->wHeap())
 	    Cast(child(0),
 		 new (generator->wHeap())
-		 SQLLargeInt(TRUE,
+		 SQLLargeInt(generator->wHeap(), TRUE,
                              child(0)->castToItemExpr()->
                              getValueId().getType().supportsSQLnull()));
 	  newChild = newChild->bindNode(generator->getBindWA());
@@ -9228,13 +9228,12 @@ ItemExpr * Cast::preCodeGen(Generator * generator)
 
 	    NAType * intermediateType =
 	      new(generator->wHeap())
-		SQLBigNum(intermediatePrecision,
+		SQLBigNum(generator->wHeap(), intermediatePrecision,
 			  intermediateScale,
 			  (sourceNumType->isBigNum() &&
 			   ((SQLBigNum*)sourceNumType)->isARealBigNum()),
 			  TRUE, // make it signed
-			  sourceNumType->supportsSQLnull(),
-			  NULL);
+			  sourceNumType->supportsSQLnull());
 
 	    child(0) = new(generator->wHeap()) Cast(child(0),intermediateType);
 
@@ -9288,7 +9287,7 @@ ItemExpr * CharFunc::preCodeGen(Generator * generator)
 
   // Insert a cast node to convert child to an INT.
   child(0) = new (generator->wHeap())
-    Cast(child(0), new (generator->wHeap()) SQLInt(FALSE,
+    Cast(child(0), new (generator->wHeap()) SQLInt(generator->wHeap(), FALSE,
 						   typ1.supportsSQLnullLogical()));
 
   child(0)->bindNode(generator->getBindWA());
@@ -9363,7 +9362,7 @@ ItemExpr * ConvertTimestamp::preCodeGen(Generator * generator)
     child(0) = new(generator->wHeap())
                  Cast(child(0),
                       new(generator->wHeap())
-                        SQLLargeInt(TRUE, numeric->supportsSQLnull()));
+                        SQLLargeInt(generator->wHeap(), TRUE, numeric->supportsSQLnull()));
     child(0)->bindNode(generator->getBindWA());
   }
   child(0) = child(0)->preCodeGen(generator);
@@ -9392,7 +9391,7 @@ ItemExpr * Extract::preCodeGen(Generator * generator)
     child(0) = new(generator->wHeap())
                  Cast(child(0), dataConvError,
                       new(generator->wHeap())
-                        SQLInterval(interval->supportsSQLnull(),
+                        SQLInterval(generator->wHeap(), interval->supportsSQLnull(),
                                     interval->getStartField(),
                                     interval->getLeadingPrecision(),
                                     getExtractField()),
@@ -9426,7 +9425,7 @@ ItemExpr * JulianTimestamp::preCodeGen(Generator * generator)
     child(0) = new(generator->wHeap())
                  Cast(child(0),
                       new(generator->wHeap())
-                        SQLTimestamp(dt->supportsSQLnull(), 6));
+                        SQLTimestamp(generator->wHeap(), dt->supportsSQLnull(), 6));
     child(0)->bindNode(generator->getBindWA());
   }
   child(0) = child(0)->preCodeGen(generator);
@@ -10004,7 +10003,7 @@ ItemExpr * MathFunc::preCodeGen(Generator * generator)
       child(i) = new (generator->wHeap())
 	Cast(child(i),
 	     new (generator->wHeap()) SQLDoublePrecision(
-		  typ.supportsSQLnullLogical()));
+		  generator->wHeap(), typ.supportsSQLnullLogical()));
 
       child(i)->bindNode(generator->getBindWA());
 
@@ -10031,7 +10030,7 @@ ItemExpr * Modulus::preCodeGen(Generator * generator)
 	{
 	  // Insert a cast node to convert child to an LARGEINT.
 	  child(i) = new (generator->wHeap())
-	    Cast(child(i), new (generator->wHeap()) SQLLargeInt(TRUE,
+	    Cast(child(i), new (generator->wHeap()) SQLLargeInt(generator->wHeap(), TRUE,
 								typ.supportsSQLnullLogical()));
 	}
 
@@ -10106,7 +10105,7 @@ ItemExpr * PivotGroup::preCodeGen(Generator * generator)
                                                 0);
 
       NAType * newType = new(generator->getBindWA()->wHeap()) 
-        SQLVarChar(displayLen, type1.supportsSQLnull());
+        SQLVarChar(generator->getBindWA()->wHeap(), displayLen, type1.supportsSQLnull());
 
       childExpr = new (generator->getBindWA()->wHeap()) Cast(childExpr, newType);
       
@@ -10137,7 +10136,7 @@ ItemExpr * RandomNum::preCodeGen(Generator * generator)
 
       // Insert a cast node to convert child to an INT.
       child(0) = new (generator->wHeap())
-	Cast(child(0), new (generator->wHeap()) SQLInt(FALSE,
+	Cast(child(0), new (generator->wHeap()) SQLInt(generator->wHeap(), FALSE,
 						       typ1.supportsSQLnullLogical()));
 
       child(0)->bindNode(generator->getBindWA());
@@ -10160,7 +10159,7 @@ ItemExpr * Repeat::preCodeGen(Generator * generator)
 
   // Insert a cast node to convert child 2 to an INT.
   child(1) = new (generator->wHeap())
-    Cast(child(1), new (generator->wHeap()) SQLInt(FALSE,
+    Cast(child(1), new (generator->wHeap()) SQLInt(generator->wHeap(), FALSE,
 						   typ2.supportsSQLnullLogical()));
 
   child(1)->bindNode(generator->getBindWA());
@@ -10373,7 +10372,7 @@ ItemExpr * Substring::preCodeGen(Generator * generator)
 
 	  // Insert a cast node to convert child to an INT.
 	  child(i) = new (generator->wHeap())
-	    Cast(child(i), new (generator->wHeap()) SQLInt(TRUE,
+	    Cast(child(i), new (generator->wHeap()) SQLInt(generator->wHeap(), TRUE,
 							   typ1.supportsSQLnullLogical()));
 
 	  child(i)->bindNode(generator->getBindWA());

--- a/core/sql/generator/GenProbeCache.cpp
+++ b/core/sql/generator/GenProbeCache.cpp
@@ -154,7 +154,7 @@ short ProbeCache::codeGen(Generator *generator)
   ItemExpr *hvAsIe = new (generator->wHeap()) Cast(
        probeHashAsIe, 
        new (generator->wHeap()) 
-            SQLInt(FALSE,   // false == unsigned.
+            SQLInt(generator->wHeap(), FALSE,   // false == unsigned.
                    FALSE    // false == not nullable.
                   ));
 
@@ -205,7 +205,7 @@ short ProbeCache::codeGen(Generator *generator)
               Cast (inputIe,
                     (new(generator->wHeap())
                       SQLChar(
-		          CharLenInfo(char_type.getStrCharLimit(), char_type.getDataStorageSize()),
+		          generator->wHeap(), CharLenInfo(char_type.getStrCharLimit(), char_type.getDataStorageSize()),
                           char_type.supportsSQLnull(),
                           FALSE, FALSE, FALSE,
                           char_type.getCharSet(),

--- a/core/sql/generator/GenRelDCL.cpp
+++ b/core/sql/generator/GenRelDCL.cpp
@@ -203,7 +203,7 @@ short RelTransaction::codeGen(Generator * generator)
       // location. Create that node.
       ItemExpr * daSize = 
 	new(generator->wHeap()) Cast (diagAreaSizeExpr_, 
-	new(generator->wHeap()) SQLInt(TRUE, FALSE));
+	new(generator->wHeap()) SQLInt(generator->wHeap(), TRUE, FALSE));
       daSize->setConstFoldingDisabled(TRUE);      
       
       daSize->bindNode(generator->getBindWA());
@@ -337,7 +337,7 @@ short RelSetTimeout::codeGen(Generator * generator)
       ItemExpr * toVal = 
 	new(generator->wHeap()) Cast(timeoutValueExpr_, 
 				     new(generator->wHeap()) 
-				     SQLInt(TRUE, FALSE));
+				     SQLInt(generator->wHeap(), TRUE, FALSE));
       toVal->setConstFoldingDisabled(TRUE);      
       
       toVal->bindNode(generator->getBindWA());

--- a/core/sql/generator/GenRelEnforcer.cpp
+++ b/core/sql/generator/GenRelEnforcer.cpp
@@ -657,7 +657,7 @@ short Exchange::codeGenForESP(Generator * generator)
         ItemExpr * cast = new (generator->wHeap()) 
           Cast(topPartExpr, 
                new (generator->wHeap()) 
-               SQLInt(FALSE,
+               SQLInt(generator->wHeap(), FALSE,
                       topPartExpr->getValueId().getType().
                       supportsSQLnullLogical()));
         
@@ -689,7 +689,7 @@ short Exchange::codeGenForESP(Generator * generator)
               ItemExpr * hashExprResult = new (generator->wHeap()) 
                 Cast( hashExpr, 
                      new (generator->wHeap()) 
-                     SQLLargeInt(TRUE, // allow negative values.
+                     SQLLargeInt(generator->wHeap(), TRUE, // allow negative values.
                                  FALSE // no nulls.
                           ));
 

--- a/core/sql/generator/GenRelExeUtil.cpp
+++ b/core/sql/generator/GenRelExeUtil.cpp
@@ -3592,7 +3592,7 @@ short ExeUtilRegionStats::codeGen(Generator * generator)
       ItemExpr * inputExpr = new(generator->wHeap())
         Cast(inputColList_, 
              new (generator->wHeap())
-             SQLVarChar(inputColList_->getValueId().getType().getNominalSize(),
+             SQLVarChar(generator->wHeap(), inputColList_->getValueId().getType().getNominalSize(),
                         inputColList_->getValueId().getType().supportsSQLnull()));
       
       inputExpr->bindNode(generator->getBindWA());

--- a/core/sql/generator/GenRelGrby.cpp
+++ b/core/sql/generator/GenRelGrby.cpp
@@ -935,7 +935,7 @@ short HashGroupBy::codeGen(Generator * generator) {
   }
 
   leftExpr = new (generator->wHeap()) Cast(leftExpr, new (generator->wHeap())
-					   SQLInt(FALSE, FALSE));
+					   SQLInt(generator->wHeap(), FALSE, FALSE));
   leftExpr->setConstFoldingDisabled(TRUE);      
 
   // bind/type propagate the hash evaluation tree

--- a/core/sql/generator/GenRelJoin.cpp
+++ b/core/sql/generator/GenRelJoin.cpp
@@ -884,9 +884,9 @@ short HashJoin::codeGen(Generator * generator) {
     // common/BaseType.h). It could be made a bigger datatype,
     // if need be.
     buildHashTree = new (generator->wHeap())
-	Cast(buildHashTree, new (generator->wHeap()) SQLInt(FALSE, FALSE));
+	Cast(buildHashTree, new (generator->wHeap()) SQLInt(generator->wHeap(), FALSE, FALSE));
     probeHashTree = new (generator->wHeap())
-	Cast(probeHashTree, new (generator->wHeap()) SQLInt(FALSE, FALSE));
+	Cast(probeHashTree, new (generator->wHeap()) SQLInt(generator->wHeap(), FALSE, FALSE));
     buildHashTree->setConstFoldingDisabled(TRUE);
     probeHashTree->setConstFoldingDisabled(TRUE);
 

--- a/core/sql/generator/GenRelMisc.cpp
+++ b/core/sql/generator/GenRelMisc.cpp
@@ -330,7 +330,7 @@ static void replaceBaseValue(ItemExpr *incomingExpr,
 
 	   newExpr->synthTypeAndValueId(TRUE);
 	   //set type to original type after if has been changed to BigNum above
-	   newExpr->getValueId().changeType(new (heap) SQLLargeInt(1 /* signed */,
+	   newExpr->getValueId().changeType(new (heap) SQLLargeInt(heap, 1 /* signed */,
 								    0 /* not null */));
 	   incomingExpr->setChild(1,newExpr);
 	   found = TRUE;
@@ -913,7 +913,7 @@ short RelRoot::codeGen(Generator * generator)
 	str_itoa(i, str2);
 	str1 += str2;
 	item_expr = new(generator->wHeap()) HostVar(str1,
-						    new(generator->wHeap()) SQLUnknown);
+						    new(generator->wHeap()) SQLUnknown(generator->wHeap()));
 	item_expr->bindNode(generator->getBindWA());
 	blankHV = TRUE;
 	val_id = item_expr->getValueId();
@@ -3407,7 +3407,7 @@ short Sort::codeGen(Generator * generator)
 	      new(generator->wHeap())
 		Cast (skey_node,
 		      (new(generator->wHeap())
-			 SQLChar(
+			 SQLChar(generator->wHeap(),
                           CharLenInfo(char_type.getStrCharLimit(), char_type.getDataStorageSize()),
 			  char_type.supportsSQLnull(),
 			  FALSE, FALSE, FALSE,
@@ -3756,7 +3756,7 @@ short SortFromTop::codeGen(Generator * generator)
 			new(generator->wHeap())
 			Cast (srcVal,
 			      (new(generator->wHeap())
-			       SQLChar(
+			       SQLChar(generator->wHeap(),
                                     CharLenInfo(char_type.getStrCharLimit(), char_type.getDataStorageSize()),
 				    char_type.supportsSQLnull(),
 				    FALSE, FALSE, FALSE,

--- a/core/sql/generator/GenRelScan.cpp
+++ b/core/sql/generator/GenRelScan.cpp
@@ -231,7 +231,7 @@ int HbaseAccess::createAsciiColAndCastExpr(Generator * generator,
   if (DFS2REC::isDoubleCharacter(newGivenType->getFSDatatype()))
     {
       asciiType =  
-        new (h) SQLVarChar(sizeof(Int64)/2, newGivenType->supportsSQLnull(),
+        new (h) SQLVarChar(h, sizeof(Int64)/2, newGivenType->supportsSQLnull(),
                            FALSE, FALSE, newGivenType->getCharSet(),
                            CharInfo::DefaultCollation,
                            CharInfo::COERCIBLE,
@@ -243,7 +243,7 @@ int HbaseAccess::createAsciiColAndCastExpr(Generator * generator,
   else if (  needTranslate == TRUE )
     {
       asciiType =  
-        new (h) SQLVarChar(sizeof(Int64), newGivenType->supportsSQLnull(),
+        new (h) SQLVarChar(h, sizeof(Int64), newGivenType->supportsSQLnull(),
                            FALSE, FALSE, CharInfo::GBK,
                            CharInfo::DefaultCollation,
                            CharInfo::COERCIBLE,
@@ -253,7 +253,7 @@ int HbaseAccess::createAsciiColAndCastExpr(Generator * generator,
   else
     {
       asciiType = 
-        new (h) SQLVarChar(sizeof(Int64), newGivenType->supportsSQLnull(),
+        new (h) SQLVarChar(h, sizeof(Int64), newGivenType->supportsSQLnull(),
                            FALSE, FALSE,
                            CharInfo::DefaultCharSet,
                            CharInfo::DefaultCollation,
@@ -355,7 +355,7 @@ int HbaseAccess::createAsciiColAndCastExpr3(Generator * generator,
       cvl = newGivenType->getNominalSize();
     }
 
-  asciiType = new (h) SQLVarChar(cvl, newGivenType->supportsSQLnull());
+  asciiType = new (h) SQLVarChar(h, cvl, newGivenType->supportsSQLnull());
 
   //  asciiValue = new (h) NATypeToItem(newGivenType->newCopy(h));
   asciiValue = new (h) NATypeToItem(asciiType);
@@ -1735,7 +1735,7 @@ short HbaseAccess::genRowIdExpr(Generator * generator,
 	      ie = new(generator->wHeap())
 		Cast (ie,
 		      (new(generator->wHeap())
-		       SQLChar(CharLenInfo(char_t.getStrCharLimit(), char_t.getDataStorageSize()),
+		       SQLChar(generator->wHeap(), CharLenInfo(char_t.getStrCharLimit(), char_t.getDataStorageSize()),
 			       givenType.supportsSQLnull(),
 			       FALSE, FALSE, FALSE,
 			       char_t.getCharSet(),
@@ -1828,7 +1828,7 @@ short HbaseAccess::genRowIdExprForNonSQ(Generator * generator,
 	  ie = new(generator->wHeap())
 	    Cast (ie,
 		  (new(generator->wHeap())
-		   ANSIChar(char_t.getDataStorageSize(),
+		   ANSIChar(generator->wHeap(), char_t.getDataStorageSize(),
 			    givenType.supportsSQLnull(),
 			    FALSE, FALSE, 
 			    char_t.getCharSet(),

--- a/core/sql/generator/GenRelSet.cpp
+++ b/core/sql/generator/GenRelSet.cpp
@@ -240,7 +240,7 @@ short MergeUnion::codeGen(Generator * generator)
 	// We indicate that the whole array is to be copied
 	SQLRowset *rowsetInfo = (SQLRowset *) &(vidu_node->getResult().getType());
         SQLRowset *newRowset =  new (generator->wHeap()) 
-	                         SQLRowset(rowsetInfo->getElementType(),
+	                         SQLRowset(generator->wHeap(), rowsetInfo->getElementType(),
 	                                   rowsetInfo->getMaxNumElements(),
                                            rowsetInfo->getNumElements());
 	newRowset->useTotalSize() = TRUE;
@@ -264,7 +264,7 @@ short MergeUnion::codeGen(Generator * generator)
 	// We indicate that the whole array is to be copied
 	SQLRowset *rowsetInfo = (SQLRowset *) &(vidu_node->getResult().getType());
         SQLRowset *newRowset =  new (generator->wHeap()) 
-	                         SQLRowset(rowsetInfo->getElementType(),
+	                         SQLRowset(generator->wHeap(), rowsetInfo->getElementType(),
 	                                   rowsetInfo->getMaxNumElements(),
                                            rowsetInfo->getNumElements());
 	newRowset->useTotalSize() = TRUE;

--- a/core/sql/generator/GenRelUpdate.cpp
+++ b/core/sql/generator/GenRelUpdate.cpp
@@ -2301,7 +2301,7 @@ short HbaseInsert::codeGen(Generator *generator)
           Lng32 cvl = givenType.getDisplayLength();
 
           NAType * asciiType = 
-            new (generator->wHeap()) SQLVarChar(cvl, givenType.supportsSQLnull());
+            new (generator->wHeap()) SQLVarChar(generator->wHeap(), cvl, givenType.supportsSQLnull());
           ie = new(generator->wHeap()) Cast(ie, asciiType);
         }
 

--- a/core/sql/generator/GenSequenceFunction.cpp
+++ b/core/sql/generator/GenSequenceFunction.cpp
@@ -97,7 +97,7 @@ ItemExpr *ItmSeqOffset::preCodeGen(Generator *generator)
     // (must be) signed; nulls allowed (if allowed by child1)   
    ItemExpr *castExpr   = new (wHeap) Cast (child(1),
                                            new (wHeap)
-                                           SQLInt(TRUE, cType.supportsSQLnullLogical()));
+                                           SQLInt(wHeap, TRUE, cType.supportsSQLnullLogical()));
    castExpr->synthTypeAndValueId(TRUE);
    child (1) = castExpr;
   }
@@ -117,7 +117,7 @@ ItemExpr *ItmLeadOlapFunction::preCodeGen(Generator *generator)
     CollHeap *wHeap = generator->wHeap();
     ItemExpr *castExpr   = new (wHeap) Cast (child(1),
                                            new (wHeap)
-                                           SQLInt(TRUE, cType.supportsSQLnullLogical()));
+                                           SQLInt(wHeap, TRUE, cType.supportsSQLnullLogical()));
     castExpr->synthTypeAndValueId(TRUE);
     child (1) = castExpr;
   }
@@ -138,7 +138,7 @@ ItemExpr *ItmLagOlapFunction::preCodeGen(Generator *generator)
     const NAType &cType = child(1)->getValueId().getType();
     ItemExpr *castExpr   = new (wHeap) Cast (child(1),
                                        new (wHeap)
-                                       SQLInt(TRUE, cType.supportsSQLnullLogical()));
+                                       SQLInt(wHeap, TRUE, cType.supportsSQLnullLogical()));
     castExpr->synthTypeAndValueId(TRUE);
     child (1) = castExpr;
   }
@@ -469,7 +469,7 @@ ItemExpr *ItmSeqOlapFunction::preCodeGen(Generator *generator)
   //
   ItemExpr *itmLocalCounter 
     = new(wHeap) HostVar("_sys_LocalCounter",
-			 new(wHeap) SQLInt(TRUE,FALSE),
+			 new(wHeap) SQLInt(wHeap, TRUE,FALSE),
 			 TRUE);
 
   // Expression to initailize the iterator.
@@ -617,7 +617,7 @@ ItemExpr *ItmSeqMovingFunction::preCodeGen(Generator *generator)
   //
   ItemExpr *itmLocalCounter 
     = new(wHeap) HostVar("_sys_LocalCounter",
-			 new(wHeap) SQLInt(TRUE,FALSE),
+			 new(wHeap) SQLInt(wHeap, TRUE,FALSE),
 			 TRUE);
 
   // Expression to initailize the iterator.

--- a/core/sql/generator/GenStoredProc.cpp
+++ b/core/sql/generator/GenStoredProc.cpp
@@ -224,7 +224,7 @@ short RelInternalSP::codeGen(Generator * generator)
 	  cn = new(generator->wHeap()) 
 	    Cast ((getProcAllParamsVids())[i].getItemExpr(), 
 		  (new(generator->wHeap())
-		   SQLChar(
+		   SQLChar(generator->wHeap(),
 		           CharLenInfo(char_type.getStrCharLimit(), char_type.getDataStorageSize()),
 			   char_type.supportsSQLnull(),
 			   FALSE, FALSE, FALSE,

--- a/core/sql/generator/Generator.cpp
+++ b/core/sql/generator/Generator.cpp
@@ -3052,6 +3052,7 @@ void GeneratorAbort(const char *file, Int32 line, const char * message)
   *CmpCommon::diags() << DgSqlCode(-7000) << DgString0(file)
                       << DgInt0(line) << DgString1(message);
 
+  abort();
   CmpInternalException("GeneratorAbort", __FILE__ , __LINE__).throwException();
 #else
   if (CmpCommon::context()->isDoNotAbort())

--- a/core/sql/generator/LmExpr.cpp
+++ b/core/sql/generator/LmExpr.cpp
@@ -283,12 +283,12 @@ LmExprResult CreateLmOutputExpr(const NAType &formalType,
     if (isResultSet || style != COM_STYLE_JAVA_CALL)
     {
       Lng32 maxLength = GetDisplayLength(formalType);
-      replyType = new (h) SQLChar(maxLength);
+      replyType = new (h) SQLChar(h, maxLength);
     }
     else
     {
       Lng32 maxLength = GetDisplayLength(formalType);
-      replyType = new (h) SQLVarChar(maxLength);
+      replyType = new (h) SQLVarChar(h, maxLength);
     }
   }
   else

--- a/core/sql/langman/LmLangManager.cpp
+++ b/core/sql/langman/LmLangManager.cpp
@@ -63,21 +63,21 @@ LmResult LmLanguageManager::convertIn(
   case NA_CHARACTER_TYPE:
   case NA_DATETIME_TYPE:
     // (VAR)CHAR and DATE/TIME.
-    *dst = new(mem) ANSIChar(src->getNominalSize(), FALSE);
+    *dst = new(mem) ANSIChar(mem, src->getNominalSize(), FALSE);
     return LM_CONV_REQUIRED;
 
   case NA_NUMERIC_TYPE:
     // NUMERIC and DECIMAL.
     if (((NumericType*)src)->decimalPrecision())
     {
-      *dst = new(mem) ANSIChar(src->getNominalSize(), FALSE);
+      *dst = new(mem) ANSIChar(mem, src->getNominalSize(), FALSE);
       return LM_CONV_REQUIRED;
     }
 
     // FLOAT.
     if (src->getPrecision() == SQL_FLOAT_PRECISION)
     {
-      *dst = new(mem) SQLDoublePrecision(src->supportsSQLnull());
+      *dst = new(mem) SQLDoublePrecision(mem, src->supportsSQLnull());
       return LM_CONV_REQUIRED;
     }
 

--- a/core/sql/optimizer/BindWA.cpp
+++ b/core/sql/optimizer/BindWA.cpp
@@ -1100,7 +1100,7 @@ void HostArraysWA::processArrayHostVar(ItemExpr *parent, Int32 childNumber)
       // will be determined on a later binding stage. In the case in which we are doing 
       // an INSERT, for instance, the types will be determined in the Insert node
       SQLRowset *rowsetType = 
-        new (bindWA_->wHeap()) SQLRowset((new (bindWA_->wHeap()) SQLUnknown()),
+        new (bindWA_->wHeap()) SQLRowset(bindWA_->wHeap(), (new (bindWA_->wHeap()) SQLUnknown(bindWA_->wHeap())),
 #pragma nowarn(1506)   // warning elimination 
                                           size, size);
 #pragma warn(1506)  // warning elimination 

--- a/core/sql/optimizer/ItemExpr.cpp
+++ b/core/sql/optimizer/ItemExpr.cpp
@@ -3509,7 +3509,7 @@ ItemExpr * BiArith::foldConstants(ComDiagsArea *diagsArea,
               NAString runningOutOfNames(numstr, CmpCommon::statementHeap());
 
 	      result = new(CmpCommon::statementHeap()) SystemLiteral(
-		   new(CmpCommon::statementHeap()) SQLLargeInt(TRUE,FALSE),
+		   new(CmpCommon::statementHeap()) SQLLargeInt(CmpCommon::statementHeap(), TRUE,FALSE),
 		   (void *) &numResult,
 		   sizeof(numResult),
 		   &runningOutOfNames);
@@ -8335,13 +8335,13 @@ ItemExpr * CurrentTimestamp::construct
     {
       if (dtCode == DatetimeType::SUBTYPE_SQLDate)
         ie = new (heap)
-          Cast(ie, new (heap) SQLDate(FALSE, heap));
+          Cast(ie, new (heap) SQLDate(heap, FALSE));
       else if (dtCode == DatetimeType::SUBTYPE_SQLTime)
         ie = new (heap)
-          Cast(ie, new (heap) SQLTime(FALSE, fractPrec, heap));
+          Cast(ie, new (heap) SQLTime(heap, FALSE, fractPrec));
       else
         ie = new (heap)
-          Cast(ie, new (heap) SQLTimestamp(FALSE, fractPrec, heap));
+          Cast(ie, new (heap) SQLTimestamp(heap, FALSE, fractPrec));
     }
 
   return ie;
@@ -9119,7 +9119,7 @@ void PackFunc::deriveTypeFromFormatInfo()
 
   Lng32 dataSizeInBytes = (width_ < 0 ? (-width_-1)/8+1 : width_);
   Lng32 packedRowSizeInBytes = (base_ + dataSizeInBytes);
-  type_ = new(CmpCommon::statementHeap()) SQLChar(packedRowSizeInBytes,FALSE);
+  type_ = new(CmpCommon::statementHeap()) SQLChar(CmpCommon::statementHeap(), packedRowSizeInBytes,FALSE);
 }
 
 void PackFunc::deriveFormatInfoFromUnpackType(const NAType* unpackType)
@@ -9171,7 +9171,7 @@ void PackFunc::deriveFormatInfoFromUnpackType(const NAType* unpackType)
   Lng32 packedRowSizeInBytes = (base_ + dataSizeInBytes);
 
   // Synthesize type of the packed column.
-  type_ = new(CmpCommon::statementHeap()) SQLChar(packedRowSizeInBytes,FALSE);
+  type_ = new(CmpCommon::statementHeap()) SQLChar(CmpCommon::statementHeap(), packedRowSizeInBytes,FALSE);
   isFormatInfoValid_ = TRUE;
 }
 
@@ -9959,7 +9959,7 @@ const NAString KeyRangeCompare::getText() const
 ConstValue::ConstValue()
 : ItemExpr(ITM_CONSTANT)
      , isNull_(IS_NULL)
-     , type_(new (CmpCommon::statementHeap()) SQLUnknown(TRUE))
+     , type_(new (CmpCommon::statementHeap()) SQLUnknown(CmpCommon::statementHeap(), TRUE))
      , value_(NULL)
      , storageSize_(0)
      , text_(new (CmpCommon::statementHeap()) NAString("NULL", CmpCommon::statementHeap()))
@@ -9978,7 +9978,7 @@ ConstValue::ConstValue(Lng32 intval, NAMemory * outHeap)
            : ItemExpr(ITM_CONSTANT)
            , isNull_(IS_NOT_NULL)
            , textIsValidatedSQLLiteralInUTF8_(FALSE)
-           , type_(new (CmpCommon::statementHeap()) SQLInt(TRUE, FALSE))
+           , type_(new (CmpCommon::statementHeap()) SQLInt(CmpCommon::statementHeap(), TRUE, FALSE))
 	   , isSystemSupplied_(FALSE)
            , locale_strval(0)
            , locale_wstrval(0)
@@ -10028,7 +10028,7 @@ void ConstValue::initCharConstValue
     {
       // create a varchar constant of length 0, in this case.
       type_ = new (outHeap)
-		SQLVarChar(0, FALSE, FALSE, FALSE,
+		SQLVarChar(outHeap, 0, FALSE, FALSE, FALSE,
 			   charSet, collation, coercibility);
       storageSize_ = type_->getVarLenHdrSize();
       value_ = (void *)( new (outHeap) 
@@ -10056,7 +10056,7 @@ void ConstValue::initCharConstValue
           , charSet                   // const CharInfo::CharSet cs
           );
         CMPASSERT(actualCharsCount >= 0); // no errors
-        type_ = new (outHeap) SQLChar ( CharLenInfo ( actualCharsCount
+        type_ = new (outHeap) SQLChar (outHeap,  CharLenInfo ( actualCharsCount
                                                     , strval.length() // str len in bytes
                                                     )
                                       , FALSE           // allowSQLnull
@@ -10071,7 +10071,7 @@ void ConstValue::initCharConstValue
       }
       else
       type_ = new (outHeap)
-		SQLChar(num_of_chars, FALSE, FALSE, FALSE, FALSE,
+		SQLChar(outHeap, num_of_chars, FALSE, FALSE, FALSE, FALSE,
 			charSet, collation, coercibility);
 
 
@@ -10126,7 +10126,7 @@ void ConstValue::initCharConstValue(const NAWString& strval,
     {
       // create a varchar constant of length 0, in this case.
       type_ = new (outHeap)
-		SQLVarChar(0, FALSE, FALSE, FALSE,
+		SQLVarChar(outHeap, 0, FALSE, FALSE, FALSE,
 			   charSet, collation, coercibility);
       storageSize_ = type_->getVarLenHdrSize();
       value_ = (void *)( new (outHeap) 
@@ -10159,7 +10159,7 @@ void ConstValue::initCharConstValue(const NAWString& strval,
       Int32 num_of_chars = (Int32)strval.length();
 
       type_ = new (outHeap)
-		SQLChar(num_of_chars, FALSE, FALSE, FALSE, FALSE,
+		SQLChar(outHeap, num_of_chars, FALSE, FALSE, FALSE, FALSE,
 			charSet, collation, coercibility);
 
 #pragma nowarn(1506)   // warning elimination

--- a/core/sql/optimizer/ItemSample.cpp
+++ b/core/sql/optimizer/ItemSample.cpp
@@ -204,7 +204,7 @@ NABoolean ItmBalance::isCovered(const ValueIdSet& newExternalInputs,
 const NAType *ItmBalance::synthesizeType()
 {
   // returns a signed, non-null integer
-  return new HEAP SQLInt(TRUE,FALSE);
+  return new HEAP SQLInt(HEAP, TRUE,FALSE);
 }
 
 double
@@ -517,5 +517,5 @@ ItemExpr * RandomSelection::copyTopNode(ItemExpr *derivedNode,
 const NAType *RandomSelection::synthesizeType()
 {
   // returns an int, unsigned and not null
-  return new HEAP SQLInt(FALSE,FALSE);
+  return new HEAP SQLInt(HEAP, FALSE,FALSE);
 }

--- a/core/sql/optimizer/ItmBitMuxFunction.cpp
+++ b/core/sql/optimizer/ItmBitMuxFunction.cpp
@@ -43,7 +43,7 @@ const NAType *ItmBitMuxFunction::synthesizeType() {
     size += type.getTotalSize();
   }
 
-  return new(CmpCommon::statementHeap()) SQLChar(size, FALSE);
+  return new(CmpCommon::statementHeap()) SQLChar(CmpCommon::statementHeap(), size, FALSE);
 };
 
 // copyTopNode

--- a/core/sql/optimizer/MVInfo.cpp
+++ b/core/sql/optimizer/MVInfo.cpp
@@ -1403,7 +1403,7 @@ MVColumnInfo::MVColumnInfo (const MVColumnInfo& other,
 	// This is a dependent COUNT for MIN or MAX on a character column. 
 	// The COUNT column type must be a numeric type.
 	colDataType_ = new(heap) 
-	  SQLLargeInt(TRUE, FALSE); // LARGEINT SIGNED NOT NULL.
+	  SQLLargeInt(heap, TRUE, FALSE); // LARGEINT SIGNED NOT NULL.
       }
       break;
 
@@ -1603,7 +1603,7 @@ MVColumnInfo::MVColumnInfo (MVInfoForDDL&   mvInfoObj,
   // create a new system column name: SYS_COUNTSTAR<running number>
   mvInfoObj.NewSystemColumName(NAString("COUNTSTAR"), colName_);
   colDataType_ = new(heap) 
-    SQLLargeInt(TRUE, FALSE);  // LARGEINT SIGNED NO NULLS
+    SQLLargeInt(heap, TRUE, FALSE);  // LARGEINT SIGNED NO NULLS
 
   setNotNull(TRUE);
   colType_ = COM_MVCOL_AGGREGATE;

--- a/core/sql/optimizer/MavRelRootBuilder.cpp
+++ b/core/sql/optimizer/MavRelRootBuilder.cpp
@@ -428,7 +428,7 @@ RelRoot *MavRelRootBuilder::buildRootForDelta(RelExpr *topNode)
     const MVColumnInfo *currentMavColumn = otherCols_[i];
     const NAString& colName = currentMavColumn->getColName();
 
-    const NAType *desiredType = new(heap_) SQLDoublePrecision(TRUE);
+    const NAType *desiredType = new(heap_) SQLDoublePrecision(heap_, TRUE);
     ItemExpr *countDepCol = buildDepColExpr(emptyCorrName, currentMavColumn->getDepCol1());
     ItemExpr *sumDepCol   = buildDepColExpr(emptyCorrName, currentMavColumn->getDepCol2());
     ItemExpr *sum2DepCol  = NULL;
@@ -667,7 +667,7 @@ RelRoot *MavRelRootBuilder::buildRootForOthers(RelExpr *topNode)
     MVColumnInfo *currentCol = otherCols_[i];
     const NAString& colName = currentCol->getColName();
 
-    const NAType *desiredType = new(heap_) SQLDoublePrecision(TRUE);
+    const NAType *desiredType = new(heap_) SQLDoublePrecision(heap_, TRUE);
 
     // Find the dependent SYS_CALC COUNT and SUM columns.
     ItemExpr *calcDep1 = 

--- a/core/sql/optimizer/NAColumn.cpp
+++ b/core/sql/optimizer/NAColumn.cpp
@@ -217,200 +217,180 @@ NABoolean NAColumn::createNAType(TrafColumnsDesc *column_desc	/*IN*/,
 
     case REC_BPINT_UNSIGNED :
       type = new (heap)
-      SQLBPInt(column_desc->precision, column_desc->isNullable(), FALSE, heap);
+      SQLBPInt(heap, column_desc->precision, column_desc->isNullable(), FALSE);
       break;
 
     case REC_BIN8_SIGNED:
       if (column_desc->precision > 0)
 	type = new (heap)
-	SQLNumeric(column_desc->length,
+	SQLNumeric(heap, column_desc->length,
 		   column_desc->precision,
 		   column_desc->scale,
 		   TRUE,
-		   column_desc->isNullable(),
-                   heap
+		   column_desc->isNullable()
 		   );
       else
 	type = new (heap)
-	SQLTiny(TRUE,
-		 column_desc->isNullable(),
-                 heap
+	SQLTiny(heap, TRUE,
+		 column_desc->isNullable()
 		 );
       break;
     case REC_BIN8_UNSIGNED:
       if (column_desc->precision > 0)
 	type = new (heap)
-	SQLNumeric(column_desc->length,
+	SQLNumeric(heap, column_desc->length,
 		   column_desc->precision,
 		   column_desc->scale,
 		   FALSE,
-		   column_desc->isNullable(),
-                   heap
+		   column_desc->isNullable()
 		   );
       else
 	type = new (heap)
-	SQLTiny(FALSE,
-		 column_desc->isNullable(),
-                 heap
+	SQLTiny(heap, FALSE,
+		 column_desc->isNullable()
 		 );
       break;
 
    case REC_BIN16_SIGNED:
       if (column_desc->precision > 0)
 	type = new (heap)
-	SQLNumeric(column_desc->length,
+	SQLNumeric(heap, column_desc->length,
 		   column_desc->precision,
 		   column_desc->scale,
 		   TRUE,
-		   column_desc->isNullable(),
-                   heap
+		   column_desc->isNullable()
 		   );
       else
 	type = new (heap)
-	SQLSmall(TRUE,
-		 column_desc->isNullable(),
-                 heap
+	SQLSmall(heap, TRUE,
+		 column_desc->isNullable()
 		 );
       break;
     case REC_BIN16_UNSIGNED:
       if (column_desc->precision > 0)
 	type = new (heap)
-	SQLNumeric(column_desc->length,
+	SQLNumeric(heap, column_desc->length,
 		   column_desc->precision,
 		   column_desc->scale,
 		   FALSE,
-		   column_desc->isNullable(),
-                   heap
+		   column_desc->isNullable()
 		   );
       else
 	type = new (heap)
-	SQLSmall(FALSE,
-		 column_desc->isNullable(),
-                 heap
+	SQLSmall(heap, FALSE,
+		 column_desc->isNullable()
 		 );
       break;
 
     case REC_BIN32_SIGNED:
       if (column_desc->precision > 0)
 	type = new (heap)
-	SQLNumeric(column_desc->length,
+	SQLNumeric(heap, column_desc->length,
 		   column_desc->precision,
 		   column_desc->scale,
 		   TRUE,
-		   column_desc->isNullable(),
-                   heap
+		   column_desc->isNullable()
 		   );
       else
 	type = new (heap)
-	SQLInt(TRUE,
-	       column_desc->isNullable(),
-               heap
+	SQLInt(heap, TRUE,
+	       column_desc->isNullable()
 	       );
       break;
     case REC_BIN32_UNSIGNED:
       if (column_desc->precision > 0)
 	type = new (heap)
-	SQLNumeric(column_desc->length,
+	SQLNumeric(heap, column_desc->length,
 		   column_desc->precision,
 		   column_desc->scale,
 		   FALSE,
-		   column_desc->isNullable(),
-                   heap
+		   column_desc->isNullable()
 		   );
       else
 	type = new (heap)
-	SQLInt(FALSE,
-	       column_desc->isNullable(),
-               heap
+	SQLInt(heap, FALSE,
+	       column_desc->isNullable()
 	       );
       break;
     case REC_BIN64_SIGNED:
       if (column_desc->precision > 0)
 	type = new (heap)
-	SQLNumeric(column_desc->length,
+	SQLNumeric(heap, column_desc->length,
 		   column_desc->precision,
 		   column_desc->scale,
 		   TRUE,
-		   column_desc->isNullable(),
-                   heap
+		   column_desc->isNullable()
 		   );
       else
 	type = new (heap)
-	SQLLargeInt(TRUE,
-		    column_desc->isNullable(),
-                    heap
+	SQLLargeInt(heap, TRUE,
+		    column_desc->isNullable()
 		    );
       break;
     case REC_BIN64_UNSIGNED:
       if (column_desc->precision > 0)
 	type = new (heap)
-	SQLNumeric(column_desc->length,
+	SQLNumeric(heap, column_desc->length,
 		   column_desc->precision,
 		   column_desc->scale,
 		   FALSE,
-		   column_desc->isNullable(),
-                   heap
+		   column_desc->isNullable()
 		   );
       else
 	type = new (heap)
-        SQLLargeInt(FALSE,
-		    column_desc->isNullable(),
-                    heap
+        SQLLargeInt(heap, FALSE,
+		    column_desc->isNullable()
 		    );
       break;
     case REC_DECIMAL_UNSIGNED:
       type = new (heap)
-	SQLDecimal(column_desc->length,
+	SQLDecimal(heap, column_desc->length,
 		   column_desc->scale,
 		   FALSE,
-		   column_desc->isNullable(),
-                   heap
+		   column_desc->isNullable()
 		   );
       break;
     case REC_DECIMAL_LSE:
       type = new (heap)
-	SQLDecimal(column_desc->length,
+	SQLDecimal(heap, column_desc->length,
 		   column_desc->scale,
 		   TRUE,
-		   column_desc->isNullable(),
-                   heap
+		   column_desc->isNullable()
 		   );
       break;
     case REC_NUM_BIG_UNSIGNED:
       type = new (heap)
-	SQLBigNum(column_desc->precision,
+	SQLBigNum(heap, column_desc->precision,
 		  column_desc->scale,
 		  TRUE, // is a real bignum
 		  FALSE,
-		  column_desc->isNullable(),
-		  heap
+		  column_desc->isNullable()
 		  );
       break;
     case REC_NUM_BIG_SIGNED:
       type = new (heap)
-	SQLBigNum(column_desc->precision,
+	SQLBigNum(heap, column_desc->precision,
 		  column_desc->scale,
 		  TRUE, // is a real bignum
 		  TRUE,
-		  column_desc->isNullable(),
-		  heap
+		  column_desc->isNullable()
 		  );
       break;
 
     case REC_FLOAT32:
       type = new (heap)
-	SQLReal(column_desc->isNullable(), heap, column_desc->precision);
+	SQLReal(heap, column_desc->isNullable(), column_desc->precision);
       break;
 
     case REC_FLOAT64:
       type = new (heap)
-	SQLDoublePrecision(column_desc->isNullable(), heap, column_desc->precision);
+	SQLDoublePrecision(heap, column_desc->isNullable(), column_desc->precision);
       break;
 
     case REC_BYTE_F_DOUBLE:
       charCount /= SQL_DBCHAR_SIZE;	    // divide the storage length by 2
       type = new (heap)
-	SQLChar(charCount,
+	SQLChar(heap, charCount,
 		column_desc->isNullable(),
 		column_desc->isUpshifted(),
 		column_desc->isCaseInsensitive(),
@@ -431,7 +411,7 @@ NABoolean NAColumn::createNAType(TrafColumnsDesc *column_desc	/*IN*/,
         if ( column_desc->precision > 0 )
            sizeInChars = column_desc->precision;
         type = new (heap)
-	SQLChar(CharLenInfo(sizeInChars, charCount/*in_bytes*/),
+	SQLChar(heap, CharLenInfo(sizeInChars, charCount/*in_bytes*/),
 		column_desc->isNullable(),
 		column_desc->isUpshifted(),
 		column_desc->isCaseInsensitive(),
@@ -444,7 +424,7 @@ NABoolean NAColumn::createNAType(TrafColumnsDesc *column_desc	/*IN*/,
       }
       else // keep the old behavior
       type = new (heap)
-	SQLChar(charCount,
+	SQLChar(heap, charCount,
 		column_desc->isNullable(),
 		column_desc->isUpshifted(),
 		column_desc->isCaseInsensitive(),
@@ -467,7 +447,7 @@ NABoolean NAColumn::createNAType(TrafColumnsDesc *column_desc	/*IN*/,
         if ( column_desc->precision > 0 )
            sizeInChars = column_desc->precision;
         type = new (heap)
-	SQLVarChar(CharLenInfo(sizeInChars, charCount/*in_bytes*/),
+	SQLVarChar(heap, CharLenInfo(sizeInChars, charCount/*in_bytes*/),
 		   column_desc->isNullable(),
 		   column_desc->isUpshifted(),
 		   column_desc->isCaseInsensitive(),
@@ -479,7 +459,7 @@ NABoolean NAColumn::createNAType(TrafColumnsDesc *column_desc	/*IN*/,
       }
       else // keep the old behavior
       type = new (heap)
-	SQLVarChar(charCount,
+	SQLVarChar(heap, charCount,
 		   column_desc->isNullable(),
 		   column_desc->isUpshifted(),
 		   column_desc->isCaseInsensitive(),
@@ -491,7 +471,7 @@ NABoolean NAColumn::createNAType(TrafColumnsDesc *column_desc	/*IN*/,
 
     case REC_BYTE_V_ASCII_LONG:
       type = new (heap)
-	SQLLongVarChar(charCount,
+	SQLLongVarChar(heap, charCount,
 		       FALSE,
 		       column_desc->isNullable(),
 		       column_desc->isUpshifted(),
@@ -530,12 +510,11 @@ NABoolean NAColumn::createNAType(TrafColumnsDesc *column_desc	/*IN*/,
       break;
     case REC_INTERVAL:
       type = new (heap)
-         SQLInterval(column_desc->isNullable(),
+         SQLInterval(heap, column_desc->isNullable(),
 		    column_desc->datetimeStart(),
 		    column_desc->intervalleadingprec,
 		    column_desc->datetimeEnd(),
-		    column_desc->datetimefractprec,
-                    heap
+		    column_desc->datetimefractprec
 		    );
       CMPASSERT(type);
       if (! ((SQLInterval *)type)->checkValid(CmpCommon::diags()))
@@ -552,18 +531,18 @@ NABoolean NAColumn::createNAType(TrafColumnsDesc *column_desc	/*IN*/,
       break;
     case REC_BLOB :
       type = new (heap)
-	SQLBlob(column_desc->precision, Lob_Invalid_Storage,
+	SQLBlob(heap, column_desc->precision, Lob_Invalid_Storage,
 		column_desc->isNullable());
       break;
 
     case REC_CLOB :
       type = new (heap)
-	SQLClob(column_desc->precision, Lob_Invalid_Storage,
+	SQLClob(heap, column_desc->precision, Lob_Invalid_Storage,
 		column_desc->isNullable());
       break;
 
     case REC_BOOLEAN :
-      type = new (heap) SQLBooleanNative(column_desc->isNullable());
+      type = new (heap) SQLBooleanNative(heap, column_desc->isNullable());
       break;
 
     default:

--- a/core/sql/optimizer/NARoutine.cpp
+++ b/core/sql/optimizer/NARoutine.cpp
@@ -219,7 +219,7 @@ NARoutine::NARoutine (  const QualifiedName &name
   for (CollIndex currentCol=0; currentCol<colCount; currentCol++)
   {
      // Create the new NAType.
-    newColType = new (heap) SQLVarChar ( 255
+    newColType = new (heap) SQLVarChar (heap, 255
                                         , 1
                                         , FALSE
 					, FALSE /*not caseinsensitive, for now*/

--- a/core/sql/optimizer/NATable.cpp
+++ b/core/sql/optimizer/NATable.cpp
@@ -2905,200 +2905,180 @@ NABoolean createNAType(TrafColumnsDesc *column_desc	/*IN*/,
 
     case REC_BPINT_UNSIGNED :
       type = new (heap)
-      SQLBPInt(column_desc->precision, column_desc->isNullable(), FALSE, heap);
+      SQLBPInt(heap, column_desc->precision, column_desc->isNullable(), FALSE);
       break;
 
     case REC_BIN8_SIGNED:
       if (column_desc->precision > 0)
 	type = new (heap)
-	SQLNumeric(column_desc->length,
+	SQLNumeric(heap, column_desc->length,
 		   column_desc->precision,
 		   column_desc->scale,
 		   TRUE,
-		   column_desc->isNullable(),
-                   heap
+		   column_desc->isNullable()
 		   );
       else
 	type = new (heap)
-	SQLTiny(TRUE,
-		 column_desc->isNullable(),
-                 heap
+	SQLTiny(heap, TRUE,
+		 column_desc->isNullable()
 		 );
       break;
     case REC_BIN8_UNSIGNED:
       if (column_desc->precision > 0)
 	type = new (heap)
-	SQLNumeric(column_desc->length,
+	SQLNumeric(heap, column_desc->length,
 		   column_desc->precision,
 		   column_desc->scale,
 		   FALSE,
-		   column_desc->isNullable(),
-                   heap
+		   column_desc->isNullable()
 		   );
       else
 	type = new (heap)
-	SQLTiny(FALSE,
-		 column_desc->isNullable(),
-                 heap
+	SQLTiny(heap, FALSE,
+		 column_desc->isNullable()
 		 );
       break;
 
     case REC_BIN16_SIGNED:
       if (column_desc->precision > 0)
 	type = new (heap)
-	SQLNumeric(column_desc->length,
+	SQLNumeric(heap, column_desc->length,
 		   column_desc->precision,
 		   column_desc->scale,
 		   TRUE,
-		   column_desc->isNullable(),
-                   heap
+		   column_desc->isNullable()
 		   );
       else
 	type = new (heap)
-	SQLSmall(TRUE,
-		 column_desc->isNullable(),
-                 heap
+	SQLSmall(heap, TRUE,
+		 column_desc->isNullable()
 		 );
       break;
     case REC_BIN16_UNSIGNED:
       if (column_desc->precision > 0)
 	type = new (heap)
-	SQLNumeric(column_desc->length,
+	SQLNumeric(heap, column_desc->length,
 		   column_desc->precision,
 		   column_desc->scale,
 		   FALSE,
-		   column_desc->isNullable(),
-                   heap
+		   column_desc->isNullable()
 		   );
       else
 	type = new (heap)
-	SQLSmall(FALSE,
-		 column_desc->isNullable(),
-                 heap
+	SQLSmall(heap, FALSE,
+		 column_desc->isNullable()
 		 );
       break;
 
     case REC_BIN32_SIGNED:
       if (column_desc->precision > 0)
 	type = new (heap)
-	SQLNumeric(column_desc->length,
+	SQLNumeric(heap, column_desc->length,
 		   column_desc->precision,
 		   column_desc->scale,
 		   TRUE,
-		   column_desc->isNullable(),
-                   heap
+		   column_desc->isNullable()
 		   );
       else
 	type = new (heap)
-	SQLInt(TRUE,
-	       column_desc->isNullable(),
-               heap
+	SQLInt(heap, TRUE,
+	       column_desc->isNullable()
 	       );
       break;
     case REC_BIN32_UNSIGNED:
       if (column_desc->precision > 0)
 	type = new (heap)
-	SQLNumeric(column_desc->length,
+	SQLNumeric(heap, column_desc->length,
 		   column_desc->precision,
 		   column_desc->scale,
 		   FALSE,
-		   column_desc->isNullable(),
-                   heap
+		   column_desc->isNullable()
 		   );
       else
 	type = new (heap)
-	SQLInt(FALSE,
-	       column_desc->isNullable(),
-               heap
+	SQLInt(heap, FALSE,
+	       column_desc->isNullable()
 	       );
       break;
     case REC_BIN64_SIGNED:
       if (column_desc->precision > 0)
 	type = new (heap)
-	SQLNumeric(column_desc->length,
+	SQLNumeric(heap, column_desc->length,
 		   column_desc->precision,
 		   column_desc->scale,
 		   TRUE,
-		   column_desc->isNullable(),
-                   heap
+		   column_desc->isNullable()
 		   );
       else
 	type = new (heap)
-	SQLLargeInt(TRUE,
-		    column_desc->isNullable(),
-                    heap
+	SQLLargeInt(heap, TRUE,
+		    column_desc->isNullable()
 		    );
       break;
     case REC_BIN64_UNSIGNED:
       if (column_desc->precision > 0)
 	type = new (heap)
-	SQLNumeric(column_desc->length,
+	SQLNumeric(heap, column_desc->length,
 		   column_desc->precision,
 		   column_desc->scale,
 		   FALSE,
-		   column_desc->isNullable(),
-                   heap
+		   column_desc->isNullable()
 		   );
       else
 	type = new (heap)
-          SQLLargeInt(FALSE,
-		    column_desc->isNullable(),
-                    heap
+          SQLLargeInt(heap, FALSE,
+		    column_desc->isNullable()
 		    );
       break;
     case REC_DECIMAL_UNSIGNED:
       type = new (heap)
-	SQLDecimal(column_desc->length,
+	SQLDecimal(heap, column_desc->length,
 		   column_desc->scale,
 		   FALSE,
-		   column_desc->isNullable(),
-                   heap
+		   column_desc->isNullable()
 		   );
       break;
     case REC_DECIMAL_LSE:
       type = new (heap)
-	SQLDecimal(column_desc->length,
+	SQLDecimal(heap, column_desc->length,
 		   column_desc->scale,
 		   TRUE,
-		   column_desc->isNullable(),
-                   heap
+		   column_desc->isNullable()
 		   );
       break;
     case REC_NUM_BIG_UNSIGNED:
       type = new (heap)
-	SQLBigNum(column_desc->precision,
+	SQLBigNum(heap, column_desc->precision,
 		  column_desc->scale,
 		  TRUE, // is a real bignum
 		  FALSE,
-		  column_desc->isNullable(),
-		  heap
+		  column_desc->isNullable()
 		  );
       break;
     case REC_NUM_BIG_SIGNED:
       type = new (heap)
-	SQLBigNum(column_desc->precision,
+	SQLBigNum(heap, column_desc->precision,
 		  column_desc->scale,
 		  TRUE, // is a real bignum
 		  TRUE,
-		  column_desc->isNullable(),
-		  heap
+		  column_desc->isNullable()
 		  );
       break;
 
     case REC_FLOAT32:
       type = new (heap)
-	SQLReal(column_desc->isNullable(), heap, column_desc->precision);
+	SQLReal(heap, column_desc->isNullable(), column_desc->precision);
       break;
 
     case REC_FLOAT64:
       type = new (heap)
-	SQLDoublePrecision(column_desc->isNullable(), heap, column_desc->precision);
+	SQLDoublePrecision(heap, column_desc->isNullable(), column_desc->precision);
       break;
 
     case REC_BYTE_F_DOUBLE:
       charCount /= SQL_DBCHAR_SIZE;	    // divide the storage length by 2
       type = new (heap)
-	SQLChar(charCount,
+	SQLChar(heap, charCount,
 		column_desc->isNullable(),
 		column_desc->isUpshifted(),
 		column_desc->isCaseInsensitive(),
@@ -3119,7 +3099,7 @@ NABoolean createNAType(TrafColumnsDesc *column_desc	/*IN*/,
         if ( column_desc->precision > 0 )
            sizeInChars = column_desc->precision;
         type = new (heap)
-	SQLChar(CharLenInfo(sizeInChars, charCount/*in_bytes*/),
+	SQLChar(heap, CharLenInfo(sizeInChars, charCount/*in_bytes*/),
 		column_desc->isNullable(),
 		column_desc->isUpshifted(),
 		column_desc->isCaseInsensitive(),
@@ -3132,7 +3112,7 @@ NABoolean createNAType(TrafColumnsDesc *column_desc	/*IN*/,
       }
       else // keep the old behavior
       type = new (heap)
-	SQLChar(charCount,
+	SQLChar(heap, charCount,
 		column_desc->isNullable(),
 		column_desc->isUpshifted(),
 		column_desc->isCaseInsensitive(),
@@ -3155,7 +3135,7 @@ NABoolean createNAType(TrafColumnsDesc *column_desc	/*IN*/,
         if ( column_desc->precision > 0 )
            sizeInChars = column_desc->precision;
         type = new (heap)
-	SQLVarChar(CharLenInfo(sizeInChars, charCount/*in_bytes*/),
+	SQLVarChar(heap, CharLenInfo(sizeInChars, charCount/*in_bytes*/),
 		   column_desc->isNullable(),
 		   column_desc->isUpshifted(),
 		   column_desc->isCaseInsensitive(),
@@ -3167,7 +3147,7 @@ NABoolean createNAType(TrafColumnsDesc *column_desc	/*IN*/,
       }
       else // keep the old behavior
       type = new (heap)
-	SQLVarChar(charCount,
+	SQLVarChar(heap, charCount,
 		   column_desc->isNullable(),
 		   column_desc->isUpshifted(),
 		   column_desc->isCaseInsensitive(),
@@ -3179,7 +3159,7 @@ NABoolean createNAType(TrafColumnsDesc *column_desc	/*IN*/,
 
     case REC_BYTE_V_ASCII_LONG:
       type = new (heap)
-	SQLLongVarChar(charCount,
+	SQLLongVarChar(heap, charCount,
 		       FALSE,
 		       column_desc->isNullable(),
 		       column_desc->isUpshifted(),
@@ -3218,13 +3198,11 @@ NABoolean createNAType(TrafColumnsDesc *column_desc	/*IN*/,
       break;
     case REC_INTERVAL:
       type = new (heap)
-         SQLInterval(column_desc->isNullable(),
+         SQLInterval(heap, column_desc->isNullable(),
 		    column_desc->datetimeStart(),
 		    column_desc->intervalleadingprec,
 		    column_desc->datetimeEnd(),
-		    column_desc->datetimefractprec,
-                    heap
-		    );
+		    column_desc->datetimefractprec);
       CMPASSERT(type);
       if (! ((SQLInterval *)type)->checkValid(CmpCommon::diags()))
          return TRUE;                                            // error
@@ -3241,19 +3219,19 @@ NABoolean createNAType(TrafColumnsDesc *column_desc	/*IN*/,
 
     case REC_BLOB :
       type = new (heap)
-	SQLBlob(column_desc->precision,Lob_Invalid_Storage,
+	SQLBlob(heap, column_desc->precision,Lob_Invalid_Storage,
 		column_desc->isNullable());
       break;
 
     case REC_CLOB :
       type = new (heap)
-	SQLClob(column_desc->precision,Lob_Invalid_Storage,
+	SQLClob(heap, column_desc->precision,Lob_Invalid_Storage,
 		column_desc->isNullable());
       break;
 
     case REC_BOOLEAN :
       {
-        type = new (heap) SQLBooleanNative(column_desc->isNullable());
+        type = new (heap) SQLBooleanNative(heap, column_desc->isNullable());
       }
       break;
 

--- a/core/sql/optimizer/NormItemExpr.cpp
+++ b/core/sql/optimizer/NormItemExpr.cpp
@@ -4772,7 +4772,7 @@ ItemExpr * ItmSeqDiff1::transformDiff1()
     {
      ItemExpr *castExpr   = new HEAP Cast (tfm2,
                                           new HEAP
-                                          SQLLargeInt(TRUE, TRUE)); // (must be) signed; nulls allowed
+                                          SQLLargeInt(HEAP, TRUE, TRUE)); // (must be) signed; nulls allowed
      tfm2 = castExpr;
     }
 
@@ -4849,7 +4849,7 @@ ItemExpr * ItmSeqDiff2::transformDiff2()
     {
      ItemExpr *castExpr   = new HEAP Cast (tfm2,
                                           new HEAP
-                                          SQLLargeInt(TRUE, TRUE)); // (must be) signed; nulls allowed
+                                          SQLLargeInt(HEAP, TRUE, TRUE)); // (must be) signed; nulls allowed
      tfm2 = castExpr;
     }
 
@@ -5015,7 +5015,7 @@ void ItmSeqRunningFunction::transformNode(NormWA & normWARef,
 //--------------------------------------------------------------------------------------
 ItemExpr * ItmSeqRunningFunction::transformRunningVariance()
 {
-  const NAType *desiredType    = new HEAP SQLDoublePrecision(TRUE);
+  const NAType *desiredType    = new HEAP SQLDoublePrecision(HEAP, TRUE);
   ItemExpr *childDouble        = new HEAP Cast(child(0), desiredType);
   ItemExpr *childDoubleSquared = new HEAP BiArith(ITM_TIMES,                       // x * x
                                                 childDouble,
@@ -5189,7 +5189,7 @@ void ItmSeqOlapFunction::transformNode(NormWA & normWARef,
 
 ItemExpr * ItmSeqOlapFunction::transformOlapVariance(CollHeap *wHeap)
 {
-  const NAType *desiredType    = new (wHeap) SQLDoublePrecision(TRUE);
+  const NAType *desiredType    = new (wHeap) SQLDoublePrecision(wHeap, TRUE);
   ItemExpr *childDouble        = new (wHeap) Cast(child(0), desiredType);
   ItemExpr *childDoubleSquared = new (wHeap) BiArith(ITM_TIMES,                       // x * x
                                                 childDouble,
@@ -5819,7 +5819,7 @@ ItemExpr * ItmSeqMovingFunction::transformMovingMinMax()
 //
 ItemExpr * ItmSeqMovingFunction::transformMovingVariance()
 {
-  const NAType *desiredType    = new HEAP SQLDoublePrecision(TRUE);
+  const NAType *desiredType    = new HEAP SQLDoublePrecision(HEAP, TRUE);
   ItemExpr *childDouble        = new HEAP Cast(child(0), desiredType);
   ItemExpr *childDoubleSquared = new HEAP BiArith(ITM_TIMES,                       // x * x
                                                 childDouble,

--- a/core/sql/optimizer/OptRange.cpp
+++ b/core/sql/optimizer/OptRange.cpp
@@ -1261,28 +1261,28 @@ static void downcastRangespecInt(Int64 val, Lng32 scale, NAType*& type,
     {
       *((Int16*)numBuf) = static_cast<Int16>(val);
       if (scale == 0)
-        type = new(heap) SQLSmall(TRUE, FALSE, heap);
+        type = new(heap) SQLSmall(heap, TRUE, FALSE);
       else
-        type = new(heap) SQLNumeric(sizeof(Int16), precision, scale,
-                                    TRUE, FALSE, heap);
+        type = new(heap) SQLNumeric(heap, sizeof(Int16), precision, scale,
+                                    TRUE, FALSE);
     }
   else if (val <= INT_MAX && val >= INT_MIN)
     {
       *((Int32*)numBuf) = static_cast<Int32>(val);
       if (scale == 0)
-        type = new(heap) SQLInt(TRUE, FALSE, heap);
+        type = new(heap) SQLInt(heap, TRUE, FALSE);
       else
-        type = new(heap) SQLNumeric(sizeof(Int32), precision, scale,
-                                    TRUE, FALSE, heap);
+        type = new(heap) SQLNumeric(heap, sizeof(Int32), precision, scale,
+                                    TRUE, FALSE);
     }
   else
     {
       *numBuf = val;
       if(scale == 0)
-        type = new(heap) SQLLargeInt(TRUE, FALSE, heap);
+        type = new(heap) SQLLargeInt(heap, TRUE, FALSE);
       else
-        type = new(heap) SQLNumeric(sizeof(Int64), precision, scale,
-                                    TRUE, FALSE, heap);
+        type = new(heap) SQLNumeric(heap, sizeof(Int64), precision, scale,
+                                    TRUE, FALSE);
     }
 }
 
@@ -1342,7 +1342,7 @@ ConstValue* OptRangeSpec::reconstituteInt64Value(NAType* type, Int64 val) const
                                   dtv.isValid(), QRLogicException,
                                   "Invalid date value reconstructed from Julian timestamp");
                 constValTextStr = dtv.getValueAsString(*dtType);
-                return new(mvqrHeap_) ConstValue(new(mvqrHeap_)SQLDate(FALSE, mvqrHeap_),
+                return new(mvqrHeap_) ConstValue(new(mvqrHeap_)SQLDate(mvqrHeap_, FALSE),
                                                  (void*)dtv.getValue(), dtv.getValueLen(),
                                                  &constValTextStr, mvqrHeap_);
                 break;
@@ -1367,9 +1367,8 @@ ConstValue* OptRangeSpec::reconstituteInt64Value(NAType* type, Int64 val) const
                                   "Invalid time value reconstructed from Int64 value");
                 constValTextStr = dtv.getValueAsString(*dtType);
                 return new(mvqrHeap_)
-                        ConstValue(new(mvqrHeap_)SQLTime(FALSE,
-                                                         dtType->getFractionPrecision(),
-                                                         mvqrHeap_),
+                        ConstValue(new(mvqrHeap_)SQLTime(mvqrHeap_, FALSE,
+                                                         dtType->getFractionPrecision()),
                                   (void*)dtv.getValue(), dtv.getValueLen(),
                                   &constValTextStr, mvqrHeap_);
                 break;
@@ -1387,9 +1386,8 @@ ConstValue* OptRangeSpec::reconstituteInt64Value(NAType* type, Int64 val) const
                                   "Invalid timestamp value reconstructed from Julian timestamp");
                 constValTextStr = dtv.getValueAsString(*dtType);
                 return new(mvqrHeap_) ConstValue(new(mvqrHeap_)
-                                                   SQLTimestamp(FALSE, 
-                                                                dtType->getFractionPrecision(),
-                                                                mvqrHeap_),
+                                                   SQLTimestamp(mvqrHeap_, FALSE, 
+                                                                dtType->getFractionPrecision()),
                                                  (void*)dtv.getValue(),
                                                  dtv.getValueLen(),
 		                            &constValTextStr, mvqrHeap_);
@@ -1509,12 +1507,11 @@ ConstValue* OptRangeSpec::reconstituteInt64Value(NAType* type, Int64 val) const
           // the Normalizer rather than MVQR, because type constraints are not
           // incorporated in that case). See bug 2974.
           return new(mvqrHeap_) ConstValue(new(mvqrHeap_)SQLInterval
-                                                 (FALSE,
+                                                 (mvqrHeap_, FALSE,
                                                   intvlType->getEndField(),
                                                   leadingPrec,
                                                   intvlType->getEndField(),
-                                                  intvlType->getFractionPrecision(),
-                                                  mvqrHeap_),
+                                                  intvlType->getFractionPrecision()),
                                       (void*)intvlVal.getValue(),
                                       intvlVal.getValueLen(),
                                       &constValTextStr, mvqrHeap_);
@@ -1560,7 +1557,7 @@ ConstValue* OptRangeSpec::reconstituteDoubleValue(NAType* type, Float64 val) con
                     "Expecting approximate numeric type in "
                         "reconstituteDoubleValue");
 
-  NAType* constType = new(mvqrHeap_) SQLDoublePrecision(FALSE, mvqrHeap_);
+  NAType* constType = new(mvqrHeap_) SQLDoublePrecision(mvqrHeap_, FALSE);
   return new(mvqrHeap_) ConstValue(constType, &val, constType->getNominalSize(),
                                    &constValTextStr, mvqrHeap_);
 } // reconstituteDoubleValue()
@@ -1573,7 +1570,7 @@ ItemExpr* OptRangeSpec::makeSubrangeORBackbone(SubrangeBase* subrange,
   QRTRACER("makeSubrangeOrBackbone");
 
   NAType* type = getType()->newCopy(mvqrHeap_);
-  NAType* int64Type = new (mvqrHeap_) SQLLargeInt(TRUE, FALSE );
+  NAType* int64Type = new (mvqrHeap_) SQLLargeInt(mvqrHeap_, TRUE, FALSE );
   type->resetSQLnullFlag();
   type->resetSQLnullHdrSize();
   assertLogAndThrow(CAT_SQL_COMP_RANGE, logLevel_,

--- a/core/sql/optimizer/PartFunc.cpp
+++ b/core/sql/optimizer/PartFunc.cpp
@@ -791,7 +791,7 @@ SinglePartitionPartitioningFunction::createPartitioningExpression()
   // ---------------------------------------------------------------------
   ItemExpr * partFunc = new (CmpCommon::statementHeap())
     Cast(new (CmpCommon::statementHeap()) SystemLiteral(0),
-	 new (CmpCommon::statementHeap()) SQLInt(FALSE,FALSE));
+	 new (CmpCommon::statementHeap()) SQLInt(CmpCommon::statementHeap(), FALSE,FALSE));
 
   partFunc->synthTypeAndValueId();
   storeExpression(partFunc);
@@ -1115,11 +1115,11 @@ void PartitioningFunction::createBetweenPartitioningKeyPredicates(
           // the partition input values are two integer values: lo and hi part #
           loPart = new (CmpCommon::statementHeap())
             HostVar(pivLoName,
-                    new (CmpCommon::statementHeap()) SQLInt(FALSE,FALSE),
+                    new (CmpCommon::statementHeap()) SQLInt(CmpCommon::statementHeap(), FALSE,FALSE),
                     TRUE);
           hiPart = new (CmpCommon::statementHeap())
             HostVar(pivHiName,
-                    new (CmpCommon::statementHeap()) SQLInt(FALSE,FALSE),
+                    new (CmpCommon::statementHeap()) SQLInt(CmpCommon::statementHeap(), FALSE,FALSE),
                     TRUE);
           loPart->synthTypeAndValueId();
           hiPart->synthTypeAndValueId();
@@ -1160,9 +1160,8 @@ void PartitioningFunction::createBetweenPartitioningKeyPredicates(
           NAString numPartsLiteral(numPartsString);
           ConstValue *numPartns = new (CmpCommon::statementHeap())
             ConstValue(new (CmpCommon::statementHeap())
-                         SQLInt(FALSE,
-                                FALSE,
-                                CmpCommon::statementHeap()),
+                         SQLInt(CmpCommon::statementHeap(), FALSE,
+                                FALSE),
                        (void *) &numOfOrigPartns,
                        (Lng32) sizeof(numOfOrigPartns),
                        &numPartsLiteral,
@@ -1457,7 +1456,7 @@ getCastedSkewValueExpr(const EncodedValue& ev, const NAType& oType, CollHeap* he
   double x = ev.getDblValue();
   return new (heap) Cast(
        new (heap) ConstValue(
-             new (heap) SQLDoublePrecision(FALSE /* no SQL NULL*/, heap), 
+             new (heap) SQLDoublePrecision(heap, FALSE /* no SQL NULL*/), 
              (char*)&x, sizeof(x)
                             ), 
        &oType
@@ -1541,7 +1540,7 @@ TableHashPartitioningFunction::createPartitionSelectionExprInputs()
   ItemExpr *numParts = new (heap)
         HostVar(hvFabricatedName,
                 // int not null
-                new (heap) SQLInt(FALSE, FALSE),
+                new (heap) SQLInt(CmpCommon::statementHeap(), FALSE, FALSE),
                 // is system-supplied
                 TRUE);
   numParts->synthTypeAndValueId();
@@ -1553,7 +1552,7 @@ TableHashPartitioningFunction::createPartitionSelectionExprInputs()
   ItemExpr *partNum = new (heap)
         HostVar(hvFabricatedName,
                 // int not null
-                new (heap) SQLInt(FALSE, FALSE),
+                new (heap) SQLInt(CmpCommon::statementHeap(), FALSE, FALSE),
                 // is system-supplied
                 TRUE);
   partNum->synthTypeAndValueId();
@@ -1718,7 +1717,7 @@ TableHashPartitioningFunction::createPartitioningExpressionImp(NABoolean doVarCh
         {
           dataConversionErrorFlag =
             new (heap) HostVar("_sys_repartConvErrorFlg",
-                               new (heap) SQLInt(TRUE,FALSE),
+                               new (heap) SQLInt(heap, TRUE,FALSE),
                                TRUE);
           storeConvErrorExpr(dataConversionErrorFlag);
         }
@@ -1884,7 +1883,7 @@ createPartitionSelectionExpr(const SearchKey *partSearchKey,
           {
             dataConversionErrorFlag =
               new (heap) HostVar("_sys_repartConvErrorFlg",
-                                 new (heap) SQLInt(TRUE,FALSE),
+                                 new (heap) SQLInt(heap, TRUE,FALSE),
                                  TRUE);
             storeConvErrorExpr(dataConversionErrorFlag);
           }
@@ -2371,7 +2370,7 @@ HashDistPartitioningFunction::buildPartitioningExpression(
 {
   CollHeap *heap = CmpCommon::statementHeap();
 
-  NAType *numPartsType = new (heap) SQLInt(FALSE,FALSE);
+  NAType *numPartsType = new (heap) SQLInt(heap, FALSE,FALSE);
   char buffer[20];
 
   // Create a ConstValue expression containing the original number of hash
@@ -2709,7 +2708,7 @@ ItemExpr *
 Hash2PartitioningFunction::buildPartitioningExpression(const ValueIdList &keyCols) const
 {
   CollHeap *heap = CmpCommon::statementHeap();
-  NAType *numPartsType = new (heap) SQLInt(FALSE,FALSE);
+  NAType *numPartsType = new (heap) SQLInt(heap, FALSE,FALSE);
 
   // Build a ConstValue expression of the scaled number of partitions.
   Lng32 numParts = getCountOfPartitions();
@@ -2757,7 +2756,7 @@ PartitioningFunction::getCastedItemExpre(ItemExpr* iv, const NAType& oType, Coll
           dataConversionErrorFlag =
             new (CmpCommon::statementHeap()) HostVar(
                  "_sys_repartConvErrorFlg",
-                 new (CmpCommon::statementHeap()) SQLInt(TRUE,FALSE),
+                 new (CmpCommon::statementHeap()) SQLInt(CmpCommon::statementHeap(), TRUE,FALSE),
                  TRUE);
           storeConvErrorExpr(dataConversionErrorFlag);
        }
@@ -2825,7 +2824,7 @@ void SkewedDataPartitioningFunction::createPIV(ValueIdList &partInputValues)
   //
   ItemExpr *dummyPIV = new (CmpCommon::statementHeap())
     HostVar("_sys_dummySkewBusterPartNo",
-	    new (CmpCommon::statementHeap()) SQLInt(FALSE, FALSE),
+	    new (CmpCommon::statementHeap()) SQLInt(CmpCommon::statementHeap(), FALSE, FALSE),
 	    TRUE);
   dummyPIV->synthTypeAndValueId();
 
@@ -4181,7 +4180,7 @@ void RangePartitioningFunction::createPartitioningKeyPredicates()
       ItemExpr *intervalExclusionIndicator =
 	new(CmpCommon::statementHeap()) HostVar(
 	     "_sys_hostVarExclRange",
-	     new(CmpCommon::statementHeap()) SQLInt(TRUE,FALSE),
+	     new(CmpCommon::statementHeap()) SQLInt(CmpCommon::statementHeap(), TRUE,FALSE),
 	     TRUE);
       intervalExclusionIndicator->synthTypeAndValueId();
       partInputValues.insert(intervalExclusionIndicator->getValueId());
@@ -4595,7 +4594,7 @@ ItemExpr* RangePartitioningFunction::createPartitioningExpression()
 	  dataConversionErrorFlag =
 	    new (CmpCommon::statementHeap()) HostVar(
 		 "_sys_repartConvErrorFlg",
-		 new (CmpCommon::statementHeap()) SQLInt(TRUE,FALSE),
+		 new (CmpCommon::statementHeap()) SQLInt(CmpCommon::statementHeap(), TRUE,FALSE),
 		 TRUE);
 	  storeConvErrorExpr(dataConversionErrorFlag);
 	}
@@ -5739,12 +5738,12 @@ void RoundRobinPartitioningFunction::createPartitioningKeyPredicates()
       //
       ItemExpr *loPart = new (CmpCommon::statementHeap())
         HostVar("_sys_HostVarLoRoundRobinPart",
-                new (CmpCommon::statementHeap()) SQLInt(FALSE, FALSE),
+                new (CmpCommon::statementHeap()) SQLInt(CmpCommon::statementHeap(), FALSE, FALSE),
                 TRUE);
 
       ItemExpr *hiPart = new (CmpCommon::statementHeap())
         HostVar("_sys_HostVarHiRoundRobinPart",
-                new (CmpCommon::statementHeap()) SQLInt(FALSE, FALSE),
+                new (CmpCommon::statementHeap()) SQLInt(CmpCommon::statementHeap(), FALSE, FALSE),
                 TRUE);
 
       loPart->synthTypeAndValueId();
@@ -5844,7 +5843,7 @@ ItemExpr* RoundRobinPartitioningFunction::createPartitioningExpression()
   // The type of the partitioning key for round robin is always
   // SQLLargeInt (the type of SYSKEY)
   //
-  NAType *desiredType = new (heap) SQLLargeInt(TRUE, FALSE);
+  NAType *desiredType = new (heap) SQLLargeInt(heap, TRUE, FALSE);
 
   // The layout of the SYSKEY is
   //
@@ -5857,9 +5856,9 @@ ItemExpr* RoundRobinPartitioningFunction::createPartitioningExpression()
                     desiredType),
                new (heap)
                ConstValue(32)),
-         new (heap) SQLInt(FALSE,FALSE));
+         new (heap) SQLInt(heap, FALSE,FALSE));
 
-  NAType *numPartsType = new (heap) SQLInt(FALSE,FALSE);
+  NAType *numPartsType = new (heap) SQLInt(heap, FALSE,FALSE);
 
   Lng32 numParts = getCountOfOrigRRPartitions();
   char buffer[20];
@@ -5919,7 +5918,7 @@ createPartitionSelectionExpr(const SearchKey *partSearchKey,
   //
   ItemExpr *numParts = new (heap) HostVar("_sys_hostVarNumParts",
                                           // int not null
-                                          new (heap) SQLInt(FALSE, FALSE),
+                                          new (heap) SQLInt(heap, FALSE, FALSE),
                                           // is system-supplied
                                           TRUE);
   numParts->synthTypeAndValueId();
@@ -5929,7 +5928,7 @@ createPartitionSelectionExpr(const SearchKey *partSearchKey,
   //
   ItemExpr *partNum = new (heap) HostVar("_sys_hostVarPartNo",
                                          // int not null
-                                         new (heap) SQLInt(FALSE, FALSE),
+                                         new (heap) SQLInt(heap, FALSE, FALSE),
                                          // is system-supplied
                                          TRUE);
   partNum->synthTypeAndValueId();
@@ -5960,7 +5959,7 @@ createPartitionSelectionExpr(const SearchKey *partSearchKey,
       new (heap) Modulus(new (heap) Cast(new (heap)
                                          BiArith(ITM_PLUS, partNum,
                                                  new (heap) SystemLiteral(1)),
-                                         new (heap) SQLInt(TRUE,FALSE)),
+                                         new (heap) SQLInt(heap, TRUE,FALSE)),
                          numParts);
 
     // Bind the expression.
@@ -5987,7 +5986,7 @@ createPartitionSelectionExpr(const SearchKey *partSearchKey,
     // The type of the partitioning key for round robin is always
     // SQLLargeInt (the type of SYSKEY)
     //
-    NAType *desiredType = new (heap) SQLLargeInt(TRUE, FALSE);
+    NAType *desiredType = new (heap) SQLLargeInt(heap,TRUE, FALSE);
 
     // The partition selection expression is:
     //
@@ -6014,7 +6013,7 @@ createPartitionSelectionExpr(const SearchKey *partSearchKey,
                                              desiredType),
                                         new (heap)
                                         SystemLiteral(0x1000)),
-                                  new (heap) SQLInt(FALSE,FALSE)),
+                                  new (heap) SQLInt(heap, FALSE,FALSE)),
                              numParts);
 
     // Bind the expression.

--- a/core/sql/optimizer/QRDescGenerator.cpp
+++ b/core/sql/optimizer/QRDescGenerator.cpp
@@ -178,22 +178,22 @@ void EqualitySet::determineType()
     {
       // Binary precision smallint, int, largeint, real, double)
       if (magnitude < 50)
-        type_ = new(heap_) SQLSmall(isSigned, isNullable, heap_);
+        type_ = new(heap_) SQLSmall(heap_,isSigned, isNullable);
       else if (magnitude < 100)
-        type_ = new(heap_) SQLInt(isSigned, isNullable, heap_);
+        type_ = new(heap_) SQLInt(heap_, isSigned, isNullable);
       else if (magnitude < 200)
-        type_ = new(heap_) SQLLargeInt(isSigned, isNullable, heap_);
+        type_ = new(heap_) SQLLargeInt(heap_, isSigned, isNullable);
       else if (magnitude < 500)
-        type_ = new(heap_) SQLReal(isNullable, heap_);
+        type_ = new(heap_) SQLReal(heap_, isNullable);
       else
-        type_ = new(heap_) SQLDoublePrecision(isNullable, heap_);
+        type_ = new(heap_) SQLDoublePrecision(heap_, isNullable);
     }
   else
     {
       // @ZX need to amend this (and elsewhere) for SQLBigNum.
       // Numeric or Decimal -- type will be generated as Numeric
       const Int16 DisAmbiguate = 0;
-      type_ = new(heap_) SQLNumeric(isSigned, (magnitude / 10) + scale, scale,
+      type_ = new(heap_) SQLNumeric(heap_, isSigned, (magnitude / 10) + scale, scale,
                                     DisAmbiguate,  // added for 64bit proj.
                                     isNullable);
     }

--- a/core/sql/optimizer/QRDescGenerator.cpp
+++ b/core/sql/optimizer/QRDescGenerator.cpp
@@ -2786,7 +2786,7 @@ void QRDescGenerator::putVegMembersInEqualitySet(
   // persist beyond this function. Note that ValueId is not an NABasicObject,
   // so we use the system heap.
   // 
-  QRValueId* vegVidPtr = new QRValueId(vegVid);
+  QRValueId* vegVidPtr = new (mvqrHeap_) QRValueId(vegVid);
   vegsUsedHash_.insert(vegVidPtr, eqSet);
 
   // Put the veg members in the list and in the hash tables.
@@ -2801,7 +2801,7 @@ void QRDescGenerator::putVegMembersInEqualitySet(
       if (op == ITM_BASECOLUMN)
         {
           eqSet->insert(itemExpr);
-          vidPtr = new QRValueId(vid);
+          vidPtr = new (mvqrHeap_) QRValueId(vid);
           vegsUsedHash_.insert(vidPtr, eqSet);
         }
       else if (op != ITM_INDEXCOLUMN)
@@ -3074,7 +3074,7 @@ void QRDescGenerator::storeRangeInfo(OptRangeSpec* range, QRJBBPtr jbbElem)
   QRTRACER("QRDescGenerator::storeRangeInfo()");
   RangeInfo* rangeInfo = NULL;
   NAString* exprText = NULL;
-  QRValueId* key = new QRValueId(range->getRangeJoinPredId());
+  QRValueId* key = new (mvqrHeap_) QRValueId(range->getRangeJoinPredId());
 
   if (*key != NULL_VALUE_ID)
     rangeInfo = rangeColHash_.getFirstValue(key);
@@ -3085,7 +3085,7 @@ void QRDescGenerator::storeRangeInfo(OptRangeSpec* range, QRJBBPtr jbbElem)
     }
   else
     {
-      exprText = new NAString(range->getRangeExprText());
+      exprText = new (mvqrHeap_) NAString(range->getRangeExprText(), mvqrHeap_);
       rangeInfo = rangeExprHash_.getFirstValue(exprText);
     }
 

--- a/core/sql/optimizer/QRDescriptorExtentions.cpp
+++ b/core/sql/optimizer/QRDescriptorExtentions.cpp
@@ -171,7 +171,7 @@ ItemExpr* QRFunction::toItemExpr(const NAString& mvName, CollHeap* heap,
     // otherwise, ScalarVariance::preCodeGen will GenAssert.
     NABoolean isScalarVariance = (getFunctionName() == "Scalar Variance"  ||
                                 getFunctionName() == "Scalar Stddev" );
-    NAType *dbl = new(heap) SQLDoublePrecision(FALSE, heap);
+    NAType *dbl = new(heap) SQLDoublePrecision(heap, FALSE);
 
     // Loop over the arguments and call recursively.
     for (CollIndex i=0; i<args.entries(); i++)

--- a/core/sql/optimizer/RelCache.cpp
+++ b/core/sql/optimizer/RelCache.cpp
@@ -241,7 +241,7 @@ RelExpr* Scan::normalizeForCache(CacheWA& cwa, BindWA& bindWA)
       HostVar * hv = 
 	new(bindWA.wHeap()) 
 	HostVar(hvName, 
-		new(bindWA.wHeap()) SQLChar(CACHED_MAX_ANSI_NAME_EXTERNAL_LEN));
+		new(bindWA.wHeap()) SQLChar(bindWA.wHeap(), CACHED_MAX_ANSI_NAME_EXTERNAL_LEN));
       hv->setPrototypeValue(origName.getQualifiedNameAsString());
       hv->synthTypeAndValueId();
       hv->setIsCachedParam(TRUE);
@@ -265,7 +265,7 @@ RelExpr* Scan::normalizeForCache(CacheWA& cwa, BindWA& bindWA)
 	new(bindWA.wHeap()) char[CACHED_MAX_ANSI_NAME_EXTERNAL_LEN];
       strcpy(strval, origName.getQualifiedNameAsString().data());
       CharType * typ = 
-	new(bindWA.wHeap()) SQLChar(CACHED_MAX_ANSI_NAME_EXTERNAL_LEN, FALSE);
+	new(bindWA.wHeap()) SQLChar(bindWA.wHeap(), CACHED_MAX_ANSI_NAME_EXTERNAL_LEN, FALSE);
       ConstValue * cv = 
 	new(bindWA.wHeap()) ConstValue(typ, strval, CACHED_MAX_ANSI_NAME_EXTERNAL_LEN);
 

--- a/core/sql/optimizer/RelStoredProc.cpp
+++ b/core/sql/optimizer/RelStoredProc.cpp
@@ -350,7 +350,7 @@ RelExpr* RelInternalSP::bindNode(BindWA *bindWA)
 	    str_cpy (&newInput[inputSize+1], defaultSchema.data(), defaultSchema.length());
 #pragma warn(1506)  // warning elimination 
 
-	    NAType *newType   = new (bindWA->wHeap()) SQLChar (newInputSize, FALSE);
+	    NAType *newType   = new (bindWA->wHeap()) SQLChar (bindWA->wHeap(), newInputSize, FALSE);
 	    ItemExpr *newItem = new (bindWA->wHeap()) ConstValue(newType, newInput, newInputSize );
 	    newItem->bindNode(bindWA);
 	    getProcAllParamsVids()[0] = newItem->getValueId();

--- a/core/sql/optimizer/SynthType.cpp
+++ b/core/sql/optimizer/SynthType.cpp
@@ -748,30 +748,29 @@ static const NAType *synthAvgSum(const NAType& operand,
 	    {
 	      if (scale > 0)
 		return new HEAP
-		  SQLNumeric(8, // length = 8 bytes
+		  SQLNumeric(HEAP, 8, // length = 8 bytes
 			     precision,
 			     scale,
                              (precision > 9 ? TRUE : type->isSigned()),
 			     aggNeedsToBeNullable);
 
 	      else
-		return new HEAP SQLLargeInt(TRUE, aggNeedsToBeNullable);
+		return new HEAP SQLLargeInt(HEAP, TRUE, aggNeedsToBeNullable);
 
 	    }
 	  else
             {
 	      return new HEAP
-	        SQLBigNum(precision,
+	        SQLBigNum(HEAP, precision,
 			  scale,
 			  isARealBigNum,
 			  type->isSigned(),
-			  aggNeedsToBeNullable,
-			  NULL);
+			  aggNeedsToBeNullable);
             }
 	}
       else
 	{
-	  return new HEAP SQLDoublePrecision(aggNeedsToBeNullable);
+	  return new HEAP SQLDoublePrecision(HEAP, aggNeedsToBeNullable);
 	}
     }
   break;
@@ -782,7 +781,7 @@ static const NAType *synthAvgSum(const NAType& operand,
       if (type->isSupportedType())
       {
        return new HEAP
-         SQLInterval(aggNeedsToBeNullable,
+         SQLInterval(HEAP, aggNeedsToBeNullable,
                      type->getStartField(),
                      type->computeLeadingPrecision(type->getStartField(),
                                                    MAX_NUMERIC_PRECISION,
@@ -925,7 +924,7 @@ const NAType *ItemExpr::synthesizeType()
 {
   if (getArity() > 0)
     return &child(0)->castToItemExpr()->getValueId().getType();
-  return new HEAP SQLUnknown();
+  return new HEAP SQLUnknown(HEAP);
 }
 
 // Propagate type information down the ItemExpr tree.
@@ -993,7 +992,7 @@ const NAType *BuiltinFunction::synthesizeType()
 	ValueId vid1 = child(0)->getValueId();
 
 	// untyped param operands are typed as Int32 Unsigned.
-	SQLInt si(FALSE);
+	SQLInt si(NULL, FALSE);
 	vid1.coerceType(si, NA_NUMERIC_TYPE);
 
 	const NAType &typ1 = vid1.getType();
@@ -1005,17 +1004,17 @@ const NAType *BuiltinFunction::synthesizeType()
 	if ( typ1.getTypeQualifier() == NA_CHARACTER_TYPE &&
 	     typ1.isVaryingLen() == TRUE )
 	  retType = new HEAP
-	    SQLVarChar(maxLength, typ1.supportsSQLnull());
+	    SQLVarChar(HEAP, maxLength, typ1.supportsSQLnull());
 	else
 	  retType = new HEAP
-	    SQLChar(maxLength, typ1.supportsSQLnull());
+	    SQLChar(HEAP, maxLength, typ1.supportsSQLnull());
       }
     break;
     case ITM_SHA1:
       {
         // type cast any params
         ValueId vid1 = child(0)->getValueId();
-        SQLChar c1(ComSqlId::MAX_QUERY_ID_LEN);
+        SQLChar c1(NULL, ComSqlId::MAX_QUERY_ID_LEN);
         vid1.coerceType(c1, NA_CHARACTER_TYPE);
         //input type must be string
         const NAType &typ1 = child(0)->getValueId().getType();
@@ -1027,7 +1026,7 @@ const NAType *BuiltinFunction::synthesizeType()
           }
 
         retType = new HEAP
-           SQLChar(128, FALSE);
+           SQLChar(HEAP, 128, FALSE);
 	if (typ1.supportsSQLnull())
 	  {
 	    retType->setNullable(TRUE);
@@ -1041,7 +1040,7 @@ const NAType *BuiltinFunction::synthesizeType()
     case ITM_SHA2_512:
       {
         ValueId vid1 = child(0)->getValueId();
-        SQLChar c1(ComSqlId::MAX_QUERY_ID_LEN);
+        SQLChar c1(NULL, ComSqlId::MAX_QUERY_ID_LEN);
         vid1.coerceType(c1, NA_CHARACTER_TYPE);
 
         const NAType &typ1 = child(0)->getValueId().getType();
@@ -1070,7 +1069,7 @@ const NAType *BuiltinFunction::synthesizeType()
             break;
         }
         retType = new HEAP
-          SQLChar(resultLen, typ1.supportsSQLnull());
+          SQLChar(HEAP, resultLen, typ1.supportsSQLnull());
       }
     break;
 
@@ -1078,7 +1077,7 @@ const NAType *BuiltinFunction::synthesizeType()
       {
         // type cast any params
         ValueId vid1 = child(0)->getValueId();
-        SQLChar c1(ComSqlId::MAX_QUERY_ID_LEN);
+        SQLChar c1(NULL, ComSqlId::MAX_QUERY_ID_LEN);
         vid1.coerceType(c1, NA_CHARACTER_TYPE);
         //input type must be string
         const NAType &typ1 = child(0)->getValueId().getType();
@@ -1090,7 +1089,7 @@ const NAType *BuiltinFunction::synthesizeType()
           }
 
         retType = new HEAP
-           SQLChar(32, FALSE);
+           SQLChar(HEAP, 32, FALSE);
 	if (typ1.supportsSQLnull())
 	  {
 	    retType->setNullable(TRUE);
@@ -1101,7 +1100,7 @@ const NAType *BuiltinFunction::synthesizeType()
       {
         const NAType &typ1 = child(0)->getValueId().getType();
         retType = new HEAP
-           SQLInt(FALSE, FALSE); //unsigned int
+           SQLInt(HEAP, FALSE, FALSE); //unsigned int
         if (typ1.supportsSQLnull())
           {
             retType->setNullable(TRUE);
@@ -1113,7 +1112,7 @@ const NAType *BuiltinFunction::synthesizeType()
       {
         // type cast any params
         ValueId vid1 = child(0)->getValueId();
-        SQLChar c1(ComSqlId::MAX_QUERY_ID_LEN);
+        SQLChar c1(NULL, ComSqlId::MAX_QUERY_ID_LEN);
         vid1.coerceType(c1, NA_CHARACTER_TYPE);
         //input type must be string
         const NAType &typ1 = child(0)->getValueId().getType();
@@ -1124,7 +1123,7 @@ const NAType *BuiltinFunction::synthesizeType()
 	    return NULL;
           }
         retType = new HEAP
-           SQLSmall(TRUE, FALSE);
+           SQLSmall(HEAP, TRUE, FALSE);
 	if (typ1.supportsSQLnull())
 	  {
 	    retType->setNullable(TRUE);
@@ -1135,7 +1134,7 @@ const NAType *BuiltinFunction::synthesizeType()
       {
         // type cast any params
         ValueId vid1 = child(0)->getValueId();
-        SQLChar c1(ComSqlId::MAX_QUERY_ID_LEN);
+        SQLChar c1(NULL, ComSqlId::MAX_QUERY_ID_LEN);
         vid1.coerceType(c1, NA_CHARACTER_TYPE);
 
         //input type must be string
@@ -1147,7 +1146,7 @@ const NAType *BuiltinFunction::synthesizeType()
 	    return NULL;
           }
         retType = new HEAP
-           SQLInt(FALSE, FALSE);
+           SQLInt(HEAP, FALSE, FALSE);
 	if (typ1.supportsSQLnull())
 	  {
 	    retType->setNullable(TRUE);
@@ -1174,7 +1173,7 @@ const NAType *BuiltinFunction::synthesizeType()
 	  }
 
 	retType = new HEAP
-	  SQLVarChar(15, FALSE);
+	  SQLVarChar(HEAP, 15, FALSE);
 
 	if (typ1.supportsSQLnull())
 	  {
@@ -1264,7 +1263,7 @@ const NAType *BuiltinFunction::synthesizeType()
         }
 
         retType = new HEAP
-        SQLVarChar(typ1.getNominalSize(), typ1.supportsSQLnull());
+        SQLVarChar(HEAP, typ1.getNominalSize(), typ1.supportsSQLnull());
     }
     break;
 
@@ -1272,11 +1271,11 @@ const NAType *BuiltinFunction::synthesizeType()
       {
 	// type cast any params
 	ValueId vid1 = child(0)->getValueId();
-	SQLChar c1(ComSqlId::MAX_QUERY_ID_LEN);
+	SQLChar c1(NULL, ComSqlId::MAX_QUERY_ID_LEN);
 	vid1.coerceType(c1, NA_CHARACTER_TYPE);
 
 	ValueId vid2 = child(1)->getValueId();
-	SQLChar c2(40, FALSE);
+	SQLChar c2(NULL, 40, FALSE);
 	vid2.coerceType(c2, NA_CHARACTER_TYPE);
 
 	const CharType &typ1 = (CharType&)child(0)->getValueId().getType();
@@ -1300,7 +1299,7 @@ const NAType *BuiltinFunction::synthesizeType()
 	  }
 
 	retType = new HEAP
-	  SQLVarChar(ComSqlId::MAX_QUERY_ID_LEN,
+	  SQLVarChar(HEAP, ComSqlId::MAX_QUERY_ID_LEN,
                      (typ1.supportsSQLnull() || typ2.supportsSQLnull()),
                      FALSE, // not upshifted
                      FALSE, // not case-insensitive
@@ -1331,7 +1330,7 @@ const NAType *BuiltinFunction::synthesizeType()
 	  }
 
 	retType = new HEAP
-	  SQLVarChar(typ2.getNominalSize(), typ2.supportsSQLnull());
+	  SQLVarChar(HEAP, typ2.getNominalSize(), typ2.supportsSQLnull());
       }
     break;
 
@@ -1359,7 +1358,7 @@ const NAType *BuiltinFunction::synthesizeType()
 
     case ITM_UNIQUE_ID:
       {
-	retType = new HEAP SQLChar(16, FALSE);
+	retType = new HEAP SQLChar(HEAP, 16, FALSE);
       }
       break;
 
@@ -1367,7 +1366,7 @@ const NAType *BuiltinFunction::synthesizeType()
       {
           // type cast any params
           ValueId vid1 = child(0)->getValueId();
-          SQLChar c1(ComSqlId::MAX_QUERY_ID_LEN);
+          SQLChar c1(NULL, ComSqlId::MAX_QUERY_ID_LEN);
           vid1.coerceType(c1, NA_CHARACTER_TYPE);
           
           //input type must be string
@@ -1379,7 +1378,7 @@ const NAType *BuiltinFunction::synthesizeType()
               return NULL;
           }
 
-          retType = new HEAP SQLChar(4, FALSE);
+          retType = new HEAP SQLChar(HEAP, 4, FALSE);
           if (typ1.supportsSQLnull())
           {
               retType->setNullable(TRUE);
@@ -1435,7 +1434,7 @@ const NAType *BuiltinFunction::synthesizeType()
         }
 
         retType = new HEAP
-            SQLVarChar(maxLength, TRUE);
+            SQLVarChar(HEAP, maxLength, TRUE);
       }
       break;
 
@@ -1483,7 +1482,7 @@ const NAType *Abs::synthesizeType()
 
   // type cast any params
   ValueId vid = child(0)->getValueId();
-  SQLDoublePrecision dp(TRUE);
+  SQLDoublePrecision dp(NULL, TRUE);
   vid.coerceType(dp, NA_NUMERIC_TYPE);
 
   const NAType &typ1 = child(0)->getValueId().getType();
@@ -1512,19 +1511,19 @@ const NAType *Abs::synthesizeType()
           else
             length = 8;
 
-          result = new HEAP SQLNumeric(length,
+          result = new HEAP SQLNumeric(HEAP, length,
                                        precision,
                                        ntyp1.getScale(),
                                        ntyp1.isSigned());
         }
       else if (NOT ntyp1.isBigNum() && (ntyp1.getScale()==0) ) // this must be LargeInt
-        result = new HEAP SQLLargeInt(ntyp1.isSigned());
+        result = new HEAP SQLLargeInt(HEAP, ntyp1.isSigned());
       else
-        result = new HEAP SQLDoublePrecision();
+        result = new HEAP SQLDoublePrecision(HEAP);
     }
   else
     {
-      result = new HEAP SQLDoublePrecision();
+      result = new HEAP SQLDoublePrecision(HEAP);
     }
 
   if (ntyp1.supportsSQLnullLogical()) result->setNullable(TRUE);
@@ -1638,7 +1637,7 @@ const NAType *CodeVal::synthesizeType()
       return NULL;
   }
 
-  NAType *result = new (HEAP) SQLInt(FALSE, typ1.supportsSQLnullLogical());
+  NAType *result = new (HEAP) SQLInt(HEAP, FALSE, typ1.supportsSQLnullLogical());
 
   return result;
 }
@@ -1654,7 +1653,7 @@ const NAType *Aggregate::synthesizeType()
   case ITM_COUNT:
   case ITM_COUNT_NONULL:
     result = new HEAP
-      SQLLargeInt(TRUE /* 'long long' on NSK can't be unsigned */,
+      SQLLargeInt(HEAP, TRUE /* 'long long' on NSK can't be unsigned */,
 		  FALSE /*not null*/);
     break;
   case ITM_AVG:
@@ -1723,7 +1722,7 @@ const NAType *Aggregate::synthesizeType()
     {
 	  // grouping result is an unsigned int (32 bit)
       result = new HEAP
-        SQLInt(FALSE /*unsigned*/,
+        SQLInt(HEAP, FALSE /*unsigned*/,
                FALSE /*not null*/);
     }
   break;
@@ -1745,7 +1744,7 @@ const NAType *Aggregate::synthesizeType()
     // The argument of a ONE/ANY TRUE must be of type SQLBoolean
     CMPASSERT(operand.getTypeQualifier() == NA_BOOLEAN_TYPE);
 
-    result = new HEAP SQLBooleanRelat(operand.canBeSQLUnknown());
+    result = new HEAP SQLBooleanRelat(HEAP, operand.canBeSQLUnknown());
     break;
   }
   default:
@@ -1774,7 +1773,7 @@ const NAType *AggrMinMax::synthesizeType()
 const NAType *AggrGrouping::synthesizeType()
 {
   // result unsigned 32 bit integer
-  const NAType *result = new HEAP SQLInt(FALSE, FALSE);
+  const NAType *result = new HEAP SQLInt(HEAP, FALSE, FALSE);
 
   return result;
 }
@@ -1784,7 +1783,7 @@ const NAType *AggrGrouping::synthesizeType()
 // -----------------------------------------------------------------------
 const NAType *PivotGroup::synthesizeType()
 {
-  return new HEAP SQLVarChar(maxLen_, TRUE);
+  return new HEAP SQLVarChar(HEAP, maxLen_, TRUE);
 }
 
 // -----------------------------------------------------------------------
@@ -1798,7 +1797,7 @@ static const Lng32 OPT_MAX_USERNAME_LEN	 = ComSqlId::MAX_LDAP_USER_NAME_LEN+1;
 
 const NAType *AnsiUSERFunction::synthesizeType()
 {
-  return new HEAP SQLVarChar(OPT_MAX_USERNAME_LEN, FALSE);
+  return new HEAP SQLVarChar(HEAP, OPT_MAX_USERNAME_LEN, FALSE);
 }
 
 const NAType *MonadicUSERFunction::synthesizeType()
@@ -1808,7 +1807,7 @@ const NAType *MonadicUSERFunction::synthesizeType()
   //
   ValueId vid = child(0)->getValueId();
 
-  SQLInt si(TRUE);
+  SQLInt si(NULL, TRUE);
   vid.coerceType(si, NA_NUMERIC_TYPE);
 
   //
@@ -1841,7 +1840,7 @@ const NAType *MonadicUSERFunction::synthesizeType()
   //
   // Return the result.
   //
-  return new HEAP SQLVarChar(OPT_MAX_USERNAME_LEN, typ1.supportsSQLnullLogical());
+  return new HEAP SQLVarChar(HEAP, OPT_MAX_USERNAME_LEN, typ1.supportsSQLnullLogical());
 }
 
 const NAType *MonadicUSERIDFunction::synthesizeType()
@@ -1864,7 +1863,7 @@ const NAType *MonadicUSERIDFunction::synthesizeType()
   //
   // Return the result.
   //
-  return new HEAP SQLVarChar(OPT_MAX_USERNAME_LEN, operand.supportsSQLnullLogical());
+  return new HEAP SQLVarChar(HEAP, OPT_MAX_USERNAME_LEN, operand.supportsSQLnullLogical());
 }
 
 // -----------------------------------------------------------------------
@@ -2089,7 +2088,7 @@ const NAType *Between::synthesizeType()
   //
   // Return the result.
   //
-  return new HEAP SQLBooleanRelat(allowsUnknown);
+  return new HEAP SQLBooleanRelat(HEAP, allowsUnknown);
 }
 
 // -----------------------------------------------------------------------
@@ -2259,7 +2258,7 @@ const NAType *UnArith::synthesizeType()
       return NULL;
     }
 
-  NAType * retType = new HEAP SQLBooleanNative(operand1.supportsSQLnull());
+  NAType * retType = new HEAP SQLBooleanNative(HEAP, operand1.supportsSQLnull());
 
   return retType;
 }
@@ -2276,7 +2275,7 @@ const NAType *BiLogic::synthesizeType()
   NABoolean allowsUnknown = operand0.canBeSQLUnknown() OR
                             operand1.canBeSQLUnknown();
 
-  return new HEAP SQLBooleanRelat(allowsUnknown);
+  return new HEAP SQLBooleanRelat(HEAP, allowsUnknown);
 }
 
 // -----------------------------------------------------------------------
@@ -2312,7 +2311,7 @@ const NAType *BiRelat::synthesizeType()
   if (!synthItemExprLists(exprList1, exprList2, allowIncompatibleComparison,
 			  allowsUnknown, this))
     return NULL;
-  return new HEAP SQLBooleanRelat(allowsUnknown);
+  return new HEAP SQLBooleanRelat(HEAP, allowsUnknown);
 }
 
 // -----------------------------------------------------------------------
@@ -2321,7 +2320,7 @@ const NAType *BiRelat::synthesizeType()
 
 const NAType *BoolResult::synthesizeType()
 {
-  return new HEAP SQLBooleanRelat(getOperatorType() == ITM_RETURN_NULL);
+  return new HEAP SQLBooleanRelat(HEAP, getOperatorType() == ITM_RETURN_NULL);
 }
 
 // -----------------------------------------------------------------------
@@ -2330,7 +2329,7 @@ const NAType *BoolResult::synthesizeType()
 
 const NAType *BoolVal::synthesizeType()
 {
-  return new HEAP SQLBooleanRelat(getOperatorType() == ITM_RETURN_NULL);
+  return new HEAP SQLBooleanRelat(HEAP, getOperatorType() == ITM_RETURN_NULL);
 }
 
 //------------------------------------------------------------------
@@ -2743,11 +2742,11 @@ const NAType *CastConvert::synthesizeType()
   CharType * origType = (CharType *)getType();
   if (DFS2REC::isAnyVarChar(origType->getFSDatatype()) == FALSE)
     type = new HEAP
-      SQLChar(maxLength, childType.supportsSQLnull(),
+      SQLChar(HEAP, maxLength, childType.supportsSQLnull(),
 	      origType->isUpshifted());
   else
     type = new HEAP
-      SQLVarChar(maxLength, childType.supportsSQLnull(),
+      SQLVarChar(HEAP, maxLength, childType.supportsSQLnull(),
 		 origType->isUpshifted());
 
   return type;
@@ -2782,7 +2781,7 @@ const NAType *CharFunc::synthesizeType()
   //
   // Type cast any params.
   //
-  SQLInt nType(FALSE);
+  SQLInt nType(NULL, FALSE);
   ValueId vid1 = child(0)->getValueId();
   vid1.coerceType(nType, NA_NUMERIC_TYPE);
 
@@ -2817,14 +2816,14 @@ const NAType *CharFunc::synthesizeType()
   CharType *result;
 
   if(charSet_ == CharInfo::UCS2 || charSet_ < 0)  // UCS2, kanji and KSC5601_MP
-    result = new (HEAP) SQLChar ( 1,
+    result = new (HEAP) SQLChar ( HEAP, 1,
                                   typ1.supportsSQLnullLogical(),
                                   FALSE/*not upshift*/,
                                   FALSE/*case sensitive*/,
                                   FALSE/*not varchar*/,
                                   charSet_);
   else
-    result = new (HEAP) SQLVarChar(CharInfo::maxBytesPerChar( cs_to_use )
+    result = new (HEAP) SQLVarChar(HEAP, CharInfo::maxBytesPerChar( cs_to_use )
                                   , typ1.supportsSQLnullLogical()
                                   , FALSE /*not upshift*/
                                   , FALSE /*case sensitive*/
@@ -2889,10 +2888,10 @@ const NAType *ConvertHex::synthesizeType()
        ( (const CharType*)operand)->getCharSet()==CharInfo::UTF8 )
      )
     type = new HEAP
-      SQLVarChar(maxLength, operand->supportsSQLnull());
+      SQLVarChar(HEAP, maxLength, operand->supportsSQLnull());
   else
     type = new HEAP
-      SQLChar(maxLength, operand->supportsSQLnull());
+      SQLChar(HEAP, maxLength, operand->supportsSQLnull());
 
   //
   // Return the result.
@@ -2953,7 +2952,7 @@ const NAType *CharLength::synthesizeType()
   // Return the result.
   //
   return new HEAP
-    SQLInt(FALSE  // unsigned
+    SQLInt(HEAP, FALSE  // unsigned
 	   ,operand.supportsSQLnullLogical()
 	   );
 }
@@ -3055,7 +3054,7 @@ const NAType *ConvertTimestamp::synthesizeType()
   // Type cast any params.
   //
   ValueId vid = child(0)->getValueId();
-  SQLLargeInt largeintType;
+  SQLLargeInt largeintType(NULL);
   vid.coerceType(largeintType);
   //
   // Check that the operands are compatible.
@@ -3070,9 +3069,8 @@ const NAType *ConvertTimestamp::synthesizeType()
   //
   // Return the result.
   //
-  return new HEAP SQLTimestamp (operand.supportsSQLnullLogical(),
-                               SQLTimestamp::DEFAULT_FRACTION_PRECISION,
-                               HEAP);
+  return new HEAP SQLTimestamp (HEAP, operand.supportsSQLnullLogical(),
+                               SQLTimestamp::DEFAULT_FRACTION_PRECISION);
 
 }
 
@@ -3082,9 +3080,8 @@ const NAType *ConvertTimestamp::synthesizeType()
 
 const NAType *CurrentTimestamp::synthesizeType()
 {
-  return new HEAP SQLTimestamp (FALSE,
-                                SQLTimestamp::DEFAULT_FRACTION_PRECISION,
-                                HEAP);
+  return new HEAP SQLTimestamp (HEAP, FALSE,
+                                SQLTimestamp::DEFAULT_FRACTION_PRECISION);
 }
 
 // -----------------------------------------------------------------------
@@ -3093,7 +3090,7 @@ const NAType *CurrentTimestamp::synthesizeType()
 
 const NAType *InternalTimestamp::synthesizeType()
 {
-  return new SQLTimestamp(FALSE);
+  return new HEAP SQLTimestamp(HEAP, FALSE);
 }
 
 // -----------------------------------------------------------------------
@@ -3102,7 +3099,7 @@ const NAType *InternalTimestamp::synthesizeType()
 
 const NAType *CurrentTimestampRunning::synthesizeType()
 {
-  return new HEAP SQLTimestamp(FALSE);
+  return new HEAP SQLTimestamp(HEAP, FALSE);
 }
 
 // -----------------------------------------------------------------------
@@ -3114,7 +3111,7 @@ const NAType *DateFormat::synthesizeType()
   // Type cast any params.
   //
   ValueId vid = child(0)->getValueId();
-  SQLTimestamp timestampType;
+  SQLTimestamp timestampType(NULL);
   vid.coerceType(timestampType);
   //
   // Check that the operands are compatible.
@@ -3179,13 +3176,13 @@ const NAType *DateFormat::synthesizeType()
     }
 
   if (formatAsDate)
-    return new HEAP SQLDate(vid.getType().supportsSQLnullLogical());
+    return new HEAP SQLDate(HEAP, vid.getType().supportsSQLnullLogical());
   else if (formatAsTimestamp)
-    return new HEAP SQLTimestamp(vid.getType().supportsSQLnullLogical());
+    return new HEAP SQLTimestamp(HEAP, vid.getType().supportsSQLnullLogical());
   else if (formatAsTime)
-    return new HEAP SQLTime(vid.getType().supportsSQLnullLogical());
+    return new HEAP SQLTime(HEAP, vid.getType().supportsSQLnullLogical());
   else
-    return new HEAP SQLChar(length, vid.getType().supportsSQLnullLogical());
+    return new HEAP SQLChar(HEAP, length, vid.getType().supportsSQLnullLogical());
 }
 
 // -----------------------------------------------------------------------
@@ -3198,7 +3195,7 @@ const NAType *DayOfWeek::synthesizeType()
   // Type cast any params.
   //
   ValueId vid = child(0)->getValueId();
-  SQLTimestamp timestampType;
+  SQLTimestamp timestampType(NULL);
   vid.coerceType(timestampType);
   //
   // Check that the operand contains a DAY field
@@ -3217,7 +3214,7 @@ const NAType *DayOfWeek::synthesizeType()
   // Return the result.
   //
   const Int16 DisAmbiguate = 0; // added for 64bit project
-  return new HEAP SQLNumeric(FALSE, 1, 0, DisAmbiguate,
+  return new HEAP SQLNumeric(HEAP, FALSE, 1, 0, DisAmbiguate,
                              operand.supportsSQLnullLogical());
 }
 
@@ -3228,7 +3225,7 @@ const NAType *DayOfWeek::synthesizeType()
 const NAType *DynamicParam::synthesizeType()
 {
   // dynamic params are always nullable.
-  return new HEAP SQLUnknown(TRUE);
+  return new HEAP SQLUnknown(HEAP, TRUE);
 }
 
 
@@ -3312,7 +3309,7 @@ if (0)
 const NAType *Hash::synthesizeType()
 {
   // result of hash function is always a non-nullable, unsigned 32 bit integer
-  return new HEAP SQLInt(FALSE, FALSE);
+  return new HEAP SQLInt(HEAP, FALSE, FALSE);
 }
 
 // -----------------------------------------------------------------------
@@ -3349,7 +3346,7 @@ const NAType *HashComb::synthesizeType()
 
   // result of hashcomb function is always a non-nullable,
   // unsigned 32 bit integer
-  return new HEAP SQLInt(FALSE, FALSE);
+  return new HEAP SQLInt(HEAP, FALSE, FALSE);
 }
 
 const NAType *HiveHashComb::synthesizeType()
@@ -3363,7 +3360,7 @@ const NAType *HiveHashComb::synthesizeType()
 
   // result of hashcomb function is always a non-nullable,
   // unsigned 32 bit integer
-  return new HEAP SQLInt(FALSE, FALSE);
+  return new HEAP SQLInt(HEAP, FALSE, FALSE);
 }
 
 // -----------------------------------------------------------------------
@@ -3376,7 +3373,7 @@ const NAType *HiveHashComb::synthesizeType()
 const NAType *HashDistPartHash::synthesizeType()
 {
   // result of hash function is always a non-nullable, unsigned 32 bit integer
-  return new HEAP SQLInt(FALSE, FALSE);
+  return new HEAP SQLInt(HEAP, FALSE, FALSE);
 }
 
 // -----------------------------------------------------------------------
@@ -3385,7 +3382,7 @@ const NAType *HashDistPartHash::synthesizeType()
 const NAType *HiveHash::synthesizeType()
 {
   // result of hivehash function is always a non-nullable, unsigned 32 bit integer
-  return new HEAP SQLInt(FALSE, FALSE);
+  return new HEAP SQLInt(HEAP, FALSE, FALSE);
 }
 
 // -----------------------------------------------------------------------
@@ -3424,7 +3421,7 @@ const NAType *HashDistPartHashComb::synthesizeType()
 
   // result of hashcomb function is always a non-nullable,
   // unsigned 32 bit integer
-  return new HEAP SQLInt(FALSE, FALSE);
+  return new HEAP SQLInt(HEAP, FALSE, FALSE);
 }
 
 // -----------------------------------------------------------------------
@@ -3451,7 +3448,7 @@ const NAType *JulianTimestamp::synthesizeType()
   // Type cast any params.
   //
   ValueId vid = child(0)->getValueId();
-  SQLTimestamp timestampType;
+  SQLTimestamp timestampType(NULL);
   vid.coerceType(timestampType);
   //
   // Check that the operands are compatible.
@@ -3465,7 +3462,7 @@ const NAType *JulianTimestamp::synthesizeType()
   //
   // Return the result.
   //
-  return new HEAP SQLLargeInt(TRUE, operand.supportsSQLnullLogical());
+  return new HEAP SQLLargeInt(HEAP, TRUE, operand.supportsSQLnullLogical());
 }
 
 // -----------------------------------------------------------------------
@@ -3473,7 +3470,7 @@ const NAType *JulianTimestamp::synthesizeType()
 // -----------------------------------------------------------------------
 const NAType * StatementExecutionCount::synthesizeType()
 {
-  return new HEAP SQLLargeInt(TRUE,FALSE);
+  return new HEAP SQLLargeInt(HEAP, TRUE,FALSE);
 }
 
 // -----------------------------------------------------------------------
@@ -3481,7 +3478,7 @@ const NAType * StatementExecutionCount::synthesizeType()
 // -----------------------------------------------------------------------
 const NAType * CurrentTransId::synthesizeType()
 {
-  return new HEAP SQLLargeInt(TRUE,FALSE);
+  return new HEAP SQLLargeInt(HEAP, TRUE,FALSE);
 }
 
 // -----------------------------------------------------------------------
@@ -3495,7 +3492,7 @@ const NAType *BitOperFunc::synthesizeType()
       // type cast any params
       ValueId vid = child(i)->getValueId();
       // untyped param operands are typed as Int32 Unsigned.
-      SQLInt dp(FALSE);
+      SQLInt dp(NULL, FALSE);
       vid.coerceType(dp, NA_NUMERIC_TYPE);
 
       const NAType &typ = vid.getType();
@@ -3599,7 +3596,7 @@ const NAType *BitOperFunc::synthesizeType()
 	else
 	  {
 	    const Int16 DisAmbiguate = 0;
-	    result1 = new HEAP SQLNumeric(NOT ntyp1.isUnsigned(),
+	    result1 = new HEAP SQLNumeric(HEAP, NOT ntyp1.isUnsigned(),
 					  ntyp1.getPrecision(),
 					  ntyp1.getScale(),
 					  DisAmbiguate); // added for 64bit proj.
@@ -3647,9 +3644,9 @@ const NAType *BitOperFunc::synthesizeType()
 	// Make the result an Int32 or Int64.
 	NAType * result1 = NULL;
 	if (ntyp1.getNominalSize() <= 9)
-	  result = new HEAP SQLInt(TRUE, nullable);
+	  result = new HEAP SQLInt(HEAP, TRUE, nullable);
 	else
-	  result = new HEAP SQLLargeInt(TRUE, nullable);
+	  result = new HEAP SQLLargeInt(HEAP, TRUE, nullable);
       }
     break;
 
@@ -3699,11 +3696,10 @@ NAType* MathFunc::findReturnTypeForFloorCeil(NABoolean nullable)
         // for SQLDecimal
         case REC_DECIMAL_UNSIGNED:
         case REC_DECIMAL_LSE:
-          return new HEAP SQLDecimal(nuTyp.getNominalSize()
+          return new HEAP SQLDecimal(HEAP, nuTyp.getNominalSize()
                                     ,0
                                     ,!nuTyp.isUnsigned()
                                     ,nuTyp.supportsSQLnull()
-                                    ,HEAP
                                     );
           break;
 
@@ -3716,19 +3712,18 @@ NAType* MathFunc::findReturnTypeForFloorCeil(NABoolean nullable)
         case REC_BIN16_SIGNED:
         case REC_BIN32_SIGNED:
         case REC_BIN64_SIGNED:
-           return new HEAP SQLNumeric(nuTyp.getNominalSize()
+           return new HEAP SQLNumeric(HEAP, nuTyp.getNominalSize()
                                      ,nuTyp.getPrecision()
                                      ,0
                                      ,!nuTyp.isUnsigned()
                                      ,nuTyp.supportsSQLnull()
-                                     ,HEAP
                                      );
 
         default: 
           break;
     }
   }
-  return new HEAP SQLDoublePrecision(nullable);
+  return new HEAP SQLDoublePrecision(HEAP, nullable);
 }
 
 const NAType *MathFunc::synthesizeType()
@@ -3742,7 +3737,7 @@ const NAType *MathFunc::synthesizeType()
       // type cast any params
       ValueId vid = child(i)->getValueId();
 
-      SQLDoublePrecision dp(TRUE);
+      SQLDoublePrecision dp(NULL, TRUE);
       vid.coerceType(dp, NA_NUMERIC_TYPE);
 
       const NAType &typ = vid.getType();
@@ -3794,7 +3789,7 @@ const NAType *MathFunc::synthesizeType()
     case ITM_TAN:
     case ITM_TANH:
       {
-	result = new HEAP SQLDoublePrecision(nullable);
+	result = new HEAP SQLDoublePrecision(HEAP, nullable);
       }
       break;
 
@@ -3835,7 +3830,7 @@ const NAType *Modulus::synthesizeType()
   //
   ValueId vid1 = child(0)->getValueId();
   ValueId vid2 = child(1)->getValueId();
-  SQLInt si(TRUE);
+  SQLInt si(NULL, TRUE);
   vid1.coerceType(si, NA_NUMERIC_TYPE);
   vid2.coerceType(si, NA_NUMERIC_TYPE);
 
@@ -4017,7 +4012,7 @@ const NAType *Repeat::synthesizeType()
     }
 
   NAType *result =
-    new (HEAP) SQLVarChar(CharLenInfo((Lng32)size_in_chars, (Lng32)size_in_bytes),
+    new (HEAP) SQLVarChar(HEAP, CharLenInfo((Lng32)size_in_chars, (Lng32)size_in_bytes),
 			  (typ1.supportsSQLnullLogical() ||
 			   typ2.supportsSQLnullLogical()),
 			  ctyp1.isUpshifted(),
@@ -4166,7 +4161,7 @@ const NAType *Replace::synthesizeType()
   CharLenInfo CLInfo( size_in_chars, size_in_bytes );
 
   NAType *result =
-    new (HEAP) SQLVarChar(CLInfo,
+    new (HEAP) SQLVarChar(HEAP, CLInfo,
 			  (typ1->supportsSQLnullLogical() ||
 			   typ2->supportsSQLnullLogical() ||
 			   typ3->supportsSQLnullLogical()),
@@ -4234,7 +4229,7 @@ const NAType *HashDistrib::synthesizeType()
 const NAType *ProgDistribKey::synthesizeType()
 {
   // return: Large Int.
-  return new HEAP SQLLargeInt(TRUE, FALSE);
+  return new HEAP SQLLargeInt(HEAP, TRUE, FALSE);
 }
 
 // -----------------------------------------------------------------------
@@ -4324,7 +4319,7 @@ const NAType *CompEncode::synthesizeType()
 
   if (src.getTypeQualifier() != NA_CHARACTER_TYPE)
     {
-      return new HEAP SQLChar(keyLength, supportsSQLnull);
+      return new HEAP SQLChar(HEAP, keyLength, supportsSQLnull);
     }
   else
     {
@@ -4355,17 +4350,17 @@ const NAType *CompEncode::synthesizeType()
 	    case CollationInfo::Sort:
 	      {
 		// in this case the encode is non nullable if not regularNullability
-		return new HEAP SQLChar(keyLength, 
+		return new HEAP SQLChar(HEAP, keyLength, 
 					supportsSQLnull); 
 	      }
 	    case CollationInfo::Compare:
 	      {
-		return new HEAP SQLChar(keyLength, 
+		return new HEAP SQLChar(HEAP, keyLength, 
 					cSrc.supportsSQLnull());
 	      }
 	    case CollationInfo::Search:
 	      {
-		return new HEAP SQLVarChar(keyLength,   
+		return new HEAP SQLVarChar(HEAP, keyLength,   
 					   cSrc.supportsSQLnull());
 	      }
 	    default:
@@ -4377,7 +4372,7 @@ const NAType *CompEncode::synthesizeType()
 	}
       else
 	{
-	  return new HEAP SQLChar(keyLength, supportsSQLnull);
+	  return new HEAP SQLChar(HEAP, keyLength, supportsSQLnull);
 	}
     }
 }
@@ -4470,7 +4465,7 @@ const NAType *Extract::synthesizeType()
   }
   const Int16 disAmbiguate = 0; // added for 64bit project
   return new HEAP
-    SQLNumeric(type == NA_INTERVAL_TYPE, /*allowNegValues*/
+    SQLNumeric(HEAP, type == NA_INTERVAL_TYPE, /*allowNegValues*/
 	       prec,
 	       scale,
                disAmbiguate,
@@ -4546,7 +4541,7 @@ const NAType *TriRelational::synthesizeType()
   //
   // Return the result.
   //
-  return new HEAP SQLBooleanRelat(allowsUnknown);
+  return new HEAP SQLBooleanRelat(HEAP, allowsUnknown);
 }
 
 // -----------------------------------------------------------------------
@@ -4556,7 +4551,7 @@ const NAType *TriRelational::synthesizeType()
 const NAType *RangeLookup::synthesizeType()
 {
   // the result is a signed 32 bit number
-  return new HEAP SQLInt(TRUE,FALSE);
+  return new HEAP SQLInt(HEAP, TRUE,FALSE);
 }
 
 // -----------------------------------------------------------------------
@@ -4625,7 +4620,7 @@ const NAType *PatternMatchingFunction::synthesizeType()
 
   if (getArity() > 2) {   // Escape clause was specified
     vid3 = child(2)->getValueId();
-    const SQLChar charType(1);
+    const SQLChar charType(NULL, 1);
     vid3.coerceType(charType);
     typ3 = &vid3.getType();
   }
@@ -4681,7 +4676,7 @@ const NAType *PatternMatchingFunction::synthesizeType()
 			   (typ3 AND
 			    typ3->supportsSQLnull());
 
-  return new HEAP SQLBooleanRelat(allowsUnknown);
+  return new HEAP SQLBooleanRelat(HEAP, allowsUnknown);
 }
 
 // -----------------------------------------------------------------------
@@ -4731,7 +4726,7 @@ const NAType *Lower::synthesizeType()
   //
   if (ct->getCharSet() == CharInfo::UTF8) {
     // NOTE: See comment near end of Upper::synthesizeType() for reason we don't multiply by 3 here.
-    ct =  new (HEAP) SQLVarChar(CharLenInfo(ct->getStrCharLimit(), (ct->getDataStorageSize()))
+    ct =  new (HEAP) SQLVarChar(HEAP, CharLenInfo(ct->getStrCharLimit(), (ct->getDataStorageSize()))
 				,ct->supportsSQLnull()
 				,ct->isUpshifted()
 				,ct->isCaseinsensitive()
@@ -4778,7 +4773,7 @@ const NAType *Upper::synthesizeType()
   }
 
   if (ct->getCharSet() == CharInfo::UNICODE) {
-    ct =  new (HEAP) SQLVarChar(3*(ct->getStrCharLimit())
+    ct =  new (HEAP) SQLVarChar(HEAP, 3*(ct->getStrCharLimit())
 				,ct->supportsSQLnull()
 				,ct->isUpshifted()
 				,ct->isCaseinsensitive()
@@ -4794,7 +4789,7 @@ const NAType *Upper::synthesizeType()
   // and for that reason, the UPPER function provides for 3 times as much output as the
   // input string is long.  HOWEVER, such is never the case for the LOWER function.
   //
-    ct =  new (HEAP) SQLVarChar(CharLenInfo(3*ct->getStrCharLimit(), 3*(ct->getDataStorageSize()))
+    ct =  new (HEAP) SQLVarChar(HEAP, CharLenInfo(3*ct->getStrCharLimit(), 3*(ct->getDataStorageSize()))
 				,ct->supportsSQLnull()
 				,ct->isUpshifted()
 				,ct->isCaseinsensitive()
@@ -4872,7 +4867,7 @@ const NAType *OctetLength::synthesizeType()
   //
   // Return the result.
   //
-  return new HEAP SQLInt(FALSE  // unsigned
+  return new HEAP SQLInt(HEAP, FALSE  // unsigned
 		     ,operand.supportsSQLnullLogical()
 		     );
 }
@@ -4916,7 +4911,7 @@ const NAType *PositionFunc::synthesizeType()
   if (getArity() == 3)
     {
       ValueId vid3 = child(2)->getValueId();
-      SQLInt si;
+      SQLInt si(NULL);
 
       vid3.coerceType(si, NA_NUMERIC_TYPE);
       operand3 = &vid3.getType();
@@ -5008,7 +5003,7 @@ const NAType *PositionFunc::synthesizeType()
   // Return the result.
   //
   return new HEAP
-    SQLInt(FALSE,  // unsigned
+    SQLInt(HEAP, FALSE,  // unsigned
 	   operand1->supportsSQLnullLogical() ||
 	   operand2->supportsSQLnullLogical()
 	  );
@@ -5027,7 +5022,7 @@ const NAType *Substring::synthesizeType()
   ValueId vid2 = child(1)->getValueId();
   vid1.coerceType(NA_CHARACTER_TYPE);
 
-  SQLInt si;
+  SQLInt si(NULL);
   vid2.coerceType(si, NA_NUMERIC_TYPE);
   if (getArity() == 3)
     {
@@ -5172,7 +5167,7 @@ const NAType *Substring::synthesizeType()
   if (operand1->getFSDatatype() == REC_CLOB)
     {
       return new HEAP
-	SQLClob(maxLength_bytes, Lob_Invalid_Storage,
+	SQLClob(HEAP, maxLength_bytes, Lob_Invalid_Storage,
 		operand1->supportsSQLnull() OR
 		operand2->supportsSQLnull() OR
 		((operand3 != NULL) AND operand3->supportsSQLnull()));
@@ -5182,7 +5177,7 @@ const NAType *Substring::synthesizeType()
     
 
       return new HEAP
-	SQLVarChar(CharLenInfo(maxLength_chars, maxLength_bytes), // OLD: maxLength
+	SQLVarChar(HEAP, CharLenInfo(maxLength_chars, maxLength_bytes), // OLD: maxLength
 		   operand1->supportsSQLnull() OR
 		   operand2->supportsSQLnull() OR
 		   ((operand3 != NULL) AND operand3->supportsSQLnull())
@@ -5286,7 +5281,7 @@ const NAType *Trim::synthesizeType()
   Int32 size = trimSource->getDataStorageSize();
 
   return new HEAP
-    SQLVarChar(CharLenInfo(trimSource->getStrCharLimit(), size )
+    SQLVarChar(HEAP, CharLenInfo(trimSource->getStrCharLimit(), size )
 	      ,trimChar->supportsSQLnull() OR trimSource->supportsSQLnull()
 	      ,trimSource->isUpshifted()
 	      ,trimSource->isCaseinsensitive()
@@ -5332,7 +5327,7 @@ const NAType *UnLogic::synthesizeType()
       break;
   }
 
-  return new HEAP SQLBooleanRelat(allowsUnknown);
+  return new HEAP SQLBooleanRelat(HEAP, allowsUnknown);
 }
 
 // -----------------------------------------------------------------------
@@ -5518,7 +5513,7 @@ const NAType *Translate::synthesizeType()
                                             translateSource->getNominalSize(),
                                             charsetTarget);
 
-      return new HEAP SQLVarChar(CharLenInfo(translateSource->getStrCharLimit(), resultLen),
+      return new HEAP SQLVarChar(HEAP, CharLenInfo(translateSource->getStrCharLimit(), resultLen),
                                  TRUE, FALSE, 
                                  translateSource->isCaseinsensitive(),
                                  charsetTarget,
@@ -5687,7 +5682,7 @@ HostVar::pushDownType(NAType& desiredType,
   // If this is a rowset host var, we need to propagate the desired type into it
   if (varType_->getTypeQualifier() == NA_ROWSET_TYPE) {
     SQLRowset *rw1 = (SQLRowset *) varType_;
-    SQLRowset *rw2 = new HEAP SQLRowset(&desiredType, rw1->getMaxNumElements(),
+    SQLRowset *rw2 = new HEAP SQLRowset(HEAP, &desiredType, rw1->getMaxNumElements(),
                                                       rw1->getNumElements());
     NAType *tempType = &desiredType;
     rw2->setNullable(*tempType);
@@ -5727,7 +5722,7 @@ ValueIdProxy::pushDownType(NAType& desiredType,
 
 const NAType *VEGPredicate::synthesizeType()
 {
-  return new HEAP SQLBooleanRelat();
+  return new HEAP SQLBooleanRelat(HEAP);
 }
 
 // -----------------------------------------------------------------------
@@ -5792,7 +5787,7 @@ const NAType *VEGReference::synthesizeType()
   }
   else
   {
-    type = new HEAP SQLUnknown();
+    type = new HEAP SQLUnknown(HEAP);
   }
 
   getVEG()->markAsNotSeenBefore();
@@ -5802,7 +5797,7 @@ const NAType *VEGReference::synthesizeType()
 
 const NAType *ScalarVariance::synthesizeType()
 {
-  return new HEAP SQLDoublePrecision(TRUE); // Variance is always Nullable
+  return new HEAP SQLDoublePrecision(HEAP, TRUE); // Variance is always Nullable
 }
 
 // UnPackCol::synthesizeType() --------------------------------
@@ -5841,7 +5836,7 @@ const NAType *RandomNum::synthesizeType()
       //
       // Type cast any params.
       //
-      SQLInt nType(FALSE);
+      SQLInt nType(NULL, FALSE);
       ValueId vid = child(0)->getValueId();
       vid.coerceType(nType, NA_NUMERIC_TYPE);
 
@@ -5870,12 +5865,12 @@ const NAType *RandomNum::synthesizeType()
 	}
 
      // return: int unsigned 
-      result = (NAType *) new HEAP SQLInt(FALSE, ntyp1.supportsSQLnullLogical());
+      result = (NAType *) new HEAP SQLInt(HEAP, FALSE, ntyp1.supportsSQLnullLogical());
     }
   else
     {
       // return: int unsigned not null 
-      result = (NAType *) new HEAP SQLInt(FALSE,FALSE);
+      result = (NAType *) new HEAP SQLInt(HEAP, FALSE,FALSE);
     }
 
   return result;
@@ -5971,7 +5966,7 @@ const NAType * ZZZBinderFunction::synthesizeType()
     case ITM_DATEDIFF_MONTH:
     case ITM_DATEDIFF_QUARTER:
     case ITM_DATEDIFF_WEEK:
-      return new HEAP SQLInt(TRUE,
+      return new HEAP SQLInt(HEAP, TRUE,
                              child(0)->getValueId().getType().supportsSQLnull() ||
                              child(1)->getValueId().getType().supportsSQLnull());
       
@@ -5987,7 +5982,7 @@ const NAType * ZZZBinderFunction::synthesizeType()
 
     case ITM_YEARWEEK:
     case ITM_YEARWEEKD:
-      return new HEAP SQLNumeric(4,
+      return new HEAP SQLNumeric(HEAP, 4,
                                  6,
                                  0,
                                  TRUE,
@@ -6001,7 +5996,7 @@ const NAType * ZZZBinderFunction::synthesizeType()
 
 const NAType *Subquery::synthesizeType()
 {
-  return new HEAP SQLBooleanRelat();
+  return new HEAP SQLBooleanRelat(HEAP);
 }
 
 const NAType *RowSubquery::synthesizeType()
@@ -6055,7 +6050,7 @@ const NAType *QuantifiedComp::synthesizeType()
   if (!synthItemExprLists(exprList1, exprList2, allowIncompatibleComparison,
 			  allowsUnknown, this))
     return NULL;
-  return new HEAP SQLBooleanRelat(allowsUnknown);
+  return new HEAP SQLBooleanRelat(HEAP, allowsUnknown);
 }
 
 // MV,
@@ -6069,7 +6064,7 @@ const NAType *GenericUpdateOutputFunction::synthesizeType()
     // Type cast any params.
     //
     ValueId vid = child(0)->getValueId();
-    SQLTimestamp timestampType;
+    SQLTimestamp timestampType(NULL);
     vid.coerceType(timestampType);
     //
     // Check that the operands are compatible.
@@ -6081,11 +6076,11 @@ const NAType *GenericUpdateOutputFunction::synthesizeType()
       return NULL;
     }
   
-    type = new HEAP SQLLargeInt(TRUE, operand.supportsSQLnullLogical());
+    type = new HEAP SQLLargeInt(HEAP, TRUE, operand.supportsSQLnullLogical());
   }
   else
   {
-    type = new HEAP SQLInt(TRUE, FALSE);
+    type = new HEAP SQLInt(HEAP, TRUE, FALSE);
   }
 
   return type;
@@ -6095,13 +6090,13 @@ const NAType *GenericUpdateOutputFunction::synthesizeType()
 
 const NAType *UniqueExecuteId::synthesizeType()
 {
-  return new HEAP SQLChar(SIZEOF_UNIQUE_EXECUTE_ID, FALSE);
+  return new HEAP SQLChar(HEAP, SIZEOF_UNIQUE_EXECUTE_ID, FALSE);
 }
 
 
 const NAType *GetTriggersStatus::synthesizeType()
 {
-  return new HEAP SQLChar(TRIGGERS_STATUS_VECTOR_SIZE, FALSE);
+  return new HEAP SQLChar(HEAP, TRIGGERS_STATUS_VECTOR_SIZE, FALSE);
 }
 
 const NAType *GetBitValueAt::synthesizeType()
@@ -6119,7 +6114,7 @@ const NAType *GetBitValueAt::synthesizeType()
     *CmpCommon::diags() << DgSqlCode(-4052) << DgString0(getTextUpper());
     return NULL;
   }
-  return new HEAP SQLInt(FALSE, FALSE);
+  return new HEAP SQLInt(HEAP, FALSE, FALSE);
 }
 
 //--Triggers,
@@ -6160,10 +6155,10 @@ const NAType *ItemList::synthesizeType()
   }
   else
   {
-    restOfRecord = new HEAP SQLRecord(&child(1)->getValueId().getType(),NULL);
+    restOfRecord = new HEAP SQLRecord(HEAP, &child(1)->getValueId().getType(),NULL);
   }
 
-  return new HEAP SQLRecord(elementType,restOfRecord);
+  return new HEAP SQLRecord(HEAP, elementType,restOfRecord);
 }
 // -----------------------------------------------------------------------
 // member functions for class ItmSeqOffset
@@ -6307,7 +6302,7 @@ const NAType *ItmSeqDiff1::synthesizeType()
   const NAType *result2 = operand2.synthesizeType(SYNTH_RULE_SUB, operand2, operand2, HEAP);
   if (result2->getTypeQualifier() == NA_INTERVAL_TYPE)
   {
-    result2 = new HEAP SQLLargeInt(TRUE, FALSE );
+    result2 = new HEAP SQLLargeInt(HEAP, TRUE, FALSE );
   }
   result = (NAType *)result2->synthesizeType(SYNTH_RULE_DIV, *result1, *result2, HEAP);
  }
@@ -6356,7 +6351,7 @@ const NAType *ItmSeqDiff2::synthesizeType()
   const NAType *result2 = operand2.synthesizeType(SYNTH_RULE_SUB, operand2, operand2, HEAP);
   if (result2->getTypeQualifier() == NA_INTERVAL_TYPE)
   {
-    result2 = new HEAP SQLLargeInt(TRUE, FALSE );
+    result2 = new HEAP SQLLargeInt(HEAP, TRUE, FALSE );
   }
   result = (NAType *)result2->synthesizeType(SYNTH_RULE_DIV, *result, *result2, HEAP);
  }
@@ -6379,7 +6374,7 @@ const NAType *ItmSeqRunningFunction::synthesizeType()
       (getOperatorType() == ITM_RUNNING_DRANK)  ||
       (getOperatorType() == ITM_RUNNING_CHANGE)) {
     result = new HEAP
-      SQLLargeInt(TRUE /* 'long long' on NSK can't be unsigned */,
+      SQLLargeInt(HEAP, TRUE /* 'long long' on NSK can't be unsigned */,
 		  FALSE /*not null*/);
   }
   else {
@@ -6388,7 +6383,7 @@ const NAType *ItmSeqRunningFunction::synthesizeType()
     switch (getOperatorType())  {
      case ITM_RUNNING_AVG:  {         // needs to mimic what will happen after transformation
        const NAType *operand1 = synthAvgSum(operand, FALSE);
-       const NAType *newInt =  new HEAP SQLLargeInt(TRUE,FALSE);
+       const NAType *newInt =  new HEAP SQLLargeInt(HEAP, TRUE,FALSE);
        if (operand1){
         result = operand1->synthesizeType(SYNTH_RULE_DIV, *operand1, *newInt, HEAP);
        }
@@ -6407,7 +6402,7 @@ const NAType *ItmSeqRunningFunction::synthesizeType()
 
      case ITM_RUNNING_SDEV:
      case ITM_RUNNING_VARIANCE:
-       result = new HEAP SQLDoublePrecision(TRUE); // See ScalarVariance::synthesizeType()
+       result = new HEAP SQLDoublePrecision(HEAP, TRUE); // See ScalarVariance::synthesizeType()
        break;
 
      default:
@@ -6431,7 +6426,7 @@ const NAType *ItmSeqOlapFunction::synthesizeType()
   if (getOperatorType() == ITM_OLAP_COUNT) 
   {
     result = new HEAP
-              SQLLargeInt(TRUE /* 'long long' on NSK can't be unsigned */,
+              SQLLargeInt(HEAP, TRUE /* 'long long' on NSK can't be unsigned */,
 		          TRUE /* null*/);
   }
   else
@@ -6440,7 +6435,7 @@ const NAType *ItmSeqOlapFunction::synthesizeType()
       (getOperatorType() == ITM_OLAP_DRANK)) 
   {
     result = new HEAP
-              SQLLargeInt(TRUE /* 'long long' on NSK can't be unsigned */,
+              SQLLargeInt(HEAP, TRUE /* 'long long' on NSK can't be unsigned */,
 		          FALSE /*not null*/);
   }
   else 
@@ -6452,7 +6447,7 @@ const NAType *ItmSeqOlapFunction::synthesizeType()
      case ITM_OLAP_AVG:  
      {         // needs to mimic what will happen after transformation
        const NAType *operand1 = synthAvgSum(operand, FALSE);
-       const NAType *newInt =  new HEAP SQLLargeInt(TRUE, TRUE /*FALSE*/);
+       const NAType *newInt =  new HEAP SQLLargeInt(HEAP, TRUE, TRUE /*FALSE*/);
        if (operand1)
        {
         result = operand1->synthesizeType(SYNTH_RULE_DIV, *operand1, *newInt, HEAP);
@@ -6471,7 +6466,7 @@ const NAType *ItmSeqOlapFunction::synthesizeType()
 
      case ITM_OLAP_SDEV:
      case ITM_OLAP_VARIANCE:
-       result = new HEAP SQLDoublePrecision(TRUE); 
+       result = new HEAP SQLDoublePrecision(HEAP, TRUE); 
        break;
 
      default:
@@ -6502,7 +6497,7 @@ const NAType *ItmSeqRowsSince::synthesizeType()
     }
   }
   return  new HEAP
-    SQLInt(TRUE /* 'long long' on NSK can't be unsigned */,
+    SQLInt(HEAP, TRUE /* 'long long' on NSK can't be unsigned */,
 	   TRUE /* nullable */);
 }
 
@@ -6542,7 +6537,7 @@ const NAType *ItmSeqMovingFunction::synthesizeType()
       (getOperatorType() == ITM_MOVING_RANK)  ||
       (getOperatorType() == ITM_MOVING_DRANK)) {
     result = new HEAP
-      SQLLargeInt(TRUE /* 'long long' on NSK can't be unsigned */,
+      SQLLargeInt(HEAP, TRUE /* 'long long' on NSK can't be unsigned */,
 		  FALSE /*not null*/);
   }
   else  {
@@ -6551,7 +6546,7 @@ const NAType *ItmSeqMovingFunction::synthesizeType()
    switch (getOperatorType())  {
     case ITM_MOVING_AVG: {          // needs to mimic what will happen after transformation
        const NAType *operand1 = synthAvgSum(operand, FALSE);
-       const NAType *newInt =  new HEAP SQLLargeInt(TRUE,FALSE);
+       const NAType *newInt =  new HEAP SQLLargeInt(HEAP, TRUE,FALSE);
        if (operand1) {
        result = operand1->synthesizeType(SYNTH_RULE_DIV, *operand1, *newInt, HEAP);
        }
@@ -6569,7 +6564,7 @@ const NAType *ItmSeqMovingFunction::synthesizeType()
 
     case ITM_MOVING_SDEV:
     case ITM_MOVING_VARIANCE:
-       result = new HEAP SQLDoublePrecision(TRUE); // See ScalarVariance::synthesizeType()
+       result = new HEAP SQLDoublePrecision(HEAP, TRUE); // See ScalarVariance::synthesizeType()
        break;
 
     default:
@@ -6721,7 +6716,7 @@ const NAType *AuditImage::synthesizeType()
   const Lng32 recordLength = naTable->getRecordLength();
 
   type = new HEAP
-    SQLVarChar(recordLength);
+    SQLVarChar(HEAP, recordLength);
 
   return type;
 }
@@ -6733,14 +6728,14 @@ const NAType * HbaseColumnLookup::synthesizeType()
   if (naType_)
     type = (NAType*)naType_;
   else
-    type = new HEAP SQLVarChar(100000);
+    type = new HEAP SQLVarChar(HEAP, 100000);
 
   return type;
 }
 
 const NAType * HbaseColumnsDisplay::synthesizeType()
 {
-  NAType * type = new HEAP SQLVarChar(displayWidth_);
+  NAType * type = new HEAP SQLVarChar(HEAP, displayWidth_);
 
   return type;
 }
@@ -6752,7 +6747,7 @@ const NAType * HbaseColumnCreate::synthesizeType()
   if (resultType_)
     type = (NAType*)resultType_;
   else
-    type = new HEAP SQLVarChar(100000);
+    type = new HEAP SQLVarChar(HEAP, 100000);
 
   return type;
 }
@@ -6761,7 +6756,7 @@ const NAType * SequenceValue::synthesizeType()
 {
   NAType * type = NULL;
 
-  type = new HEAP SQLLargeInt(TRUE, FALSE);
+  type = new HEAP SQLLargeInt(HEAP, TRUE, FALSE);
 
   return type;
 }
@@ -6770,7 +6765,7 @@ const NAType * HbaseTimestamp::synthesizeType()
 {
   NAType * type = NULL;
 
-  type = new HEAP SQLLargeInt(TRUE,  
+  type = new HEAP SQLLargeInt(HEAP, TRUE,  
                               col_->getValueId().getType().supportsSQLnull());
 
   return type;
@@ -6780,7 +6775,7 @@ const NAType * HbaseVersion::synthesizeType()
 {
   NAType * type = NULL;
 
-  type = new HEAP SQLLargeInt(TRUE, FALSE); 
+  type = new HEAP SQLLargeInt(HEAP, TRUE, FALSE); 
 
   return type;
 }
@@ -6789,7 +6784,7 @@ const NAType * RowNumFunc::synthesizeType()
 {
   NAType * type = NULL;
 
-  type = new HEAP SQLLargeInt(TRUE, FALSE);
+  type = new HEAP SQLLargeInt(HEAP, TRUE, FALSE);
 
   return type;
 }
@@ -6798,7 +6793,7 @@ const NAType *LOBoper::synthesizeType()
 {
   // Return blob or clob type
   
-  NAType *result = new HEAP SQLBlob(1000);
+  NAType *result = new HEAP SQLBlob(HEAP, 1000);
 
   if (child(0))
     {
@@ -6807,12 +6802,12 @@ const NAType *LOBoper::synthesizeType()
       
       if (typ1.getFSDatatype() == REC_BLOB)
 	{
-	  result = new HEAP SQLBlob(1000, Lob_Local_File,
+	  result = new HEAP SQLBlob(HEAP, 1000, Lob_Local_File,
 				    typ1.supportsSQLnull());
 	}
       else if (typ1.getFSDatatype() == REC_CLOB)
 	{
-	  result = new HEAP SQLClob(1000, Lob_Invalid_Storage,
+	  result = new HEAP SQLClob(HEAP, 1000, Lob_Invalid_Storage,
 				    typ1.supportsSQLnull());
 	}
     } 
@@ -6883,12 +6878,12 @@ const NAType *LOBinsert::synthesizeType()
   NAType * result = NULL;
   if (lobFsType() == REC_BLOB)
     {
-      result = new HEAP SQLBlob(lobSize(), Lob_Invalid_Storage,
+      result = new HEAP SQLBlob(HEAP, lobSize(), Lob_Invalid_Storage,
 				(obj_ ==EMPTY_LOB_) ? FALSE:typ1->supportsSQLnull());
     }
   else if (lobFsType() == REC_CLOB)
     {
-      result = new HEAP SQLClob(lobSize(), Lob_Invalid_Storage,
+      result = new HEAP SQLClob(HEAP, lobSize(), Lob_Invalid_Storage,
 				(obj_ == EMPTY_LOB_)? FALSE:typ1->supportsSQLnull());
     }
     
@@ -6978,14 +6973,14 @@ const NAType *LOBupdate::synthesizeType()
   if (typ2->getFSDatatype() == REC_BLOB)
     {
       SQLBlob &blob = (SQLBlob&)*typ2;
-      result = new HEAP SQLBlob(blob.getLobLength(), Lob_Invalid_Storage,
+      result = new HEAP SQLBlob(HEAP, blob.getLobLength(), Lob_Invalid_Storage,
 				(obj_ ==EMPTY_LOB_) ? FALSE:typ2->supportsSQLnull());
     }
   else if (typ2->getFSDatatype() == REC_CLOB)
     {
       SQLClob &clob = (SQLClob&)*typ2;
 
-      result = new HEAP SQLClob(clob.getLobLength(), Lob_Invalid_Storage,
+      result = new HEAP SQLClob(HEAP, clob.getLobLength(), Lob_Invalid_Storage,
 				(obj_ ==EMPTY_LOB_) ? FALSE:typ2->supportsSQLnull());
     }
     
@@ -7015,7 +7010,7 @@ const NAType *LOBconvertHandle::synthesizeType()
 	{
 	  SQLBlob& op1 = (SQLBlob&)vid1.getType();
 	  
-	  result = new HEAP SQLBlob(op1.getLobLength(), Lob_Invalid_Storage,
+	  result = new HEAP SQLBlob(HEAP, op1.getLobLength(), Lob_Invalid_Storage,
 				    typ1.supportsSQLnull(), FALSE, 
 				    TRUE);
 	}
@@ -7023,7 +7018,7 @@ const NAType *LOBconvertHandle::synthesizeType()
 	{
 	  SQLClob& op1 = (SQLClob&)vid1.getType();
 	  
-	  result = new HEAP SQLClob(op1.getLobLength(), Lob_Invalid_Storage,
+	  result = new HEAP SQLClob(HEAP, op1.getLobLength(), Lob_Invalid_Storage,
 				    typ1.supportsSQLnull(), FALSE, 
 				    TRUE);
 	}
@@ -7040,7 +7035,7 @@ const NAType *LOBconvertHandle::synthesizeType()
 	  return NULL;
 	}
       
-      result = new HEAP SQLBlob(1000, Lob_Invalid_Storage, typ1.supportsSQLnull(), FALSE, 
+      result = new HEAP SQLBlob(HEAP, 1000, Lob_Invalid_Storage, typ1.supportsSQLnull(), FALSE, 
 					FALSE);
       return result;
     }
@@ -7073,7 +7068,7 @@ const NAType *LOBconvert::synthesizeType()
 
       Lng32 tgtSize = MINOF((Lng32)op1.getLobLength(), tgtSize_);
 
-      NAType *result = new HEAP SQLVarChar(tgtSize, Lob_Invalid_Storage,
+      NAType *result = new HEAP SQLVarChar(HEAP, tgtSize, Lob_Invalid_Storage,
 					   typ1.supportsSQLnull());
       return result;
     }
@@ -7105,7 +7100,7 @@ const NAType *LOBextract::synthesizeType()
   
   Lng32 tgtSize = MINOF((Lng32)op1.getLobLength(), tgtSize_);
   
-  NAType *result = new HEAP SQLVarChar(tgtSize, Lob_Invalid_Storage,
+  NAType *result = new HEAP SQLVarChar(HEAP, tgtSize, Lob_Invalid_Storage,
 				       typ1.supportsSQLnull());
   return result;
 }

--- a/core/sql/optimizer/UdfDllInteraction.cpp
+++ b/core/sql/optimizer/UdfDllInteraction.cpp
@@ -1851,31 +1851,27 @@ NAType *TMUDFInternalSetup::createNATypeFromTypeInfo(
     case tmudr::TypeInfo::TINYINT:
     case tmudr::TypeInfo::TINYINT_UNSIGNED:
       result = new(heap)
-        SQLTiny((typeCode == tmudr::TypeInfo::TINYINT),
-                src.getIsNullable(),
-                heap);
+        SQLTiny(heap, (typeCode == tmudr::TypeInfo::TINYINT),
+                src.getIsNullable());
       break;
 
     case tmudr::TypeInfo::SMALLINT:
     case tmudr::TypeInfo::SMALLINT_UNSIGNED:
       result = new(heap)
-        SQLSmall((typeCode == tmudr::TypeInfo::SMALLINT),
-                 src.getIsNullable(),
-                 heap);
+        SQLSmall(heap, (typeCode == tmudr::TypeInfo::SMALLINT),
+                 src.getIsNullable());
       break;
 
     case tmudr::TypeInfo::INT:
     case tmudr::TypeInfo::INT_UNSIGNED:
       result = new(heap)
-        SQLInt((typeCode == tmudr::TypeInfo::INT),
-               src.getIsNullable(),
-               heap);
+        SQLInt(heap, (typeCode == tmudr::TypeInfo::INT),
+               src.getIsNullable());
       break;
 
     case tmudr::TypeInfo::LARGEINT:
-      result = new(heap) SQLLargeInt(TRUE,
-                                     src.getIsNullable(),
-                                     heap);
+      result = new(heap) SQLLargeInt(heap, TRUE,
+                                     src.getIsNullable());
       break;
 
     case tmudr::TypeInfo::NUMERIC:
@@ -1893,33 +1889,29 @@ NAType *TMUDFInternalSetup::createNATypeFromTypeInfo(
           }
         else
           result = new(heap) 
-            SQLNumeric(storageSize,
+            SQLNumeric(heap, storageSize,
                        src.getPrecision(),
                        src.getScale(),
                        (typeCode == tmudr::TypeInfo::NUMERIC),
-                       src.getIsNullable(),
-                       heap);
+                       src.getIsNullable());
       }
       break;
 
     case tmudr::TypeInfo::DECIMAL_LSE:
     case tmudr::TypeInfo::DECIMAL_UNSIGNED:
       result = new(heap)
-        SQLDecimal(src.getPrecision(),
+        SQLDecimal(heap, src.getPrecision(),
                    src.getScale(),
                    (typeCode == tmudr::TypeInfo::DECIMAL_LSE),
-                   src.getIsNullable(),
-                   heap);
+                   src.getIsNullable());
       break;
 
     case tmudr::TypeInfo::REAL:
-      result = new(heap) SQLReal(src.getIsNullable(),
-                                 heap);
+      result = new(heap) SQLReal(heap, src.getIsNullable());
       break;
 
     case tmudr::TypeInfo::DOUBLE_PRECISION:
-      result = new(heap) SQLDoublePrecision(src.getIsNullable(),
-                                            heap);
+      result = new(heap) SQLDoublePrecision(heap, src.getIsNullable());
       break;
 
     case tmudr::TypeInfo::CHAR:
@@ -1954,7 +1946,7 @@ NAType *TMUDFInternalSetup::createNATypeFromTypeInfo(
 
             if (typeCode == tmudr::TypeInfo::CHAR)
               result = new(heap)
-                SQLChar(lenInfo,
+                SQLChar(heap, lenInfo,
                         src.getIsNullable(),
                         FALSE,
                         FALSE,
@@ -1962,7 +1954,7 @@ NAType *TMUDFInternalSetup::createNATypeFromTypeInfo(
                         cs);
             else
               result = new(heap)
-                SQLVarChar(lenInfo,
+                SQLVarChar(heap, lenInfo,
                            src.getIsNullable(),
                            FALSE,
                            FALSE,
@@ -1972,20 +1964,17 @@ NAType *TMUDFInternalSetup::createNATypeFromTypeInfo(
       break;
 
     case tmudr::TypeInfo::DATE:
-      result = new(heap) SQLDate(src.getIsNullable(),
-                                 heap);
+      result = new(heap) SQLDate(heap, src.getIsNullable());
       break;
 
     case tmudr::TypeInfo::TIME:
-      result = new(heap) SQLTime(src.getIsNullable(),
-                                 src.getScale(),
-                                 heap);
+      result = new(heap) SQLTime(heap, src.getIsNullable(),
+                                 src.getScale());
       break;
 
     case tmudr::TypeInfo::TIMESTAMP:
-      result = new(heap) SQLTimestamp(src.getIsNullable(),
-                                      src.getScale(),
-                                      heap);
+      result = new(heap) SQLTimestamp(heap, src.getIsNullable(),
+                                      src.getScale());
       break;
 
     case tmudr::TypeInfo::INTERVAL:
@@ -2069,12 +2058,11 @@ NAType *TMUDFInternalSetup::createNATypeFromTypeInfo(
 
         if (startField != REC_DATE_UNKNOWN)
           {
-            result = new(heap) SQLInterval(src.getIsNullable(),
+            result = new(heap) SQLInterval(heap, src.getIsNullable(),
                                            startField,
                                            src.getPrecision(),
                                            endField,
-                                           src.getScale(),
-                                           heap);
+                                           src.getScale());
             if (!static_cast<SQLInterval *>(result)->checkValid(diags))
               {
                 *diags << DgSqlCode(-11152)
@@ -2088,8 +2076,7 @@ NAType *TMUDFInternalSetup::createNATypeFromTypeInfo(
       break;
 
     case tmudr::TypeInfo::BOOLEAN:
-      result = new(heap) SQLBooleanNative(src.getIsNullable(),
-                                          heap);
+      result = new(heap) SQLBooleanNative(heap, src.getIsNullable());
       break;
 
     default:

--- a/core/sql/optimizer/ValueDesc.cpp
+++ b/core/sql/optimizer/ValueDesc.cpp
@@ -247,7 +247,7 @@ void ValueId::coerceType(enum NABuiltInTypeEnum desiredQualifier,
   NAType *desiredType = NULL;
   switch (desiredQualifier) {
   case NA_BOOLEAN_TYPE:
-    desiredType = new STMTHEAP SQLBooleanNative(originalType.supportsSQLnull());
+    desiredType = new STMTHEAP SQLBooleanNative(STMTHEAP, originalType.supportsSQLnull());
     break;
   case NA_CHARACTER_TYPE:
     {
@@ -258,7 +258,7 @@ void ValueId::coerceType(enum NABuiltInTypeEnum desiredQualifier,
 #pragma warning (default : 4244)  // warning elimination
 
       desiredType = new STMTHEAP
-	SQLVarChar(len, //DEFAULT_CHARACTER_LENGTH,
+	SQLVarChar(STMTHEAP, len, //DEFAULT_CHARACTER_LENGTH,
 		   originalType.supportsSQLnull(),
 		   FALSE/*isUpShifted*/,
 		   FALSE/*isCaseinsensitive*/,
@@ -271,7 +271,7 @@ void ValueId::coerceType(enum NABuiltInTypeEnum desiredQualifier,
     {
       Int16 DisAmbiguate = 0;
       desiredType = new STMTHEAP
-      SQLNumeric(TRUE,   		// signed
+      SQLNumeric(STMTHEAP, TRUE,   		// signed
                  MAX_NUMERIC_PRECISION,	// precision
                  6,    			// scale
                  DisAmbiguate, // added for 64bit proj.
@@ -355,16 +355,14 @@ void ValueId::coerceType(const NAType& desiredType,
     {
       if (desiredType.getFSDatatype() == REC_FLOAT32)
         newType = new STMTHEAP
-          SQLReal(desiredType.supportsSQLnull(),
-                  STMTHEAP,
+          SQLReal(STMTHEAP, desiredType.supportsSQLnull(),
                   desiredType.getPrecision());
       else
         // ieee double, tandem real and tandem double are all
         // cast as IEEE double. Tandem real is cast as ieee double as
         // it won't 'fit' into ieee real.
         newType = new STMTHEAP
-          SQLDoublePrecision(desiredType.supportsSQLnull(),
-                             STMTHEAP,
+          SQLDoublePrecision(STMTHEAP, desiredType.supportsSQLnull(),
                              desiredType.getPrecision());
     }
   else {
@@ -383,10 +381,10 @@ void ValueId::coerceType(const NAType& desiredType,
              NABoolean isSigned = numType.isSigned();
              if (numType.getScale() == 0)
                newType = new (STMTHEAP)
-                 SQLSmall(isSigned, desiredType.supportsSQLnull());
+                 SQLSmall(STMTHEAP, isSigned, desiredType.supportsSQLnull());
              else
                newType = new (STMTHEAP)
-                 SQLNumeric(sizeof(short), 
+                 SQLNumeric(STMTHEAP, sizeof(short), 
                             numType.getPrecision(), 
                             numType.getScale(),
                             isSigned, 
@@ -401,28 +399,26 @@ void ValueId::coerceType(const NAType& desiredType,
                {
 		 Int16 DisAmbiguate = 0;
                  newType = new (STMTHEAP)
-                   SQLLargeInt(nTyp.getScale(),
+                   SQLLargeInt(STMTHEAP, nTyp.getScale(),
                                DisAmbiguate,
                                TRUE,
-                               nTyp.supportsSQLnull(),
-                               NULL);
+                               nTyp.supportsSQLnull());
                }
              else
                {
                  newType = new (STMTHEAP)
-                   SQLBigNum(MAX_HARDWARE_SUPPORTED_UNSIGNED_NUMERIC_PRECISION,
+                   SQLBigNum(STMTHEAP, MAX_HARDWARE_SUPPORTED_UNSIGNED_NUMERIC_PRECISION,
                              nTyp.getScale(),
                              FALSE,
                              FALSE,
-                             nTyp.supportsSQLnull(),
-                             NULL);
+                             nTyp.supportsSQLnull());
                }
            }
 	 else if ((desiredType.getFSDatatype() == REC_BOOLEAN) &&
                   (CmpCommon::getDefault(TRAF_BOOLEAN_IO) == DF_OFF))
            {
              newType = new (STMTHEAP)
-               SQLVarChar(SQL_BOOLEAN_DISPLAY_SIZE, 
+               SQLVarChar(STMTHEAP, SQL_BOOLEAN_DISPLAY_SIZE, 
                           desiredType.supportsSQLnull());
            }
 	 else if (DFS2REC::isBigNum(desiredType.getFSDatatype()))
@@ -455,11 +451,10 @@ void ValueId::coerceType(const NAType& desiredType,
 			 CmpCommon::getDefaultNumeric(MAX_NUMERIC_PRECISION_ALLOWED));
 		 Lng32 scale     = MINOF(desiredType.getScale(), precision);
 		 newType = new (STMTHEAP)
-		   SQLBigNum(precision, scale, 
+		   SQLBigNum(STMTHEAP, precision, scale, 
 			     ((SQLBigNum&)desiredType).isARealBigNum(),
 			     ((NumericType&)desiredType).isSigned(),
-			     desiredType.supportsSQLnull(),
-			     NULL);
+			     desiredType.supportsSQLnull());
 	       }
 	     else
 	       {
@@ -472,7 +467,7 @@ void ValueId::coerceType(const NAType& desiredType,
 		   
 		 Int16 DisAmbiguate = 0;
 		 newType = new (STMTHEAP)
-		   SQLNumeric(isSigned,
+		   SQLNumeric(STMTHEAP, isSigned,
 			      precision,
 			      scale,
 			      DisAmbiguate, // added for 64bit proj.
@@ -5128,7 +5123,7 @@ NABoolean ValueIdList::canSimplify(ItemExpr *itemExpr,
 	return FALSE;
 
       NumericType * ntyp = new (CmpCommon::statementHeap())
-	SQLNumeric(4, scale, scale, TRUE, FALSE);
+	SQLNumeric(CmpCommon::statementHeap(), 4, scale, scale, TRUE, FALSE);
       Lng32 cval = (Lng32)div;
       char cvalStr[20];
       cvalStr[0] = '.';

--- a/core/sql/optimizer/mdam.cpp
+++ b/core/sql/optimizer/mdam.cpp
@@ -1016,7 +1016,7 @@ static ItemExpr *convertCastToNarrow(ItemExpr *expr,
       return new(outHeap)
         Narrow(expr->child(0),
                new(outHeap) HostVar("_sys_ignored_CC_convErrorFlag",
-                                    new (outHeap) SQLInt(TRUE,FALSE),
+                                    new (outHeap) SQLInt(outHeap, TRUE,FALSE),
                                     TRUE),
                src->getType()->newCopy(outHeap));
     }

--- a/core/sql/parser/SqlParserAux.cpp
+++ b/core/sql/parser/SqlParserAux.cpp
@@ -477,7 +477,7 @@ RelRoot *finalize(RelExpr *top, NABoolean outputVarCntValid)
                       argInfo = TheProcArgTypes->get(ivName);
                       if (!argInfo)
                         argInfo = new (PARSERHEAP()) HVArgType
-                          (ivName, new (PARSERHEAP()) SQLUnknown);
+                          (ivName, new (PARSERHEAP()) SQLUnknown(PARSERHEAP()));
                       argInfo->useCount()++;
                       argInfo->intoCount()++;
                     }
@@ -658,7 +658,7 @@ HostVar *makeHostVar(NAString *hvName, NAString *indName, NABoolean isDynamic)
   HVArgType *argInfo = TheProcArgTypes ?
 		       TheProcArgTypes->get(hvName) : NULL;
   NAType    *naType  = argInfo ?
-		       argInfo->getType() : new (PARSERHEAP()) SQLUnknown;
+		       argInfo->getType() : new (PARSERHEAP()) SQLUnknown(PARSERHEAP());
   ComASSERT(naType);
   naType->setNullable(!!indName);
 
@@ -889,7 +889,7 @@ ItemExpr *literalOfNumericPassingScale(NAString *strptr, char sign,
 	returnValue = 
 	  new (PARSERHEAP()) ConstValue
 	  (new (PARSERHEAP()) SQLLargeInt
-	    ((Lng32)scale, 
+	    (PARSERHEAP(), (Lng32)scale, 
              (UInt16) 0, // 64-bit
 	     TRUE,
 	     FALSE),
@@ -900,7 +900,7 @@ ItemExpr *literalOfNumericPassingScale(NAString *strptr, char sign,
 	returnValue = 
 	  new (PARSERHEAP()) ConstValue
 	  (new (PARSERHEAP()) SQLNumeric
-	   (length,
+	   (PARSERHEAP(), length,
 	    (Lng32)strSize, // precision
 	    (Lng32)scale, 
 	    createSignedDatatype,
@@ -956,12 +956,11 @@ ItemExpr *literalOfNumericPassingScale(NAString *strptr, char sign,
     
       returnValue = new (PARSERHEAP()) ConstValue
 #pragma nowarn(1506)   // warning elimination 
-        (new (PARSERHEAP()) SQLBigNum(strSize, 
+        (new (PARSERHEAP()) SQLBigNum(PARSERHEAP(), strSize, 
                                       scale,
                                       TRUE,
                                       TRUE,
-                                      FALSE,
-				      NULL),
+                                      FALSE),
          (void *) bigNumData,
          bigNumSize,
          strptr);
@@ -1162,7 +1161,7 @@ ItemExpr *literalOfApproxNumeric(NAString *strptr, char sign)
     }
 
   returnValue = new (PARSERHEAP()) ConstValue (new (PARSERHEAP())
-					       SQLDoublePrecision(FALSE),
+					       SQLDoublePrecision(PARSERHEAP(), FALSE),
 					       (void *)&doubleVal,
 					       sizeof(double),
 					       strptr);
@@ -1184,12 +1183,11 @@ ItemExpr *literalOfInterval(NAString *strptr,
                               qualifier->getFractionPrecision(),
                               sign);
   IntervalType *intervalType = new (PARSERHEAP())
-		  SQLInterval(FALSE,
+		  SQLInterval(PARSERHEAP(), FALSE,
 			      qualifier->getStartField(),
 			      qualifier->getLeadingPrecision(),
 			      qualifier->getEndField(),
-			      qualifier->getFractionPrecision(),
-                              PARSERHEAP());
+			      qualifier->getFractionPrecision());
   strptr->prepend("'");
   strptr->append ("' ");
   strptr->append (intervalType->getIntervalQualifierAsString());
@@ -1229,7 +1227,7 @@ ItemExpr *literalOfDate(NAString *strptr, NABoolean noDealloc)
      *SqlParser_Diags << DgSqlCode(-3045) << DgString0(*strptr);
   else
     returnValue = new (PARSERHEAP()) ConstValue (new (PARSERHEAP())
-		    SQLDate(FALSE, PARSERHEAP()),
+		    SQLDate(PARSERHEAP(), FALSE),
 		    (void *) dtValue.getValue(),
 		    dtValue.getValueLen(),
 		    strptr);
@@ -1251,7 +1249,7 @@ ItemExpr *literalOfTime(NAString *strptr)
       *SqlParser_Diags << DgSqlCode(-3046) << DgString0(*strptr);
   else
     returnValue = new (PARSERHEAP()) ConstValue (new (PARSERHEAP())
-		    SQLTime(FALSE, fractionPrec,PARSERHEAP()),
+		    SQLTime(PARSERHEAP(), FALSE, fractionPrec),
 		    (void *) dtValue.getValue(),
 		    dtValue.getValueLen(),
 		    strptr);
@@ -1330,7 +1328,7 @@ ItemExpr *literalOfTimestamp(NAString *strptr)
   else
     returnValue = new (PARSERHEAP())
       ConstValue (new (PARSERHEAP())
-                  SQLTimestamp (FALSE, fractionPrec, PARSERHEAP()),
+                  SQLTimestamp (PARSERHEAP(), FALSE, fractionPrec),
                   (void *) dtValue.getValue(),
                   dtValue.getValueLen(),
                   strptr);
@@ -2057,7 +2055,7 @@ NAType *picNAType(const NABoolean      isString,
             Int32 maxBytesPerChar = CharInfo::maxBytesPerChar(charset);
             returnValue = new (PARSERHEAP())
               //            SQLChar(precision,TRUE,FALSE,isCaseinsensitive,FALSE,charset,collation,coerc);
-              SQLChar(CharLenInfo(characterLimit, maxLenInBytes),
+              SQLChar(PARSERHEAP(), CharLenInfo(characterLimit, maxLenInBytes),
                       TRUE,FALSE,isCaseinsensitive,FALSE,
                       charset,collation,coerc,eEncodingCharSet);
             assert(returnValue);
@@ -2066,7 +2064,7 @@ NAType *picNAType(const NABoolean      isString,
         case STYLE_UPSHIFT:
 	    returnValue = new (PARSERHEAP())
 #pragma nowarn(1506)   // warning elimination 
-  		SQLChar(precision,TRUE,TRUE,isCaseinsensitive,FALSE,charset,collation,coerc);
+  		SQLChar(PARSERHEAP(), precision,TRUE,TRUE,isCaseinsensitive,FALSE,charset,collation,coerc);
 #pragma warn(1506)  // warning elimination 
             assert(returnValue);
             break;
@@ -2105,7 +2103,7 @@ NAType *picNAType(const NABoolean      isString,
            else
               returnValue = new (PARSERHEAP())
 #pragma nowarn(1506)   // warning elimination 
-		SQLDecimal(precision,scale,hasSign);
+		SQLDecimal(PARSERHEAP(), precision,scale,hasSign);
 #pragma warn(1506)  // warning elimination 
            assert(returnValue);
            break;
@@ -2128,7 +2126,7 @@ NAType *picNAType(const NABoolean      isString,
               const Int16 DisAmbiguate = 0; // added for 64bit project
               returnValue = new (PARSERHEAP())
 #pragma nowarn(1506)   // warning elimination 
-		SQLNumeric(hasSign, precision, scale, DisAmbiguate);
+		SQLNumeric(PARSERHEAP(), hasSign, precision, scale, DisAmbiguate);
 #pragma warn(1506)  // warning elimination 
               assert(returnValue);
            }

--- a/core/sql/parser/StmtDDLCreate.cpp
+++ b/core/sql/parser/StmtDDLCreate.cpp
@@ -2913,32 +2913,32 @@ StmtDDLCreateRoutine::synthesize()
             {
             case COM_UUDF_PARAM_ACTION:
               pParamName2     = new(STMTHEAP) ElemDDLParamName("ACTION");
-              pParamDataType2 = new(STMTHEAP) SQLVarChar ( 1024  // long maxLength
+              pParamDataType2 = new(STMTHEAP) SQLVarChar (STMTHEAP, 1024  // long maxLength
                                                          , FALSE // NABoolean allowSQLnull
                                                          );
               break;
             case COM_UUDF_PARAM_SAS_FORMAT:
               pParamName2     = new(STMTHEAP) ElemDDLParamName("SAS_FORMAT");
-              pParamDataType2 = new(STMTHEAP) SQLVarChar ( 1024  // long maxLength
+              pParamDataType2 = new(STMTHEAP) SQLVarChar (STMTHEAP, 1024  // long maxLength
                                                          , FALSE // NABoolean allowSQLnull
                                                          );
               break;
             case COM_UUDF_PARAM_SAS_LOCALE:
               pParamName2     = new(STMTHEAP) ElemDDLParamName("SAS_LOCALE");
-              pParamDataType2 = new(STMTHEAP) SQLInt ( TRUE  // NABoolean allowNegValues
+              pParamDataType2 = new(STMTHEAP) SQLInt (STMTHEAP,  TRUE  // NABoolean allowNegValues
                                                      , FALSE // NABoolean allowSQLnull
                                                      );
               break;
             case COM_UUDF_PARAM_SAS_MODEL_INPUT_TABLE:
               pParamName2     = new(STMTHEAP) ElemDDLParamName("SAS_MODEL_INPUT_TABLE");
-              pParamDataType2 = new(STMTHEAP) SQLVarChar ( 1024  // long maxLength
+              pParamDataType2 = new(STMTHEAP) SQLVarChar (STMTHEAP, 1024  // long maxLength
                                                          , FALSE // NABoolean allowSQLnull
                                                          );
               break;
             default:
             case COM_UUDF_PARAM_OMITTED:           // any dummy data type would do
               pParamName2     = NULL;
-              pParamDataType2 = new(STMTHEAP) SQLChar ( 1     // long maxLength
+              pParamDataType2 = new(STMTHEAP) SQLChar (STMTHEAP, 1     // long maxLength
                                                       , FALSE // NABoolean allowSQLnull
                                                       );
               break;

--- a/core/sql/parser/sqlparser.y
+++ b/core/sql/parser/sqlparser.y
@@ -3322,7 +3322,7 @@ boolean_literal : truth_value
                     char v = ($1 == TOK_TRUE ? 1 : 0);
                     NAString literalBuf($1 == TOK_TRUE ? "TRUE" : "FALSE");
                     $$ = new (PARSERHEAP()) ConstValue 
-                      (new (PARSERHEAP()) SQLBooleanNative(FALSE),
+                      (new (PARSERHEAP()) SQLBooleanNative(PARSERHEAP(), FALSE),
                        (void *) &v, 1, &literalBuf);
                   }
 
@@ -5476,7 +5476,7 @@ actual_table_name : qualified_name
 				  HostVar *vvX = new (PARSERHEAP()) 
 				    HostVar(*defineName, new (PARSERHEAP()) 
 				      SQLChar(
-				        ComAnsiNamePart::MAX_IDENTIFIER_EXT_LEN));
+				        PARSERHEAP(), ComAnsiNamePart::MAX_IDENTIFIER_EXT_LEN));
 				  vvX->setIsDefine();
                                   $$ = new (PARSERHEAP())
 				    CorrName("envVar$", 
@@ -8144,7 +8144,7 @@ primary :     '(' value_expression ')'
                                   {
                                     SQLInterval *iq =
 				      new (PARSERHEAP()) SQLInterval(
-					TRUE,
+					PARSERHEAP(), TRUE,
 					$4->getStartField(),
 					$4->getLeadingPrecision(),
 					$4->getEndField(),
@@ -8824,7 +8824,7 @@ datetime_misc_function : TOK_CONVERTTIMESTAMP '(' value_expression ')'
      | TOK_EXTEND '(' value_expression ')'
                                 {
                                 DatetimeType *dt = new (PARSERHEAP())
-                                                SQLTimestamp(TRUE, SQLTimestamp::DEFAULT_FRACTION_PRECISION, PARSERHEAP());
+                                                SQLTimestamp(PARSERHEAP(), TRUE, SQLTimestamp::DEFAULT_FRACTION_PRECISION);
 
                                 $$ = new (PARSERHEAP()) Cast ($3, dt);
                                 }
@@ -9870,7 +9870,7 @@ misc_function :
                                                 HashDistPartHash($3),
                                                 new (PARSERHEAP())
                                                 Cast($5, new (PARSERHEAP())
-                                                     SQLInt(FALSE, FALSE)));
+                                                     SQLInt(PARSERHEAP(), FALSE, FALSE)));
                                 }
      | TOK_HASH2PARTFUNC '(' value_expression_list TOK_FOR value_expression ')'
                                 {
@@ -9879,7 +9879,7 @@ misc_function :
                                                  HashDistPartHash($3),
                                                  new (PARSERHEAP())
                                                  Cast($5, new (PARSERHEAP())
-                                                      SQLInt(FALSE, FALSE)));
+                                                      SQLInt(PARSERHEAP(), FALSE, FALSE)));
                                 }
      | TOK_RRPARTFUNC '(' value_expression TOK_FOR value_expression ')'
                                 {
@@ -9891,10 +9891,10 @@ misc_function :
                                                            new (PARSERHEAP()) 
                                                            ConstValue(32)),
                                                      new (PARSERHEAP())
-                                                     SQLInt(FALSE,FALSE)),
+                                                     SQLInt(PARSERHEAP(), FALSE,FALSE)),
                                                 new (PARSERHEAP())
                                                 Cast($5, new (PARSERHEAP())
-                                                     SQLInt(FALSE, FALSE))); */
+                                                     SQLInt(PARSERHEAP(), FALSE, FALSE))); */
                                 }
 
      | TOK_DATE_PART '(' QUOTED_STRING ',' value_expression  ')'
@@ -10024,7 +10024,7 @@ misc_function :
                             maybeNullable = FALSE;
                            }
 
-                         SQLInterval *iq = new (PARSERHEAP()) SQLInterval(maybeNullable, REC_DATE_MONTH, 6, REC_DATE_MONTH, 1);
+                         SQLInterval *iq = new (PARSERHEAP()) SQLInterval(PARSERHEAP(), maybeNullable, REC_DATE_MONTH, 6, REC_DATE_MONTH, 1);
                          ItemExpr *iq2 =	new (PARSERHEAP()) Cast($5, iq);
                          $$ = new (PARSERHEAP())  BiArith(ITM_PLUS, $3,iq2);
 						 ((BiArith*) $$)->setStandardNormalization();
@@ -10046,7 +10046,7 @@ misc_function :
                             maybeNullable = FALSE;
                            }
 
-                         SQLInterval *iq = new (PARSERHEAP()) SQLInterval(maybeNullable, REC_DATE_MONTH, 6, REC_DATE_MONTH, 1);
+                         SQLInterval *iq = new (PARSERHEAP()) SQLInterval(PARSERHEAP(), maybeNullable, REC_DATE_MONTH, 6, REC_DATE_MONTH, 1);
                          ItemExpr *iq2 =	new (PARSERHEAP()) Cast($5, iq);
                          $$ = new (PARSERHEAP())  BiArith(ITM_PLUS, $3,iq2);
 						 UInt32 value = $7;
@@ -10125,7 +10125,7 @@ misc_function :
 				}
          | TOK_COLUMN_LOOKUP '(' dml_column_reference ',' QUOTED_STRING ')'
                               {
-				NAType * type = new(PARSERHEAP()) SQLVarChar(100000);
+				NAType * type = new(PARSERHEAP()) SQLVarChar(PARSERHEAP(), 100000);
 				$$ = new (PARSERHEAP()) 
 				    HbaseColumnLookup($3, *$5, type);
 			      }
@@ -10401,54 +10401,54 @@ audit_image_object: TOK_INDEX_TABLE actual_table_name
 /* type token */
 datetime_keywords : TOK_QUARTER  ',' value_expression 		  // 3 months	Cast 3*num_expr to months
                    	{
-					SQLInterval *iq = new (PARSERHEAP()) SQLInterval(TRUE, REC_DATE_MONTH, 6, REC_DATE_MONTH, 1);
+					SQLInterval *iq = new (PARSERHEAP()) SQLInterval(PARSERHEAP(), TRUE, REC_DATE_MONTH, 6, REC_DATE_MONTH, 1);
 					$$ = new (PARSERHEAP()) 
 					       Cast(new (PARSERHEAP())BiArith(ITM_TIMES, $3,  new (PARSERHEAP()) ConstValue(3)), iq);
 					}                    
                    | TOK_WEEK   ',' value_expression 		  // 7 days	  Cast 7*num_expr to days
                     {
-					SQLInterval *iq = new (PARSERHEAP()) SQLInterval(TRUE, REC_DATE_DAY, 6, REC_DATE_DAY, 1);
+					SQLInterval *iq = new (PARSERHEAP()) SQLInterval(PARSERHEAP(), TRUE, REC_DATE_DAY, 6, REC_DATE_DAY, 1);
 					$$ = new (PARSERHEAP()) 
 					       Cast(new (PARSERHEAP())BiArith(ITM_TIMES, $3,  new (PARSERHEAP()) ConstValue(7)), iq);
 					}
                    | TOK_YEAR   ',' value_expression
 				    {
-					SQLInterval *iq = new (PARSERHEAP()) SQLInterval(TRUE, REC_DATE_YEAR, 6, REC_DATE_YEAR, 1);
+					SQLInterval *iq = new (PARSERHEAP()) SQLInterval(PARSERHEAP(), TRUE, REC_DATE_YEAR, 6, REC_DATE_YEAR, 1);
 					$$ = new (PARSERHEAP()) Cast($3, iq);
 					}
                    | TOK_MONTH  ',' value_expression 
 				    {
-					SQLInterval *iq = new (PARSERHEAP()) SQLInterval(TRUE, REC_DATE_MONTH, 6, REC_DATE_MONTH, 1);
+					SQLInterval *iq = new (PARSERHEAP()) SQLInterval(PARSERHEAP(), TRUE, REC_DATE_MONTH, 6, REC_DATE_MONTH, 1);
 					$$ = new (PARSERHEAP()) Cast($3, iq);
 					}
 				   | TOK_DAY    ',' value_expression 
                    	{
-					SQLInterval *iq = new (PARSERHEAP()) SQLInterval(TRUE, REC_DATE_DAY, 6, REC_DATE_DAY, 1);
+					SQLInterval *iq = new (PARSERHEAP()) SQLInterval(PARSERHEAP(), TRUE, REC_DATE_DAY, 6, REC_DATE_DAY, 1);
 					$$ = new (PARSERHEAP()) Cast($3, iq);
 					}
                    | TOK_M  ',' value_expression 
 				    {
-					SQLInterval *iq = new (PARSERHEAP()) SQLInterval(TRUE, REC_DATE_MONTH, 6, REC_DATE_MONTH, 1);
+					SQLInterval *iq = new (PARSERHEAP()) SQLInterval(PARSERHEAP(), TRUE, REC_DATE_MONTH, 6, REC_DATE_MONTH, 1);
 					$$ = new (PARSERHEAP()) Cast($3, iq);
 					}
 				   | TOK_D    ',' value_expression 
                    	{
-					SQLInterval *iq = new (PARSERHEAP()) SQLInterval(TRUE, REC_DATE_DAY, 6, REC_DATE_DAY, 1);
+					SQLInterval *iq = new (PARSERHEAP()) SQLInterval(PARSERHEAP(), TRUE, REC_DATE_DAY, 6, REC_DATE_DAY, 1);
 					$$ = new (PARSERHEAP()) Cast($3, iq);
 					}                   
                    | TOK_HOUR   ',' value_expression
                     {
-					SQLInterval *iq = new (PARSERHEAP()) SQLInterval(TRUE, REC_DATE_HOUR, 8, REC_DATE_HOUR, 1);
+					SQLInterval *iq = new (PARSERHEAP()) SQLInterval(PARSERHEAP(), TRUE, REC_DATE_HOUR, 8, REC_DATE_HOUR, 1);
 					$$ = new (PARSERHEAP()) Cast($3, iq);
 					}                    
                    | TOK_MINUTE ',' value_expression
 				    {
-					SQLInterval *iq = new (PARSERHEAP()) SQLInterval(TRUE, REC_DATE_MINUTE, 10, REC_DATE_MINUTE, 1);
+					SQLInterval *iq = new (PARSERHEAP()) SQLInterval(PARSERHEAP(), TRUE, REC_DATE_MINUTE, 10, REC_DATE_MINUTE, 1);
 					$$ = new (PARSERHEAP()) Cast($3, iq);
 					}                    
                    | TOK_SECOND ',' value_expression 
 				    {
-					SQLInterval *iq = new (PARSERHEAP()) SQLInterval(TRUE, REC_DATE_SECOND, 12, REC_DATE_SECOND, 1);
+					SQLInterval *iq = new (PARSERHEAP()) SQLInterval(PARSERHEAP(), TRUE, REC_DATE_SECOND, 12, REC_DATE_SECOND, 1);
 					$$ = new (PARSERHEAP()) Cast($3, iq);
 					}
 				   | IDENTIFIER ',' value_expression
@@ -10456,43 +10456,43 @@ datetime_keywords : TOK_QUARTER  ',' value_expression 		  // 3 months	Cast 3*num
                       $1->toUpper();
                       if      ( *$1 == "YYYY" | *$1 == "YY" )
 					    {
-					      SQLInterval *iq = new (PARSERHEAP()) SQLInterval(TRUE, REC_DATE_YEAR, 6, REC_DATE_YEAR, 1);
+					      SQLInterval *iq = new (PARSERHEAP()) SQLInterval(PARSERHEAP(), TRUE, REC_DATE_YEAR, 6, REC_DATE_YEAR, 1);
 					      $$ = new (PARSERHEAP()) Cast($3, iq);
 					    }
                       else if ( *$1 == "MM" ) 
 				        {
-					      SQLInterval *iq = new (PARSERHEAP()) SQLInterval(TRUE, REC_DATE_MONTH, 6, REC_DATE_MONTH, 1);
+					      SQLInterval *iq = new (PARSERHEAP()) SQLInterval(PARSERHEAP(), TRUE, REC_DATE_MONTH, 6, REC_DATE_MONTH, 1);
 					      $$ = new (PARSERHEAP()) Cast($3, iq);
 					    }                       
                       else if ( *$1 == "DD" ) 
                    	    {
-					       SQLInterval *iq = new (PARSERHEAP()) SQLInterval(TRUE, REC_DATE_DAY, 6, REC_DATE_DAY, 1);
+					       SQLInterval *iq = new (PARSERHEAP()) SQLInterval(PARSERHEAP(), TRUE, REC_DATE_DAY, 6, REC_DATE_DAY, 1);
 					       $$ = new (PARSERHEAP()) Cast($3, iq);
 					    }                       
                       else if ( *$1 == "HH"  ) 
                         {
-        					SQLInterval *iq = new (PARSERHEAP()) SQLInterval(TRUE, REC_DATE_HOUR, 8, REC_DATE_HOUR, 1);
+        					SQLInterval *iq = new (PARSERHEAP()) SQLInterval(PARSERHEAP(), TRUE, REC_DATE_HOUR, 8, REC_DATE_HOUR, 1);
 		        			$$ = new (PARSERHEAP()) Cast($3, iq);
 					    }
                       else if ( *$1 == "MI" | *$1 == "N" ) 
 				        {
-				       	   SQLInterval *iq = new (PARSERHEAP()) SQLInterval(TRUE, REC_DATE_MINUTE, 10, REC_DATE_MINUTE, 1);
+				       	   SQLInterval *iq = new (PARSERHEAP()) SQLInterval(PARSERHEAP(), TRUE, REC_DATE_MINUTE, 10, REC_DATE_MINUTE, 1);
 				       	   $$ = new (PARSERHEAP()) Cast($3, iq);
 					    }                       
                       else if ( *$1 == "SS" | *$1 == "S" ) 
 				        {
-					      SQLInterval *iq = new (PARSERHEAP()) SQLInterval(TRUE, REC_DATE_SECOND, 12, REC_DATE_SECOND, 1);
+					      SQLInterval *iq = new (PARSERHEAP()) SQLInterval(PARSERHEAP(), TRUE, REC_DATE_SECOND, 12, REC_DATE_SECOND, 1);
 					      $$ = new (PARSERHEAP()) Cast($3, iq);
 					    }                        
                       else if ( *$1 == "QQ" | *$1 == "Q" ) 
                         {
-					      SQLInterval *iq = new (PARSERHEAP()) SQLInterval(TRUE, REC_DATE_MONTH, 6, REC_DATE_MONTH, 1);
+					      SQLInterval *iq = new (PARSERHEAP()) SQLInterval(PARSERHEAP(), TRUE, REC_DATE_MONTH, 6, REC_DATE_MONTH, 1);
 					      $$ = new (PARSERHEAP()) 
 					             Cast(new (PARSERHEAP())BiArith(ITM_TIMES, $3,  new (PARSERHEAP()) ConstValue(3)), iq);
 					    }                       
                       else if ( *$1 == "WK" | *$1 == "WW" ) 
                        	{
-				         SQLInterval *iq = new (PARSERHEAP()) SQLInterval(TRUE, REC_DATE_DAY, 6, REC_DATE_DAY, 1);
+				         SQLInterval *iq = new (PARSERHEAP()) SQLInterval(PARSERHEAP(), TRUE, REC_DATE_DAY, 6, REC_DATE_DAY, 1);
 					     $$ = new (PARSERHEAP()) 
 					          Cast(new (PARSERHEAP())BiArith(ITM_TIMES, $3,  new (PARSERHEAP()) ConstValue(7)), iq);
 				     	}
@@ -10508,43 +10508,43 @@ timestamp_keywords : IDENTIFIER ',' value_expression
     $1->toUpper();
     if ( *$1 == "SQL_TSI_YEAR" )
       {
-        SQLInterval *iq = new (PARSERHEAP()) SQLInterval(TRUE, REC_DATE_YEAR, 6, REC_DATE_YEAR, 1);
+        SQLInterval *iq = new (PARSERHEAP()) SQLInterval(PARSERHEAP(), TRUE, REC_DATE_YEAR, 6, REC_DATE_YEAR, 1);
         $$ = new (PARSERHEAP()) Cast($3, iq);
       }
     else if ( *$1 == "SQL_TSI_MONTH" )
       {
-        SQLInterval *iq = new (PARSERHEAP()) SQLInterval(TRUE, REC_DATE_MONTH, 6, REC_DATE_MONTH, 1);
+        SQLInterval *iq = new (PARSERHEAP()) SQLInterval(PARSERHEAP(), TRUE, REC_DATE_MONTH, 6, REC_DATE_MONTH, 1);
         $$ = new (PARSERHEAP()) Cast($3, iq);
       }
     else if ( *$1 == "SQL_TSI_DAY" )
       {
-        SQLInterval *iq = new (PARSERHEAP()) SQLInterval(TRUE, REC_DATE_DAY, 6, REC_DATE_DAY, 1);
+        SQLInterval *iq = new (PARSERHEAP()) SQLInterval(PARSERHEAP(), TRUE, REC_DATE_DAY, 6, REC_DATE_DAY, 1);
         $$ = new (PARSERHEAP()) Cast($3, iq);
       }
     else if ( *$1 == "SQL_TSI_HOUR" )
       {
-        SQLInterval *iq = new (PARSERHEAP()) SQLInterval(TRUE, REC_DATE_HOUR, 8, REC_DATE_HOUR, 1);
+        SQLInterval *iq = new (PARSERHEAP()) SQLInterval(PARSERHEAP(), TRUE, REC_DATE_HOUR, 8, REC_DATE_HOUR, 1);
         $$ = new (PARSERHEAP()) Cast($3, iq);
       }
     else if ( *$1 == "SQL_TSI_MINUTE" )
       {
-        SQLInterval *iq = new (PARSERHEAP()) SQLInterval(TRUE, REC_DATE_MINUTE, 10, REC_DATE_MINUTE, 1);
+        SQLInterval *iq = new (PARSERHEAP()) SQLInterval(PARSERHEAP(), TRUE, REC_DATE_MINUTE, 10, REC_DATE_MINUTE, 1);
         $$ = new (PARSERHEAP()) Cast($3, iq);
       }
     else if ( *$1 == "SQL_TSI_SECOND" )
       {
-        SQLInterval *iq = new (PARSERHEAP()) SQLInterval(TRUE, REC_DATE_SECOND, 12, REC_DATE_SECOND, 1);
+        SQLInterval *iq = new (PARSERHEAP()) SQLInterval(PARSERHEAP(), TRUE, REC_DATE_SECOND, 12, REC_DATE_SECOND, 1);
         $$ = new (PARSERHEAP()) Cast($3, iq);
       }
     else if ( *$1 == "SQL_TSI_QUARTER" )
       {
-        SQLInterval *iq = new (PARSERHEAP()) SQLInterval(TRUE, REC_DATE_MONTH, 6, REC_DATE_MONTH, 1);
+        SQLInterval *iq = new (PARSERHEAP()) SQLInterval(PARSERHEAP(), TRUE, REC_DATE_MONTH, 6, REC_DATE_MONTH, 1);
         $$ = new (PARSERHEAP()) 
               Cast(new (PARSERHEAP())BiArith(ITM_TIMES, $3,  new (PARSERHEAP()) ConstValue(3)), iq);
       }
     else if ( *$1 == "SQL_TSI_WEEK" )
       {
-        SQLInterval *iq = new (PARSERHEAP()) SQLInterval(TRUE, REC_DATE_DAY, 6, REC_DATE_DAY, 1);
+        SQLInterval *iq = new (PARSERHEAP()) SQLInterval(PARSERHEAP(), TRUE, REC_DATE_DAY, 6, REC_DATE_DAY, 1);
         $$ = new (PARSERHEAP()) 
         Cast(new (PARSERHEAP())BiArith(ITM_TIMES, $3,  new (PARSERHEAP()) ConstValue(7)), iq);
       }
@@ -10928,21 +10928,21 @@ predefined_type : date_time_type
 rowset_type : TOK_ROWSET unsigned_integer predefined_type
 	      {
 #pragma nowarn(1506)   // warning elimination 
-		$$ = new (PARSERHEAP()) SQLRowset( $3, $2, $2);
+		$$ = new (PARSERHEAP()) SQLRowset(PARSERHEAP(), $3, $2, $2);
 	      }
              | TOK_ROWSET unsigned_integer float_type
 	      {
-		$$ = new (PARSERHEAP()) SQLRowset( $3, $2, $2);
+		$$ = new (PARSERHEAP()) SQLRowset(PARSERHEAP(), $3, $2, $2);
 	      }
 
 /* type na_type */
 proc_arg_rowset_type : TOK_ROWSET unsigned_integer predefined_type
 	      {
-		$$ = new (PARSERHEAP()) SQLRowset( $3, $2, $2);
+		$$ = new (PARSERHEAP()) SQLRowset(PARSERHEAP(), $3, $2, $2);
 	      }
              | TOK_ROWSET unsigned_integer proc_arg_float_type
 	      {
-		$$ = new (PARSERHEAP()) SQLRowset( $3, $2, $2);
+		$$ = new (PARSERHEAP()) SQLRowset(PARSERHEAP(), $3, $2, $2);
 #pragma warn(1506)  // warning elimination
 	      }
 
@@ -10953,15 +10953,15 @@ numeric_type : non_int_type
 /* na type for the numeric */
 int_type : TOK_INTEGER signed_option
              {
-		$$ = new (PARSERHEAP()) SQLInt( $2, TRUE);
+		$$ = new (PARSERHEAP()) SQLInt(PARSERHEAP(),  $2, TRUE);
              }
 	 | TOK_SMALLINT signed_option
              {
-		$$ = new (PARSERHEAP()) SQLSmall( $2, TRUE);
+		$$ = new (PARSERHEAP()) SQLSmall( PARSERHEAP(), $2, TRUE);
              }
 	 | TOK_LARGEINT signed_option
              {
-               $$ = new (PARSERHEAP()) SQLLargeInt( $2, TRUE);
+               $$ = new (PARSERHEAP()) SQLLargeInt(PARSERHEAP(),  $2, TRUE);
              }
          | TOK_BIGINT signed_option
              {
@@ -10972,7 +10972,7 @@ int_type : TOK_INTEGER signed_option
                   yyerror(""); 
                   YYERROR;
                 }
-                $$ = new (PARSERHEAP()) SQLLargeInt ($2,TRUE);
+                $$ = new (PARSERHEAP()) SQLLargeInt (PARSERHEAP(), $2,TRUE);
                 // ((SQLLargeInt *)$$)->setDisplayDataType("BIGINT");
 	     }
 	 | TOK_BIT TOK_PRECISION TOK_INTEGER left_unsigned_right signed_option
@@ -10987,12 +10987,12 @@ int_type : TOK_INTEGER signed_option
                    *SqlParser_Diags << DgSqlCode(-3126);
 		   YYABORT;
 		}
-		$$ = new (PARSERHEAP()) SQLBPInt ($4, TRUE, FALSE);
+		$$ = new (PARSERHEAP()) SQLBPInt (PARSERHEAP(), $4, TRUE, FALSE);
 	     }
 	 | TOK_BIT
        { 
          // odbc SQL_BIT is single bit binary data
-         $$ = new (PARSERHEAP()) SQLChar(1);
+         $$ = new (PARSERHEAP()) SQLChar(PARSERHEAP(), 1);
          // ((SQLChar *)$$)->setDisplayDataType("BIT");
        }
 	 | TOK_TINYINT signed_option
@@ -11000,9 +11000,9 @@ int_type : TOK_INTEGER signed_option
          // odbc SQL_TINYINT is exact numeric value with precision 3 &
          // scale 0. signed: -128<=n<=127, unsigned: 0<=n<=255.
          if (CmpCommon::getDefault(TRAF_TINYINT_SUPPORT) == DF_OFF)
-           $$ = new (PARSERHEAP()) SQLSmall( $2, TRUE);
+           $$ = new (PARSERHEAP()) SQLSmall(PARSERHEAP(),  $2, TRUE);
          else
-           $$ = new (PARSERHEAP()) SQLTiny( $2, TRUE);
+           $$ = new (PARSERHEAP()) SQLTiny(PARSERHEAP(),  $2, TRUE);
        }
 	 | TOK_BYTEINT signed_option
        {
@@ -11010,9 +11010,9 @@ int_type : TOK_INTEGER signed_option
          // BYTEINT is supposed to be exact numeric value with precision 3 &
          // scale 0. signed: -128<=n<=127, unsigned: 0<=n<=255.
          if (CmpCommon::getDefault(TRAF_TINYINT_SUPPORT) == DF_OFF)
-           $$ = new (PARSERHEAP()) SQLSmall( $2, TRUE);
+           $$ = new (PARSERHEAP()) SQLSmall(PARSERHEAP(),  $2, TRUE);
          else
-           $$ = new (PARSERHEAP()) SQLTiny( $2, TRUE);
+           $$ = new (PARSERHEAP()) SQLTiny(PARSERHEAP(),  $2, TRUE);
        }
 
 numeric_type_token :    TOK_NUMERIC
@@ -11079,11 +11079,11 @@ non_int_type : numeric_type_token left_uint_uint_right signed_option
 	       if (($2->left() > MAX_HARDWARE_SUPPORTED_SIGNED_NUMERIC_PRECISION) ||
 		   (($2->left() > MAX_HARDWARE_SUPPORTED_UNSIGNED_NUMERIC_PRECISION) AND NOT $3))
 		 $$ = new (PARSERHEAP())
-		   SQLBigNum($2->left(), $2->right(), TRUE, $3, TRUE, NULL);
+		   SQLBigNum(PARSERHEAP(), $2->left(), $2->right(), TRUE, $3, TRUE);
 	       else {
 		 const Int16 DisAmbiguate = 0; // added for 64bit project
 		 $$ = new (PARSERHEAP())
-		   SQLNumeric( $3,$2->left(), $2->right(), DisAmbiguate );
+		   SQLNumeric(PARSERHEAP(), $3,$2->left(), $2->right(), DisAmbiguate );
 	       }
 	       delete $2;
              }
@@ -11096,7 +11096,7 @@ non_int_type : numeric_type_token left_uint_uint_right signed_option
                  prec = 18; 
 
 	       const Int16 DisAmbiguate = 0; // added for 64bit project
-	       $$ = new (PARSERHEAP()) SQLNumeric($2, prec, 0, DisAmbiguate);
+	       $$ = new (PARSERHEAP()) SQLNumeric(PARSERHEAP(), $2, prec, 0, DisAmbiguate);
 	     }
 	 | TOK_LSDECIMAL left_uint_uint_right signed_option
              {
@@ -11133,14 +11133,14 @@ non_int_type : numeric_type_token left_uint_uint_right signed_option
                     YYABORT;
                 }
 		$$ = new (PARSERHEAP())
-		  LSDecimal( $2->left(), $2->right(), $3);
+		  LSDecimal(PARSERHEAP(), $2->left(), $2->right(), $3);
                 delete $2;
 #pragma warn(1506)  // warning elimination
              }
 	 | TOK_LSDECIMAL signed_option 
              {
 	       // Default (precision,scale) for DECIMAL is (9,0)
-	       $$ = new (PARSERHEAP()) LSDecimal(9, 0, $2);
+	       $$ = new (PARSERHEAP()) LSDecimal(PARSERHEAP(),9, 0, $2);
 	     }
 	 | TOK_DECIMAL left_uint_uint_right signed_option
              {
@@ -11177,23 +11177,23 @@ non_int_type : numeric_type_token left_uint_uint_right signed_option
                     YYABORT;
                 }
 		$$ = new (PARSERHEAP())
-		  SQLDecimal( $2->left(), $2->right(), $3);
+		  SQLDecimal(PARSERHEAP(), $2->left(), $2->right(), $3);
                 delete $2;
 #pragma warn(1506)  // warning elimination
              }
 	 | TOK_DECIMAL signed_option
              {
 	       // Default (precision,scale) for DECIMAL is (9,0)
-	       $$ = new (PARSERHEAP()) SQLDecimal(9, 0, $2);
+	       $$ = new (PARSERHEAP()) SQLDecimal(PARSERHEAP(),9, 0, $2);
 	     }
 float_type : TOK_FLOAT
              {
-               //               $$ = new (PARSERHEAP()) SQLDoublePrecision(TRUE, NULL, SQL_DOUBLE_PRECISION, TRUE);
-               $$ = new (PARSERHEAP()) SQLDoublePrecision(TRUE, NULL, 0, TRUE);
+               //               $$ = new (PARSERHEAP()) SQLDoublePrecision(PARSERHEAP(), TRUE, SQL_DOUBLE_PRECISION, TRUE);
+               $$ = new (PARSERHEAP()) SQLDoublePrecision(PARSERHEAP(), TRUE, 0, TRUE);
              }
 	 | TOK_FLOAT left_unsigned_right
              {
-               $$ = new (PARSERHEAP()) SQLDoublePrecision(TRUE, NULL, $2, TRUE);
+               $$ = new (PARSERHEAP()) SQLDoublePrecision(PARSERHEAP(), TRUE, $2, TRUE);
 
                if (CmpCommon::getDefault(MODE_SPECIAL_4) == DF_OFF)
                  {
@@ -11203,15 +11203,15 @@ float_type : TOK_FLOAT
              }
 	 | TOK_REAL
              {
-		$$ = new (PARSERHEAP()) SQLReal(TRUE, PARSERHEAP());
+		$$ = new (PARSERHEAP()) SQLReal(PARSERHEAP(), TRUE); 
              }
 	 | TOK_DOUBLE TOK_PRECISION
              {
-		$$ = new (PARSERHEAP()) SQLDoublePrecision(TRUE, PARSERHEAP(), 0);
+		$$ = new (PARSERHEAP()) SQLDoublePrecision(PARSERHEAP(), TRUE, 0);
              }
 	 | TOK_SQL_DOUBLE
              {
-		$$ = new (PARSERHEAP()) SQLDoublePrecision(TRUE, PARSERHEAP(), 0);
+		$$ = new (PARSERHEAP()) SQLDoublePrecision(PARSERHEAP(), TRUE, 0);
              }
 
 /* na type for the ieee or tandem floats as PROCEDURE argument in mdf.
@@ -11219,32 +11219,32 @@ float_type : TOK_FLOAT
    not IEEE floats. This is for upward compatibility from pre R2 releases */
 proc_arg_float_type : TOK_FLOAT_IEEE
              {
-		$$ = new (PARSERHEAP()) SQLDoublePrecision(TRUE, PARSERHEAP(), 0);
+		$$ = new (PARSERHEAP()) SQLDoublePrecision(PARSERHEAP(), TRUE, 0);
              }
 	 | TOK_FLOAT_IEEE left_unsigned_right
              {
 #pragma nowarn(1506)  // warning elimination
-		$$ = new (PARSERHEAP()) SQLDoublePrecision(TRUE, NULL, $2);
+		$$ = new (PARSERHEAP()) SQLDoublePrecision(PARSERHEAP(), TRUE, $2);
 #pragma warn(1506)  // warning elimination
                 if (! ((SQLDoublePrecision *)$$)->checkValid(SqlParser_Diags))
                    YYERROR;
              }
 	 | TOK_REAL_IEEE
              {
-		$$ = new (PARSERHEAP()) SQLReal(TRUE, PARSERHEAP(), 0);
+		$$ = new (PARSERHEAP()) SQLReal(PARSERHEAP(), TRUE, 0);
              }
 	 | TOK_DOUBLE_IEEE
              {
-		$$ = new (PARSERHEAP()) SQLDoublePrecision(TRUE, PARSERHEAP(), 0);
+		$$ = new (PARSERHEAP()) SQLDoublePrecision(PARSERHEAP(), TRUE, 0);
              }
 	 | TOK_FLOAT
              {
-		$$ = new (PARSERHEAP()) SQLDoublePrecision(TRUE, PARSERHEAP(), 0);
+		$$ = new (PARSERHEAP()) SQLDoublePrecision(PARSERHEAP(), TRUE, 0);
              }
 	 | TOK_FLOAT left_unsigned_right
              {
 #pragma nowarn(1506)  // warning elimination
-		$$ = new (PARSERHEAP()) SQLDoublePrecision(TRUE, NULL, $2);
+		$$ = new (PARSERHEAP()) SQLDoublePrecision(PARSERHEAP(), TRUE, $2);
 #pragma warn(1506)  // warning elimination
                 if (! ((SQLDoublePrecision *)$$)->checkValid(SqlParser_Diags))
                    YYERROR;
@@ -11253,13 +11253,13 @@ proc_arg_float_type : TOK_FLOAT_IEEE
              {
 	       // For upward compatability, 
 	       // REAL is IEEE real on NT, tandem real on NSK.
-		$$ = new (PARSERHEAP()) SQLReal(TRUE, PARSERHEAP(), 0);
+		$$ = new (PARSERHEAP()) SQLReal(PARSERHEAP(), TRUE, 0);
              }
 	 | TOK_DOUBLE TOK_PRECISION
              {
 	       // For upward compatability, 
 	       // DOUBLE is IEEE double on NT, tandem double on NSK.
-		$$ = new (PARSERHEAP()) SQLDoublePrecision(TRUE, PARSERHEAP(), 0);
+		$$ = new (PARSERHEAP()) SQLDoublePrecision(PARSERHEAP(), TRUE);
              }
 
 /* na_type */
@@ -11392,7 +11392,7 @@ string_type : tok_char_or_character_or_byte new_optional_left_charlen_right char
                  {
                    maxLenInBytes = characterLimit * maxBytesPerChar;
                  }
-                 $$ = new (PARSERHEAP()) SQLChar ( CharLenInfo(characterLimit, maxLenInBytes), TRUE,
+                 $$ = new (PARSERHEAP()) SQLChar ( PARSERHEAP(), CharLenInfo(characterLimit, maxLenInBytes), TRUE,
                                                    $5, $6, FALSE, eCharSet, $4.collation_,
                                                    $4.coercibility_, eEncodingCharSet );
                  NAString ddt("CHAR", PARSERHEAP());
@@ -11401,7 +11401,7 @@ string_type : tok_char_or_character_or_byte new_optional_left_charlen_right char
                else // keep the old behavior
 #pragma nowarn(1506)  // warning elimination
                $$ = new (PARSERHEAP()) SQLChar
-			(specifiedLength, TRUE, $5, $6, FALSE, 
+			(PARSERHEAP(), specifiedLength, TRUE, $5, $6, FALSE, 
 			 eCharSet, $4.collation_, $4.coercibility_);
 #pragma warn(1506)  // warning elimination
 	       if (checkError3179($$)) YYERROR;
@@ -11411,7 +11411,7 @@ string_type : tok_char_or_character_or_byte new_optional_left_charlen_right char
             {
 #pragma nowarn(1506)  // warning elimination
                $$ = new (PARSERHEAP()) ANSIChar
-	       		($2, TRUE, $5, TRUE,
+	       		(PARSERHEAP(), $2, TRUE, $5, TRUE,
 			 $3, $4.collation_, $4.coercibility_);
 #pragma warn(1506)  // warning elimination
 	       if (checkError3179($$)) YYERROR;
@@ -11461,7 +11461,7 @@ string_type : tok_char_or_character_or_byte new_optional_left_charlen_right char
                  {
                    maxLenInBytes = characterLimit * maxBytesPerChar; 
                  }
-                 $$ = new (PARSERHEAP()) SQLVarChar ( CharLenInfo(characterLimit, maxLenInBytes),
+                 $$ = new (PARSERHEAP()) SQLVarChar ( PARSERHEAP(), CharLenInfo(characterLimit, maxLenInBytes),
                                                       TRUE, $6, $7, eCharSet, $5.collation_,
                                                       $5.coercibility_, eEncodingCharSet );
                  NAString ddt("VARCHAR", PARSERHEAP());
@@ -11470,7 +11470,7 @@ string_type : tok_char_or_character_or_byte new_optional_left_charlen_right char
                else // keep the old behavior
 #pragma nowarn(1506)  // warning elimination
                $$ = new (PARSERHEAP()) SQLVarChar
-			(specifiedLength, TRUE, $6, $7,
+			(PARSERHEAP(), specifiedLength, TRUE, $6, $7,
 			 eCharSet, $5.collation_, $5.coercibility_);
 #pragma warn(1506)  // warning elimination
 	       if (checkError3179($$)) YYERROR;
@@ -11510,7 +11510,7 @@ string_type : tok_char_or_character_or_byte new_optional_left_charlen_right char
                  {
                    maxLenInBytes = characterLimit * maxBytesPerChar;
                  }
-                 $$ = new (PARSERHEAP()) SQLVarChar ( CharLenInfo(characterLimit, maxLenInBytes), TRUE,
+                 $$ = new (PARSERHEAP()) SQLVarChar (PARSERHEAP(),  CharLenInfo(characterLimit, maxLenInBytes), TRUE,
                                                       $5, $6, eCharSet, $4.collation_,
                                                       $4.coercibility_, eEncodingCharSet );
                  NAString ddt("VARCHAR", PARSERHEAP());
@@ -11519,7 +11519,7 @@ string_type : tok_char_or_character_or_byte new_optional_left_charlen_right char
                else // keep the old behavior
 #pragma nowarn(1506)  // warning elimination
                $$ = new (PARSERHEAP()) SQLVarChar
-			(specifiedLength, TRUE, $5, $6,
+			(PARSERHEAP(), specifiedLength, TRUE, $5, $6,
 			 eCharSet, $4.collation_, $4.coercibility_);
 #pragma warn(1506)  // warning elimination
 	       if (checkError3179($$)) YYERROR;
@@ -11548,7 +11548,7 @@ string_type : tok_char_or_character_or_byte new_optional_left_charlen_right char
            Int32 maxBytesPerChar = CharInfo::maxBytesPerChar(eCharSet);
            // compute the length in UCS4 characters for the worse case scenarios
            Int32 characterLimit = maxLenInBytes ;
-           $$ = new (PARSERHEAP()) SQLLongVarChar ( CharLenInfo(characterLimit, maxLenInBytes),
+           $$ = new (PARSERHEAP()) SQLLongVarChar ( PARSERHEAP(), (characterLimit, maxLenInBytes),
                                                     FALSE, TRUE,
                                                     $5, $6, eCharSet, $4.collation_,
                                                     $4.coercibility_, eEncodingCharSet );
@@ -11558,7 +11558,7 @@ string_type : tok_char_or_character_or_byte new_optional_left_charlen_right char
          }
          else // keep the old behavior
          $$ = new (PARSERHEAP()) SQLLongVarChar
-           (maxLenInBytes, FALSE, TRUE, $5, $6,
+           (PARSERHEAP(), maxLenInBytes, FALSE, TRUE, $5, $6,
             eCharSet, $4.collation_, $4.coercibility_);
          if (checkError3179($$)) YYERROR;
 
@@ -11607,7 +11607,7 @@ string_type : tok_char_or_character_or_byte new_optional_left_charlen_right char
            Int32 maxBytesPerChar = CharInfo::maxBytesPerChar(eCharSet);
            // compute the length in UCS4 characters for the worse case scenarios
            Int32 characterLimit = maxLenInBytes ;
-           $$ = new (PARSERHEAP()) SQLVarChar ( CharLenInfo ( characterLimit , maxLenInBytes)
+           $$ = new (PARSERHEAP()) SQLVarChar ( PARSERHEAP(), CharLenInfo ( characterLimit , maxLenInBytes)
                                               , TRUE // allowSQLnull
                                               , $6   // isUpShifted
                                               , $7   // isCaseInsensitive
@@ -11626,7 +11626,7 @@ string_type : tok_char_or_character_or_byte new_optional_left_charlen_right char
          //   "create table t(c long varchar, w longwvarchar)" into
          //   "create table t(c varchar(n),   w varwchar(m))".
          $$ = new (PARSERHEAP()) SQLVarChar
-           (maxLenInBytes, TRUE, $6, $7, eCharSet, $5.collation_, $5.coercibility_);
+           (PARSERHEAP(), maxLenInBytes, TRUE, $6, $7, eCharSet, $5.collation_, $5.coercibility_);
          // end KLUDGE.
 #pragma warn(1506)  // warning elimination
 	       if (checkError3179($$)) YYERROR;
@@ -11636,7 +11636,7 @@ string_type : tok_char_or_character_or_byte new_optional_left_charlen_right char
             {
 #pragma nowarn(1506)  // warning elimination
                $$ = new (PARSERHEAP()) SQLChar
-		 	($2, TRUE, $4, $5, FALSE,
+		 	(PARSERHEAP(), $2, TRUE, $4, $5, FALSE,
 			 SqlParser_NATIONAL_CHARSET,
 			 $3.collation_, $3.coercibility_);
 #pragma warn(1506)  // warning elimination
@@ -11646,7 +11646,7 @@ string_type : tok_char_or_character_or_byte new_optional_left_charlen_right char
             {
 #pragma nowarn(1506)  // warning elimination
                $$ = new (PARSERHEAP()) SQLVarChar
-		 	($2, TRUE, $4, $5,
+		 	(PARSERHEAP(), $2, TRUE, $4, $5,
 			 SqlParser_NATIONAL_CHARSET,
 			 $3.collation_, $3.coercibility_);
 #pragma warn(1506)  // warning elimination
@@ -11658,7 +11658,7 @@ string_type : tok_char_or_character_or_byte new_optional_left_charlen_right char
          // of fixed string length n.
 #pragma nowarn(1506)  // warning elimination
          $$ = new (PARSERHEAP()) SQLChar
-           ($2, TRUE, $4, $5, FALSE, CharInfo::UNICODE, 
+           (PARSERHEAP(), $2, TRUE, $4, $5, FALSE, CharInfo::UNICODE, 
             $3.collation_, $3.coercibility_);
 #pragma warn(1506)  // warning elimination
          if (checkError3179($$)) YYERROR;
@@ -11669,7 +11669,7 @@ string_type : tok_char_or_character_or_byte new_optional_left_charlen_right char
          // character string with a maximum string length n.
 #pragma nowarn(1506)  // warning elimination
          $$ = new (PARSERHEAP()) SQLVarChar
-           ($2, TRUE, $4, $5, CharInfo::UNICODE, 
+           (PARSERHEAP(), $2, TRUE, $4, $5, CharInfo::UNICODE, 
             $3.collation_, $3.coercibility_);
 #pragma warn(1506)  // warning elimination
          if (checkError3179($$)) YYERROR;
@@ -11680,7 +11680,7 @@ string_type : tok_char_or_character_or_byte new_optional_left_charlen_right char
          // character data. Maximum length is data source-dependent (can be
          // set by control query default MAX_LONG_WVARCHAR_DEFAULT_SIZE).
          $$ = new (PARSERHEAP()) SQLLongVarChar
-           (getDefaultMaxLengthForLongVarChar(CharInfo::UNICODE), 
+           (PARSERHEAP(), getDefaultMaxLengthForLongVarChar(CharInfo::UNICODE), 
             FALSE, TRUE, $3, $4, CharInfo::UNICODE, 
             $2.collation_, $2.coercibility_);
          if (checkError3179($$)) YYERROR;
@@ -11703,7 +11703,7 @@ string_type : tok_char_or_character_or_byte new_optional_left_charlen_right char
          }
 #pragma nowarn(1506)  // warning elimination
          $$ = new (PARSERHEAP()) SQLLongVarChar
-           ($2, TRUE, TRUE, $4, $5, CharInfo::UNICODE, 
+           (PARSERHEAP(), $2, TRUE, TRUE, $4, $5, CharInfo::UNICODE, 
             $3.collation_, $3.coercibility_);
 #pragma warn(1506)  // warning elimination
          if (checkError3179($$)) YYERROR;
@@ -11712,7 +11712,7 @@ string_type : tok_char_or_character_or_byte new_optional_left_charlen_right char
        {
          // odbc SQL_BINARY is BINARY(n). Binary data of fixed length n.
 #pragma nowarn(1506)  // warning elimination
-         $$ = new (PARSERHEAP()) SQLChar($2, TRUE, FALSE, FALSE);
+         $$ = new (PARSERHEAP()) SQLChar(PARSERHEAP(), $2, TRUE, FALSE, FALSE);
 #pragma warn(1506)  // warning elimination
          if (checkError3179($$)) YYERROR;
        }
@@ -11721,7 +11721,7 @@ string_type : tok_char_or_character_or_byte new_optional_left_charlen_right char
          // odbc SQL_VARBINARY is VARBINARY(n). Variable length binary data 
          // of maximum length n. The maximum length is set by the user.
 #pragma nowarn(1506)  // warning elimination
-         $$ = new (PARSERHEAP()) SQLVarChar($2);
+         $$ = new (PARSERHEAP()) SQLVarChar(PARSERHEAP(), $2);
 #pragma warn(1506)  // warning elimination
          if (checkError3179($$)) YYERROR;
        }
@@ -11729,7 +11729,7 @@ string_type : tok_char_or_character_or_byte new_optional_left_charlen_right char
        {
          // odbc SQL_LONGVARBINARY is LONG VARBINARY(n). Variable length 
          // binary data. Maximum length is data source-dependent.
-         $$ = new (PARSERHEAP()) SQLLongVarChar(0, FALSE);
+         $$ = new (PARSERHEAP()) SQLLongVarChar(PARSERHEAP(), 0, FALSE);
          if (checkError3179($$)) YYERROR;
        }
      | TOK_LONG TOK_VARBINARY left_unsigned_right
@@ -11751,7 +11751,7 @@ string_type : tok_char_or_character_or_byte new_optional_left_charlen_right char
          // soln 10-040610-6863 by temporarily mapping
          //   "create table t(b long varbinary(n))" into
          //   "create table t(b varchar(n))".
-         $$ = new (PARSERHEAP()) SQLVarChar($3);
+         $$ = new (PARSERHEAP()) SQLVarChar(PARSERHEAP(), $3);
          // end KLUDGE.
 #pragma warn(1506)  // warning elimination
          if (checkError3179($$)) YYERROR;
@@ -11771,24 +11771,24 @@ blob_type : TOK_BLOB blob_optional_left_len_right
             {
 	      if (CmpCommon::getDefault(TRAF_BLOB_AS_VARCHAR) == DF_ON)
 		{
-		  $$ = new (PARSERHEAP()) SQLVarChar($2);
+		  $$ = new (PARSERHEAP()) SQLVarChar(PARSERHEAP(), $2);
                   ((SQLVarChar*)$$)->setClientDataType("BLOB");
 		}
 	      else
 		{
-    		  $$ = new (PARSERHEAP()) SQLBlob ( $2 );
+    		  $$ = new (PARSERHEAP()) SQLBlob (PARSERHEAP(),  $2 );
 		}
             }
           | TOK_CLOB clob_optional_left_len_right
             {
 	      if (CmpCommon::getDefault(TRAF_CLOB_AS_VARCHAR) == DF_ON)
 		{
-		  $$ = new (PARSERHEAP()) SQLVarChar($2);
+		  $$ = new (PARSERHEAP()) SQLVarChar(PARSERHEAP(), $2);
                   ((SQLVarChar*)$$)->setClientDataType("CLOB");
 		}
 	      else
 		{
-                  $$ = new (PARSERHEAP()) SQLClob ( $2 );
+                  $$ = new (PARSERHEAP()) SQLClob (PARSERHEAP(),  $2 );
 		}
             }
  
@@ -11864,7 +11864,7 @@ clob_optional_left_len_right: '(' NUMERIC_LITERAL_EXACT_NO_SCALE optional_lob_un
 /* type na_type */
 boolean_type : TOK_BOOLEAN
             {
-              $$ = new (PARSERHEAP()) SQLBooleanNative (TRUE);
+              $$ = new (PARSERHEAP()) SQLBooleanNative (PARSERHEAP(), TRUE);
             }
 
 /* type pCharLenSpec */
@@ -12204,7 +12204,7 @@ left_uint_uint_right: '(' NUMERIC_LITERAL_EXACT_NO_SCALE ',' NUMERIC_LITERAL_EXA
 /* type na_type */
 date_time_type : TOK_DATE disableCharsetInference format_attributes
                           {
-                            $$ = new (PARSERHEAP()) SQLDate(TRUE,PARSERHEAP());
+                            $$ = new (PARSERHEAP()) SQLDate(PARSERHEAP(), TRUE);
                             SQLDate *pDate = (SQLDate *)$$;
                             // Leave the field blank if FORMAT clause not
                             // specified to leave SHOWDDL output remain
@@ -12221,29 +12221,26 @@ date_time_type : TOK_DATE disableCharsetInference format_attributes
                           }
                | TOK_TIME
                           {
-                              $$ = new (PARSERHEAP()) SQLTime(TRUE, 
-                                                              SQLTime::DEFAULT_FRACTION_PRECISION,
-                                                              PARSERHEAP());
+                              $$ = new (PARSERHEAP()) SQLTime(PARSERHEAP(), TRUE, 
+                                                              SQLTime::DEFAULT_FRACTION_PRECISION);
                           }
                | TOK_TIME ts_left_unsigned_right
                           {
-                              $$ = new (PARSERHEAP()) SQLTime(TRUE,
-                                                              $2,
-                                                              PARSERHEAP());
+                              $$ = new (PARSERHEAP()) SQLTime(PARSERHEAP(), TRUE,
+                                                              $2);
 
                               if (! ((SQLTime *)$$)->checkValid(SqlParser_Diags)) YYERROR;
                           }
 	       | TOK_TIMESTAMP disableCharsetInference  format_attributes
                           {
                               $$ = new (PARSERHEAP()) 
-                                SQLTimestamp(TRUE, 
-                                             SQLTimestamp::DEFAULT_FRACTION_PRECISION, 
-                                             PARSERHEAP() );
+                                SQLTimestamp(PARSERHEAP(), TRUE, 
+                                             SQLTimestamp::DEFAULT_FRACTION_PRECISION); 
                               restoreInferCharsetState();
                           }
 	       | TOK_TIMESTAMP ts_left_unsigned_right disableCharsetInference format_attributes
                           {
-                              $$ = new (PARSERHEAP()) SQLTimestamp(TRUE, $2, PARSERHEAP());
+                              $$ = new (PARSERHEAP()) SQLTimestamp(PARSERHEAP(), TRUE, $2);
                               if (! ((SQLTimestamp *)$$)->checkValid(SqlParser_Diags)) YYERROR;
                               restoreInferCharsetState();
                           }
@@ -12337,7 +12334,7 @@ datetime_fraction_field  : TOK_FRACTION                            // returned i
 interval_type : TOK_INTERVAL interval_qualifier
               {
                 $$ = new (PARSERHEAP())
-		  SQLInterval(TRUE,
+		  SQLInterval(PARSERHEAP(), TRUE,
 			      $2->getStartField(),
 			      $2->getLeadingPrecision(),
 			      $2->getEndField(),
@@ -12356,11 +12353,10 @@ interval_type : TOK_INTERVAL interval_qualifier
 interval_qualifier : start_field TOK_TO end_field
                    {
                       $$ = new (PARSERHEAP())
-	              IntervalQualifier($1->getStartField(),
+	              IntervalQualifier(PARSERHEAP(), $1->getStartField(),
                                         $1->getLeadingPrecision(),
 					$3->getEndField(),
-				        $3->getFractionPrecision(),
-                                        PARSERHEAP());
+				        $3->getFractionPrecision());
 
 		      // Check to see if FRACTION used, pass along to new object
 		      if($3->getDTIFlag(IntervalType::UNSUPPORTED_DDL_DATA_TYPE))
@@ -12379,11 +12375,10 @@ interval_qualifier : start_field TOK_TO end_field
                    | TOK_SECOND TOK_TO interval_fraction_field
                    {
                        $$ = new (PARSERHEAP()) 
-                           IntervalQualifier(REC_DATE_SECOND,
+                           IntervalQualifier(PARSERHEAP(), REC_DATE_SECOND,
                                      SQLInterval::DEFAULT_LEADING_PRECISION,
                                      REC_DATE_SECOND,
-                                     $3,
-                                     PARSERHEAP());
+                                     $3);
 
                       if (! $$->checkValid(SqlParser_Diags)) YYERROR;
 
@@ -12393,11 +12388,10 @@ interval_qualifier : start_field TOK_TO end_field
                    | TOK_SECOND ts_left_unsigned_right TOK_TO interval_fraction_field
                    {
                         $$ = new (PARSERHEAP())
-                          IntervalQualifier(REC_DATE_SECOND,
+                          IntervalQualifier(PARSERHEAP(), REC_DATE_SECOND,
                                     $2,
                                     REC_DATE_SECOND,
-                                    $4,
-                                    PARSERHEAP());
+                                    $4);
 
                         if (! $$->checkValid(SqlParser_Diags)) YYERROR;
 			
@@ -12407,19 +12401,17 @@ interval_qualifier : start_field TOK_TO end_field
                    | TOK_SECOND TOK_TO TOK_SECOND
                    {
                         $$ = new (PARSERHEAP()) 
-                            IntervalQualifier(REC_DATE_SECOND,
-                                              IntervalQualifier::DEFAULT_LEADING_PRECISION,
-                                              PARSERHEAP());
+                            IntervalQualifier(PARSERHEAP(), REC_DATE_SECOND,
+                                              IntervalQualifier::DEFAULT_LEADING_PRECISION);
                    }
 
                    | TOK_SECOND ts_left_unsigned_right TOK_TO TOK_SECOND
                    {
                         $$ = new (PARSERHEAP())
-                          IntervalQualifier(REC_DATE_SECOND,
+                          IntervalQualifier(PARSERHEAP(), REC_DATE_SECOND,
                                    $2,
                                    REC_DATE_SECOND,
-                                   0,
-                                   PARSERHEAP());
+                                   0);
                         if (! $$->checkValid(SqlParser_Diags)) YYERROR;
                     }
                     | fraction_only_interval
@@ -12433,51 +12425,47 @@ interval_qualifier : start_field TOK_TO end_field
 /* type intervalQualifier */
 start_field : non_second_datetime_field
             {
-              $$ = new (PARSERHEAP()) IntervalQualifier($1, IntervalQualifier::DEFAULT_LEADING_PRECISION, PARSERHEAP());
+              $$ = new (PARSERHEAP()) IntervalQualifier(PARSERHEAP(), $1, IntervalQualifier::DEFAULT_LEADING_PRECISION);
             }
             | non_second_datetime_field ts_left_unsigned_right
             {
-              $$ = new (PARSERHEAP()) IntervalQualifier($1, $2, PARSERHEAP());
+              $$ = new (PARSERHEAP()) IntervalQualifier(PARSERHEAP(), $1, $2);
             }
 
 fraction_only_interval :  TOK_FRACTION                           // returned in MP mode only
                 {                                  
                    $$ = new (PARSERHEAP())
-                        IntervalQualifier(REC_DATE_FRACTION_MP,
+                        IntervalQualifier(PARSERHEAP(), REC_DATE_FRACTION_MP,
                                       SQLInterval::DEFAULT_LEADING_PRECISION,
                                       REC_DATE_FRACTION_MP,
-                                      SQLInterval::MAX_FRACTION_PRECISION,
-                                      PARSERHEAP() );
+                                      SQLInterval::MAX_FRACTION_PRECISION);
                 }
                 | TOK_FRACTION ts_left_unsigned_right   
                 {                                  
                    $$ = new (PARSERHEAP())
-                        IntervalQualifier(REC_DATE_FRACTION_MP,
+                        IntervalQualifier(PARSERHEAP(), REC_DATE_FRACTION_MP,
                                       $2,
                                       REC_DATE_FRACTION_MP,
-                                      SQLInterval::MAX_FRACTION_PRECISION,
-                                      PARSERHEAP() );
+                                      SQLInterval::MAX_FRACTION_PRECISION);
                    if (! $$->checkValid(SqlParser_Diags)) YYERROR;
                 }
                 | TOK_FRACTION TOK_TO interval_fraction_field
                 {
                    $$ = new (PARSERHEAP())
-                        IntervalQualifier(REC_DATE_FRACTION_MP,
+                        IntervalQualifier(PARSERHEAP(), REC_DATE_FRACTION_MP,
                                       SQLInterval::DEFAULT_LEADING_PRECISION,
                                       REC_DATE_FRACTION_MP,
-                                      $3,
-                                      PARSERHEAP());
+                                      $3);
 
                    if (! $$->checkValid(SqlParser_Diags)) YYERROR;
                 }
                 | TOK_FRACTION ts_left_unsigned_right  TOK_TO interval_fraction_field
                 {
                    $$ = new (PARSERHEAP())
-                        IntervalQualifier(REC_DATE_FRACTION_MP,
+                        IntervalQualifier(PARSERHEAP(), REC_DATE_FRACTION_MP,
                                       $2,
                                       REC_DATE_FRACTION_MP,
-                                      $4,
-                                      PARSERHEAP());
+                                      $4);
 
                    if (! $$->checkValid(SqlParser_Diags)) YYERROR;
                 }
@@ -12493,31 +12481,29 @@ interval_fraction_field  : TOK_FRACTION                            // returned i
 /* type intervalQualifier */
 end_field : non_second_datetime_field
           {
-            $$ = new (PARSERHEAP()) IntervalQualifier($1, IntervalQualifier::DEFAULT_LEADING_PRECISION, PARSERHEAP());
+            $$ = new (PARSERHEAP()) IntervalQualifier(PARSERHEAP(), $1, IntervalQualifier::DEFAULT_LEADING_PRECISION);
           }
           | TOK_SECOND
           {
-            $$ = new (PARSERHEAP()) IntervalQualifier(REC_DATE_SECOND, IntervalQualifier::DEFAULT_LEADING_PRECISION, PARSERHEAP());
+            $$ = new (PARSERHEAP()) IntervalQualifier(PARSERHEAP(), REC_DATE_SECOND, IntervalQualifier::DEFAULT_LEADING_PRECISION);
           }
           | TOK_SECOND ts_left_unsigned_right
           {
              $$ = new (PARSERHEAP())
-	       IntervalQualifier(REC_DATE_SECOND,
+	       IntervalQualifier(PARSERHEAP(), REC_DATE_SECOND,
                             SQLInterval::DEFAULT_LEADING_PRECISION,
                             REC_DATE_SECOND,
-                            $2,
-                            PARSERHEAP());                 
+                            $2);
 
              if (! $$->checkValid(SqlParser_Diags)) YYERROR;
           }
           | interval_fraction_field
             {
              $$ = new (PARSERHEAP())
-	       IntervalQualifier(REC_DATE_SECOND,
+	       IntervalQualifier(PARSERHEAP(), REC_DATE_SECOND,
                             SQLInterval::DEFAULT_LEADING_PRECISION,
                             REC_DATE_SECOND,
-                            $1,
-                            PARSERHEAP());                 
+                            $1);
 
              if (! $$->checkValid(SqlParser_Diags)) YYERROR;
 
@@ -12533,14 +12519,13 @@ single_datetime_field : start_field
                       | TOK_SECOND
                       {
                         $$ = new (PARSERHEAP())
-			  IntervalQualifier(REC_DATE_SECOND,
-                                            IntervalQualifier::DEFAULT_LEADING_PRECISION,
-                                            PARSERHEAP());
+			  IntervalQualifier(PARSERHEAP(), REC_DATE_SECOND,
+                                            IntervalQualifier::DEFAULT_LEADING_PRECISION);
                       }
                       | TOK_SECOND ts_left_unsigned_right
                       {
                         $$ = new (PARSERHEAP())
-			  IntervalQualifier(REC_DATE_SECOND, $2, PARSERHEAP());
+			  IntervalQualifier(PARSERHEAP(), REC_DATE_SECOND, $2);
                         if (! $$->checkValid(SqlParser_Diags)) YYERROR;
                       }
                       | TOK_SECOND '(' unsigned_integer ',' unsigned_integer ')'
@@ -12552,11 +12537,10 @@ single_datetime_field : start_field
                         // to be 6.
                         //
                         $$ = new (PARSERHEAP())
-			  IntervalQualifier(REC_DATE_SECOND,
+			  IntervalQualifier(PARSERHEAP(), REC_DATE_SECOND,
 					    $3,
 					    REC_DATE_SECOND,
-					    $5,
-                                            PARSERHEAP());
+					    $5);
                         if (! $$->checkValid(SqlParser_Diags)) YYERROR;
                       }
 
@@ -13024,9 +13008,9 @@ insert_obj_to_lob_function :
 			        {
 				  ItemExpr *bufAddr = $4;
 				  ItemExpr *bufSize = $7;
-				  bufAddr = new (PARSERHEAP())Cast(bufAddr, new (PARSERHEAP()) SQLLargeInt(TRUE,FALSE));
+				  bufAddr = new (PARSERHEAP())Cast(bufAddr, new (PARSERHEAP()) SQLLargeInt(PARSERHEAP(), TRUE,FALSE));
 				  bufSize = new (PARSERHEAP())
-				    Cast(bufSize, new (PARSERHEAP()) SQLLargeInt(TRUE, FALSE));
+				    Cast(bufSize, new (PARSERHEAP()) SQLLargeInt(PARSERHEAP(), TRUE, FALSE));
 				  $$ = new (PARSERHEAP()) LOBinsert( bufAddr, bufSize, LOBoper::BUFFER_, FALSE);
 				}
                           | TOK_FILETOLOB '(' character_literal_sbyte ')'
@@ -13080,18 +13064,18 @@ update_obj_to_lob_function :
 			        {
 				  ItemExpr *bufAddr = $4;
 				  ItemExpr *bufSize = $7;
-				  bufAddr = new (PARSERHEAP())Cast(bufAddr, new (PARSERHEAP()) SQLLargeInt(TRUE,FALSE));
+				  bufAddr = new (PARSERHEAP())Cast(bufAddr, new (PARSERHEAP()) SQLLargeInt(PARSERHEAP(), TRUE,FALSE));
 				  bufSize = new (PARSERHEAP())
-				    Cast(bufSize, new (PARSERHEAP()) SQLLargeInt(TRUE, FALSE));
+				    Cast(bufSize, new (PARSERHEAP()) SQLLargeInt(PARSERHEAP(), TRUE, FALSE));
 				  $$ = new (PARSERHEAP()) LOBupdate( bufAddr, NULL,bufSize, LOBoper::BUFFER_, FALSE);
 				}
 			  | TOK_BUFFERTOLOB '(' TOK_LOCATION value_expression ',' TOK_SIZE value_expression ',' TOK_APPEND')'
 			        {
 				  ItemExpr *bufAddr = $4;
 				  ItemExpr *bufSize = $7;
-				  bufAddr = new (PARSERHEAP())Cast(bufAddr, new (PARSERHEAP()) SQLLargeInt(TRUE,FALSE));
+				  bufAddr = new (PARSERHEAP())Cast(bufAddr, new (PARSERHEAP()) SQLLargeInt(PARSERHEAP(), TRUE,FALSE));
 				  bufSize = new (PARSERHEAP())
-				    Cast(bufSize, new (PARSERHEAP()) SQLLargeInt(TRUE, FALSE));
+				    Cast(bufSize, new (PARSERHEAP()) SQLLargeInt(PARSERHEAP(), TRUE, FALSE));
 				  $$ = new (PARSERHEAP()) LOBupdate( bufAddr, NULL,bufSize, LOBoper::BUFFER_, TRUE);
 				}
 
@@ -14206,7 +14190,7 @@ rowwise_rowset_info : '(' TOK_MAX TOK_ROWSET TOK_SIZE literal ','
 			  {
 			    ((DynamicParam*)irs)->setDPRowsetForInputSize();
 			    irs = new (PARSERHEAP()) 
-			      Cast(irs, new (PARSERHEAP()) SQLInt(TRUE, FALSE));
+			      Cast(irs, new (PARSERHEAP()) SQLInt(PARSERHEAP(), TRUE, FALSE));
 			  }
 			else
 			  YYERROR;
@@ -14215,7 +14199,7 @@ rowwise_rowset_info : '(' TOK_MAX TOK_ROWSET TOK_SIZE literal ','
 			  {
 			    ((DynamicParam*)irml)->setRowwiseRowsetInputMaxRowlen();
 			    irml = new (PARSERHEAP()) 
-			      Cast(irml, new (PARSERHEAP()) SQLInt(TRUE, FALSE));
+			      Cast(irml, new (PARSERHEAP()) SQLInt(PARSERHEAP(), TRUE, FALSE));
 			  }
 			else
 			  YYERROR;
@@ -14224,7 +14208,7 @@ rowwise_rowset_info : '(' TOK_MAX TOK_ROWSET TOK_SIZE literal ','
 			  {
 			    ((DynamicParam *)rrb)->setRowwiseRowsetInputBuffer();
 			    rrb = new (PARSERHEAP()) 
-			      Cast(rrb, new (PARSERHEAP()) SQLLargeInt(TRUE, FALSE));
+			      Cast(rrb, new (PARSERHEAP()) SQLLargeInt(PARSERHEAP(), TRUE, FALSE));
 			  }
 			else
 			  YYERROR;
@@ -23887,7 +23871,7 @@ schema_definition : TOK_CREATE schema_class TOK_SCHEMA schema_name_clause char_s
 
                     // allocate the CharType object and pass it to StmDDLCreateSchema. 
                     // StmtDDLCreateSchema will free the memory there.
-                    CharType *charType = new CharType(CharType::LiteralSchema, 
+                    CharType *charType = new (PARSERHEAP()) CharType(PARSERHEAP(), CharType::LiteralSchema, 
                                                       0, 0, FALSE, FALSE, FALSE, FALSE, FALSE,
                                                       $5, $6.collation_, $6.coercibility_ );
                                                          
@@ -23911,7 +23895,7 @@ schema_definition : TOK_CREATE schema_class TOK_SCHEMA TOK_IF TOK_NOT TOK_EXISTS
 
                       // allocate the CharType object and pass it to StmDDLCreateSchema. 
                       // StmtDDLCreateSchema will free the memory there.
-                      CharType *charType = new CharType(CharType::LiteralSchema,
+                      CharType *charType = new (PARSERHEAP()) CharType(PARSERHEAP(), CharType::LiteralSchema,
                                                         0, 0, FALSE, FALSE, FALSE, FALSE, FALSE,
                                                         $8, $9.collation_, $9.coercibility_ );
 
@@ -24524,7 +24508,7 @@ routine_predef_type : predef_type
                    {
                      NumericType * nt = (NumericType*)$1;
                      $$ = new (PARSERHEAP()) 
-                       SQLSmall(NOT nt->isUnsigned(), $1->supportsSQLnull());
+                       SQLSmall(PARSERHEAP(), NOT nt->isUnsigned(), $1->supportsSQLnull());
                    }
                }
 
@@ -25550,7 +25534,7 @@ column_definition : qualified_name data_type optional_column_attributes
                                       if ((type->getTypeQualifier() == NA_DATETIME_TYPE) &&
                                           (type->getPrecision() == SQLDTCODE_DATE))
                                         {
-                                          type = new (PARSERHEAP()) SQLTimestamp(TRUE, 0, PARSERHEAP());
+                                          type = new (PARSERHEAP()) SQLTimestamp(PARSERHEAP(), TRUE, 0);
                                         }
 
                                       // change FLOAT(p) to NUMERIC(p)
@@ -25564,13 +25548,13 @@ column_definition : qualified_name data_type optional_column_attributes
 
                                           if (numPrec > MAX_HARDWARE_SUPPORTED_SIGNED_NUMERIC_PRECISION)
                                             type = new (PARSERHEAP()) 
-                                              SQLBigNum(numPrec, 0, TRUE, TRUE, TRUE, NULL);
+                                              SQLBigNum(PARSERHEAP(), numPrec, 0, TRUE, TRUE, TRUE);
                                           else
                                             {
                                               const Int16 DisAmbiguate = 0; // added for 64bit project
 
                                               type = new (PARSERHEAP()) 
-                                                SQLNumeric(TRUE, numPrec, 0, DisAmbiguate);
+                                                SQLNumeric(PARSERHEAP(), TRUE, numPrec, 0, DisAmbiguate);
                                             }
                                         }
                                     }

--- a/core/sql/qmscommon/Range.cpp
+++ b/core/sql/qmscommon/Range.cpp
@@ -635,7 +635,7 @@ IntervalType* RangeSpec::parseIntervalTypeText(const char* text) const
     trailingField = leadingField;  // Only one field specified.
 
   // Construct and return the interval type.
-  return new(mvqrHeap_) SQLInterval(TRUE, leadingField, lp, trailingField, fp, mvqrHeap_);
+  return new(mvqrHeap_) SQLInterval(mvqrHeap_, TRUE, leadingField, lp, trailingField, fp);
 }
 
 void RangeSpec::addDenormalizedSubrange(const char* typeText,
@@ -657,36 +657,36 @@ void RangeSpec::addDenormalizedSubrange(const char* typeText,
 
   // Parse the type text and create the corresponding type object.
   if (!strncmp(typeText, "INTEGER", typeNameLen))
-    numType = new(mvqrHeap_) SQLInt(isSigned, TRUE/*don't care*/, mvqrHeap_);
+    numType = new(mvqrHeap_) SQLInt(mvqrHeap_, isSigned, TRUE/*don't care*/);
   else if (!strncmp(typeText, "SMALLINT", typeNameLen))
-    numType = new(mvqrHeap_) SQLSmall(isSigned, TRUE/*don't care*/, mvqrHeap_);
+    numType = new(mvqrHeap_) SQLSmall(mvqrHeap_, isSigned, TRUE/*don't care*/);
   else if (!strncmp(typeText, "NUMERIC", typeNameLen))
     {
       getPrecScale(typeText + typeNameLen, prec, scale);
-      numType = new(mvqrHeap_) SQLNumeric(isSigned, prec, scale,
+      numType = new(mvqrHeap_) SQLNumeric(mvqrHeap_, isSigned, prec, scale,
                                           DisAmbiguate); // added for 64bit proj.
     }
   else if (!strncmp(typeText, "DECIMAL", typeNameLen))
     {
       getPrecScale(typeText + typeNameLen, prec, scale);
-      numType = new(mvqrHeap_) SQLNumeric(isSigned, prec, scale,
+      numType = new(mvqrHeap_) SQLNumeric(mvqrHeap_, isSigned, prec, scale,
                                           DisAmbiguate); // added for 64bit proj.
     }
   else if (!strncmp(typeText, "REAL", typeNameLen))
-    numType = new(mvqrHeap_) SQLReal(TRUE/*don't care*/, mvqrHeap_);
+    numType = new(mvqrHeap_) SQLReal(mvqrHeap_, TRUE/*don't care*/);
   else if (!strncmp(typeText, "DATE", typeNameLen))
-    dtType = new(mvqrHeap_) SQLDate(TRUE/*don't care*/, mvqrHeap_);
+    dtType = new(mvqrHeap_) SQLDate(mvqrHeap_, TRUE/*don't care*/);
   else if (!strncmp(typeText, "TIME", typeNameLen))
     {
       // Only one value (fractional seconds precision) will be given for this.
       getPrecScale(typeText + typeNameLen, prec, scale);
-      dtType = new(mvqrHeap_) SQLTime(TRUE/*don't care*/, prec, mvqrHeap_);
+      dtType = new(mvqrHeap_) SQLTime(mvqrHeap_, TRUE/*don't care*/, prec);
     }
   else if (!strncmp(typeText, "TIMESTAMP", typeNameLen))
     {
       // Only one value (fractional seconds precision) will be given for this.
       getPrecScale(typeText + typeNameLen, prec, scale);
-      dtType = new(mvqrHeap_) SQLTimestamp(TRUE/*don't care*/, prec, mvqrHeap_);
+      dtType = new(mvqrHeap_) SQLTimestamp(mvqrHeap_, TRUE/*don't care*/, prec);
     }
   else if (!strncmp(typeText, "INTERVAL", typeNameLen))
     intvlType = parseIntervalTypeText(typeText + typeNameLen);

--- a/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
@@ -4692,7 +4692,6 @@ short CmpSeabaseDDL::updateSeabaseMDTable(
     {
       useRWRS = TRUE;
     }
-
   Int32 objOwnerID = (tableInfo) ? tableInfo->objOwnerID : SUPER_USER;
   Int32 schemaOwnerID = (tableInfo) ? tableInfo->schemaOwnerID : SUPER_USER;
   Int64 objectFlags = (tableInfo) ? tableInfo->objectFlags : 0;

--- a/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
@@ -2021,14 +2021,14 @@ short CmpSeabaseDDL::createSeabaseTable2(
   NABoolean implicitPK = FALSE;
 
   NAString syskeyColName("SYSKEY");
-  SQLLargeInt * syskeyType = new(STMTHEAP) SQLLargeInt(TRUE, FALSE, STMTHEAP);
+  SQLLargeInt * syskeyType = new(STMTHEAP) SQLLargeInt(STMTHEAP, TRUE, FALSE);
   ElemDDLColDef syskeyColDef(NULL, &syskeyColName, syskeyType, NULL,
                              STMTHEAP);
   ElemDDLColRef edcr("SYSKEY", COM_ASCENDING_ORDER);
   syskeyColDef.setColumnClass(COM_SYSTEM_COLUMN);
 
   NAString hbRowIdColName("ROW_ID");
-  SQLVarChar * hbRowIdType = new(STMTHEAP) SQLVarChar(1000, FALSE);
+  SQLVarChar * hbRowIdType = new(STMTHEAP) SQLVarChar(STMTHEAP, 1000, FALSE);
   ElemDDLColDef hbRowIdColDef(NULL, &hbRowIdColName, hbRowIdType, NULL,
                               STMTHEAP);
   ElemDDLColRef hbcr("ROW_ID", COM_ASCENDING_ORDER);
@@ -2188,7 +2188,7 @@ short CmpSeabaseDDL::createSeabaseTable2(
         }
 
       NAString saltColName(ElemDDLSaltOptionsClause::getSaltSysColName());
-      SQLInt * saltType = new(STMTHEAP) SQLInt(FALSE, FALSE, STMTHEAP);
+      SQLInt * saltType = new(STMTHEAP) SQLInt(STMTHEAP, FALSE, FALSE);
       ElemDDLColDefault *saltDef = 
         new(STMTHEAP) ElemDDLColDefault(
              ElemDDLColDefault::COL_COMPUTED_DEFAULT);

--- a/core/sql/ustat/hs_cli.cpp
+++ b/core/sql/ustat/hs_cli.cpp
@@ -3224,7 +3224,8 @@ template <class T> class HSBin : public SQLInt {
 public:
 
   HSBin(Lng32 id)
-    : id_(id) {}
+    : SQLInt(NULL)
+    , id_(id) {}
   ~HSBin() {}
   double encode(void *data) const
   {  return *((T *)data);  }
@@ -3242,7 +3243,8 @@ class HSLargeint : public SQLInt {
 public:
 
   HSLargeint(Lng32 id)
-    : id_(id) {}
+    : SQLInt(NULL)
+    , id_(id) {}
   ~HSLargeint() {}
   double encode(void *data) const
   {  return convertInt64ToDouble(*((Int64 *)data)); }
@@ -3258,7 +3260,7 @@ class HSDate : public SQLDate {
 
 public:
 
-  HSDate() : SQLDate(FALSE /*nullflag*/) {}
+  HSDate() : SQLDate(NULL, FALSE /*nullflag*/) {}
   double encode(void *data) const
   {
     ULng32 w[4];
@@ -3283,12 +3285,12 @@ NAType* ConstructNumericType( Long addr
   NAType *type;
   switch(length) {
   case 1:
-    type = new(currHeap) SQLTiny(allowNeg, nullflag, currHeap);
+    type = new(currHeap) SQLTiny(currHeap, allowNeg, nullflag);
     break;
   case 2:
     if (!ALIGN2(addr))
       {
-        type = new(currHeap) SQLSmall(allowNeg, nullflag, currHeap);
+        type = new(currHeap) SQLSmall(currHeap, allowNeg, nullflag);
         break;
       }
     if (allowNeg)  // 2-byte aligned
@@ -3299,7 +3301,7 @@ NAType* ConstructNumericType( Long addr
   case 4:
     if (!ALIGN4(addr))
       {
-        type = new(currHeap) SQLInt(allowNeg, nullflag, currHeap);
+        type = new(currHeap) SQLInt(currHeap, allowNeg, nullflag);
         break;
       }
     if (allowNeg)  // 4-byte aligned
@@ -3310,16 +3312,16 @@ NAType* ConstructNumericType( Long addr
   case 8:
     if (!ALIGN8(addr))
       {
-        type = new(currHeap) SQLLargeInt(allowNeg, nullflag);
+        type = new(currHeap) SQLLargeInt(currHeap, allowNeg, nullflag);
         break;
       }
     if (allowNeg)  // 8-byte aligned
       type = new(currHeap) HSLargeint(id);
     else
-      type = new(currHeap) SQLLargeInt(allowNeg, nullflag);
+      type = new(currHeap) SQLLargeInt(currHeap, allowNeg, nullflag);
     break;
   default:
-    type = new(currHeap) SQLNumeric(length, precision, scale, allowNeg, nullflag, currHeap);
+    type = new(currHeap) SQLNumeric(currHeap, length, precision, scale, allowNeg, nullflag);
     break;
   }
   return type;
@@ -3435,29 +3437,29 @@ Lng32 HSCursor::buildNAType()
 	  //datatype = ((precision <= SQL_REAL_PRECISION) ?
 	  //           REC_FLOAT32 : REC_FLOAT64);
 	  if (datatype == REC_FLOAT32)
-	    type = new(heap_) SQLReal(nullflag, NULL, precision);
+	    type = new(heap_) SQLReal(heap_, nullflag, precision);
 	  else  if (datatype == REC_FLOAT64)
-	    type = new(heap_) SQLDoublePrecision(nullflag, NULL, precision);
+	    type = new(heap_) SQLDoublePrecision(heap_, nullflag, precision);
 	  break;
         //
         //
         case REC_DECIMAL_UNSIGNED:
-          type = new(heap_) SQLDecimal(length, scale, FALSE, nullflag, heap_);
+          type = new(heap_) SQLDecimal(heap_, length, scale, FALSE, nullflag);
           break;
         case REC_DECIMAL_LSE:
-          type = new(heap_) SQLDecimal(length, scale, TRUE, nullflag, heap_);
+          type = new(heap_) SQLDecimal(heap_, length, scale, TRUE, nullflag);
           break;
         case REC_NUM_BIG_UNSIGNED:
-          type = new(heap_) SQLBigNum(precision, scale, FALSE, FALSE, nullflag, heap_);
+          type = new(heap_) SQLBigNum(heap_, precision, scale, FALSE, FALSE, nullflag);
           break;
         case REC_NUM_BIG_SIGNED:
-          type = new(heap_) SQLBigNum(precision, scale, FALSE, TRUE, nullflag, heap_);
+          type = new(heap_) SQLBigNum(heap_, precision, scale, FALSE, TRUE, nullflag);
           break;
          //
         //
         case REC_BYTE_F_ASCII:
         case REC_NCHAR_F_UNICODE:
-          type = new(heap_) SQLChar(    length
+          type = new(heap_) SQLChar(heap_,    length
                              ,   nullflag
                              #ifdef FULL_CHARSET_SUPPORT  //##NCHAR: to be done!
                              ,   colDesc_[i].upshifted
@@ -3470,7 +3472,7 @@ Lng32 HSCursor::buildNAType()
           break;
         case REC_BYTE_V_ASCII:
         case REC_NCHAR_V_UNICODE:
-          type = new(heap_) SQLVarChar( length
+          type = new(heap_) SQLVarChar(heap_,  length
                              ,   nullflag
                              #ifdef FULL_CHARSET_SUPPORT  //##NCHAR: to be done!
                              ,   colDesc_[i].upshifted
@@ -3486,14 +3488,14 @@ Lng32 HSCursor::buildNAType()
 	  // be encoded correctly.
 	case REC_DATETIME:
 	case REC_INTERVAL:
-          type = new(heap_) SQLChar(    length
+          type = new(heap_) SQLChar(heap_,    length
                              ,   nullflag
                             );
 
 	  break;
 
         case REC_BOOLEAN:
-          type = new(heap_) SQLBooleanNative(nullflag,heap_);
+          type = new(heap_) SQLBooleanNative(heap_, nullflag);
           break;
 
         default:


### PR DESCRIPTION
 Compiler objects were refactored to use the heap infrastructure to ensure that it is accounted and allocated within the trafodion memory management.
    
The commonly used NAType and derived classes are mostly created via heap, but the heap was not passed in the constructor. The embedded objects used the system heap though the container object is allocated in the compiler heap. This could result in memory leak when the container object is destroyed.
