### PR TITLE
[TRAFODION-2729] Fix bug reading region keys for hbase _ROW_, _CELL_ access

### DIFF
--- a/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
@@ -11692,8 +11692,13 @@ short CmpSeabaseDDL::genHbaseRegionDescs(TrafDesc * desc,
   if (ehi == NULL) 
     return -1;
   
-  const NAString extNameForHbase = genHBaseObjName
-    (catName, schName, objName);
+  NAString extNameForHbase;
+  if ((catName != HBASE_SYSTEM_CATALOG) ||
+      ((schName != HBASE_ROW_SCHEMA) && (schName != HBASE_CELL_SCHEMA)))
+    extNameForHbase = genHBaseObjName(catName, schName, objName);
+  else
+    // for HBASE._ROW_.objName or HBASE._CELL_.objName, just pass objName
+    extNameForHbase = objName;
 
   NAArray<HbaseStr>* endKeyArray  = 
     ehi->getRegionEndKeys(extNameForHbase);


### PR DESCRIPTION
At compile time, the NATable layer has logic to construct a metadata definition when accessing native HBase tables via HBASE."_ROW_".objectName and HBASE."_CELL_".objectName syntax. Unfortunately, when calling the HBase client routines to read region key information, the HBASE._ROW_ and HBASE._CELL_ prefixes were passed down as part of the object name. So of course HBase could not find the object, and the Trafodion compiler would think there was only one region in the object. That would result in serial plans, even in the presence of cardinality hints.

The fix is to check for HBASE._ROW_ and HBASE._CELL_ prefixes, and if present, not pass them down to HBase when reading region keys.