### PR TITLE
[TRAFODION-2746] Fixed various problem detected in large clusters (> 30)

### DIFF
--- a/core/sqf/monitor/linux/cluster.cxx
+++ b/core/sqf/monitor/linux/cluster.cxx
@@ -346,17 +346,15 @@ void CCluster::NodeReady( CNode *spareNode )
         lnode->Up();
     }
 
-    ResetIntegratingPNid();
     spareNode->SetActivatingSpare( false );
-
     if ( MyNode->IsCreator() )
     {
         MyNode->SetCreator( false, -1, -1 );
     }
+    ResetIntegratingPNid();
 
     TRACE_EXIT;
 }
-
 
 // Assigns a new TMLeader if given pnid is same as TmLeaderNid 
 // TmLeader is a logical node num. 
@@ -804,11 +802,11 @@ void CCluster::HardNodeDown (int pnid, bool communicate_state)
         {
             if ( node->GetPNid() == integratingPNid_ )
             {
-                ResetIntegratingPNid();
                 if ( MyNode->IsCreator() )
                 {
                     MyNode->SetCreator( false, -1, -1 );
                 }
+                ResetIntegratingPNid();
             }
             node->KillAllDown();
             node->SetState( State_Down ); 
@@ -1425,11 +1423,11 @@ int CCluster::HardNodeUp( int pnid, char *node_name )
                 }
             }
 
-            ResetIntegratingPNid();
             if ( MyNode->IsCreator() )
             {
                 MyNode->SetCreator( false, -1, -1 );
             }
+            ResetIntegratingPNid();
 
             if (trace_settings & (TRACE_INIT | TRACE_RECOVERY))
                trace_printf( "%s@%d" " - New monitor %s, pnid=%d, state=%s, spare=%d\n"
@@ -7541,7 +7539,7 @@ int CCluster::ReceiveSock(char *buf, int size, int sockFd)
             }
             else
             {
-                sizeCount -= received;
+                sizeCount -= readCount;
                 readAgain = true;
             }
         }

--- a/core/sqf/monitor/linux/redirector.cxx
+++ b/core/sqf/monitor/linux/redirector.cxx
@@ -1271,11 +1271,23 @@ void CRedirectStderr::handleOutput(ssize_t count, char *buffer)
     if ( buf )
     {
         memset(buf, 0, buf_size);
-        ssize_t size = snprintf(buf, 
-                                (buf_size<MON_EVENT_BUF_SIZE)?buf_size:MON_EVENT_BUF_SIZE, 
-                                "STDERR redirected from %s.%s.%d.%d: %s",
-                                nodeName(), processName(), nid(), pid(), buffer );
-        if ( size > 0 && buf[size-1] != '\n') buf[size-1] = '\n';
+        // Copy up to MON_EVENT_BUF_SIZE
+        ssize_t size = snprintf( buf
+                               , (buf_size<MON_EVENT_BUF_SIZE)?buf_size:MON_EVENT_BUF_SIZE
+                               , "STDERR redirected from %s.%s.%d.%d: %s"
+                               ,  nodeName(), processName(), nid(), pid(), buffer );
+        if ( size > 0 )
+        {
+            if (size >= MON_EVENT_BUF_SIZE )
+            { // truncated
+                buf[MON_EVENT_BUF_SIZE-2] = '\n';
+                buf[MON_EVENT_BUF_SIZE-1] = 0;
+            }
+            else if ( buf[size-1] != '\n')
+            {
+                buf[size-1] = '\n';
+            }
+        }
         mon_log_write(MON_REDIR_STDERR, SQ_LOG_INFO, buf);
 
         delete [] buf;

--- a/core/sqf/monitor/linux/reqqueue.cxx
+++ b/core/sqf/monitor/linux/reqqueue.cxx
@@ -2464,17 +2464,19 @@ void CIntSnapshotReq::performRequest()
     }
 
     // estimate size of snapshot buffer
-    // about 100 bytes per process, 1.5 times total
-    int procSize = Nodes->ProcessCount() * 1.75 * 100;
-    int spareNodeSize = Nodes->GetSpareNodesList()->size() * sizeof(int); // pnids
+    // about 100 bytes per process, 2 times total
+    int procSize = Nodes->ProcessCount() * 2 * 100;
+    int idsSize = Nodes->GetSNodesCount() * sizeof(int); // spare pnids
+    idsSize += (Nodes->GetPNodesCount() + Nodes->GetLNodesCount()) * sizeof(int); // pnid/nid map
+    idsSize += Nodes->GetLNodesCount() * sizeof(int);    // nids
 
     if (trace_settings & (TRACE_REQUEST | TRACE_INIT | TRACE_RECOVERY))
-        trace_printf("%s@%d - Snapshot sizes, procSize = %d, spareNodeSize = %d\n",
-                      method_name, __LINE__, procSize, spareNodeSize);
+        trace_printf("%s@%d - Snapshot sizes, procSize = %d, idsSize = %d\n",
+                      method_name, __LINE__, procSize, idsSize);
 
-    mem_log_write(MON_REQQUEUE_SNAPSHOT_4, procSize, spareNodeSize);
+    mem_log_write(MON_REQQUEUE_SNAPSHOT_4, procSize, idsSize);
 
-    snapshotBuf = (char *) malloc (procSize + spareNodeSize); 
+    snapshotBuf = (char *) malloc (procSize + idsSize); 
 
     if (!snapshotBuf) 
     {


### PR DESCRIPTION
The problems were:

1. A segmentation violation occurred during the Integration phase, when the new 
   monitor is establishing the socket communication paths between itself and 
   the existing monitors.
   a. Information is exchanged between the master (creator) monitor and the
      slave (new) monitor process which tells the new monitor which nodes
      monitor process make up the existing cluster instance. During these
      exchanges, in CCluster::ReceiveSock() one of the messages was large
      enough to require chunking and the logic which kept track of the
      number of bytes received was not calculated correctly which resulted
      in an overwrite past the boundary of the receive buffer. 
2. A second segmentation violation was due to a buffer overwrite during the
   Joining (revive) phase.
   a. In requeue.cxx, when creating the buffer in the master (creator) monitor
      which is populated with the cluster state information to be sent to the
      slave (new) monitor process, the calculation did not properly account for
      the number of logical and physical nodes. So that when the buffer was
      populated, it would overwrite past the allocated buffer.
3. A third problem was also note in the one of the monitor would remain in
   the Joining state and never come out of it.
   a. The problem was in the order of logic when calling 
      CCluster::ResetIntegratingPNid() which triggers the
      CCommAccept::commAcceptorSock() to accept another new node to
      integrate. The invocation to ResetIntegratingPNid() was done before
      resetting the creator flag. Due to kernel scheduling, this resetting
      of the creator flag was happening after another monitor started the
      Integration phase and it was breaking the node integration protocol
      by terminating it too early. So the new monitor would stay in the
      Joining state for ever since the protocol was broken.
4. The last segmentation violation was due to stderr buffer overwrite in
   CRedirectStderr::handleOutput() where the size returned by snprintf() 
   was used to terminate the buffer containing stderr data >= 4096 which
   is the size of the buffer.
