### PR TITLE
[TRAFODION-2725] SQL types are REAL, FLOAT, and DOUBLE. Some values are inserted, a stack overflow occurs when SQLGetData is executed.

### DIFF
--- a/win-odbc64/odbcclient/drvr35/drvrglobal.cpp
+++ b/win-odbc64/odbcclient/drvr35/drvrglobal.cpp
@@ -876,7 +876,7 @@ bool double_to_char (double number, int precision, char* string, short size)
     precision = precision < size ? precision : size - 1;
 
     // precission should be limit to a reasonable range.
-    if ((precision < 0) && (precision >(DBL_MANT_DIG - DBL_MIN_EXP))) {
+    if ((precision < 0) || (precision >(DBL_MANT_DIG - DBL_MIN_EXP))) {
         goto fun_exit;
     }
 

--- a/win-odbc64/odbcclient/drvr35/drvrglobal.cpp
+++ b/win-odbc64/odbcclient/drvr35/drvrglobal.cpp
@@ -867,7 +867,7 @@ bool double_to_char (double number, int precision, char* string, short size)
 {
     bool rc = false;
     char format[16];
-    char buf[512];
+    char buf[MAX_DOUBLE_TO_CHAR_LEN];
 
     sprintf(format, "%%.%dl%c", precision, number < 1e-6 ? 'g':'f');
     sprintf(buf, format, number);

--- a/win-odbc64/odbcclient/drvr35/drvrglobal.cpp
+++ b/win-odbc64/odbcclient/drvr35/drvrglobal.cpp
@@ -866,8 +866,8 @@ bool use_gcvt(double number, char* string, short size)
 bool double_to_char (double number, int precision, char* string, short size)
 {
     bool rc = false;
-    char format[16];
-    char buf[MAX_DOUBLE_TO_CHAR_LEN];
+    char format[16] = { '\0' };
+    char buf[MAX_DOUBLE_TO_CHAR_LEN] = { '\0' };
 
     sprintf(format, "%%.%dlg", precision);
     sprintf(buf, format, number);

--- a/win-odbc64/odbcclient/drvr35/drvrglobal.cpp
+++ b/win-odbc64/odbcclient/drvr35/drvrglobal.cpp
@@ -865,77 +865,18 @@ bool use_gcvt(double number, char* string, short size)
 
 bool double_to_char (double number, int precision, char* string, short size)
 {
-	char *buffer,*temp ;
-	bool rc = true;
+    bool rc = false;
+    char format[16];
+    char buf[512];
 
-	int	decimal_spot,
-		sign,
-		count,
-		current_location = 0,
-		length;
+    sprintf(format, "%%.%dl%c", precision, number < 1e-6 ? 'g':'f');
+    sprintf(buf, format, number);
 
-	*string = 0;
+    if (size > strlen(buf)) {
+        strcpy(string, buf);
+        rc = true;
+    }
 
-	temp = _fcvt (number, precision, &decimal_spot, &sign) ;
-	length = strlen(temp);
-	if (length == 0)
-	{
-		return use_gcvt(number,string,size);
-	}
-	if (length > precision)
-		buffer = (char *) malloc (length + 3) ;
-	else
-		buffer = (char *) malloc (precision + 3) ;
-
-	if (buffer == NULL)
-		return false;
-
-/* Add negative sign if required. */ 
-
-	if (sign)
-		buffer [current_location++] = '-' ;
-
-/* Place decimal point in the correct location. */ 
-
-	if (decimal_spot > 0)
-	{
-		strncpy (&buffer [current_location], temp, decimal_spot) ;
-		buffer [decimal_spot + current_location] = '.' ;
-		strcpy (&buffer [decimal_spot + current_location + 1],
-					&temp [decimal_spot]) ;
-	}
-	else
-	{
-		buffer [current_location] = '.' ;
-		for(count = current_location;
-			count< abs(decimal_spot)+current_location; count++)
-			buffer [count + 1] = '0' ;
-		strcpy (&buffer [count + 1], temp) ;
-	}
-
-	rSup(buffer);
-	length = strlen(buffer);
-	if (buffer[0] == '.' || (buffer[0] == '-' && buffer[1] == '.')) length++;
-
-	if (length>size)
-		rc = use_gcvt(number,string,size);
-	else
-	{
-		if (buffer[0] == '.')
-		{
-			strcpy( string, "0");
-			strcat( string, buffer);
-		}
-		else if (buffer[0] == '-' && buffer[1] == '.')
-		{
-			strcpy( string, "-0");
-			strcat( string, &buffer[1]);
-		}
-		else
-			strcpy( string, buffer);
-	}
-
-	free (buffer);
 	return rc;
 } 
 

--- a/win-odbc64/odbcclient/drvr35/drvrglobal.cpp
+++ b/win-odbc64/odbcclient/drvr35/drvrglobal.cpp
@@ -869,7 +869,7 @@ bool double_to_char (double number, int precision, char* string, short size)
     char format[16];
     char buf[MAX_DOUBLE_TO_CHAR_LEN];
 
-    sprintf(format, "%%.%dl%c", precision, number < 1e-6 ? 'g':'f');
+    sprintf(format, "%%.%dlg", precision);
     sprintf(buf, format, number);
 
     if (size > strlen(buf)) {

--- a/win-odbc64/odbcclient/drvr35/drvrglobal.h
+++ b/win-odbc64/odbcclient/drvr35/drvrglobal.h
@@ -103,7 +103,7 @@ extern char* VprocString;
 
 #define STRICT_SCHEMA_ENV_VAL_SIZE 100
 
-#define MAX_DOUBLE_TO_CHAR_LEN 308 + 12
+#define MAX_DOUBLE_TO_CHAR_LEN (DBL_MANT_DIG - DBL_MIN_EXP + 12)
 
 typedef enum SRVR_TYPE
 {

--- a/win-odbc64/odbcclient/drvr35/drvrglobal.h
+++ b/win-odbc64/odbcclient/drvr35/drvrglobal.h
@@ -103,6 +103,8 @@ extern char* VprocString;
 
 #define STRICT_SCHEMA_ENV_VAL_SIZE 100
 
+#define MAX_DOUBLE_TO_CHAR_LEN 308 + 12
+
 typedef enum SRVR_TYPE
 {
 	SRVR_UNKNOWN = 0,

--- a/win-odbc64/odbcclient/drvr35/sqltocconv.cpp
+++ b/win-odbc64/odbcclient/drvr35/sqltocconv.cpp
@@ -167,7 +167,7 @@ unsigned long ODBC::ConvertSQLToC(SQLINTEGER	ODBCAppVersion,
 	USHORT		usTmp;
 	SLONG		lTmp;
 	ULONG		ulTmp;
-	CHAR		cTmpBuf[132];
+	CHAR		cTmpBuf[MAX_DOUBLE_TO_CHAR_LEN];
 	CHAR		cTmpBuf1[30];
 	__int64		tempVal64;
 	__int64		power;

--- a/win-odbc64/odbcclient/drvr35/sqltocconv.cpp
+++ b/win-odbc64/odbcclient/drvr35/sqltocconv.cpp
@@ -946,7 +946,7 @@ unsigned long ODBC::ConvertSQLToC(SQLINTEGER	ODBCAppVersion,
 							dTmp)  != SQL_SUCCESS)
 					return IDS_07_006;
 //				_gcvt(dTmp, DBL_DIG, cTmpBuf);
-				if (!double_to_char (dTmp, DBL_DIG, cTmpBuf, targetLength))
+				if (!double_to_char (dTmp, DBL_DIG, cTmpBuf, sizeof(cTmpBuf)))
 					return IDS_22_001;
 			
 			}
@@ -955,13 +955,13 @@ unsigned long ODBC::ConvertSQLToC(SQLINTEGER	ODBCAppVersion,
 				if (ODBCDataType == SQL_REAL) {
 					dTmp = (double)(*(float *)srcDataPtr);
 //					_gcvt(dTmp, FLT_DIG + 1, cTmpBuf);
-					if (!double_to_char (dTmp, FLT_DIG + 1, cTmpBuf, targetLength))
+                    if (!double_to_char(dTmp, FLT_DIG + 1, cTmpBuf, sizeof(cTmpBuf)))
 						return IDS_22_001;
 				}
 				else {
 					dTmp = *(double *)srcDataPtr;
 //					_gcvt(dTmp, DBL_DIG, cTmpBuf);
-					if (!double_to_char (dTmp, DBL_DIG + 1, cTmpBuf, targetLength))
+                    if (!double_to_char(dTmp, DBL_DIG + 1, cTmpBuf, sizeof(cTmpBuf)))
 						return IDS_22_001;
 				}
 			}

--- a/win-odbc64/odbcclient/drvr35/sqltocconv.cpp
+++ b/win-odbc64/odbcclient/drvr35/sqltocconv.cpp
@@ -594,7 +594,7 @@ unsigned long ODBC::ConvertSQLToC(SQLINTEGER	ODBCAppVersion,
 							dTmp)  != SQL_SUCCESS)
 					return IDS_07_006;
 //				_gcvt(dTmp, DBL_DIG, cTmpBuf);
-				if (!double_to_char (dTmp, DBL_DIG, cTmpBuf, targetLength))
+				if (!double_to_char (dTmp, DBL_DIG, cTmpBuf, sizeof(cTmpBuf)))
 					return IDS_22_001;
 			
 			}
@@ -603,13 +603,13 @@ unsigned long ODBC::ConvertSQLToC(SQLINTEGER	ODBCAppVersion,
 				if (ODBCDataType == SQL_REAL) {
 					dTmp = (double)(*(float *)srcDataPtr);
 //					_gcvt(dTmp, FLT_DIG + 1, cTmpBuf);
-					if (!double_to_char (dTmp, FLT_DIG + 1, cTmpBuf, targetLength))
+					if (!double_to_char (dTmp, FLT_DIG + 1, cTmpBuf, sizeof(cTmpBuf)))
 						return IDS_22_001;
 				}
 				else {
 					dTmp = *(double *)srcDataPtr;
 //					_gcvt(dTmp, DBL_DIG, cTmpBuf);
-					if (!double_to_char (dTmp, DBL_DIG + 1, cTmpBuf, targetLength))
+					if (!double_to_char (dTmp, DBL_DIG + 1, cTmpBuf, sizeof(cTmpBuf)))
 						return IDS_22_001;
 				}
 			}


### PR DESCRIPTION
**_root cause:_** write stack variable out of range.
unsigned long ODBC::ConvertSQLToC(...., targetLength) {
...
CHAR	cTmpBuf[132];
...
double_to_char (dTmp, FLT_DIG + 1, cTmpBuf, targetLength) **// when targetLength > 132, the stack will be broken.**
...
}
**_fixed by:_** limit the max size to sizeof(cTmpBuf)
**_test result:_** run coast to check, no new issue introduced.