### PR TITLE
Trafodion-2735 :LOB: Drop table/schema returns 8616 error but the drop statement can't be retried

### DIFF
--- a/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
@@ -2929,7 +2929,8 @@ short CmpSeabaseDDL::createSeabaseTable2(
        
       if (rc < 0)
         {
-          //sss TBD need to retrive the cli diags here.
+          // retrieve the cli diags here.
+          CmpCommon::diags()->mergeAfter(*(GetCliGlobals()->currContext()->getDiagsArea()));
           *CmpCommon::diags() << DgSqlCode(-CAT_CREATE_OBJECT_ERROR)
                               << DgTableName(extTableName);
           deallocEHI(ehi); 	   
@@ -4403,6 +4404,8 @@ short CmpSeabaseDDL::dropSeabaseTable2(
                                     lobLocList,NULL,lobHdfsServer, lobHdfsPort,0,lobTrace);
       if (rc < 0)
 	{
+          // retrieve the cli diags here.
+          CmpCommon::diags()->mergeAfter( *(GetCliGlobals()->currContext()->getDiagsArea()));
 	  *CmpCommon::diags() << DgSqlCode(-CAT_UNABLE_TO_DROP_OBJECT)
 			      << DgTableName(extTableName);
 	  deallocEHI(ehi); 


### PR DESCRIPTION


LOB drop table is not supported by DTM currently. 
Each LOB tables contains 3 underlying Hbase tables and one or more HDFS data files that contain the LOB data.
During drop the code used to delete all the HDFS files first and then drop the LOB hbase tables.
This PR chnages that by doing 2 things  1. Move the code drop HDFS files below the calls that drop the Hase tables. This way if there are any errors during the Hbase drop tables, the TM will protect them and roll them back. The HDFS files will stay intact. 2. Ignore errors from "File Not Found" errors when dropping a LOB table. 
The issue is that twhen a conflict  occured between 2 sessions and the LOB table lost its HDFS data but the LOB Hbase descriptor tables got rolled back. A subsequenct drop from another session, expected the HDFS files to be there and raised an error. SInce the HDFS files are not protected by TM, there is currently no way to roll them back.   So the current fix doe snot fully addressthe issue but alleviates the issue and allows 2 streams of tests to run and handle conflict errors just fine. 


The real fix need to be in TM where the LOB data files are also  protected by a transaction. 
