### PR TITLE
[TRAFODION-2726] odb support to load json file

### DIFF
--- a/core/conn/odb/Makefile
+++ b/core/conn/odb/Makefile
@@ -65,9 +65,9 @@ profile: CFLAGS_LNX += -DODB_PROFILE
 profile: LIBS_64luo += -lrt
 profile: generic 
 
-odb64luo: odb64luo.o mreadline.o memcpy_wrapper.o versodb.o
+odb64luo: odb64luo.o mreadline.o memcpy_wrapper.o versodb.o JsonReader.o
 	gcc -m64 -O2 -mtune=generic  -DODBC64 -DHDFS -DXML $(LDFLAGS_LNX) \
-		-o $(EXEC_64luo) bin/memcpy_wrapper.o bin/odb64luo.o bin/mreadline.o bin/versodb.o \
+		-o $(EXEC_64luo) bin/memcpy_wrapper.o bin/odb64luo.o bin/mreadline.o bin/versodb.o bin/JsonReader.o \
 		-D ODBBLD=$(ODBBLD_64luo) $(LIBPATH_64luo) $(INCPATH_64luo) $(LIBS_64luo) -o bin/odb64luo
 	tar -czf ../clients/odb64_linux.tar.gz bin/odb64luo README
 	ln -sf $(TRAF_HOME)/../conn/odb/bin/odb64luo $(TRAF_HOME)/export/bin$(SQ_MBTYPE)/odb64luo
@@ -91,6 +91,9 @@ memcpy_wrapper.o: memcpy_wrapper.c
 
 versodb.o: versodb.c
 	gcc -m64 -O2 -mtune=generic -g -c src/versodb.c $(INCPATH_64luo) -o bin/versodb.o
+
+JsonReader.o: JsonReader.c
+	gcc $(CFLAGS_LNX) -c src/JsonReader.c -o bin/JsonReader.o
 
 clean: 
 	rm -f bin/*.o bin/odb64luo

--- a/core/conn/odb/odb/odb.vcxproj
+++ b/core/conn/odb/odb/odb.vcxproj
@@ -153,12 +153,14 @@
     </Link>
   </ItemDefinitionGroup>
   <ItemGroup>
+    <ClCompile Include="..\src\JsonReader.c" />
     <ClCompile Include="..\src\memcpy_wrapper.c" />
     <ClCompile Include="..\src\mreadline.c" />
     <ClCompile Include="..\src\odb.c" />
     <ClCompile Include="..\src\versodb.c" />
   </ItemGroup>
   <ItemGroup>
+    <ClInclude Include="..\src\JsonReader.h" />
     <ClInclude Include="..\src\verslib.h" />
     <ClInclude Include="resource.h" />
   </ItemGroup>

--- a/core/conn/odb/odb/odb.vcxproj.filters
+++ b/core/conn/odb/odb/odb.vcxproj.filters
@@ -27,6 +27,9 @@
     <ClCompile Include="..\src\versodb.c">
       <Filter>Source Files</Filter>
     </ClCompile>
+    <ClCompile Include="..\src\JsonReader.c">
+      <Filter>Source Files</Filter>
+    </ClCompile>
   </ItemGroup>
   <ItemGroup>
     <ClInclude Include="..\src\verslib.h">
@@ -34,6 +37,9 @@
     </ClInclude>
     <ClInclude Include="resource.h">
       <Filter>Header Files</Filter>
+    </ClInclude>
+    <ClInclude Include="..\src\JsonReader.h">
+      <Filter>Source Files</Filter>
     </ClInclude>
   </ItemGroup>
   <ItemGroup>

--- a/core/conn/odb/src/JsonReader.c
+++ b/core/conn/odb/src/JsonReader.c
@@ -1,4 +1,27 @@
-﻿#include "JsonReader.h"
+﻿//------------------------------------------------------------------
+//
+// @@@ START COPYRIGHT @@@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// @@@ END COPYRIGHT @@@
+
+#include "JsonReader.h"
 #include <errno.h>
 #include <string.h>
 

--- a/core/conn/odb/src/JsonReader.c
+++ b/core/conn/odb/src/JsonReader.c
@@ -1,0 +1,540 @@
+﻿#include "JsonReader.h"
+#include <errno.h>
+#include <string.h>
+
+JsonReader *jsonReaderNew(const char *path)
+{
+    JsonReader *pJsonReader = (JsonReader *)calloc(1, sizeof(JsonReader));
+    if (!pJsonReader) {
+        return NULL;
+    }
+
+    pJsonReader->jsonFile = fopen(path, "r");
+    if (!pJsonReader->jsonFile) {
+        free(pJsonReader);
+        return NULL;
+    }
+
+    strncpy(pJsonReader->jsonFileName, path, JSON_PARSER_MAX_FILE_NAME_LEN);
+    pJsonReader->nestDepth = 0;
+    pJsonReader->state = JSON_STATE_START;
+    pJsonReader->errorCode = JSON_SUCCESS;
+    pJsonReader->currentCharPtr = pJsonReader->buf;
+
+    return pJsonReader;
+}
+
+JsonReaderError jsonMoveCurrentCharPtr(JsonReader *pJsonReader)
+{
+    if (pJsonReader->isBufReady) {
+        ++pJsonReader->currentCharPtr;
+    }
+
+    if (pJsonReader->currentCharPtr == pJsonReader->buf + pJsonReader->numberReadBuf) {
+        if ((pJsonReader->numberReadBuf = fread(pJsonReader->buf, sizeof(char), JSON_PARSER_BUF_LEN, pJsonReader->jsonFile))) {
+            pJsonReader->currentCharPtr = pJsonReader->buf;
+            pJsonReader->isBufReady = true;
+        }
+        else {
+            pJsonReader->errorCode = JSON_ERROR_PARSE_EOF;
+        }
+    }
+
+    if (*(pJsonReader->currentCharPtr) == '\n') {
+        ++pJsonReader->lineNum;
+        pJsonReader->linePos = 0;
+    }
+    else {
+        ++pJsonReader->linePos;
+    }
+
+    return pJsonReader->errorCode;
+}
+
+JsonReaderError jsonSaveAndToState(JsonReader *pJsonReader, JsonReaderState state)
+{
+    if (pJsonReader->nestDepth < JSON_PARSER_MAX_NESTED_NUM) {
+        pJsonReader->statesSave[(pJsonReader->nestDepth)++] = pJsonReader->state;
+        pJsonReader->state = state;
+    }
+    else {
+        pJsonReader->errorCode = JSON_ERROR_DEPTH;
+    }
+
+    return pJsonReader->errorCode;
+}
+
+JsonReaderError jsonReaderSetTmpbuf(JsonReader *pJsonReader, char *buf, size_t len)
+{
+    pJsonReader->tmpSaveBuf = buf;
+    pJsonReader->bufLen = len;
+    return pJsonReader->errorCode;
+}
+
+JsonReaderError jsonReaderUnsetTmpbuf(JsonReader *pJsonReader)
+{
+    pJsonReader->tmpSaveBuf = NULL;
+    pJsonReader->bufLen = 0;
+    return pJsonReader->errorCode;
+}
+
+JsonReaderError jsonParseStateStart(JsonReader *pJsonReader)
+{
+    while (jsonMoveCurrentCharPtr(pJsonReader) == JSON_SUCCESS) {
+        if (IS_NOT_WHITE_SPACE(*(pJsonReader->currentCharPtr))) {
+            if (*pJsonReader->currentCharPtr == '{') {
+                pJsonReader->state = JSON_STATE_OBJECT_INITIAL;
+                break;
+            }
+            else if (*pJsonReader->currentCharPtr == '[') {
+                pJsonReader->state = JSON_STATE_ARRAY_INITIAL;
+                break;
+            }
+            else {
+                pJsonReader->errorCode = JSON_ERROR_BAD_FORMAT;
+                break;
+            }
+        }
+    }
+
+    return pJsonReader->errorCode;
+}
+
+JsonReaderError jsonParseObjectInitial(JsonReader *pJsonReader)
+{
+    while (jsonMoveCurrentCharPtr(pJsonReader) == JSON_SUCCESS) {
+        if (IS_NOT_WHITE_SPACE(*(pJsonReader->currentCharPtr))) {
+            switch (*pJsonReader->currentCharPtr)
+            {
+            case '"':
+                pJsonReader->state = JSON_STATE_MEMBER_KEY;
+                goto ret;
+            case '}':
+                pJsonReader->state = JSON_STATE_OBJECT_FINISH;
+                goto ret;
+            default:
+                pJsonReader->errorCode = JSON_ERROR_BAD_FORMAT;
+                goto ret;
+            }
+        }
+    }
+
+ret:
+    return pJsonReader->errorCode;
+}
+
+char *jsonGetStringValue(JsonReader *pJsonReader, char *strValue, size_t len)
+{
+    bool isEscape = 0;
+    size_t pos = 0;
+
+    while (jsonMoveCurrentCharPtr(pJsonReader) == JSON_SUCCESS) {
+        if (isEscape) {
+            if (strValue && pos < len)
+                strValue[pos++] = *pJsonReader->currentCharPtr;
+            isEscape = false;
+        }
+        else {
+            switch (*pJsonReader->currentCharPtr) {
+            case '"':
+                if (strValue && pos < len)
+                    strValue[pos++] = '\0';
+                goto ret;
+            case '\\':
+                isEscape = true; 
+                break;
+            default:
+                if (strValue && pos < len)
+                    strValue[pos++] = *pJsonReader->currentCharPtr;
+                break;
+            }
+        }
+    }
+
+ret:
+    if (strValue)
+        strValue[len - 1] = '\0';
+    return strValue;
+}
+
+JsonReaderError jsonParseMemberKey(JsonReader *pJsonReader)
+{
+    jsonGetStringValue(pJsonReader, pJsonReader->tmpSaveBuf, pJsonReader->bufLen);
+    while (jsonMoveCurrentCharPtr(pJsonReader) == JSON_SUCCESS) {
+        if (IS_NOT_WHITE_SPACE(*(pJsonReader->currentCharPtr))) {
+            if (*pJsonReader->currentCharPtr == ':') {
+                pJsonReader->state = JSON_STATE_KEY_VALUE_DELIMITER;
+                break;
+            }
+            else {
+                pJsonReader->errorCode = JSON_ERROR_BAD_FORMAT;
+                break;
+            }
+        }
+    }
+
+    return pJsonReader->errorCode;
+}
+
+JsonReaderError jsonParseKeyValueDelimiter(JsonReader *pJsonReader)
+{
+    while (jsonMoveCurrentCharPtr(pJsonReader) == JSON_SUCCESS) {
+        if (IS_NOT_WHITE_SPACE(*(pJsonReader->currentCharPtr))) {
+            switch (*(pJsonReader->currentCharPtr)) {
+            CASE_VALUE:
+                pJsonReader->state = JSON_STATE_MEMBER_VALUE;
+                goto ret;
+            case '[':
+                jsonSaveAndToState(pJsonReader, JSON_STATE_ARRAY_INITIAL);
+                goto ret;
+            case '{':
+                jsonSaveAndToState(pJsonReader, JSON_STATE_OBJECT_INITIAL);
+                goto ret;
+            default:
+                pJsonReader->errorCode = JSON_ERROR_BAD_FORMAT;
+                goto ret;
+            }
+        }
+    }
+ret:
+    return pJsonReader->errorCode;
+}
+
+JsonReaderError jsonInternalGetValue(JsonReader *pJsonReader, char *endChars, size_t len)
+{
+    const char *pBooleanOrNull = NULL;
+    // string
+    if (*pJsonReader->currentCharPtr == '"' && pJsonReader->tmpSaveBuf) {
+        jsonGetStringValue(pJsonReader, pJsonReader->tmpSaveBuf, pJsonReader->bufLen);
+    }
+    // maybe false,true,null
+    else if ((*pJsonReader->currentCharPtr == 'f' ? (pBooleanOrNull = "false") : 0) ||
+        (*pJsonReader->currentCharPtr == 't' ? (pBooleanOrNull = "true") : 0) ||
+        (*pJsonReader->currentCharPtr == 'n' ? (pBooleanOrNull = "null") : 0)) {
+        size_t lenBN = strlen(pBooleanOrNull);
+        size_t pos = 1;
+        while ((jsonMoveCurrentCharPtr(pJsonReader) == JSON_SUCCESS) && (pos < lenBN)) {
+            if (pBooleanOrNull[pos] != *pJsonReader->currentCharPtr) {
+                break;
+            }
+            ++pos;
+        }
+        if ((pos < lenBN) || (IS_NOT_WHITE_SPACE(*pJsonReader->currentCharPtr) &&
+            !IN_CHARS(*pJsonReader->currentCharPtr, endChars, lenBN))) {
+            pJsonReader->errorCode = JSON_ERROR_BAD_FORMAT;
+        }
+        if (pJsonReader->tmpSaveBuf) {
+            strncpy(pJsonReader->tmpSaveBuf, pBooleanOrNull, pJsonReader->bufLen);
+        }
+    }
+    // should be number
+    else {
+        size_t pos = 0;
+        do {
+            if (IS_NOT_WHITE_SPACE(*pJsonReader->currentCharPtr) &&
+                !IN_CHARS(*pJsonReader->currentCharPtr, endChars, len)) {
+                if (pJsonReader->tmpSaveBuf && pos < pJsonReader->bufLen) {
+                    pJsonReader->tmpSaveBuf[pos++] = *pJsonReader->currentCharPtr;
+                }
+            }
+            else {
+                break;
+            }
+        } while (jsonMoveCurrentCharPtr(pJsonReader) == JSON_SUCCESS);
+        if (pJsonReader->tmpSaveBuf) {
+            pJsonReader->tmpSaveBuf[pos < len ? pos : len] = '\0';
+        }
+    }
+    return pJsonReader->errorCode;
+}
+
+JsonReaderError jsonParseMemberValueEnd(JsonReader *pJsonReader)
+{
+    do {
+        if (IS_NOT_WHITE_SPACE(*pJsonReader->currentCharPtr)) {
+            if (*pJsonReader->currentCharPtr == ',') {
+                pJsonReader->state = JSON_STATE_MEMBER_DELIMITER;
+                break;
+            }
+            else if (*pJsonReader->currentCharPtr == '}') {
+                pJsonReader->state = JSON_STATE_OBJECT_FINISH;
+                break;
+            }
+            else if (*pJsonReader->currentCharPtr != '"') {
+                pJsonReader->errorCode = JSON_ERROR_BAD_FORMAT;
+                break;
+            }
+        }
+    } while (jsonMoveCurrentCharPtr(pJsonReader) == JSON_SUCCESS);
+    return pJsonReader->errorCode;
+}
+
+JsonReaderError jsonParseElementEnd(JsonReader *pJsonReader)
+{
+    do {
+        if (IS_NOT_WHITE_SPACE(*pJsonReader->currentCharPtr)) {
+            if (*pJsonReader->currentCharPtr == ',') {
+                pJsonReader->state = JSON_STATE_ELEMENT_DELIMITER;
+                break;
+            }
+            else if (*pJsonReader->currentCharPtr == ']') {
+                pJsonReader->state = JSON_STATE_ARRAY_FINISH;
+                break;
+            }
+            else if (*pJsonReader->currentCharPtr != '"') {
+                pJsonReader->errorCode = JSON_ERROR_BAD_FORMAT;
+                break;
+            }
+        }
+    } while (jsonMoveCurrentCharPtr(pJsonReader) == JSON_SUCCESS);
+
+    return pJsonReader->errorCode;
+}
+
+JsonReaderError jsonParseMemberValue(JsonReader *pJsonReader) {
+    
+    if (jsonInternalGetValue(pJsonReader, ",}", 2) == JSON_SUCCESS) {
+        jsonParseMemberValueEnd(pJsonReader);
+    }
+
+    return pJsonReader->errorCode;
+}
+
+JsonReaderError jsonParseMemberDelimiter(JsonReader *pJsonReader)
+{
+    while (jsonMoveCurrentCharPtr(pJsonReader) == JSON_SUCCESS) {
+        if (IS_NOT_WHITE_SPACE(*pJsonReader->currentCharPtr)) {
+            if (*pJsonReader->currentCharPtr == '"') {
+                pJsonReader->state = JSON_STATE_MEMBER_KEY;
+                break;
+            }
+            else {
+                pJsonReader->errorCode = JSON_ERROR_BAD_FORMAT;
+                break;
+            }
+        }
+    }
+    
+    return pJsonReader->errorCode;
+}
+
+JsonReaderError jsonParseObjectFinish(JsonReader *pJsonReader)
+{
+    if (pJsonReader->nestDepth == 0) {
+        while (jsonMoveCurrentCharPtr(pJsonReader) == JSON_SUCCESS) {
+            if (IS_NOT_WHITE_SPACE(*pJsonReader->currentCharPtr)) {
+                pJsonReader->errorCode = JSON_ERROR_BAD_FORMAT;
+                break;
+            }
+        }
+    }
+    else {
+        switch (pJsonReader->statesSave[--(pJsonReader->nestDepth)])
+        {
+        case JSON_STATE_ARRAY_INITIAL:
+        case JSON_STATE_ELEMENT_DELIMITER:
+            jsonMoveCurrentCharPtr(pJsonReader);
+            jsonParseElementEnd(pJsonReader);
+            break;
+        case JSON_STATE_KEY_VALUE_DELIMITER:
+            jsonMoveCurrentCharPtr(pJsonReader);
+            jsonParseMemberValueEnd(pJsonReader);
+            break;
+        default:
+            pJsonReader->errorCode = JSON_ERROR_STATE;
+            break;
+        }
+    }
+    return pJsonReader->errorCode;
+}
+
+JsonReaderError jsonParseArrayInitial(JsonReader *pJsonReader)
+{
+    while (jsonMoveCurrentCharPtr(pJsonReader) == JSON_SUCCESS) {
+        if (IS_NOT_WHITE_SPACE(*pJsonReader->currentCharPtr)) {
+            switch (*pJsonReader->currentCharPtr)
+            {
+            case '{':
+                jsonSaveAndToState(pJsonReader, JSON_STATE_OBJECT_INITIAL);
+                goto ret;
+            case '[':
+                jsonSaveAndToState(pJsonReader, JSON_STATE_ARRAY_INITIAL);
+                goto ret;
+            case ']':
+                pJsonReader->state = JSON_STATE_ARRAY_FINISH;
+                goto ret;
+            CASE_VALUE:
+                pJsonReader->state = JSON_STATE_ELEMENT;
+                goto ret;
+            default:
+                pJsonReader->errorCode = JSON_ERROR_BAD_FORMAT;
+                goto ret;
+            }
+        }
+    }
+
+ret:
+    return pJsonReader->errorCode;
+}
+
+JsonReaderError jsonParseElement(JsonReader *pJsonReader)
+{
+    if (jsonInternalGetValue(pJsonReader, "],", 2) == JSON_SUCCESS) {
+        jsonParseElementEnd(pJsonReader);
+    }
+
+    return pJsonReader->errorCode;
+}
+
+JsonReaderError jsonParseElementDelimiter(JsonReader *pJsonReader)
+{
+    while (jsonMoveCurrentCharPtr(pJsonReader) == JSON_SUCCESS) {
+        if (IS_NOT_WHITE_SPACE(*pJsonReader->currentCharPtr)) {
+            switch (*pJsonReader->currentCharPtr)
+            {
+            CASE_VALUE:
+                pJsonReader->state = JSON_STATE_ELEMENT;
+                goto ret;
+            case '[':
+                jsonSaveAndToState(pJsonReader, JSON_STATE_ARRAY_INITIAL);
+                goto ret;
+            case '{':
+                jsonSaveAndToState(pJsonReader, JSON_STATE_OBJECT_INITIAL);
+                goto ret;
+            default:
+                pJsonReader->errorCode = JSON_ERROR_BAD_FORMAT;
+                goto ret;
+            }
+        }
+    }
+
+ret:
+    return pJsonReader->errorCode;
+}
+
+JsonReaderError jsonParseArrayFinish(JsonReader *pJsonReader)
+{
+    if (pJsonReader->nestDepth == 0) {
+        while (jsonMoveCurrentCharPtr(pJsonReader) == JSON_SUCCESS) {
+            if (IS_NOT_WHITE_SPACE(*pJsonReader->currentCharPtr)) {
+                pJsonReader->errorCode = JSON_ERROR_BAD_FORMAT;
+                break;
+            }
+        }
+    }
+    else {
+        switch (pJsonReader->statesSave[--(pJsonReader->nestDepth)])
+        {
+        case JSON_STATE_KEY_VALUE_DELIMITER:
+            jsonMoveCurrentCharPtr(pJsonReader);
+            jsonParseMemberValueEnd(pJsonReader);
+            break;
+        case JSON_STATE_ELEMENT_DELIMITER:
+        case JSON_STATE_ARRAY_INITIAL:
+            jsonMoveCurrentCharPtr(pJsonReader);
+            jsonParseElementEnd(pJsonReader);
+            break;
+        default:
+            pJsonReader->errorCode = JSON_ERROR_BAD_FORMAT;
+            break;
+        }
+    }
+
+    return pJsonReader->errorCode;
+}
+
+JsonReaderError jsonReadKey(JsonReader *pJsonReader, char *keyBuf, size_t len)
+{
+    if (pJsonReader->state == JSON_STATE_MEMBER_KEY) {
+        jsonReaderSetTmpbuf(pJsonReader, keyBuf, len);
+        jsonParseMemberKey(pJsonReader);
+        jsonReaderUnsetTmpbuf(pJsonReader);
+    }
+    else {
+        pJsonReader->errorCode = JSON_ERROR_STATE;
+    }
+    return pJsonReader->errorCode;
+}
+
+JsonReaderError jsonReadMemberValue(JsonReader *pJsonReader, char *memberValbuf, size_t len)
+{
+    if (pJsonReader->state == JSON_STATE_MEMBER_VALUE) {
+        jsonReaderSetTmpbuf(pJsonReader, memberValbuf, len);
+        jsonParseMemberValue(pJsonReader);
+        jsonReaderUnsetTmpbuf(pJsonReader);
+    }
+    else {
+        pJsonReader->errorCode = JSON_ERROR_STATE;
+    }
+    return pJsonReader->errorCode;
+}
+
+JsonReaderError jsonReadArrayValue(JsonReader *pJsonReader, char *arrayValBuf, size_t len)
+{
+    if (pJsonReader->state == JSON_STATE_ELEMENT) {
+        jsonReaderSetTmpbuf(pJsonReader, arrayValBuf, len);
+        jsonParseElement(pJsonReader);
+        jsonReaderUnsetTmpbuf(pJsonReader);
+    }
+    else {
+        pJsonReader->errorCode = JSON_ERROR_STATE;
+    }
+    return pJsonReader->errorCode;
+}
+
+JsonReaderError jsonRead(JsonReader *pJsonReader) {
+    switch (pJsonReader->state)
+    {
+    case JSON_STATE_START:
+        jsonParseStateStart(pJsonReader);
+        break;
+    case JSON_STATE_OBJECT_INITIAL:
+        jsonParseObjectInitial(pJsonReader);
+        break;
+    case JSON_STATE_ARRAY_INITIAL:
+        jsonParseArrayInitial(pJsonReader);
+        break;
+    case JSON_STATE_MEMBER_KEY:
+        jsonParseMemberKey(pJsonReader);
+        break;
+    case JSON_STATE_ELEMENT:
+        jsonParseElement(pJsonReader);
+        break;
+    case JSON_STATE_KEY_VALUE_DELIMITER:
+        jsonParseKeyValueDelimiter(pJsonReader);
+        break;
+    case JSON_STATE_ELEMENT_DELIMITER:
+        jsonParseElementDelimiter(pJsonReader);
+        break;
+    case JSON_STATE_ARRAY_FINISH:
+        jsonParseArrayFinish(pJsonReader);
+        break;
+    case JSON_STATE_MEMBER_VALUE:
+        jsonParseMemberValue(pJsonReader);
+        break;
+    case JSON_STATE_MEMBER_DELIMITER:
+        jsonParseMemberDelimiter(pJsonReader);
+        break;
+    case JSON_STATE_OBJECT_FINISH:
+        jsonParseObjectFinish(pJsonReader);
+        break;
+    default:
+        break;
+    }
+    return pJsonReader->errorCode;
+}
+
+JsonReaderError jsonParse(JsonReader *pJsonReader)
+{
+    while ((pJsonReader->errorCode == JSON_SUCCESS)) {
+        jsonRead(pJsonReader);
+    }
+
+    return pJsonReader->errorCode;
+}
+
+void jsonReaderFree(JsonReader *pJsonReader)
+{
+    fclose(pJsonReader->jsonFile);
+    free(pJsonReader);
+}

--- a/core/conn/odb/src/JsonReader.h
+++ b/core/conn/odb/src/JsonReader.h
@@ -1,0 +1,142 @@
+#ifndef JSONREADER_H
+#define JSONREADER_H
+
+#include <stdlib.h>
+#include <stdio.h>
+
+#define JSON_PARSER_BUF_LEN 1024
+#define JSON_PARSER_ERROR_MESSAGE_LEN 512
+#define JSON_PARSER_MAX_FILE_NAME_LEN 256
+#define JSON_PARSER_MAX_NESTED_NUM 100
+
+#ifndef bool
+#define bool unsigned char
+#endif // !_Bool
+
+#ifndef true
+#define true 1
+#endif // !true
+
+#ifndef false
+#define false 0
+#endif // !false
+
+
+enum JsonReaderState_
+{
+    JSON_STATE_START,
+    JSON_STATE_OBJECT_INITIAL,
+    JSON_STATE_ARRAY_INITIAL,
+    JSON_STATE_MEMBER_KEY,
+    JSON_STATE_ELEMENT,
+    JSON_STATE_KEY_VALUE_DELIMITER,
+    JSON_STATE_ELEMENT_DELIMITER,
+    JSON_STATE_ARRAY_FINISH,
+    JSON_STATE_MEMBER_VALUE,
+    JSON_STATE_MEMBER_DELIMITER,
+    JSON_STATE_OBJECT_FINISH,
+    JSON_STATE_FINISH
+};
+typedef enum JsonReaderState_ JsonReaderState;
+
+enum JsonReaderError_
+{
+    JSON_SUCCESS,
+    JSON_CONTINUE,
+    JSON_ERROR_DEPTH,
+    JSON_ERROR_PARSE_EOF,
+    JSON_ERROR_PARSE_UNEXPECTED,
+    JSON_ERROR_PARSE_NULL,
+    JSON_ERROR_PARSE_BOOLEAN,
+    JSON_ERROR_PARSE_NUMBER,
+    JSON_ERROR_PARSE_ARRAY,
+    JSON_ERROR_PARSE_OBJECT_KEY_NAME,
+    JSON_ERROR_PARSE_OBJECT_KEY_SEP,
+    JSON_ERROR_PARSE_OBJECT_VALUE_SEP,
+    JSON_ERROR_PARSE_STRING,
+    JSON_ERROR_PARSE_COMMENT,
+    JSON_ERROR_SIZE,
+    JSON_ERROR_STATE,
+    JSON_ERROR_BAD_FORMAT
+};
+typedef enum JsonReaderError_ JsonReaderError;
+
+#define IS_NOT_WHITE_SPACE(c) (((c)!=' ') && ((c)!='\t') && ((c)!='\n') && ((c)!='\r'))
+// 1 <= len <= 3
+#define IN_CHARS(c, cs, len) (((c) == (cs)[0]) || ((len) > 1 && (c) == (cs)[1]) || ((len) > 2 && (c) == (cs)[2]))
+#define CASE_VALUE case '1':case '2':case '3':case '4':case '5':case '6':case '7':case '8':case '9':case '-':case 'f':case 't':case 'n':case '"'
+
+struct JsonReader_
+{
+    bool isBufReady;
+    FILE *jsonFile;
+    char *tmpSaveBuf; // save parsed contents.
+    size_t bufLen;
+    size_t nestDepth;
+    JsonReaderState state;
+    JsonReaderError errorCode;
+    char errorMsg[JSON_PARSER_ERROR_MESSAGE_LEN];
+    char buf[JSON_PARSER_BUF_LEN];
+    char *currentCharPtr;
+    char jsonFileName[JSON_PARSER_MAX_FILE_NAME_LEN];
+    size_t numberReadBuf;
+    size_t lineNum;
+    size_t linePos;
+    JsonReaderState statesSave[JSON_PARSER_MAX_NESTED_NUM];
+};
+
+typedef struct JsonReader_ JsonReader;
+
+JsonReader *jsonReaderNew(const char *path);
+
+JsonReaderError jsonMoveCurrentCharPtr(JsonReader *pJsonReader);
+
+JsonReaderError jsonSaveAndToState(JsonReader *pJsonReader, JsonReaderState state);
+
+JsonReaderError jsonReaderSetTmpbuf(JsonReader *pJsonReader, char *buf, size_t len);
+
+JsonReaderError jsonReaderUnsetTmpbuf(JsonReader *pJsonReader);
+
+JsonReaderError jsonParseStateStart(JsonReader *pJsonReader);
+
+JsonReaderError jsonParseObjectInitial(JsonReader *pJsonReader);
+
+char *jsonGetStringValue(JsonReader *pJsonReader, char *strValue, size_t len);
+
+JsonReaderError jsonParseMemberKey(JsonReader *pJsonReader);
+
+JsonReaderError jsonParseKeyValueDelimiter(JsonReader *pJsonReader);
+
+JsonReaderError jsonInternalGetValue(JsonReader *pJsonReader, char *endChars, size_t len);
+
+JsonReaderError jsonParseMemberValueEnd(JsonReader *pJsonReader);
+
+JsonReaderError jsonParseElementEnd(JsonReader *pJsonReader);
+
+JsonReaderError jsonParseMemberValue(JsonReader *pJsonReader);
+
+JsonReaderError jsonParseMemberDelimiter(JsonReader *pJsonReader);
+
+JsonReaderError jsonParseObjectFinish(JsonReader *pJsonReader);
+
+JsonReaderError jsonParseArrayInitial(JsonReader *pJsonReader);
+
+JsonReaderError jsonParseElement(JsonReader *pJsonReader);
+
+JsonReaderError jsonParseElementDelimiter(JsonReader *pJsonReader);
+
+JsonReaderError jsonParseArrayFinish(JsonReader *pJsonReader);
+
+JsonReaderError jsonReadKey(JsonReader *pJsonReader, char *keyBuf, size_t len);
+
+JsonReaderError jsonReadMemberValue(JsonReader *pJsonReader, char *memberValbuf, size_t len);
+
+JsonReaderError jsonReadArrayValue(JsonReader *pJsonReader, char *arrayValBuf, size_t len);
+
+JsonReaderError jsonRead(JsonReader *pJsonReader);
+
+JsonReaderError jsonParse(JsonReader *pJsonReader);
+
+void jsonReaderFree(JsonReader *pJsonReader);
+
+#endif //JSONREADER_H

--- a/core/conn/odb/src/JsonReader.h
+++ b/core/conn/odb/src/JsonReader.h
@@ -1,3 +1,26 @@
+//------------------------------------------------------------------
+//
+// @@@ START COPYRIGHT @@@
+//
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+//
+// @@@ END COPYRIGHT @@@
+
 #ifndef JSONREADER_H
 #define JSONREADER_H
 
@@ -87,56 +110,199 @@ struct JsonReader_
 
 typedef struct JsonReader_ JsonReader;
 
+/* jsonReaderNew: create a json reader
+ *
+ * path: path of json file
+ * return: pointer to json reader
+ */
 JsonReader *jsonReaderNew(const char *path);
 
+/* jsonMoveCurrentCharPtr: move current char pointer forward.
+ *
+ * pJsonReader: pointer of json reader
+ * return: json reader error code
+ */
 JsonReaderError jsonMoveCurrentCharPtr(JsonReader *pJsonReader);
 
+/* jsonSaveAndToState: save and change parser state
+ *
+ * pJsonReader: pointer of json reader
+ * JsonReaderState : parser state
+ * return: json reader error code
+ */
 JsonReaderError jsonSaveAndToState(JsonReader *pJsonReader, JsonReaderState state);
 
+/* jsonReaderSetTmpbuf: set temp buffer to save parsed contents
+ *
+ * pJsonReader: pointer of json reader
+ * buf: the buf to save contents
+ * len: length of buf
+ * return: json reader error code
+ */
 JsonReaderError jsonReaderSetTmpbuf(JsonReader *pJsonReader, char *buf, size_t len);
 
+/* jsonReaderUnsetTmpbuf: unset tempbuf to save parsed contents.
+ *
+ * pJsonReader: pointer of json reader
+ * return: json reader error code
+ */
 JsonReaderError jsonReaderUnsetTmpbuf(JsonReader *pJsonReader);
 
+/* jsonParseStateStart: parse json file start
+ *
+ * pJsonReader: pointer of json reader
+ * return: json reader error code
+ */
 JsonReaderError jsonParseStateStart(JsonReader *pJsonReader);
 
+/* jsonParseObjectInitial: encuntered '{'
+ *
+ * pJsonReader: pointer of json reader
+ * return: json reader error code
+ */
 JsonReaderError jsonParseObjectInitial(JsonReader *pJsonReader);
 
+/* jsonGetStringValue: parse string value
+ *
+ * pJsonReader: pointer of json reader
+ * strValue: pointer to buf to save string
+ * len: length of strValue
+ * return: strValue
+ */
 char *jsonGetStringValue(JsonReader *pJsonReader, char *strValue, size_t len);
 
+/* jsonParseMemberKey: parse member key
+ *
+ * pJsonReader: pointer of json reader
+ * return: json reader error code
+ */
 JsonReaderError jsonParseMemberKey(JsonReader *pJsonReader);
 
+/* jsonParseKeyValueDelimiter: encountered key value delimiter
+ *
+ * pJsonReader: pointer of json reader
+ * return: json reader error code
+ */
 JsonReaderError jsonParseKeyValueDelimiter(JsonReader *pJsonReader);
 
+/* jsonInternalGetValue: common function to get string value
+ *
+ * pJsonReader: pointer of json reader
+ * endChars: encounter these chars function end
+ * len: length of end chars
+ * return: json reader error code
+ */
 JsonReaderError jsonInternalGetValue(JsonReader *pJsonReader, char *endChars, size_t len);
 
+/* jsonParseMemberValueEnd: parse member value end
+ *
+ * pJsonReader: pointer of json reader
+ * return: json reader error code
+ */
 JsonReaderError jsonParseMemberValueEnd(JsonReader *pJsonReader);
 
+/* jsonParseElementEnd: parse element value end
+ *
+ * pJsonReader: pointer of json reader
+ * return: json reader error code
+ */
 JsonReaderError jsonParseElementEnd(JsonReader *pJsonReader);
 
+/* jsonParseMemberValue: parse member value
+ *
+ * pJsonReader: pointer of json reader
+ * return: json reader error code
+ */
 JsonReaderError jsonParseMemberValue(JsonReader *pJsonReader);
 
+/* jsonParseMemberDelimiter: parse contents after member delimiter
+ *
+ * pJsonReader: pointer of json reader
+ * return: json reader error code
+ */
 JsonReaderError jsonParseMemberDelimiter(JsonReader *pJsonReader);
 
+/* jsonParseObjectFinish: parse contents after object finish
+ *
+ * pJsonReader: pointer of json reader
+ * return: json reader error code
+ */
 JsonReaderError jsonParseObjectFinish(JsonReader *pJsonReader);
 
+/* jsonParseArrayInitial: encounter '['
+ *
+ * pJsonReader: pointer of json reader
+ * return: json reader error code
+ */
 JsonReaderError jsonParseArrayInitial(JsonReader *pJsonReader);
 
+/* jsonParseElement: parse array element
+ *
+ * pJsonReader: pointer of json reader
+ * return: json reader error code
+ */
 JsonReaderError jsonParseElement(JsonReader *pJsonReader);
 
+/* jsonParseElementDelimiter: parse contents after array elements delimiter
+ *
+ * pJsonReader: pointer of json reader
+ * return: json reader error code
+ */
 JsonReaderError jsonParseElementDelimiter(JsonReader *pJsonReader);
 
+/* jsonParseArrayFinish: parse contents after array finish
+ *
+ * pJsonReader: pointer of json reader
+ * return: json reader error code
+ */
 JsonReaderError jsonParseArrayFinish(JsonReader *pJsonReader);
 
+/* jsonReadKey: parse key
+ *
+ * pJsonReader: pointer of json reader
+ * keyBuf: buf to save key
+ * len: keyBuf length
+ * return: json reader error code
+ */
 JsonReaderError jsonReadKey(JsonReader *pJsonReader, char *keyBuf, size_t len);
 
+/* jsonReadMemberValue: parse member value
+ *
+ * pJsonReader: pointer of json reader
+ * memberValbuf: buf to save member value
+ * len: memberValbuf length
+ * return: json reader error code
+ */
 JsonReaderError jsonReadMemberValue(JsonReader *pJsonReader, char *memberValbuf, size_t len);
 
+/* jsonReadArrayValue: parse array value
+ *
+ * pJsonReader: pointer of json reader
+ * arrayValbuf: buf to save array value
+ * len: arrayValbuf length
+ * return: json reader error code
+ */
 JsonReaderError jsonReadArrayValue(JsonReader *pJsonReader, char *arrayValBuf, size_t len);
 
+/* jsonRead: parse stream to next state
+ *
+ * pJsonReader: pointer of json reader
+ * return: json reader error code
+ */
 JsonReaderError jsonRead(JsonReader *pJsonReader);
 
+/* jsonParse: parse stream to end if no error
+ *
+ * pJsonReader: pointer of json reader
+ * return: json reader error code
+ */
 JsonReaderError jsonParse(JsonReader *pJsonReader);
 
+/* jsonReaderFree: free json reader
+ *
+ * pJsonReader: pointer of json reader
+ * return: json reader error code
+ */
 void jsonReaderFree(JsonReader *pJsonReader);
 
 #endif //JSONREADER_H

--- a/core/conn/odb/src/JsonReader.h
+++ b/core/conn/odb/src/JsonReader.h
@@ -29,7 +29,6 @@
 
 #define JSON_PARSER_BUF_LEN 1024
 #define JSON_PARSER_ERROR_MESSAGE_LEN 512
-#define JSON_PARSER_MAX_FILE_NAME_LEN 256
 #define JSON_PARSER_MAX_NESTED_NUM 100
 
 #ifndef bool
@@ -65,20 +64,8 @@ typedef enum JsonReaderState_ JsonReaderState;
 enum JsonReaderError_
 {
     JSON_SUCCESS,
-    JSON_CONTINUE,
     JSON_ERROR_DEPTH,
     JSON_ERROR_PARSE_EOF,
-    JSON_ERROR_PARSE_UNEXPECTED,
-    JSON_ERROR_PARSE_NULL,
-    JSON_ERROR_PARSE_BOOLEAN,
-    JSON_ERROR_PARSE_NUMBER,
-    JSON_ERROR_PARSE_ARRAY,
-    JSON_ERROR_PARSE_OBJECT_KEY_NAME,
-    JSON_ERROR_PARSE_OBJECT_KEY_SEP,
-    JSON_ERROR_PARSE_OBJECT_VALUE_SEP,
-    JSON_ERROR_PARSE_STRING,
-    JSON_ERROR_PARSE_COMMENT,
-    JSON_ERROR_SIZE,
     JSON_ERROR_STATE,
     JSON_ERROR_BAD_FORMAT
 };
@@ -98,10 +85,10 @@ struct JsonReader_
     size_t nestDepth;
     JsonReaderState state;
     JsonReaderError errorCode;
-    char errorMsg[JSON_PARSER_ERROR_MESSAGE_LEN];
     char buf[JSON_PARSER_BUF_LEN];
+    char errorMessage[JSON_PARSER_ERROR_MESSAGE_LEN];
     char *currentCharPtr;
-    char jsonFileName[JSON_PARSER_MAX_FILE_NAME_LEN];
+    char *jsonFileName;
     size_t numberReadBuf;
     size_t lineNum;
     size_t linePos;
@@ -116,6 +103,12 @@ typedef struct JsonReader_ JsonReader;
  * return: pointer to json reader
  */
 JsonReader *jsonReaderNew(const char *path);
+
+/* jsonReaderErrorMessage: get json reader error message
+ * pJsonReader: pointer to json reader
+ * return: pointer to json reader
+ */
+const char *jsonReaderErrorMessage(JsonReader *pJsonReader);
 
 /* jsonMoveCurrentCharPtr: move current char pointer forward.
  *

--- a/core/conn/odb/src/odb.c
+++ b/core/conn/odb/src/odb.c
@@ -9736,6 +9736,11 @@ static void OloadJson(int eid)
             k = 0;
         }
     }
+
+    if (pJsonReader->errorCode != JSON_ERROR_PARSE_EOF) {
+        fprintf(stderr, "odb [OloadJson(%d)] - Error parse json file encountered error:%s\n", __LINE__, jsonReaderErrorMessage(pJsonReader));
+    }
+
     jsonReaderFree(pJsonReader);
     /* load trailing rows */
     if (m) {                          /* Insert rowset */


### PR DESCRIPTION
**1. Why support json?**
    1. custormer needed.
    2. JSON is a data inter-exchange format. When compared to XML, it is very lightweight and more human-readable.

**2. Why not use existing c json lib?**
    Considered using the json-c and json-glibc, but seems neither them support stream parse.  For a large file, the memory may not enough.

**3. How odb support json loading function?**
   1. Create table tbjson(id int, name char(20));
   2. cat test.json
       {
          "test":[
              { "id":1 , "name":"hello" },
              { "id":2 , "name":"world" },
          ]
      }
   3. Load Command
      ./odb64luo -l src=test.json:tgt=tbjson:jsonkey=test
odb [parseopt(14249)] - Warning: this function is not fully tested "jsonkey"
odb [2017-09-18 15:28:39]: starting ODBC connection(s)... 0
Connected to Trafodion
[0] 2 records inserted [commit]
[0] odb version 1.1.0 Load(X) statistics:
        [0] Target table: (null).(null).TBJSON
        [0] Source: test.json
        [0] Pre-loading time: 0.308 s (00:00:00.308)
        [0] Loading time: 0.021 s(00:00:00.021)
        [0] Total records read: 0
        [0] Total records inserted: 2
        [0] Total number of columns: 2
        [0] Average input row size: NaN B
        [0] ODBC row size: 31 B (data) + 16 B (len ind)
        [0] Rowset size: 100
        [0] Rowset buffer size: 4.59 KiB
        [0] Load throughput (real data): 0.000 KiB/s
        [0] Load throughput (ODBC): 2.883 KiB/s
odb [2017-09-18 15:28:39]: exiting. Session Elapsed time 0.338 seconds (00:00:00.338)
-bash-4.1$ ./odb64luo -x "select * from tbjson"   
odb [2017-09-18 15:29:28]: starting ODBC connection(s)... 0
1,hello               
2,world               
[0.0.0]--- 2 row(s) selected in 0.025s (prep 0.006s, exec 0.008s, fetch 0.011s/0.006s)
odb [2017-09-18 15:29:28]: exiting. Session Elapsed time 0.284 seconds (00:00:00.284)
