### PR TITLE
[Trafodion 2739] RMS semaphore handling need to log the error for easy resolution of the issue

### DIFF
--- a/core/sql/bin/SqlciMain.cpp
+++ b/core/sql/bin/SqlciMain.cpp
@@ -209,15 +209,14 @@ _callable void removeProcess()
 {
   CliGlobals *cliGlobals = GetCliGlobals();
   StatsGlobals *statsGlobals = cliGlobals->getStatsGlobals();
-  short savedPriority, savedStopMode;
   if (statsGlobals != NULL)
   {
-    short error = statsGlobals->getStatsSemaphore(cliGlobals->getSemId(),
-                cliGlobals->myPin(),savedPriority, savedStopMode, TRUE /*shouldTimeout*/);
+    int error = statsGlobals->getStatsSemaphore(cliGlobals->getSemId(),
+                cliGlobals->myPin());
     if (error == 0)
     {
       statsGlobals->removeProcess(cliGlobals->myPin());
-      statsGlobals->releaseStatsSemaphore(cliGlobals->getSemId(), cliGlobals->myPin(), savedPriority, savedStopMode);
+      statsGlobals->releaseStatsSemaphore(cliGlobals->getSemId(), cliGlobals->myPin());
     }
     else if (error == 4011)
     {

--- a/core/sql/bin/ex_ssmp_main.cpp
+++ b/core/sql/bin/ex_ssmp_main.cpp
@@ -193,21 +193,17 @@ void runServer(Int32 argc, char **argv)
       NAProcessHandle myPhandle;
       myPhandle.getmine();
       myPhandle.decompose();
-      short savedPriority, savedStopMode;
-      short error =
+      int error =
            statsGlobals->releaseAndGetStatsSemaphore(
                      statsGlobals->getSsmpProcSemId(),
                      (pid_t) myPhandle.getPin(),
-                     (pid_t) prevSsmpPhandle.getPin(),
-                     savedPriority, savedStopMode,
-                     FALSE /*shouldTimeout*/);
+                     (pid_t) prevSsmpPhandle.getPin());
       ex_assert(error == 0,
                "releaseAndGetStatsSemaphore() returned error");
 
       statsGlobals->releaseStatsSemaphore(
                      statsGlobals->getSsmpProcSemId(),
-                     (pid_t) myPhandle.getPin(),
-                     savedPriority, savedStopMode);
+                     (pid_t) myPhandle.getPin());
     }
   }
   // LCOV_EXCL_STOP

--- a/core/sql/cli/Cli.cpp
+++ b/core/sql/cli/Cli.cpp
@@ -8325,19 +8325,15 @@ Lng32 SQLCLI_RegisterQuery(CliGlobals *cliGlobals,
   StatsGlobals *statsGlobals = cliGlobals->getStatsGlobals();
   if (statsGlobals == NULL)
     return retcode;
-  short error;
-  short savedPriority, savedStopMode;
+  int error;
   error = statsGlobals->getStatsSemaphore(cliGlobals->getSemId(),
-                 cliGlobals->myPin(), 
-                savedPriority, savedStopMode, FALSE /*shouldTimeout*/);
-  ex_assert(error == 0, "getStatsSemaphore() returned an error");
-
+                 cliGlobals->myPin());
   retcode = statsGlobals->registerQuery(diags, cliGlobals->myPin(), queryId, 
                             fragId, tdbId, explainTdbId, collectStatsType, instNum, 
                             (ComTdb::ex_node_type)tdbType,
                             tdbName, tdbNameLen);
   statsGlobals->releaseStatsSemaphore(cliGlobals->getSemId(),
-            cliGlobals->myPin(), savedPriority, savedStopMode);
+            cliGlobals->myPin());
   return retcode;
 
 } 
@@ -8354,16 +8350,13 @@ Lng32 SQLCLI_DeregisterQuery(CliGlobals *cliGlobals,
   StatsGlobals *statsGlobals = cliGlobals->getStatsGlobals();
   if (statsGlobals == NULL)
     return retcode;
-  short error;
-  short savedPriority, savedStopMode;
+  int error;
   error = statsGlobals->getStatsSemaphore(cliGlobals->getSemId(),
-                 cliGlobals->myPin(), 
-                savedPriority, savedStopMode, FALSE /*shouldTimeout*/);
-  ex_assert(error == 0, "getStatsSemaphore() returned an error");
+                 cliGlobals->myPin());
   retcode = statsGlobals->deregisterQuery(diags, cliGlobals->myPin(), queryId,
                             fragId);
   statsGlobals->releaseStatsSemaphore(cliGlobals->getSemId(),
-            cliGlobals->myPin(), savedPriority, savedStopMode);
+            cliGlobals->myPin());
   return retcode;
 }
 

--- a/core/sql/cli/Context.cpp
+++ b/core/sql/cli/Context.cpp
@@ -3232,16 +3232,11 @@ ExStatisticsArea *ContextCli::getMergedStats(
         StatsGlobals *statsGlobals = cliGlobals_->getStatsGlobals();
         if (statsGlobals != NULL)
         {
-          short savedPriority, savedStopMode;
-          short error = statsGlobals->getStatsSemaphore(cliGlobals_->getSemId(),
-                                                      cliGlobals_->myPin(),
-                                                      savedPriority, savedStopMode,
-                                                      FALSE );
-          ex_assert(error == 0, "getStatsSemaphore() returned an error");
+          int error = statsGlobals->getStatsSemaphore(cliGlobals_->getSemId(),
+                                                      cliGlobals_->myPin());
           stats->merge(statsTmp, tmpStatsMergeType);
           setDeleteStats(TRUE);
-          statsGlobals->releaseStatsSemaphore(cliGlobals_->getSemId(),cliGlobals_->myPin(),
-                          savedPriority, savedStopMode);
+          statsGlobals->releaseStatsSemaphore(cliGlobals_->getSemId(),cliGlobals_->myPin());
         }
         else
         {
@@ -3530,8 +3525,8 @@ Lng32 ContextCli::GetStatistics2(
 void ContextCli::setStatsArea(ExStatisticsArea *stats, NABoolean isStatsCopy,
                               NABoolean inSharedSegment, NABoolean getSemaphore)
 {
-   StatsGlobals *statsGlobals = cliGlobals_->getStatsGlobals();
-   short savedPriority, savedStopMode, error;
+  int error;
+  StatsGlobals *statsGlobals = cliGlobals_->getStatsGlobals();
 
   // Delete Stats only when it is different from the incomng stats
   if (statsCopy() && stats_ != NULL && stats != stats_)
@@ -3540,15 +3535,12 @@ void ContextCli::setStatsArea(ExStatisticsArea *stats, NABoolean isStatsCopy,
     {
       if (statsGlobals != NULL)
       {
-        short error = statsGlobals->getStatsSemaphore(cliGlobals_->getSemId(),
-                                                      cliGlobals_->myPin(), 
-                                                      savedPriority, savedStopMode, FALSE );
-        ex_assert(error == 0, "getStatsSemaphore() returned an error");
+        error = statsGlobals->getStatsSemaphore(cliGlobals_->getSemId(),
+                                                      cliGlobals_->myPin());
       }
       NADELETE(stats_, ExStatisticsArea, stats_->getHeap());
       if (statsGlobals != NULL)
-        statsGlobals->releaseStatsSemaphore(cliGlobals_->getSemId(),cliGlobals_->myPin(),
-                          savedPriority, savedStopMode);
+        statsGlobals->releaseStatsSemaphore(cliGlobals_->getSemId(),cliGlobals_->myPin());
     }
     else
       NADELETE(stats_, ExStatisticsArea, stats_->getHeap());
@@ -3566,14 +3558,13 @@ void ContextCli::setStatsArea(ExStatisticsArea *stats, NABoolean isStatsCopy,
         if (getSemaphore)
         {
            error = statsGlobals->getStatsSemaphore(cliGlobals_->getSemId(),
-                  cliGlobals_->myPin(), savedPriority, savedStopMode, FALSE );
-           ex_assert(error == 0, "getStatsSemaphore() returned an error");
+                  cliGlobals_->myPin());
         }
         prevStmtStats_->setStmtStatsUsed(FALSE);
         statsGlobals->removeQuery(cliGlobals_->myPin(), prevStmtStats_); 
         if (getSemaphore)
            statsGlobals->releaseStatsSemaphore(cliGlobals_->getSemId(),
-              cliGlobals_->myPin(), savedPriority, savedStopMode);
+                                   cliGlobals_->myPin());
       }
     }
     else

--- a/core/sql/cli/Globals.cpp
+++ b/core/sql/cli/Globals.cpp
@@ -199,7 +199,7 @@ void CliGlobals::init( NABoolean espProcess,
     // before cli_globals is fully initialized, but it is being done
     // here because the code below expects it 
     cli_globals = this;
-    short error;
+    int error;
     statsGlobals_ = (StatsGlobals *)shareStatsSegment(shmId_);
     if (statsGlobals_ == NULL
       || (statsGlobals_ != NULL && 
@@ -226,10 +226,7 @@ void CliGlobals::init( NABoolean espProcess,
       //LCOV_EXCL_STOP
       else
       {
-        short savedPriority, savedStopMode;
-        error = statsGlobals_->getStatsSemaphore(semId_, myPin_, 
-                      savedPriority, savedStopMode, FALSE /*shouldTimeout*/);
-        ex_assert(error == 0, "getStatsSemaphore() returned an error");
+        error = statsGlobals_->getStatsSemaphore(semId_, myPin_);
 
         statsHeap_ = (NAHeap *)statsGlobals_->
                getStatsHeap()->allocateHeapMemory(sizeof *statsHeap_, FALSE);
@@ -247,7 +244,7 @@ void CliGlobals::init( NABoolean espProcess,
 	statsGlobals_->addProcess(myPin_, statsHeap_);
         processStats_ = statsGlobals_->getExProcessStats(myPin_);
         processStats_->setStartTime(myStartTime_);
-	statsGlobals_->releaseStatsSemaphore(semId_, myPin_, savedPriority, savedStopMode);
+	statsGlobals_->releaseStatsSemaphore(semId_, myPin_);
       }
     }
     // create a default context and make it the current context
@@ -330,12 +327,9 @@ CliGlobals::~CliGlobals()
   }
   if (statsGlobals_ != NULL)
   {
-    short savedPriority, savedStopMode;
-    error = statsGlobals_->getStatsSemaphore(semId_, myPin_, 
-              savedPriority, savedStopMode, FALSE /*shouldTimeout*/);
-    ex_assert(error == 0, "getStatsSemaphore() returned an error");
+    error = statsGlobals_->getStatsSemaphore(semId_, myPin_);
     statsGlobals_->removeProcess(myPin_);
-    statsGlobals_->releaseStatsSemaphore(semId_, myPin_, savedPriority, savedStopMode);
+    statsGlobals_->releaseStatsSemaphore(semId_, myPin_);
     sem_close((sem_t *)semId_);
   }
 }

--- a/core/sql/cli/Statement.cpp
+++ b/core/sql/cli/Statement.cpp
@@ -678,18 +678,15 @@ Statement::~Statement()
   {
     if (stmtStats_ != NULL)
     {
-      short savedPriority, savedStopMode;
-      short error = cliGlobals_->getStatsGlobals()->getStatsSemaphore(cliGlobals_->getSemId(),
-                    cliGlobals_->myPin(), savedPriority, savedStopMode, FALSE /*shouldTimeout*/);
-      ex_assert(error == 0, "getStatsSemaphore() returned an error");
+      int error = cliGlobals_->getStatsGlobals()->getStatsSemaphore(cliGlobals_->getSemId(),
+                    cliGlobals_->myPin());
       if (stmtStats_->getMasterStats() != NULL)
 	{
 	  stmtStats_->getMasterStats()->setStmtState(Statement::DEALLOCATED_);
 	  stmtStats_->getMasterStats()->setEndTimes(! stmtStats_->aqrInProgress());
 	}
       cliGlobals_->getStatsGlobals()->removeQuery(cliGlobals_->myPin(), stmtStats_);
-      cliGlobals_->getStatsGlobals()->releaseStatsSemaphore(cliGlobals_->getSemId(),cliGlobals_->myPin(),
-                      savedPriority, savedStopMode);
+      cliGlobals_->getStatsGlobals()->releaseStatsSemaphore(cliGlobals_->getSemId(),cliGlobals_->myPin());
     }
   }
   else
@@ -1916,14 +1913,10 @@ Lng32 Statement::unpackAndInit(ComDiagsArea &diagsArea,
         rootTdb->getFragDir()->getExplainFragDirEntry
                  (fragOffset, fragLen, topNodeOffset) == 0)
     {
-      short savedPriority, savedStopMode;
-      short error = statsGlobals->getStatsSemaphore(cliGlobals_->getSemId(),
-            cliGlobals_->myPin(), savedPriority, savedStopMode, 
-            FALSE /*shouldTimeout*/);
-      ex_assert(error == 0, "getStatsSemaphore() returned an error");
+      int error = statsGlobals->getStatsSemaphore(cliGlobals_->getSemId(),
+            cliGlobals_->myPin());
       stmtStats_->setExplainFrag((void *)(((char *)root_tdb)+fragOffset), fragLen, topNodeOffset);
-      statsGlobals->releaseStatsSemaphore(cliGlobals_->getSemId(),cliGlobals_->myPin(),
-                          savedPriority, savedStopMode);
+      statsGlobals->releaseStatsSemaphore(cliGlobals_->getSemId(),cliGlobals_->myPin());
     }
   }
   return prepareReturn ((RETCODE)retcode);
@@ -2639,15 +2632,11 @@ RETCODE Statement::execute(CliGlobals * cliGlobals, Descriptor * input_desc,
               StatsGlobals *statsGlobals = cliGlobals->getStatsGlobals();
               if (statsGlobals != NULL)
               {
-                short savedPriority, savedStopMode;
-                short error = statsGlobals->getStatsSemaphore(cliGlobals->getSemId(),
-						      cliGlobals->myPin(), savedPriority, savedStopMode, 
-                                                      FALSE /*shouldTimeout*/);
-                ex_assert(error == 0, "getStatsSemaphore() returned an error");
+                int error = statsGlobals->getStatsSemaphore(cliGlobals->getSemId(),
+						      cliGlobals->myPin());
                 statsArea->initEntries();
                 statsArea->restoreDop();
-                statsGlobals->releaseStatsSemaphore(cliGlobals->getSemId(),cliGlobals->myPin(),
-                          savedPriority, savedStopMode);
+                statsGlobals->releaseStatsSemaphore(cliGlobals->getSemId(),cliGlobals->myPin());
               }
               else
               {
@@ -3961,15 +3950,11 @@ RETCODE Statement::doOltExecute(CliGlobals *cliGlobals,
       StatsGlobals *statsGlobals = cliGlobals->getStatsGlobals();
       if (statsGlobals != NULL)
       {
-        short savedPriority, savedStopMode;
-        short error = statsGlobals->getStatsSemaphore(cliGlobals->getSemId(),
-					      cliGlobals->myPin(), savedPriority, savedStopMode,
-					      FALSE /*shouldTimeout*/);
-        ex_assert(error == 0, "getStatsSemaphore() returned an error");
+        int error = statsGlobals->getStatsSemaphore(cliGlobals->getSemId(),
+					      cliGlobals->myPin());
         statsArea->initEntries();
         statsArea->restoreDop();
-        statsGlobals->releaseStatsSemaphore(cliGlobals->getSemId(),cliGlobals->myPin(),
-	  savedPriority, savedStopMode);
+        statsGlobals->releaseStatsSemaphore(cliGlobals->getSemId(),cliGlobals->myPin());
       }
       else
       {
@@ -4202,11 +4187,8 @@ void Statement::releaseStats()
     if (statsGlobals != NULL && stmtStats_ != NULL &&
         (Int32)myStats->getCollectStatsType() != SQLCLI_ALL_STATS) 
     {
-      short savedPriority, savedStopMode;
-      short error = statsGlobals->getStatsSemaphore(cliGlobals_->getSemId(),
-                            cliGlobals_->myPin(), 
-                            savedPriority, savedStopMode, FALSE );
-      ex_assert(error == 0, "getStatsSemaphore() returned an error");
+      int error = statsGlobals->getStatsSemaphore(cliGlobals_->getSemId(),
+                            cliGlobals_->myPin());
       // Make sure the ex_globals doesn't delete this stats area
       // in case of dynamic statements, since stmtStats is also
       // pointing to the same area
@@ -4218,8 +4200,7 @@ void Statement::releaseStats()
       // Set the StmtStats that can be used to reset the used flag
       context_->setPrevStmtStats(stmtStats_);
       statsGlobals->releaseStatsSemaphore(cliGlobals_->getSemId(),
-                                cliGlobals_->myPin(), 
-                                savedPriority, savedStopMode);
+                                cliGlobals_->myPin());
     }
     else
     {
@@ -6102,9 +6083,8 @@ ExStatisticsArea *Statement::getCompileStatsArea()
 void Statement::setStmtStats(NABoolean autoRetry)
 {
   StatsGlobals *statsGlobals = NULL;
-  short error;
+  int error;
   NABoolean stmtStatsRetained = FALSE;
-  short savedPriority, savedStopMode;
   StmtStats *stmtStats = NULL;
   if (stmtStats_ != NULL)
   {
@@ -6115,9 +6095,7 @@ void Statement::setStmtStats(NABoolean autoRetry)
   if (statsGlobals != NULL)
   {
     error = statsGlobals->getStatsSemaphore(cliGlobals_->getSemId(),
-                  cliGlobals_->myPin(), savedPriority, savedStopMode,
-                  FALSE /*shouldTimeout*/);
-    ex_assert(error == 0, "getStatsSemaphore() returned an error");
+                  cliGlobals_->myPin());
     if (autoRetry)
     {
       if (getUniqueStmtId() != NULL)
@@ -6180,8 +6158,7 @@ void Statement::setStmtStats(NABoolean autoRetry)
     }
     else
       stmtStats_ = NULL;
-    statsGlobals->releaseStatsSemaphore(cliGlobals_->getSemId(), cliGlobals_->myPin(),
-       savedPriority, savedStopMode);
+    statsGlobals->releaseStatsSemaphore(cliGlobals_->getSemId(), cliGlobals_->myPin());
   }
   else
   {
@@ -7045,11 +7022,8 @@ NABoolean Statement::updateChildQid()
   if (statsGlobals != NULL && uniqueStmtId_ != NULL && parentQid_ != NULL &&
       getStatsArea() != NULL && stmtStats_ != NULL && stmtStats_->updateChildQid())
   {
-    short savedPriority, savedStopMode;
-    short error = statsGlobals->getStatsSemaphore(cliGlobals_->getSemId(),
-          cliGlobals_->myPin(), savedPriority, savedStopMode, 
-          FALSE /*shouldTimeout*/);
-    ex_assert(error == 0, "getStatsSemaphore() returned an error");
+    int error = statsGlobals->getStatsSemaphore(cliGlobals_->getSemId(),
+          cliGlobals_->myPin());
     StmtStats *ss = statsGlobals->getMasterStmtStats(parentQid_, str_len(parentQid_), RtsQueryId::ANY_QUERY_);
     if (ss != NULL)
     {
@@ -7061,8 +7035,7 @@ NABoolean Statement::updateChildQid()
           parentIsCanceled = TRUE;
       }
     }
-    statsGlobals->releaseStatsSemaphore(cliGlobals_->getSemId(),cliGlobals_->myPin(),
-                    savedPriority, savedStopMode);
+    statsGlobals->releaseStatsSemaphore(cliGlobals_->getSemId(),cliGlobals_->myPin());
   }
   return parentIsCanceled;
 }

--- a/core/sql/executor/ExStats.cpp
+++ b/core/sql/executor/ExStats.cpp
@@ -7550,14 +7550,10 @@ short ExStatsTcb::work()
                           if (statsGlobals != NULL)
                           {
                             semId = getGlobals()->getSemId();
-                            short savedPriority, savedStopMode;
-                            short error = statsGlobals->getStatsSemaphore(semId, getGlobals()->getPid(), 
-                                  savedPriority, savedStopMode, FALSE /*shouldTimeout*/);
-                            ex_assert(error == 0, "getStatsSemaphore() returned an error");
+                            int error = statsGlobals->getStatsSemaphore(semId, getGlobals()->getPid());
                             stats_->merge(stats, statsMergeType_);
                             setDeleteStats(TRUE);
-                            statsGlobals->releaseStatsSemaphore(semId, getGlobals()->getPid(),
-                                      savedPriority, savedStopMode);
+                            statsGlobals->releaseStatsSemaphore(semId, getGlobals()->getPid());
                           }
                           else
                           {
@@ -7623,14 +7619,10 @@ short ExStatsTcb::work()
                             if (statsGlobals != NULL)
                             {
                               semId = getGlobals()->getSemId();
-                              short savedPriority, savedStopMode;
-                              short error = statsGlobals->getStatsSemaphore(semId, getGlobals()->getPid(), 
-                                    savedPriority, savedStopMode, FALSE /*shouldTimeout*/);
-                              ex_assert(error == 0, "getStatsSemaphore() returned an error");
+                              int error = statsGlobals->getStatsSemaphore(semId, getGlobals()->getPid());
                               stats_->merge(stats, statsMergeType_);
                               setDeleteStats(TRUE);
-                              statsGlobals->releaseStatsSemaphore(semId, getGlobals()->getPid(),
-                                        savedPriority, savedStopMode);
+                              statsGlobals->releaseStatsSemaphore(semId, getGlobals()->getPid());
                             }
                             else
                             {
@@ -9493,16 +9485,12 @@ void ExMasterStats::setInvalidationKeys(CliGlobals *cliGlobals,
   if ((numSIKeys > PreAllocatedSikKeys) || 
       (numObjUIDs > PreAllocatedObjUIDs))
   {
-    short savedPriority, savedStopMode;
     Long semId = cliGlobals->getSemId();
     StatsGlobals *statsGlobals = cliGlobals->getStatsGlobals();
     if (statsGlobals)
     {
-      short error = statsGlobals->getStatsSemaphore(
-                    semId, cliGlobals->myPin(), 
-                    savedPriority, savedStopMode,
-                    FALSE /*shouldTimeout*/);
-      ex_assert(error == 0, "getStatsSemaphore() returned an error");
+      int error = statsGlobals->getStatsSemaphore(
+                    semId, cliGlobals->myPin());
     }
 
     if (numSIKeys > PreAllocatedSikKeys)
@@ -9520,8 +9508,7 @@ void ExMasterStats::setInvalidationKeys(CliGlobals *cliGlobals,
 
     if (statsGlobals)
       statsGlobals->releaseStatsSemaphore(
-                      semId, cliGlobals->myPin(), 
-                      savedPriority, savedStopMode);
+                      semId, cliGlobals->myPin());
   }
 
   numSIKeys_ = numSIKeys;

--- a/core/sql/executor/ex_esp_frag_dir.cpp
+++ b/core/sql/executor/ex_esp_frag_dir.cpp
@@ -92,7 +92,7 @@ ExEspFragInstanceDir::ExEspFragInstanceDir(CliGlobals *cliGlobals,
   numActiveInstances_ = 0;
   highWaterMark_      = 0;
   numMasters_         = 1;
-  short error;
+  int error;
 
   //Phandle wrapper in porting layer
   NAProcessHandle phandle;
@@ -127,10 +127,7 @@ ExEspFragInstanceDir::ExEspFragInstanceDir(CliGlobals *cliGlobals,
     {
       cliGlobals_->setStatsGlobals(statsGlobals_);
       cliGlobals_->setSemId(semId_);
-      short savedPriority, savedStopMode;
-      error = statsGlobals_->getStatsSemaphore(semId_, pid_,savedPriority, savedStopMode,
-                      FALSE /*shouldTimeout*/);
-      ex_assert(error == 0, "getStatsSemaphore() returned an error");
+      error = statsGlobals_->getStatsSemaphore(semId_, pid_);
       statsHeap_ = (NAHeap *)statsGlobals->getStatsHeap()->allocateHeapMemory(sizeof *statsHeap_);
       statsHeap_ = new (statsHeap_, statsGlobals->getStatsHeap()) 
         NAHeap("Process Stats Heap", statsGlobals->getStatsHeap(),
@@ -144,7 +141,7 @@ ExEspFragInstanceDir::ExEspFragInstanceDir(CliGlobals *cliGlobals,
            statsGlobals_->getExProcessStats(pid_);
       processStats->setStartTime(cliGlobals_->myStartTime());
       cliGlobals_->setExProcessStats(processStats);
-      statsGlobals_->releaseStatsSemaphore(semId_, pid_, savedPriority, savedStopMode);
+      statsGlobals_->releaseStatsSemaphore(semId_, pid_);
     }
   }
   cliGlobals_->setStatsHeap(statsHeap_);
@@ -185,13 +182,10 @@ ExEspFragInstanceDir::~ExEspFragInstanceDir()
   // no point in making error checks
   if (statsGlobals_ != NULL)
   {
-    short savedPriority, savedStopMode;
-    short error = statsGlobals_->getStatsSemaphore(semId_, pid_, savedPriority, savedStopMode,
-                        FALSE /*shouldTimeout*/);
-    ex_assert(error == 0, "getStatsSemaphore() returned an error");
+    int error = statsGlobals_->getStatsSemaphore(semId_, pid_);
     statsGlobals_->removeProcess(pid_);
-    statsGlobals_->releaseStatsSemaphore(semId_, pid_, savedPriority, savedStopMode);
-   sem_close((sem_t *)semId_);
+    statsGlobals_->releaseStatsSemaphore(semId_, pid_);
+    sem_close((sem_t *)semId_);
   }
 }
 

--- a/core/sql/executor/ex_ex.cpp
+++ b/core/sql/executor/ex_ex.cpp
@@ -488,13 +488,9 @@ void ex_tcb::mergeStats(ExStatisticsArea *otherStats)
   if (statsGlobals != NULL)
   {
     semId = glob->getSemId();
-    short savedPriority, savedStopMode;
-    short error = statsGlobals->getStatsSemaphore(semId, glob->getPid(), 
-      savedPriority, savedStopMode,
-      FALSE /*shouldTimeout*/);
-    ex_assert(error == 0, "getStatsSemaphore() returned an error");
+    int error = statsGlobals->getStatsSemaphore(semId, glob->getPid());
     glob->getStatsArea()->merge(otherStats);
-    statsGlobals->releaseStatsSemaphore(semId, glob->getPid(), savedPriority, savedStopMode);
+    statsGlobals->releaseStatsSemaphore(semId, glob->getPid());
   }
   else
     glob->getStatsArea()->merge(otherStats);

--- a/core/sql/executor/ex_exe_stmt_globals.cpp
+++ b/core/sql/executor/ex_exe_stmt_globals.cpp
@@ -1140,15 +1140,12 @@ void ExEspStmtGlobals::deleteMe(NABoolean fatalError)
   statsGlobals = espFragInstanceDir_->getStatsGlobals();
   if (statsGlobals != NULL)
   {
-    short savedPriority, savedStopMode;
-    short error = statsGlobals->getStatsSemaphore(espFragInstanceDir_->getSemId(),
-                      espFragInstanceDir_->getPid(),savedPriority, savedStopMode,
-                      FALSE /*shouldTimeout*/);
-    ex_assert(error == 0, "getStatsSemaphore() returned an error");
+    int error = statsGlobals->getStatsSemaphore(espFragInstanceDir_->getSemId(),
+                      espFragInstanceDir_->getPid());
     if (stmtStats_ != NULL)
       statsGlobals->removeQuery(espFragInstanceDir_->getPid(), stmtStats_);
     statsGlobals->releaseStatsSemaphore(espFragInstanceDir_->getSemId(),
-            espFragInstanceDir_->getPid(), savedPriority, savedStopMode);
+            espFragInstanceDir_->getPid());
     stmtStats_ = NULL;
 
   }

--- a/core/sql/executor/ex_globals.cpp
+++ b/core/sql/executor/ex_globals.cpp
@@ -127,12 +127,9 @@ void ex_globals::deleteMe(NABoolean fatalError)
     else
     {
       Long semId = getSemId();
-      short savedPriority, savedStopMode;
-      short error = statsGlobals->getStatsSemaphore(semId, getPid(), savedPriority, savedStopMode,
-                        FALSE /*shouldTimeout*/);
-      ex_assert(error == 0, "getStatsSemaphore() returned an error");
+      int error = statsGlobals->getStatsSemaphore(semId, getPid());
       NADELETE(statsArea_, ExStatisticsArea, statsArea_->getHeap());
-      statsGlobals->releaseStatsSemaphore(semId, getPid(), savedPriority, savedStopMode);
+      statsGlobals->releaseStatsSemaphore(semId, getPid());
     }
   }
   statsArea_ = NULL;

--- a/core/sql/executor/ex_root.cpp
+++ b/core/sql/executor/ex_root.cpp
@@ -243,14 +243,9 @@ ex_tcb * ex_root_tdb::build(CliGlobals *cliGlobals, ex_globals * glob)
             }
           else
             {
-              short savedPriority, savedStopMode;
-              short error = 
+              int error = 
                 statsGlobals->getStatsSemaphore(cliGlobals->getSemId(),
-                  cliGlobals->myPin(), savedPriority, savedStopMode,
-                  FALSE /*shouldTimeout*/);
-
-              ex_assert(error == 0, "getStatsSemaphore() returned an error");
-
+                  cliGlobals->myPin());
               statsArea = new(cliGlobals->getStatsHeap())
                               ExStatisticsArea(cliGlobals->getStatsHeap(), 0, 
                               getCollectStatsType());
@@ -271,7 +266,7 @@ ex_tcb * ex_root_tdb::build(CliGlobals *cliGlobals, ex_globals * glob)
               statsArea->setRtsStatsCollectEnabled(getCollectRtsStats());
               root_tcb->allocateStatsEntry();
               statsGlobals->releaseStatsSemaphore(cliGlobals->getSemId(), 
-                                 cliGlobals->myPin(),savedPriority, savedStopMode);
+                                 cliGlobals->myPin());
             }
         }
       statsArea->setExplainPlanId(explainPlanId_);
@@ -2903,12 +2898,8 @@ void ex_root_tcb::deregisterCB()
     mStats = sStats->getMasterStats();
   if (statsGlobals && mStats && mStats->isReadyToSuspend())
   {
-    short savedPriority, savedStopMode;
-    short error = statsGlobals->getStatsSemaphore(cliGlobals->getSemId(),
-                cliGlobals->myPin(), savedPriority, savedStopMode,
-                FALSE /*shouldTimeout*/);
-
-    ex_assert(error == 0, "getStatsSemaphore() returned an error");
+    int error = statsGlobals->getStatsSemaphore(cliGlobals->getSemId(),
+                cliGlobals->myPin());
 
     while (mStats->isQuerySuspended())
     {
@@ -2917,14 +2908,11 @@ void ex_root_tcb::deregisterCB()
       // test in an automated script.
       // LCOV_EXCL_START
       statsGlobals->releaseStatsSemaphore(cliGlobals->getSemId(),
-               cliGlobals->myPin(),savedPriority, savedStopMode);
+               cliGlobals->myPin());
       DELAY(300);
 
-      short error = statsGlobals->getStatsSemaphore(cliGlobals->getSemId(),
-                  cliGlobals->myPin(), savedPriority, savedStopMode,
-                  FALSE /*shouldTimeout*/);
-
-      ex_assert(error == 0, "getStatsSemaphore() returned an error");
+      int error = statsGlobals->getStatsSemaphore(cliGlobals->getSemId(),
+                  cliGlobals->myPin());
       // LCOV_EXCL_STOP
     }
 
@@ -2934,7 +2922,7 @@ void ex_root_tcb::deregisterCB()
 
     // Now it is safe to let MXSSMP process another SUSPEND.
     statsGlobals->releaseStatsSemaphore(cliGlobals->getSemId(),
-               cliGlobals->myPin(),savedPriority, savedStopMode);
+               cliGlobals->myPin());
   }
 
   // No started message sent, so no finished message should be sent.
@@ -3034,11 +3022,8 @@ void ex_root_tcb::dumpCb()
   StatsGlobals *statsGlobals = cliGlobals->getStatsGlobals();
   if (statsGlobals == NULL)
     return; 
-  short savedPriority, savedStopMode;
-  short error =
-         statsGlobals->getStatsSemaphore(cliGlobals->getSemId(),
-          cliGlobals->myPin(), savedPriority, savedStopMode,
-          FALSE /*shouldTimeout*/);
+  int error = statsGlobals->getStatsSemaphore(cliGlobals->getSemId(),
+          cliGlobals->myPin());
   bool doDump = false;
   Int64 timenow = NA_JulianTimestamp();
   if ((timenow - statsGlobals->getSsmpDumpTimestamp()) > 
@@ -3048,7 +3033,7 @@ void ex_root_tcb::dumpCb()
     statsGlobals->setSsmpDumpTimestamp(timenow);
   }
   statsGlobals->releaseStatsSemaphore(cliGlobals->getSemId(),
-                      cliGlobals->myPin(),savedPriority, savedStopMode);
+                      cliGlobals->myPin());
   if (doDump)
     cbServer_->getServerId().getPhandle().dumpAndStop(true, false);
 }

--- a/core/sql/executor/ex_send_bottom.cpp
+++ b/core/sql/executor/ex_send_bottom.cpp
@@ -591,17 +591,12 @@ short ex_send_bottom_tcb::checkRequest()
                if (statsGlobals != NULL)
                {
                   Long semId = getGlobals()->getSemId();
-                  short savedPriority, savedStopMode;
-                  short error = statsGlobals->getStatsSemaphore(semId,
-                                       getGlobals()->getPid(),
-                                       savedPriority, savedStopMode,
-                                       FALSE /*shouldTimeout*/);
-                  ex_assert(error == 0, "getStatsSemaphore() returned an error");
+                  int error = statsGlobals->getStatsSemaphore(semId,
+                                       getGlobals()->getPid());
                   statsArea->setDonotUpdateCounters(FALSE);
                   statsArea->restoreDop();
                   statsGlobals->releaseStatsSemaphore(semId, 
-                      getGlobals()->getPid(),
-                      savedPriority, savedStopMode);
+                      getGlobals()->getPid());
                }
                else
                {
@@ -916,17 +911,12 @@ short ex_send_bottom_tcb::checkReply()
 	  if (statsGlobals != NULL)
           {
             Long semId = getGlobals()->getSemId();
-            short savedPriority, savedStopMode;
-            short error = statsGlobals->getStatsSemaphore(semId, 
-                                                    getGlobals()->getPid(),
-                                                    savedPriority, savedStopMode,
-                                                    FALSE /*shouldTimeout*/);
-            ex_assert(error == 0, "getStatsSemaphore() returned an error");
+            int error = statsGlobals->getStatsSemaphore(semId, 
+                                                    getGlobals()->getPid());
 	    *workMsgStream_ << *(getGlobals()->getStatsArea());
 	    getGlobals()->getStatsArea()->initEntries();
             getGlobals()->getStatsArea()->setDonotUpdateCounters(TRUE);
-            statsGlobals->releaseStatsSemaphore(semId, getGlobals()->getPid(),
-                      savedPriority, savedStopMode);
+            statsGlobals->releaseStatsSemaphore(semId, getGlobals()->getPid());
           }
           else
           {

--- a/core/sql/executor/ex_split_bottom.cpp
+++ b/core/sql/executor/ex_split_bottom.cpp
@@ -135,11 +135,8 @@ ex_split_bottom_tcb * ex_split_bottom_tdb::buildESPTcbTree(
     }
     else
     {
-      short savedPriority, savedStopMode;
-      short error = statsGlobals->getStatsSemaphore(espInstanceDir->getSemId(),
-                      espInstanceDir->getPid(), savedPriority, savedStopMode,
-                      FALSE /*shouldTimeout*/);
-      ex_assert(error == 0, "getStatsSemaphore() returned an error");
+      int error = statsGlobals->getStatsSemaphore(espInstanceDir->getSemId(),
+                      espInstanceDir->getPid());
       statsArea = new(espInstanceDir->getStatsHeap())
         ExStatisticsArea(espInstanceDir->getStatsHeap(), numOfParentInstances,
 		       getCollectStatsType());
@@ -151,8 +148,7 @@ ex_split_bottom_tcb * ex_split_bottom_tdb::buildESPTcbTree(
       statsArea->setRtsStatsCollectEnabled(getCollectRtsStats());
       glob->setStatsArea(statsArea);
       result->allocateStatsEntry();
-      statsGlobals->releaseStatsSemaphore(espInstanceDir->getSemId(), espInstanceDir->getPid(),
-                savedPriority, savedStopMode);
+      statsGlobals->releaseStatsSemaphore(espInstanceDir->getSemId(), espInstanceDir->getPid());
     }
   }
   else

--- a/core/sql/executor/ex_split_top.cpp
+++ b/core/sql/executor/ex_split_top.cpp
@@ -389,19 +389,16 @@ void ex_split_top_tcb::allocateStatsEntry(Int32 c, ex_tcb *childTcb)
   ex_globals * glob    = getGlobals();
   StatsGlobals *statsGlobals = getGlobals()->getStatsGlobals();
   Long semId;
-  short savedPriority, savedStopMode;
   if (statsGlobals != NULL)
   {
     semId = glob->getSemId();
-    short error = statsGlobals->getStatsSemaphore(semId, glob->getPid(), 
-      savedPriority, savedStopMode, FALSE /*shouldTimeout*/);
-    ex_assert(error == 0, "getStatsSemaphore() returned an error");
+    int error = statsGlobals->getStatsSemaphore(semId, glob->getPid());
   }
   childTcb->allocateStatsEntry();
   if (childTcb->getStatsEntry()->getCollectStatsType() == ComTdb::ALL_STATS)
     childTcb->getStatsEntry()->setSubInstNum(c);
   if (statsGlobals != NULL)
-    statsGlobals->releaseStatsSemaphore(semId, glob->getPid(), savedPriority, savedStopMode);
+    statsGlobals->releaseStatsSemaphore(semId, glob->getPid());
 }
 
 void ex_split_top_tcb::addChild(Int32 c, NABoolean atWorktime, ExOperStats* statsEntry)

--- a/core/sql/exp/ExpHbaseInterface.cpp
+++ b/core/sql/exp/ExpHbaseInterface.cpp
@@ -89,10 +89,8 @@ NABoolean isParentQueryCanceled()
   const char *parentQid = CmpCommon::context()->sqlSession()->getParentQid();
   if (statsGlobals && parentQid)
   {
-    short savedPriority, savedStopMode;
     statsGlobals->getStatsSemaphore(cliGlobals->getSemId(),
-      cliGlobals->myPin(), savedPriority, savedStopMode,
-      FALSE /*shouldTimeout*/);
+      cliGlobals->myPin());
     StmtStats *ss = statsGlobals->getMasterStmtStats(parentQid, 
       strlen(parentQid), RtsQueryId::ANY_QUERY_);
     if (ss)
@@ -102,7 +100,7 @@ NABoolean isParentQueryCanceled()
         isCanceled = TRUE;
     }
     statsGlobals->releaseStatsSemaphore(cliGlobals->getSemId(),
-       cliGlobals->myPin(), savedPriority, savedStopMode);
+       cliGlobals->myPin());
   }
   return isCanceled;
 }

--- a/core/sql/runtimestats/CancelBroker.cpp
+++ b/core/sql/runtimestats/CancelBroker.cpp
@@ -345,10 +345,8 @@ void PendingQueryMgr::killPendingCanceled()
   {
     if (!haveSema4)
     {
-      short error = statsGlobals->getStatsSemaphore(ssmpGlobals_->getSemId(),
-                      ssmpGlobals_->myPin(),
-                      savedPriority, savedStopMode, FALSE /*shouldTimeout*/);
-      ex_assert(error == 0, "getStatsSemaphore() returned an error");
+      int error = statsGlobals->getStatsSemaphore(ssmpGlobals_->getSemId(),
+                      ssmpGlobals_->myPin());
       haveSema4 = true;
     }
 
@@ -416,8 +414,8 @@ void PendingQueryMgr::killPendingCanceled()
                 "Internal error in PendingQueryMgr::killPendingCanceled()");
 
       // Release semaphore before messaging.
-      statsGlobals->releaseStatsSemaphore(ssmpGlobals_->getSemId(),
-                  ssmpGlobals_->myPin(), savedPriority, savedStopMode);
+      statsGlobals->releaseStatsSemaphore(ssmpGlobals_->getSemId(), 
+          ssmpGlobals_->myPin());
       haveSema4 = false;
 
       askSscpsToStopServers(pq);
@@ -454,7 +452,7 @@ void PendingQueryMgr::killPendingCanceled()
 
         // Release semaphore.
         statsGlobals->releaseStatsSemaphore(ssmpGlobals_->getSemId(),
-                  ssmpGlobals_->myPin(), savedPriority, savedStopMode);
+                  ssmpGlobals_->myPin());
         haveSema4 = false;
 
         gph.dumpAndStop(makeSavebend, // do make a core-file.
@@ -487,7 +485,7 @@ void PendingQueryMgr::killPendingCanceled()
   if (haveSema4)
   {
     statsGlobals->releaseStatsSemaphore(ssmpGlobals_->getSemId(),
-                ssmpGlobals_->myPin(), savedPriority, savedStopMode);
+                ssmpGlobals_->myPin());
     haveSema4 = false;
   }
 

--- a/core/sql/runtimestats/SqlStats.h
+++ b/core/sql/runtimestats/SqlStats.h
@@ -361,16 +361,12 @@ public:
                   NABoolean calledFromRemoveProcess = FALSE); 
 
   // global scan when the stmtList is positioned from begining and searched for pid
-  short openStatsSemaphore(Long &semId);
-  short getStatsSemaphore(Long &semId, pid_t pid, short &savedPriority, 
-       short &savedStopMode, NABoolean shouldTimeout = FALSE);
-  void releaseStatsSemaphore(Long &semId, pid_t pid, short savedPriority, 
-       short savedStopMode, NABoolean canAssert = TRUE);
+  int openStatsSemaphore(Long &semId);
+  int getStatsSemaphore(Long &semId, pid_t pid);
+  void releaseStatsSemaphore(Long &semId, pid_t pid);
 
-  short releaseAndGetStatsSemaphore(Long &semId, 
-       pid_t pid, pid_t releasePid,
-       short &savedPriority,
-       short &savedStopMode, NABoolean shouldTimeout = FALSE);
+  int releaseAndGetStatsSemaphore(Long &semId, 
+       pid_t pid, pid_t releasePid);
   void cleanupDanglingSemaphore(NABoolean checkForSemaphoreHolder);
   void checkForDeadProcesses(pid_t myPid);
   SyncHashQueue *getStmtStatsList() { return stmtStatsList_; }

--- a/core/sql/runtimestats/sscpipc.cpp
+++ b/core/sql/runtimestats/sscpipc.cpp
@@ -50,9 +50,8 @@ SscpGlobals::SscpGlobals(NAHeap *sscpheap, StatsGlobals *statsGlobals)
     statsGlobals_(statsGlobals)
   , doLogCancelKillServers_(false)
 {
-  short error;
+  int error;
   Int32 myCpu;
-  short savedPriority, savedStopMode;
   char programDir[100];
   short processType;
   char myNodeName[MAX_SEGMENT_NAME_LEN+1];
@@ -66,15 +65,13 @@ SscpGlobals::SscpGlobals(NAHeap *sscpheap, StatsGlobals *statsGlobals)
   ex_assert(error == 0, "BINSEM_OPEN returned an error");
 
 
-  error = (short) ComRtGetProgramInfo(programDir, 100, processType,
+  error = ComRtGetProgramInfo(programDir, 100, processType,
     myCpu, myPin_,
     myNodeNumber, myNodeName, myNodeNameLen, myStartTime, myProcessNameString);
   ex_assert(error == 0,"Error in ComRtGetProgramInfo");
 
   pri = 0;
-  error = statsGlobals_->getStatsSemaphore(semId_, myPin_, savedPriority, savedStopMode,
-                                          FALSE /*shouldTimeout*/);
-  ex_assert(error == 0, "getStatsSemaphore() returned an error");
+  error = statsGlobals_->getStatsSemaphore(semId_, myPin_);
   // ProcessHandle wrapper in porting layer library
   NAProcessHandle sscpPhandle;
   error = sscpPhandle.getmine(statsGlobals->getSscpProcHandle());
@@ -98,7 +95,7 @@ SscpGlobals::SscpGlobals(NAHeap *sscpheap, StatsGlobals *statsGlobals)
                0);
   statsGlobals_->addProcess(myPin_, statsHeap);
 
-  statsGlobals_->releaseStatsSemaphore(semId_, myPin_, savedPriority, savedStopMode);
+  statsGlobals_->releaseStatsSemaphore(semId_, myPin_);
   CliGlobals *cliGlobals = GetCliGlobals();
   cliGlobals->setSemId(semId_);
   cliGlobals->setStatsHeap(statsHeap);
@@ -268,10 +265,8 @@ void SscpNewIncomingConnectionStream::processStatsReq(IpcConnection *connection)
         clearAllObjects();
         setType(IPC_MSG_SSCP_REPLY);
         setVersion(CurrSscpReplyMessageVersion);
-        short savedPriority, savedStopMode;
-        short error = statsGlobals->getStatsSemaphore(sscpGlobals->getSemId(),
-                sscpGlobals->myPin(), savedPriority, savedStopMode, FALSE /*shouldTimeout*/);
-        ex_assert(error == 0, "getStatsSemaphore() returned an error");
+        int error = statsGlobals->getStatsSemaphore(sscpGlobals->getSemId(),
+                sscpGlobals->myPin());
         SyncHashQueue *stmtStatsList = statsGlobals->getStmtStatsList();
         StmtStats *stmtStats = statsGlobals->getStmtStats(qid, str_len(qid));
         ExStatisticsArea *stats;
@@ -345,7 +340,7 @@ void SscpNewIncomingConnectionStream::processStatsReq(IpcConnection *connection)
           } while (stmtStats != NULL && str_cmp(qid, stmtStats->getQueryId(), stmtStats->getQueryIdLen()) != 0);
         }
 
-        statsGlobals->releaseStatsSemaphore(sscpGlobals->getSemId(), sscpGlobals->myPin(), savedPriority, savedStopMode);
+        statsGlobals->releaseStatsSemaphore(sscpGlobals->getSemId(), sscpGlobals->myPin());
 #ifdef _DEBUG_RTS
         cerr << "Merged Stats " << mergedStats << " \n";
 #endif
@@ -436,10 +431,8 @@ void SscpNewIncomingConnectionStream::processCpuStatsReq(IpcConnection *connecti
   if (reqType != SQLCLI_STATS_REQ_RMS_INFO &&
           reqType != SQLCLI_STATS_REQ_MEM_OFFENDER)
   {
-    short savedPriority, savedStopMode;
-    short error = statsGlobals->getStatsSemaphore(sscpGlobals->getSemId(),
-            sscpGlobals->myPin(), savedPriority, savedStopMode, FALSE /*shouldTimeout*/);
-    ex_assert(error == 0, "getStatsSemaphore() returned an error");
+    int error = statsGlobals->getStatsSemaphore(sscpGlobals->getSemId(),
+            sscpGlobals->myPin());
     SyncHashQueue *stmtStatsList = statsGlobals->getStmtStatsList();
     stmtStatsList->position();
     if (reqType == SQLCLI_STATS_REQ_ET_OFFENDER)
@@ -474,7 +467,7 @@ void SscpNewIncomingConnectionStream::processCpuStatsReq(IpcConnection *connecti
              mergedStats->appendCpuStats(stats, FALSE);
        }
     }
-    statsGlobals->releaseStatsSemaphore(sscpGlobals->getSemId(), sscpGlobals->myPin(), savedPriority, savedStopMode);
+    statsGlobals->releaseStatsSemaphore(sscpGlobals->getSemId(), sscpGlobals->myPin());
   }
   if (reqType == SQLCLI_STATS_REQ_RMS_INFO)
   {
@@ -510,8 +503,6 @@ int reportStops(int alreadyStoppedCnt, int stoppedCnt)
 
 void SscpNewIncomingConnectionStream::processKillServersReq()
 {
-
-  short savedPriority, savedStopMode;
   int alreadyStoppedCnt = 0;
   int stoppedCnt = 0;
 
@@ -554,10 +545,8 @@ void SscpNewIncomingConnectionStream::processKillServersReq()
   setType(IPC_MSG_SSCP_REPLY);
   setVersion(CurrSscpReplyMessageVersion);
 
-  short error = statsGlobals->getStatsSemaphore(sscpGlobals->getSemId(),
-                  sscpGlobals->myPin(),
-                  savedPriority, savedStopMode, FALSE /*shouldTimeout*/);
-  ex_assert(error == 0, "getStatsSemaphore() returned an error");
+  int error = statsGlobals->getStatsSemaphore(sscpGlobals->getSemId(),
+                  sscpGlobals->myPin());
 
   SyncHashQueue *stmtStatsList = statsGlobals->getStmtStatsList();
   stmtStatsList->position(qid, qidLen);
@@ -648,8 +637,7 @@ void SscpNewIncomingConnectionStream::processKillServersReq()
     // Okay, here goes...
     stoppedCnt++;
     statsGlobals->releaseStatsSemaphore(sscpGlobals->getSemId(),
-                                      sscpGlobals->myPin(), savedPriority,
-                                      savedStopMode);
+                                      sscpGlobals->myPin());
     gph.dumpAndStop(request->getMakeSaveabend(),
                     true);                    // doStop
 
@@ -660,16 +648,13 @@ void SscpNewIncomingConnectionStream::processKillServersReq()
 
     // Reacquire the sema4.  And reposition into the HashQueue.
     error = statsGlobals->getStatsSemaphore(sscpGlobals->getSemId(),
-                    sscpGlobals->myPin(),
-                    savedPriority, savedStopMode, FALSE /*shouldTimeout*/);
-    ex_assert(error == 0, "getStatsSemaphore() returned an error");
+                    sscpGlobals->myPin());
 
     stmtStatsList->position(qid, qidLen);
   }
 
   statsGlobals->releaseStatsSemaphore(sscpGlobals->getSemId(),
-                                    sscpGlobals->myPin(), savedPriority,
-                                    savedStopMode);
+                                    sscpGlobals->myPin());
 
   if (sscpGlobals->shouldLogCancelKillServers() ||
       request->getCancelLogging())
@@ -703,7 +688,6 @@ void SscpNewIncomingConnectionStream::processKillServersReq()
 void SscpNewIncomingConnectionStream::suspendActivateSchedulers()
 {
   int espFragCnt = 0;
-  short savedPriority, savedStopMode;
   IpcMessageObjVersion msgVer = getNextObjVersion();
 
   ex_assert(msgVer <= currRtsStatsReqVersionNumber, "Up-rev message received.");
@@ -732,10 +716,8 @@ void SscpNewIncomingConnectionStream::suspendActivateSchedulers()
   setType(IPC_MSG_SSCP_REPLY);
   setVersion(CurrSscpReplyMessageVersion);
 
-  short error = statsGlobals->getStatsSemaphore(sscpGlobals->getSemId(),
-                  sscpGlobals->myPin(),
-                  savedPriority, savedStopMode, FALSE /*shouldTimeout*/);
-  ex_assert(error == 0, "getStatsSemaphore() returned an error");
+  int error = statsGlobals->getStatsSemaphore(sscpGlobals->getSemId(),
+                  sscpGlobals->myPin());
 
   SyncHashQueue *stmtStatsList = statsGlobals->getStmtStatsList();
   stmtStatsList->position(qid, qidLen);
@@ -778,8 +760,7 @@ void SscpNewIncomingConnectionStream::suspendActivateSchedulers()
   }
 
   statsGlobals->releaseStatsSemaphore(sscpGlobals->getSemId(),
-                                    sscpGlobals->myPin(), savedPriority,
-                                    savedStopMode);
+                                    sscpGlobals->myPin());
 
   if (request->getSuspendLogging())
   {
@@ -833,11 +814,8 @@ void SscpNewIncomingConnectionStream::processSecInvReq()
     }
     SscpGlobals *sscpGlobals = getSscpGlobals();
     StatsGlobals *statsGlobals = sscpGlobals->getStatsGlobals();
-    short savedPriority, savedStopMode;
-    short error = statsGlobals->getStatsSemaphore(sscpGlobals->getSemId(),
-                  sscpGlobals->myPin(),
-                  savedPriority, savedStopMode, FALSE /*shouldTimeout*/);
-    ex_assert(error == 0, "getStatsSemaphore() returned an error");
+    int error = statsGlobals->getStatsSemaphore(sscpGlobals->getSemId(),
+                  sscpGlobals->myPin());
     ExTimeStats timer;
     if (revokeTimer)
       timer.start();
@@ -893,8 +871,7 @@ void SscpNewIncomingConnectionStream::processSecInvReq()
     statsGlobals->mergeNewSikeys(numSiks, request->getSik());
 
     statsGlobals->releaseStatsSemaphore(sscpGlobals->getSemId(),
-                                    sscpGlobals->myPin(), savedPriority,
-                                    savedStopMode);
+                                    sscpGlobals->myPin());
     if (revokeTimer)
     {
       timer.stop();


### PR DESCRIPTION
RMS semaphore handling had the following:
1) Passed in parameters that are no longer used. It had these parameters for legacy reasons
2) Was returning errno for short return code. This might have caused unexplainable behavior
   at times.
3) The caller was aborting for non-zero return value, but the return value is not easily visible.

All the above problems have been fixed in this PR.