### PR TITLE
[TRAFODION-2730] process loop when infer_charset cqd is ON and query …

### DIFF
--- a/core/sql/executor/ExSequence.cpp
+++ b/core/sql/executor/ExSequence.cpp
@@ -1130,7 +1130,6 @@ short ExSequenceTcb::work()
             //
             pstate->step_ = ExSeq_EMPTY;
             pstate->matchCount_ = 0;
-            workAtp_->release();
 
             // Initialize the history buffer in preparation for the
             // next request.

--- a/core/sql/executor/ExSequence.cpp
+++ b/core/sql/executor/ExSequence.cpp
@@ -350,6 +350,8 @@ ExSequenceTcb::ExSequenceTcb (const ExSequenceTdb &  myTdb,
       ((void*)this, GetHistoryRow, GetHistoryRowOLAP);
     checkPartitionChangeExpr()->fixup(0, getExpressionMode(), this, space, heap_, FALSE, glob);
   }
+
+  workAtp_->getTupp(myTdb.tuppIndex_) = new(space) tupp_descriptor;
 }
 
 // Destructor
@@ -404,6 +406,8 @@ void ExSequenceTcb::freeResources()
   }
   firstOLAPBuffer_ = NULL;
   lastOLAPBuffer_ = NULL;
+
+  workAtp_->getTupp(myTdb().tuppIndex_).release();
 }
 
 // work - doit...
@@ -461,6 +465,10 @@ short ExSequenceTcb::work()
   pentry_down = qparent_.down->getHeadEntry();
   pstate = (ExSequencePrivateState*) pentry_down->pstate;
   request = pentry_down->downState.request;
+  workAtp_->copyPartialAtp(pentry_down->getAtp(),0,
+			   MINOF(myTdb().tuppIndex_,
+				 pentry_down->numTuples())-1);
+  // copy temp and input tupps. Last tupp history row
 
   // Take any child replies and process them. Return the processed
   // rows as long the parent queue has room.
@@ -610,10 +618,6 @@ short ExSequenceTcb::work()
               //
             case ex_queue::Q_OK_MMORE:
               {
-                tupp_descriptor histTupp;
-                workAtp_->copyAtp(pentry_down->getAtp());
-                workAtp_->getTupp(myTdb().tuppIndex_) = &histTupp;
-
                 if ( checkPartitionChangeExpr() &&
                        currentHistRowPtr_)
                 {
@@ -1117,7 +1121,8 @@ short ExSequenceTcb::work()
               = pentry_down->downState.parentIndex;
             pentry_up->upState.downIndex = qparent_.down->getHeadIndex();
             pentry_up->upState.setMatchNo(pstate->matchCount_);
-            
+	    workAtp_->releasePartialAtp(0,MINOF(myTdb().tuppIndex_,
+						pentry_down->numTuples())-1);
             qparent_.down->removeHead();
             qparent_.up->insert();
 

--- a/core/sql/exp/ExpAtp.h
+++ b/core/sql/exp/ExpAtp.h
@@ -91,6 +91,8 @@ class atp_struct
 				       short last_tupp);
     inline unsigned short  numTuples() const;
     inline void         release();   // de-initialize
+    inline void releasePartialAtp(short from_first_tupp,
+				  short last_tupp) ;
 
   // 
   // Methods for manipulating diagnostics area.
@@ -306,6 +308,21 @@ inline void atp_struct::release()
     tuppArray_[i].release();
   }
 
+  // null-out diags area pointer; setDiagsArea releases existing
+  // reference to diags area if it is non-null
+  setDiagsArea(0);
+}
+
+inline void atp_struct::releasePartialAtp(short from_first_tupp,
+ 					  short last_tupp)
+{
+  // Release each tupp.
+  //
+  for(Int32 i=from_first_tupp; i<=last_tupp; i++)
+  {
+    tuppArray_[i].release();
+  }
+  
   // null-out diags area pointer; setDiagsArea releases existing
   // reference to diags area if it is non-null
   setDiagsArea(0);

--- a/core/sql/generator/GenExplain.cpp
+++ b/core/sql/generator/GenExplain.cpp
@@ -949,10 +949,11 @@ HbaseAccess::addSpecificExplainInfo(ExplainTupleMaster *explainTuple,
   description += cacheBuf ;
   description += " " ;
 
-  if (!(((ComTdbHbaseAccess *)tdb)->getHbasePerfAttributes()->cacheBlocks())) {
-    description += "cache_blocks: " ;
+  description += "cache_blocks: " ;
+  if (!(((ComTdbHbaseAccess *)tdb)->getHbasePerfAttributes()->cacheBlocks()))
     description += "OFF " ;
-  }
+  else
+    description += "ON " ;
 
   if ((((ComTdbHbaseAccess *)tdb)->getHbasePerfAttributes()->useSmallScanner())) {
     description += "small_scanner: " ;

--- a/core/sql/generator/GenPreCode.cpp
+++ b/core/sql/generator/GenPreCode.cpp
@@ -4190,6 +4190,12 @@ RelExpr * FileScan::preCodeGen(Generator * generator,
           // assign individual files and blocks to each ESPs
           ((NodeMap *) getPartFunc()->getNodeMap())->assignScanInfos(hiveSearchKey_);
           generator->setProcessLOB(TRUE);
+	  
+	  // flag set for HBase scan in HbaseAccess::preCodeGen
+	  // unique scan unlikely for hive scans except 
+	  // with predicate on virtual cols.
+	  if (!(searchKey() && searchKey()->isUnique()))
+	    generator->oltOptInfo()->setMultipleRowsReturned(TRUE);
         }
     }
 

--- a/core/sql/regress/executor/EXPECTED131
+++ b/core/sql/regress/executor/EXPECTED131
@@ -103,6 +103,7 @@ DESCRIPTION
   columns ................ all
   begin_keys(excl) ....... 2
   end_keys(excl) ......... 5
+  cache_blocks ........... ON
   small_scanner .......... ON
   column_retrieved ....... #1:1
   key_columns ............ UNIQ
@@ -146,6 +147,7 @@ DESCRIPTION
   columns ................ all
   begin_keys(excl) ....... 2
   end_keys(excl) ........ 99
+  cache_blocks ........... ON
   column_retrieved ....... #1:1
   key_columns ............ UNIQ
   executor_predicates .... (UNIQ > 2) and (UNIQ < 99)
@@ -301,6 +303,7 @@ DESCRIPTION
   columns ................ all
   begin_keys(excl) ....... 2
   end_keys(excl) ........ 30
+  cache_blocks ........... ON
   column_retrieved ....... #1:1
   key_columns ............ UNIQ
   executor_predicates .... (UNIQ > 2) and (UNIQ < 30)
@@ -344,6 +347,7 @@ DESCRIPTION
   columns ................ all
   begin_keys(excl) ....... 2
   end_keys(excl) ........ 30
+  cache_blocks ........... ON
   small_scanner .......... ON
   column_retrieved ....... #1:1
   key_columns ............ UNIQ

--- a/core/sql/regress/executor/EXPECTED140
+++ b/core/sql/regress/executor/EXPECTED140
@@ -124,18 +124,18 @@
 +>  , SS_NET_PROFIT     
 +>from hive.hive.store_sales where ss_sold_date_sk is not null;
 Task:  LOAD            Status: Started    Object: TRAFODION.SCH.T140C
-Task:  CLEANUP         Status: Started    Time: 2017-03-15 05:17:16.759
-Task:  CLEANUP         Status: Ended      Time: 2017-03-15 05:17:16.781
-Task:  CLEANUP         Status: Ended      Elapsed Time:    00:00:00.022
-Task:  LOADING DATA    Status: Started    Time: 2017-03-15 05:17:16.781
+Task:  CLEANUP         Status: Started    Time: 2017-09-18 15:49:46.789
+Task:  CLEANUP         Status: Ended      Time: 2017-09-18 15:49:46.816
+Task:  CLEANUP         Status: Ended      Elapsed Time:    00:00:00.027
+Task:  LOADING DATA    Status: Started    Time: 2017-09-18 15:49:46.816
        Rows Processed: 2750311 
        Error Rows:     0 
-Task:  LOADING DATA    Status: Ended      Time: 2017-03-15 05:18:33.540
-Task:  LOADING DATA    Status: Ended      Elapsed Time:    00:01:16.759
-Task:  COMPLETION      Status: Started    Time: 2017-03-15 05:18:33.540
+Task:  LOADING DATA    Status: Ended      Time: 2017-09-18 15:50:33.561
+Task:  LOADING DATA    Status: Ended      Elapsed Time:    00:00:46.744
+Task:  COMPLETION      Status: Started    Time: 2017-09-18 15:50:33.561
        Rows Loaded:    2750311 
-Task:  COMPLETION      Status: Ended      Time: 2017-03-15 05:18:34.657
-Task:  COMPLETION      Status: Ended      Elapsed Time:    00:00:01.117
+Task:  COMPLETION      Status: Ended      Time: 2017-09-18 15:50:35.404
+Task:  COMPLETION      Status: Ended      Elapsed Time:    00:00:01.843
 
 --- 2750311 row(s) loaded.
 >>update statistics for table t140c on every column sample;
@@ -193,6 +193,7 @@ DESCRIPTION
   columns ................ all
   begin_keys(incl)
   end_keys(incl)
+  cache_blocks ........... ON
   small_scanner .......... ON
   column_retrieved ....... #1:3
   pushed_down_rpn ........ (#1:4>?)
@@ -255,6 +256,7 @@ DESCRIPTION
   columns ................ all
   begin_keys(incl)
   end_keys(incl)
+  cache_blocks ........... ON
   small_scanner .......... ON
   column_retrieved ....... #1:2,#1:6
   pushed_down_rpn ........ (#1:4<=?)
@@ -304,6 +306,7 @@ DESCRIPTION
   columns ................ all
   begin_keys(incl)
   end_keys(incl)
+  cache_blocks ........... ON
   small_scanner .......... ON
   column_retrieved ....... #1:2,#1:6
   pushed_down_rpn ........ (#1:4<=?)
@@ -365,6 +368,7 @@ DESCRIPTION
   columns ................ all
   begin_keys(incl)
   end_keys(incl)
+  cache_blocks ........... ON
   small_scanner .......... ON
   column_retrieved ....... #1:6
   pushed_down_rpn ........ (#1:4=?)(#1:6 is_not_null.)AND
@@ -422,6 +426,7 @@ DESCRIPTION
   columns ................ all
   begin_keys(incl)
   end_keys(incl)
+  cache_blocks ........... ON
   small_scanner .......... ON
   column_retrieved ....... #1:3,#1:6
   pushed_down_rpn ........ (#1:4<?)(#1:4>?)OR
@@ -517,6 +522,7 @@ DESCRIPTION
   columns ................ all
   begin_keys(incl)
   end_keys(incl)
+  cache_blocks ........... ON
   small_scanner .......... ON
   column_retrieved ....... #1:6
   pushed_down_rpn ........ (#1:7=.?)(#1:6 is_not_null.)AND
@@ -573,6 +579,7 @@ DESCRIPTION
   columns ................ all
   begin_keys(incl)
   end_keys(incl)
+  cache_blocks ........... ON
   small_scanner .......... ON
   column_retrieved ....... #1:3,#1:6
   pushed_down_rpn ........ (#1:7<.?)(#1:7>.?)OR
@@ -682,6 +689,7 @@ DESCRIPTION
   columns ................ all
   begin_keys(incl)
   end_keys(incl)
+  cache_blocks ........... ON
   small_scanner .......... ON
   column_retrieved ....... #1:6
   pushed_down_rpn ........ (#1:6>=.?)(#1:6<=.?)AND
@@ -775,6 +783,7 @@ DESCRIPTION
   columns ................ all
   begin_keys(incl)
   end_keys(incl)
+  cache_blocks ........... ON
   parallel_scanner ....... 2
   column_retrieved ....... #1:3
   key_columns ............ _SALT_, UNIQ, UNIQ2
@@ -846,6 +855,7 @@ DESCRIPTION
   columns ................ all
   begin_keys(incl)
   end_keys(incl)
+  cache_blocks ........... ON
   parallel_scanner ....... 1
   column_retrieved ....... #1:3
   key_columns ............ _SALT_, UNIQ, UNIQ2
@@ -912,6 +922,7 @@ DESCRIPTION
   columns ................ all
   begin_keys(incl)
   end_keys(incl)
+  cache_blocks ........... ON
   parallel_scanner ....... 1
   column_retrieved ....... #1:3
   key_columns ............ _SALT_, UNIQ, UNIQ2

--- a/core/sql/regress/seabase/EXPECTED010
+++ b/core/sql/regress/seabase/EXPECTED010
@@ -58,7 +58,7 @@
 >>invoke t010t1;
 
 -- Definition of Trafodion table TRAFODION.SCH.T010T1
--- Definition current  Sun Sep  3 07:14:29 2017
+-- Definition current  Mon Sep 18 16:05:40 2017
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -71,7 +71,7 @@
 >>invoke hbase."_CELL_"."TRAFODION.SCH.T010T1";
 
 -- Definition of Trafodion table HBASE."_CELL_"."TRAFODION.SCH.T010T1"
--- Definition current  Sun Sep  3 07:14:30 2017
+-- Definition current  Mon Sep 18 16:05:40 2017
 
   (
     ROW_ID                           VARCHAR(10) CHARACTER SET ISO88591 COLLATE
@@ -90,7 +90,7 @@
 >>invoke hbase."_ROW_"."TRAFODION.SCH.T010T1";
 
 -- Definition of Trafodion table HBASE."_ROW_"."TRAFODION.SCH.T010T1"
--- Definition current  Sun Sep  3 07:14:31 2017
+-- Definition current  Mon Sep 18 16:05:41 2017
 
   (
     ROW_ID                           VARCHAR(10) CHARACTER SET ISO88591 COLLATE
@@ -221,7 +221,7 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... XX
-PLAN_ID .................. 212371182873097135
+PLAN_ID .................. 212372510743136532
 ROWS_OUT ................ 11
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select * from t010t1 where a=1 or b='1';
@@ -263,7 +263,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208413466
+  ObjectUIDs ............. 5892537540705208217
   select_list ............ TRAFODION.SCH.T010T1.A, TRAFODION.SCH.T010T1.B
 
 
@@ -284,6 +284,7 @@ DESCRIPTION
   begin_keys(incl)
   end_keys(incl)
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -303,7 +304,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... XX
-PLAN_ID .................. 212371182873185952
+PLAN_ID .................. 212372510743216468
 ROWS_OUT ................. 1
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select * from t010t1 where a=1 and b='1';
@@ -346,7 +347,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208413466
+  ObjectUIDs ............. 5892537540705208217
   select_list ............ %(1), %('1')
   input_variables ........ %(1), %('1')
 
@@ -365,6 +366,7 @@ DESCRIPTION
   scan_type .............. subset scan of table TRAFODION.SCH.T010T1
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed .......... 1
@@ -385,7 +387,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... XX
-PLAN_ID .................. 212371182873280690
+PLAN_ID .................. 212372510743326023
 ROWS_OUT ................ 10
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select * from t010t1 where b='1';
@@ -427,7 +429,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208413466
+  ObjectUIDs ............. 5892537540705208217
   select_list ............ TRAFODION.SCH.T010T1.A, %('1')
   input_variables ........ %('1')
 
@@ -449,6 +451,7 @@ DESCRIPTION
   begin_keys(incl)
   end_keys(incl)
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -467,7 +470,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... XX
-PLAN_ID .................. 212371182872306074
+PLAN_ID .................. 212372510742386836
 ROWS_OUT ................. 1
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select * from t010t1 where a = 2;
@@ -510,7 +513,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208413466
+  ObjectUIDs ............. 5892537540705208217
   select_list ............ %(2), TRAFODION.SCH.T010T1.B
   input_variables ........ %(2)
 
@@ -529,6 +532,7 @@ DESCRIPTION
   scan_type .............. subset scan of table TRAFODION.SCH.T010T1
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed .......... 1
@@ -773,7 +777,7 @@ A            B           C            D
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... X1
-PLAN_ID .................. 212371182874064550
+PLAN_ID .................. 212372510744251128
 ROWS_OUT ................. 2
 EST_TOTAL_COST ........... 0
 STATEMENT ................ select *
@@ -817,7 +821,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208414002
+  ObjectUIDs ............. 5892537540705208633
   select_list ............ TRAFODION.SCH.T010T2.A, %('a'), %(1),
                              TRAFODION.SCH.T010T2.D
   input_variables ........ %('a'), %(1)
@@ -838,6 +842,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -851,7 +856,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... X2
-PLAN_ID .................. 212371182874153559
+PLAN_ID .................. 212372510744321090
 ROWS_OUT ................. 5
 EST_TOTAL_COST ........... 0
 STATEMENT ................ select *
@@ -896,7 +901,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208414002
+  ObjectUIDs ............. 5892537540705208633
   select_list ............ TRAFODION.SCH.T010T2.A, %('a'),
                              TRAFODION.SCH.T010T2.C, TRAFODION.SCH.T010T2.D
   input_variables ........ %('a')
@@ -917,6 +922,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -931,7 +937,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... X3
-PLAN_ID .................. 212371182874257819
+PLAN_ID .................. 212372510744403400
 ROWS_OUT ................. 4
 EST_TOTAL_COST ........... 0
 STATEMENT ................ select *
@@ -975,7 +981,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208414002
+  ObjectUIDs ............. 5892537540705208633
   select_list ............ TRAFODION.SCH.T010T2.A, %('a'),
                              TRAFODION.SCH.T010T2.C, TRAFODION.SCH.T010T2.D
   input_variables ........ %('a')
@@ -996,6 +1002,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -1010,7 +1017,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... X4
-PLAN_ID .................. 212371182874350776
+PLAN_ID .................. 212372510744506903
 ROWS_OUT ................. 4
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ delete from t010t2
@@ -1054,7 +1061,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208414002
+  ObjectUIDs ............. 5892537540705208633
   input_variables ........ %('a')
 
 
@@ -1103,6 +1110,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -1118,7 +1126,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... X5
-PLAN_ID .................. 212371182874559871
+PLAN_ID .................. 212372510744679860
 ROWS_OUT ................. 2
 EST_TOTAL_COST ........... 0
 STATEMENT ................ update t010t2
@@ -1164,7 +1172,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208414002
+  ObjectUIDs ............. 5892537540705208633
   input_variables ........ %('upd'), %(4)
 
 
@@ -1191,7 +1199,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... Y1
-PLAN_ID .................. 212371182874642434
+PLAN_ID .................. 212372510744762969
 ROWS_OUT ................. 2
 EST_TOTAL_COST ........... 0
 STATEMENT ................ select *
@@ -1236,7 +1244,7 @@ DESCRIPTION
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... ON
   HBASE_MAX_NUM_SEARCH_KE  1
-  ObjectUIDs ............. 8861534267208414002
+  ObjectUIDs ............. 5892537540705208633
   select_list ............ TRAFODION.SCH.T010T2.A, %('a'), %(1),
                              TRAFODION.SCH.T010T2.D
   input_variables ........ %('a'), %(1)
@@ -1257,6 +1265,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -1270,7 +1279,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... Y2
-PLAN_ID .................. 212371182874716809
+PLAN_ID .................. 212372510744826272
 ROWS_OUT ................. 5
 EST_TOTAL_COST ........... 0
 STATEMENT ................ select *
@@ -1316,7 +1325,7 @@ DESCRIPTION
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... ON
   HBASE_MAX_NUM_SEARCH_KE  1
-  ObjectUIDs ............. 8861534267208414002
+  ObjectUIDs ............. 5892537540705208633
   select_list ............ TRAFODION.SCH.T010T2.A, %('a'),
                              TRAFODION.SCH.T010T2.C, TRAFODION.SCH.T010T2.D
   input_variables ........ %('a')
@@ -1337,6 +1346,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -1351,7 +1361,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... Y3
-PLAN_ID .................. 212371182874808020
+PLAN_ID .................. 212372510744914026
 ROWS_OUT ................. 4
 EST_TOTAL_COST ........... 0
 STATEMENT ................ select *
@@ -1396,7 +1406,7 @@ DESCRIPTION
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... ON
   HBASE_MAX_NUM_SEARCH_KE  1
-  ObjectUIDs ............. 8861534267208414002
+  ObjectUIDs ............. 5892537540705208633
   select_list ............ TRAFODION.SCH.T010T2.A, %('a'),
                              TRAFODION.SCH.T010T2.C, TRAFODION.SCH.T010T2.D
   input_variables ........ %('a')
@@ -1417,6 +1427,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -1431,7 +1442,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... Y4
-PLAN_ID .................. 212371182874909059
+PLAN_ID .................. 212372510744992870
 ROWS_OUT ................. 4
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ delete from t010t2
@@ -1476,7 +1487,7 @@ DESCRIPTION
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... ON
   HBASE_MAX_NUM_SEARCH_KE  1
-  ObjectUIDs ............. 8861534267208414002
+  ObjectUIDs ............. 5892537540705208633
   input_variables ........ %('a')
 
 
@@ -1525,6 +1536,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -1540,7 +1552,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... Y5
-PLAN_ID .................. 212371182875095004
+PLAN_ID .................. 212372510745170839
 ROWS_OUT ................. 2
 EST_TOTAL_COST ........... 0
 STATEMENT ................ update t010t2
@@ -1587,7 +1599,7 @@ DESCRIPTION
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... ON
   HBASE_MAX_NUM_SEARCH_KE  1
-  ObjectUIDs ............. 8861534267208414002
+  ObjectUIDs ............. 5892537540705208633
   input_variables ........ %('uuu'), %(4)
 
 
@@ -1764,7 +1776,7 @@ _SALT_      A            B           C            D
 >>invoke t010t1;
 
 -- Definition of Trafodion table TRAFODION.SCH.T010T1
--- Definition current  Sun Sep  3 07:15:05 2017
+-- Definition current  Mon Sep 18 16:06:13 2017
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -1777,7 +1789,7 @@ _SALT_      A            B           C            D
 >>invoke hbase."_CELL_"."TRAFODION.SCH.T010T1";
 
 -- Definition of Trafodion table HBASE."_CELL_"."TRAFODION.SCH.T010T1"
--- Definition current  Sun Sep  3 07:15:06 2017
+-- Definition current  Mon Sep 18 16:06:13 2017
 
   (
     ROW_ID                           VARCHAR(10) CHARACTER SET ISO88591 COLLATE
@@ -1796,7 +1808,7 @@ _SALT_      A            B           C            D
 >>invoke hbase."_ROW_"."TRAFODION.SCH.T010T1";
 
 -- Definition of Trafodion table HBASE."_ROW_"."TRAFODION.SCH.T010T1"
--- Definition current  Sun Sep  3 07:15:06 2017
+-- Definition current  Mon Sep 18 16:06:13 2017
 
   (
     ROW_ID                           VARCHAR(10) CHARACTER SET ISO88591 COLLATE
@@ -1927,7 +1939,7 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... XX
-PLAN_ID .................. 212371182907907658
+PLAN_ID .................. 212372510775355462
 ROWS_OUT ................ 11
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select * from t010t1 where a=1 or b='1';
@@ -1969,7 +1981,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... OFF
-  ObjectUIDs ............. 8861534267208417374
+  ObjectUIDs ............. 5892537540705211716
   select_list ............ TRAFODION.SCH.T010T1.A, TRAFODION.SCH.T010T1.B
 
 
@@ -1990,6 +2002,7 @@ DESCRIPTION
   begin_keys(incl)
   end_keys(incl)
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -2009,7 +2022,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... XX
-PLAN_ID .................. 212371182907988752
+PLAN_ID .................. 212372510775435387
 ROWS_OUT ................. 1
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select * from t010t1 where a=1 and b='1';
@@ -2052,7 +2065,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... OFF
-  ObjectUIDs ............. 8861534267208417374
+  ObjectUIDs ............. 5892537540705211716
   select_list ............ 1, '1'
 
 
@@ -2072,6 +2085,7 @@ DESCRIPTION
   columns ................ all
   unique_rows ............ 1
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed .......... 1
@@ -2090,7 +2104,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... XX
-PLAN_ID .................. 212371182908067727
+PLAN_ID .................. 212372510775513753
 ROWS_OUT ................ 10
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select * from t010t1 where b='1';
@@ -2132,7 +2146,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... OFF
-  ObjectUIDs ............. 8861534267208417374
+  ObjectUIDs ............. 5892537540705211716
   select_list ............ TRAFODION.SCH.T010T1.A, '1'
 
 
@@ -2153,6 +2167,7 @@ DESCRIPTION
   begin_keys(incl)
   end_keys(incl)
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -2171,7 +2186,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... XX
-PLAN_ID .................. 212371182908151747
+PLAN_ID .................. 212372510775595020
 ROWS_OUT ................. 1
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select * from t010t1 where a=1;
@@ -2214,7 +2229,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... OFF
-  ObjectUIDs ............. 8861534267208417374
+  ObjectUIDs ............. 5892537540705211716
   select_list ............ 1, TRAFODION.SCH.T010T1.B
 
 
@@ -2234,6 +2249,7 @@ DESCRIPTION
   columns ................ all
   unique_rows ............ 1
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed .......... 1
@@ -2476,7 +2492,7 @@ A            B           C            D
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... X1
-PLAN_ID .................. 212371182910444555
+PLAN_ID .................. 212372510777807806
 ROWS_OUT ................. 2
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select *
@@ -2520,7 +2536,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... OFF
-  ObjectUIDs ............. 8861534267208417710
+  ObjectUIDs ............. 5892537540705212102
   select_list ............ TRAFODION.SCH.T010T2.A, 'a', 1,
                              TRAFODION.SCH.T010T2.D
 
@@ -2542,6 +2558,7 @@ DESCRIPTION
   unique_rows ............ 1,a,1
   unique_rows ............ 4,a,1
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -2554,7 +2571,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... X2
-PLAN_ID .................. 212371182910487314
+PLAN_ID .................. 212372510777847080
 ROWS_OUT ................. 5
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select *
@@ -2599,7 +2616,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... OFF
-  ObjectUIDs ............. 8861534267208417710
+  ObjectUIDs ............. 5892537540705212102
   select_list ............ TRAFODION.SCH.T010T2.A, 'a', TRAFODION.SCH.T010T2.C,
                              TRAFODION.SCH.T010T2.D
 
@@ -2634,6 +2651,7 @@ DESCRIPTION
   begin_keys(incl) ....... 4,a,5
   end_keys(incl) ......... 4,a,2147483647
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -2646,7 +2664,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... X3
-PLAN_ID .................. 212371182910529822
+PLAN_ID .................. 212372510777884929
 ROWS_OUT ................. 4
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select *
@@ -2690,7 +2708,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... OFF
-  ObjectUIDs ............. 8861534267208417710
+  ObjectUIDs ............. 5892537540705212102
   select_list ............ TRAFODION.SCH.T010T2.A, 'a', TRAFODION.SCH.T010T2.C,
                              TRAFODION.SCH.T010T2.D
 
@@ -2716,6 +2734,7 @@ DESCRIPTION
   unique_rows ............ 4,a,1
   unique_rows ............ 4,a,3
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -2728,7 +2747,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... X4
-PLAN_ID .................. 212371182910574355
+PLAN_ID .................. 212372510777938513
 ROWS_OUT ................. 4
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ delete from t010t2
@@ -2772,7 +2791,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... OFF
-  ObjectUIDs ............. 8861534267208417710
+  ObjectUIDs ............. 5892537540705212102
 
 
 TUPLE_FLOW ================================  SEQ_NO 3        CHILDREN 1, 2
@@ -2826,6 +2845,7 @@ DESCRIPTION
   unique_rows ............ 6,a,1
   unique_rows ............ 6,a,3
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -2839,7 +2859,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... X5
-PLAN_ID .................. 212371182910674353
+PLAN_ID .................. 212372510778036529
 ROWS_OUT ................. 2
 EST_TOTAL_COST ........... 0
 STATEMENT ................ update t010t2
@@ -2885,7 +2905,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... OFF
-  ObjectUIDs ............. 8861534267208417710
+  ObjectUIDs ............. 5892537540705212102
 
 
 TRAFODION_UPDATE ==========================  SEQ_NO 1        NO CHILDREN
@@ -2915,7 +2935,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... Y1
-PLAN_ID .................. 212371182910760217
+PLAN_ID .................. 212372510778110007
 ROWS_OUT ................. 2
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select *
@@ -2960,7 +2980,7 @@ DESCRIPTION
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... OFF
   HBASE_MAX_NUM_SEARCH_KE  1
-  ObjectUIDs ............. 8861534267208417710
+  ObjectUIDs ............. 5892537540705212102
   select_list ............ TRAFODION.SCH.T010T2.A, 'a', 1,
                              TRAFODION.SCH.T010T2.D
 
@@ -2982,6 +3002,7 @@ DESCRIPTION
   begin_keys(incl)
   end_keys(incl)
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -2995,7 +3016,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... Y2
-PLAN_ID .................. 212371182910801321
+PLAN_ID .................. 212372510778154911
 ROWS_OUT ................. 5
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select *
@@ -3041,7 +3062,7 @@ DESCRIPTION
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... OFF
   HBASE_MAX_NUM_SEARCH_KE  1
-  ObjectUIDs ............. 8861534267208417710
+  ObjectUIDs ............. 5892537540705212102
   select_list ............ TRAFODION.SCH.T010T2.A, 'a', TRAFODION.SCH.T010T2.C,
                              TRAFODION.SCH.T010T2.D
 
@@ -3063,6 +3084,7 @@ DESCRIPTION
   begin_keys(incl)
   end_keys(incl)
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -3077,7 +3099,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... Y3
-PLAN_ID .................. 212371182910844058
+PLAN_ID .................. 212372510778204183
 ROWS_OUT ................. 4
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select *
@@ -3122,7 +3144,7 @@ DESCRIPTION
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... OFF
   HBASE_MAX_NUM_SEARCH_KE  1
-  ObjectUIDs ............. 8861534267208417710
+  ObjectUIDs ............. 5892537540705212102
   select_list ............ TRAFODION.SCH.T010T2.A, 'a', TRAFODION.SCH.T010T2.C,
                              TRAFODION.SCH.T010T2.D
 
@@ -3144,6 +3166,7 @@ DESCRIPTION
   begin_keys(incl)
   end_keys(incl)
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -3158,7 +3181,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... Y4
-PLAN_ID .................. 212371182910894572
+PLAN_ID .................. 212372510778249743
 ROWS_OUT ................. 4
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ delete from t010t2
@@ -3203,7 +3226,7 @@ DESCRIPTION
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... OFF
   HBASE_MAX_NUM_SEARCH_KE  1
-  ObjectUIDs ............. 8861534267208417710
+  ObjectUIDs ............. 5892537540705212102
 
 
 TUPLE_FLOW ================================  SEQ_NO 3        CHILDREN 1, 2
@@ -3253,6 +3276,7 @@ DESCRIPTION
   begin_keys(incl)
   end_keys(incl)
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -3267,7 +3291,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... Y5
-PLAN_ID .................. 212371182910991800
+PLAN_ID .................. 212372510778336974
 ROWS_OUT ................. 2
 EST_TOTAL_COST ........... 0
 STATEMENT ................ update t010t2
@@ -3314,7 +3338,7 @@ DESCRIPTION
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... OFF
   HBASE_MAX_NUM_SEARCH_KE  1
-  ObjectUIDs ............. 8861534267208417710
+  ObjectUIDs ............. 5892537540705212102
 
 
 TRAFODION_UPDATE ==========================  SEQ_NO 1        NO CHILDREN
@@ -3491,7 +3515,7 @@ _SALT_      A            B           C            D
 >>invoke t010t1;
 
 -- Definition of Trafodion table TRAFODION.SCH.T010T1
--- Definition current  Sun Sep  3 07:15:35 2017
+-- Definition current  Mon Sep 18 16:06:48 2017
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -3504,7 +3528,7 @@ _SALT_      A            B           C            D
 >>invoke hbase."_CELL_"."TRAFODION.SCH.T010T1";
 
 -- Definition of Trafodion table HBASE."_CELL_"."TRAFODION.SCH.T010T1"
--- Definition current  Sun Sep  3 07:15:35 2017
+-- Definition current  Mon Sep 18 16:06:48 2017
 
   (
     ROW_ID                           VARCHAR(10) CHARACTER SET ISO88591 COLLATE
@@ -3523,7 +3547,7 @@ _SALT_      A            B           C            D
 >>invoke hbase."_ROW_"."TRAFODION.SCH.T010T1";
 
 -- Definition of Trafodion table HBASE."_ROW_"."TRAFODION.SCH.T010T1"
--- Definition current  Sun Sep  3 07:15:36 2017
+-- Definition current  Mon Sep 18 16:06:49 2017
 
   (
     ROW_ID                           VARCHAR(10) CHARACTER SET ISO88591 COLLATE
@@ -3654,7 +3678,7 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... XX
-PLAN_ID .................. 212371182937604679
+PLAN_ID .................. 212372510810689778
 ROWS_OUT ................ 11
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select * from t010t1 where a=1 or b='1';
@@ -3696,7 +3720,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... OFF
-  ObjectUIDs ............. 8861534267208420341
+  ObjectUIDs ............. 5892537540705215251
   select_list ............ TRAFODION.SCH.T010T1.A, TRAFODION.SCH.T010T1.B
 
 
@@ -3717,6 +3741,7 @@ DESCRIPTION
   begin_keys(incl)
   end_keys(incl)
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -3736,7 +3761,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... XX
-PLAN_ID .................. 212371182937724275
+PLAN_ID .................. 212372510810785182
 ROWS_OUT ................. 1
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select * from t010t1 where a=1 and b='1';
@@ -3779,7 +3804,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... OFF
-  ObjectUIDs ............. 8861534267208420341
+  ObjectUIDs ............. 5892537540705215251
   select_list ............ %(1), %('1')
   input_variables ........ %(1), %('1')
 
@@ -3798,6 +3823,7 @@ DESCRIPTION
   scan_type .............. subset scan of table TRAFODION.SCH.T010T1
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed .......... 1
@@ -3818,7 +3844,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... XX
-PLAN_ID .................. 212371182937835572
+PLAN_ID .................. 212372510810887577
 ROWS_OUT ................ 10
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select * from t010t1 where b='1';
@@ -3860,7 +3886,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... OFF
-  ObjectUIDs ............. 8861534267208420341
+  ObjectUIDs ............. 5892537540705215251
   select_list ............ TRAFODION.SCH.T010T1.A, %('1')
   input_variables ........ %('1')
 
@@ -3882,6 +3908,7 @@ DESCRIPTION
   begin_keys(incl)
   end_keys(incl)
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -3900,7 +3927,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... XX
-PLAN_ID .................. 212371182936838415
+PLAN_ID .................. 212372510809929666
 ROWS_OUT ................. 1
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select * from t010t1 where a = 2;
@@ -3943,7 +3970,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... OFF
-  ObjectUIDs ............. 8861534267208420341
+  ObjectUIDs ............. 5892537540705215251
   select_list ............ %(2), TRAFODION.SCH.T010T1.B
   input_variables ........ %(2)
 
@@ -3962,6 +3989,7 @@ DESCRIPTION
   scan_type .............. subset scan of table TRAFODION.SCH.T010T1
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed .......... 1
@@ -4206,7 +4234,7 @@ A            B           C            D
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... X1
-PLAN_ID .................. 212371182940175352
+PLAN_ID .................. 212372510813424935
 ROWS_OUT ................. 2
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select *
@@ -4250,7 +4278,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... OFF
-  ObjectUIDs ............. 8861534267208420692
+  ObjectUIDs ............. 5892537540705215610
   select_list ............ TRAFODION.SCH.T010T2.A, %('a'), %(1),
                              TRAFODION.SCH.T010T2.D
   input_variables ........ %('a'), %(1)
@@ -4270,6 +4298,7 @@ DESCRIPTION
   scan_type .............. subset scan of table TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -4285,7 +4314,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... X2
-PLAN_ID .................. 212371182940212922
+PLAN_ID .................. 212372510813467701
 ROWS_OUT ................. 5
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select *
@@ -4330,7 +4359,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... OFF
-  ObjectUIDs ............. 8861534267208420692
+  ObjectUIDs ............. 5892537540705215610
   select_list ............ TRAFODION.SCH.T010T2.A, %('a'),
                              TRAFODION.SCH.T010T2.C, TRAFODION.SCH.T010T2.D
   input_variables ........ %('a')
@@ -4350,6 +4379,7 @@ DESCRIPTION
   scan_type .............. subset scan of table TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -4366,7 +4396,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... X3
-PLAN_ID .................. 212371182940255134
+PLAN_ID .................. 212372510813513582
 ROWS_OUT ................. 4
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select *
@@ -4410,7 +4440,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... OFF
-  ObjectUIDs ............. 8861534267208420692
+  ObjectUIDs ............. 5892537540705215610
   select_list ............ TRAFODION.SCH.T010T2.A, %('a'),
                              TRAFODION.SCH.T010T2.C, TRAFODION.SCH.T010T2.D
   input_variables ........ %('a')
@@ -4430,6 +4460,7 @@ DESCRIPTION
   scan_type .............. subset scan of table TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -4446,7 +4477,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... X4
-PLAN_ID .................. 212371182940306145
+PLAN_ID .................. 212372510813555013
 ROWS_OUT ................. 4
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ delete from t010t2
@@ -4490,7 +4521,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... OFF
-  ObjectUIDs ............. 8861534267208420692
+  ObjectUIDs ............. 5892537540705215610
   input_variables ........ %('a')
 
 
@@ -4538,6 +4569,7 @@ DESCRIPTION
   scan_type .............. subset scan of table TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -4554,7 +4586,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... X5
-PLAN_ID .................. 212371182940487507
+PLAN_ID .................. 212372510813664352
 ROWS_OUT ................. 2
 EST_TOTAL_COST ........... 0
 STATEMENT ................ update t010t2
@@ -4600,7 +4632,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... OFF
-  ObjectUIDs ............. 8861534267208420692
+  ObjectUIDs ............. 5892537540705215610
   input_variables ........ %('upd'), %(4)
 
 
@@ -4627,7 +4659,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... Y1
-PLAN_ID .................. 212371182940578372
+PLAN_ID .................. 212372510813764883
 ROWS_OUT ................. 2
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select *
@@ -4672,7 +4704,7 @@ DESCRIPTION
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... OFF
   HBASE_MAX_NUM_SEARCH_KE  1
-  ObjectUIDs ............. 8861534267208420692
+  ObjectUIDs ............. 5892537540705215610
   select_list ............ TRAFODION.SCH.T010T2.A, %('a'), %(1),
                              TRAFODION.SCH.T010T2.D
   input_variables ........ %('a'), %(1)
@@ -4692,6 +4724,7 @@ DESCRIPTION
   scan_type .............. subset scan of table TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -4707,7 +4740,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... Y2
-PLAN_ID .................. 212371182940619202
+PLAN_ID .................. 212372510813822752
 ROWS_OUT ................. 5
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select *
@@ -4753,7 +4786,7 @@ DESCRIPTION
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... OFF
   HBASE_MAX_NUM_SEARCH_KE  1
-  ObjectUIDs ............. 8861534267208420692
+  ObjectUIDs ............. 5892537540705215610
   select_list ............ TRAFODION.SCH.T010T2.A, %('a'),
                              TRAFODION.SCH.T010T2.C, TRAFODION.SCH.T010T2.D
   input_variables ........ %('a')
@@ -4773,6 +4806,7 @@ DESCRIPTION
   scan_type .............. subset scan of table TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -4789,7 +4823,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... Y3
-PLAN_ID .................. 212371182940658230
+PLAN_ID .................. 212372510813873480
 ROWS_OUT ................. 4
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select *
@@ -4834,7 +4868,7 @@ DESCRIPTION
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... OFF
   HBASE_MAX_NUM_SEARCH_KE  1
-  ObjectUIDs ............. 8861534267208420692
+  ObjectUIDs ............. 5892537540705215610
   select_list ............ TRAFODION.SCH.T010T2.A, %('a'),
                              TRAFODION.SCH.T010T2.C, TRAFODION.SCH.T010T2.D
   input_variables ........ %('a')
@@ -4854,6 +4888,7 @@ DESCRIPTION
   scan_type .............. subset scan of table TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -4870,7 +4905,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... Y4
-PLAN_ID .................. 212371182940708419
+PLAN_ID .................. 212372510813926991
 ROWS_OUT ................. 4
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ delete from t010t2
@@ -4915,7 +4950,7 @@ DESCRIPTION
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... OFF
   HBASE_MAX_NUM_SEARCH_KE  1
-  ObjectUIDs ............. 8861534267208420692
+  ObjectUIDs ............. 5892537540705215610
   input_variables ........ %('a')
 
 
@@ -4963,6 +4998,7 @@ DESCRIPTION
   scan_type .............. subset scan of table TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -4979,7 +5015,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... Y5
-PLAN_ID .................. 212371182940807391
+PLAN_ID .................. 212372510814057803
 ROWS_OUT ................. 2
 EST_TOTAL_COST ........... 0
 STATEMENT ................ update t010t2
@@ -5026,7 +5062,7 @@ DESCRIPTION
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... OFF
   HBASE_MAX_NUM_SEARCH_KE  1
-  ObjectUIDs ............. 8861534267208420692
+  ObjectUIDs ............. 5892537540705215610
   input_variables ........ %('uuu'), %(4)
 
 
@@ -5203,7 +5239,7 @@ _SALT_      A            B           C            D
 >>invoke t010t1;
 
 -- Definition of Trafodion table TRAFODION.SCH.T010T1
--- Definition current  Sun Sep  3 07:16:06 2017
+-- Definition current  Mon Sep 18 16:07:19 2017
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -5216,7 +5252,7 @@ _SALT_      A            B           C            D
 >>invoke hbase."_CELL_"."TRAFODION.SCH.T010T1";
 
 -- Definition of Trafodion table HBASE."_CELL_"."TRAFODION.SCH.T010T1"
--- Definition current  Sun Sep  3 07:16:06 2017
+-- Definition current  Mon Sep 18 16:07:19 2017
 
   (
     ROW_ID                           VARCHAR(10) CHARACTER SET ISO88591 COLLATE
@@ -5235,7 +5271,7 @@ _SALT_      A            B           C            D
 >>invoke hbase."_ROW_"."TRAFODION.SCH.T010T1";
 
 -- Definition of Trafodion table HBASE."_ROW_"."TRAFODION.SCH.T010T1"
--- Definition current  Sun Sep  3 07:16:07 2017
+-- Definition current  Mon Sep 18 16:07:20 2017
 
   (
     ROW_ID                           VARCHAR(10) CHARACTER SET ISO88591 COLLATE
@@ -5366,7 +5402,7 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... XX
-PLAN_ID .................. 212371182968766991
+PLAN_ID .................. 212372510841638220
 ROWS_OUT ................ 11
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select * from t010t1 where a=1 or b='1';
@@ -5408,7 +5444,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208423369
+  ObjectUIDs ............. 5892537540705218307
   select_list ............ TRAFODION.SCH.T010T1.A, TRAFODION.SCH.T010T1.B
 
 
@@ -5429,6 +5465,7 @@ DESCRIPTION
   begin_keys(incl)
   end_keys(incl)
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -5448,7 +5485,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... XX
-PLAN_ID .................. 212371182968849794
+PLAN_ID .................. 212372510841720052
 ROWS_OUT ................. 1
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select * from t010t1 where a=1 and b='1';
@@ -5491,7 +5528,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208423369
+  ObjectUIDs ............. 5892537540705218307
   select_list ............ 1, '1'
 
 
@@ -5511,6 +5548,7 @@ DESCRIPTION
   columns ................ all
   unique_rows ............ 1
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed .......... 1
@@ -5529,7 +5567,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... XX
-PLAN_ID .................. 212371182968944690
+PLAN_ID .................. 212372510841806680
 ROWS_OUT ................ 10
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select * from t010t1 where b='1';
@@ -5571,7 +5609,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208423369
+  ObjectUIDs ............. 5892537540705218307
   select_list ............ TRAFODION.SCH.T010T1.A, '1'
 
 
@@ -5592,6 +5630,7 @@ DESCRIPTION
   begin_keys(incl)
   end_keys(incl)
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -5610,7 +5649,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... XX
-PLAN_ID .................. 212371182969035632
+PLAN_ID .................. 212372510841894956
 ROWS_OUT ................. 1
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select * from t010t1 where a=1;
@@ -5653,7 +5692,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208423369
+  ObjectUIDs ............. 5892537540705218307
   select_list ............ 1, TRAFODION.SCH.T010T1.B
 
 
@@ -5673,6 +5712,7 @@ DESCRIPTION
   columns ................ all
   unique_rows ............ 1
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed .......... 1
@@ -5915,7 +5955,7 @@ A            B           C            D
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... X1
-PLAN_ID .................. 212371182971295321
+PLAN_ID .................. 212372510844145441
 ROWS_OUT ................. 2
 EST_TOTAL_COST ........... 0
 STATEMENT ................ select *
@@ -5959,7 +5999,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208423734
+  ObjectUIDs ............. 5892537540705218678
   select_list ............ TRAFODION.SCH.T010T2.A, 'a', 1,
                              TRAFODION.SCH.T010T2.D
 
@@ -5979,6 +6019,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -5992,7 +6033,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... X2
-PLAN_ID .................. 212371182971376208
+PLAN_ID .................. 212372510844225191
 ROWS_OUT ................. 5
 EST_TOTAL_COST ........... 0
 STATEMENT ................ select *
@@ -6037,7 +6078,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208423734
+  ObjectUIDs ............. 5892537540705218678
   select_list ............ TRAFODION.SCH.T010T2.A, 'a', TRAFODION.SCH.T010T2.C,
                              TRAFODION.SCH.T010T2.D
 
@@ -6057,6 +6098,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -6071,7 +6113,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... X3
-PLAN_ID .................. 212371182971470942
+PLAN_ID .................. 212372510844303373
 ROWS_OUT ................. 4
 EST_TOTAL_COST ........... 0
 STATEMENT ................ select *
@@ -6115,7 +6157,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208423734
+  ObjectUIDs ............. 5892537540705218678
   select_list ............ TRAFODION.SCH.T010T2.A, 'a', TRAFODION.SCH.T010T2.C,
                              TRAFODION.SCH.T010T2.D
 
@@ -6135,6 +6177,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -6149,7 +6192,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... X4
-PLAN_ID .................. 212371182971557639
+PLAN_ID .................. 212372510844389798
 ROWS_OUT ................. 4
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ delete from t010t2
@@ -6193,7 +6236,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208423734
+  ObjectUIDs ............. 5892537540705218678
 
 
 TUPLE_FLOW ================================  SEQ_NO 3        CHILDREN 1, 2
@@ -6241,6 +6284,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -6256,7 +6300,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... X5
-PLAN_ID .................. 212371182971723888
+PLAN_ID .................. 212372510844550022
 ROWS_OUT ................. 2
 EST_TOTAL_COST ........... 0
 STATEMENT ................ update t010t2
@@ -6302,7 +6346,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  OFF
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208423734
+  ObjectUIDs ............. 5892537540705218678
 
 
 TRAFODION_UPDATE ==========================  SEQ_NO 1        NO CHILDREN
@@ -6332,7 +6376,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... Y1
-PLAN_ID .................. 212371182971801817
+PLAN_ID .................. 212372510844652886
 ROWS_OUT ................. 2
 EST_TOTAL_COST ........... 0
 STATEMENT ................ select *
@@ -6377,7 +6421,7 @@ DESCRIPTION
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... ON
   HBASE_MAX_NUM_SEARCH_KE  1
-  ObjectUIDs ............. 8861534267208423734
+  ObjectUIDs ............. 5892537540705218678
   select_list ............ TRAFODION.SCH.T010T2.A, 'a', 1,
                              TRAFODION.SCH.T010T2.D
 
@@ -6397,6 +6441,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -6410,7 +6455,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... Y2
-PLAN_ID .................. 212371182971866281
+PLAN_ID .................. 212372510844727465
 ROWS_OUT ................. 5
 EST_TOTAL_COST ........... 0
 STATEMENT ................ select *
@@ -6456,7 +6501,7 @@ DESCRIPTION
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... ON
   HBASE_MAX_NUM_SEARCH_KE  1
-  ObjectUIDs ............. 8861534267208423734
+  ObjectUIDs ............. 5892537540705218678
   select_list ............ TRAFODION.SCH.T010T2.A, 'a', TRAFODION.SCH.T010T2.C,
                              TRAFODION.SCH.T010T2.D
 
@@ -6476,6 +6521,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -6490,7 +6536,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... Y3
-PLAN_ID .................. 212371182971954454
+PLAN_ID .................. 212372510844821878
 ROWS_OUT ................. 4
 EST_TOTAL_COST ........... 0
 STATEMENT ................ select *
@@ -6535,7 +6581,7 @@ DESCRIPTION
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... ON
   HBASE_MAX_NUM_SEARCH_KE  1
-  ObjectUIDs ............. 8861534267208423734
+  ObjectUIDs ............. 5892537540705218678
   select_list ............ TRAFODION.SCH.T010T2.A, 'a', TRAFODION.SCH.T010T2.C,
                              TRAFODION.SCH.T010T2.D
 
@@ -6555,6 +6601,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -6569,7 +6616,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... Y4
-PLAN_ID .................. 212371182972078318
+PLAN_ID .................. 212372510844904137
 ROWS_OUT ................. 4
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ delete from t010t2
@@ -6614,7 +6661,7 @@ DESCRIPTION
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... ON
   HBASE_MAX_NUM_SEARCH_KE  1
-  ObjectUIDs ............. 8861534267208423734
+  ObjectUIDs ............. 5892537540705218678
 
 
 TUPLE_FLOW ================================  SEQ_NO 3        CHILDREN 1, 2
@@ -6662,6 +6709,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -6677,7 +6725,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... Y5
-PLAN_ID .................. 212371182972263598
+PLAN_ID .................. 212372510845062874
 ROWS_OUT ................. 2
 EST_TOTAL_COST ........... 0
 STATEMENT ................ update t010t2
@@ -6724,7 +6772,7 @@ DESCRIPTION
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... ON
   HBASE_MAX_NUM_SEARCH_KE  1
-  ObjectUIDs ............. 8861534267208423734
+  ObjectUIDs ............. 5892537540705218678
 
 
 TRAFODION_UPDATE ==========================  SEQ_NO 1        NO CHILDREN
@@ -6924,7 +6972,7 @@ _SALT_      A            B           C            D
 >>invoke t010t1;
 
 -- Definition of Trafodion table TRAFODION.SCH.T010T1
--- Definition current  Sun Sep  3 07:16:38 2017
+-- Definition current  Mon Sep 18 16:07:54 2017
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -6937,7 +6985,7 @@ _SALT_      A            B           C            D
 >>invoke hbase."_CELL_"."TRAFODION.SCH.T010T1";
 
 -- Definition of Trafodion table HBASE."_CELL_"."TRAFODION.SCH.T010T1"
--- Definition current  Sun Sep  3 07:16:38 2017
+-- Definition current  Mon Sep 18 16:07:54 2017
 
   (
     ROW_ID                           VARCHAR(10) CHARACTER SET ISO88591 COLLATE
@@ -6956,7 +7004,7 @@ _SALT_      A            B           C            D
 >>invoke hbase."_ROW_"."TRAFODION.SCH.T010T1";
 
 -- Definition of Trafodion table HBASE."_ROW_"."TRAFODION.SCH.T010T1"
--- Definition current  Sun Sep  3 07:16:39 2017
+-- Definition current  Mon Sep 18 16:07:54 2017
 
   (
     ROW_ID                           VARCHAR(10) CHARACTER SET ISO88591 COLLATE
@@ -7087,7 +7135,7 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... XX
-PLAN_ID .................. 212371183000667659
+PLAN_ID .................. 212372510876531459
 ROWS_OUT ................ 11
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select * from t010t1 where a=1 or b='1';
@@ -7129,7 +7177,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  ON
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208426637
+  ObjectUIDs ............. 5892537540705221801
   select_list ............ TRAFODION.SCH.T010T1.A, TRAFODION.SCH.T010T1.B
 
 
@@ -7150,6 +7198,7 @@ DESCRIPTION
   begin_keys(incl)
   end_keys(incl)
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -7169,7 +7218,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... XX
-PLAN_ID .................. 212371183000746918
+PLAN_ID .................. 212372510876627518
 ROWS_OUT ................. 1
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select * from t010t1 where a=1 and b='1';
@@ -7212,7 +7261,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  ON
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208426637
+  ObjectUIDs ............. 5892537540705221801
   select_list ............ %(1), %('1')
   input_variables ........ %(1), %('1')
 
@@ -7231,6 +7280,7 @@ DESCRIPTION
   scan_type .............. subset scan of table TRAFODION.SCH.T010T1
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed .......... 1
@@ -7251,7 +7301,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... XX
-PLAN_ID .................. 212371183000843568
+PLAN_ID .................. 212372510876720520
 ROWS_OUT ................ 10
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select * from t010t1 where b='1';
@@ -7293,7 +7343,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  ON
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208426637
+  ObjectUIDs ............. 5892537540705221801
   select_list ............ TRAFODION.SCH.T010T1.A, %('1')
   input_variables ........ %('1')
 
@@ -7315,6 +7365,7 @@ DESCRIPTION
   begin_keys(incl)
   end_keys(incl)
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -7333,7 +7384,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... XX
-PLAN_ID .................. 212371182999882511
+PLAN_ID .................. 212372510875730083
 ROWS_OUT ................. 1
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select * from t010t1 where a = 2;
@@ -7376,7 +7427,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  ON
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208426637
+  ObjectUIDs ............. 5892537540705221801
   select_list ............ %(2), TRAFODION.SCH.T010T1.B
   input_variables ........ %(2)
 
@@ -7395,6 +7446,7 @@ DESCRIPTION
   scan_type .............. subset scan of table TRAFODION.SCH.T010T1
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed .......... 1
@@ -7639,7 +7691,7 @@ A            B           C            D
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... X1
-PLAN_ID .................. 212371183003187666
+PLAN_ID .................. 212372510879119333
 ROWS_OUT ................. 2
 EST_TOTAL_COST ........... 0
 STATEMENT ................ select *
@@ -7683,7 +7735,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  ON
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208427012
+  ObjectUIDs ............. 5892537540705222172
   select_list ............ TRAFODION.SCH.T010T2.A, %('a'), %(1),
                              TRAFODION.SCH.T010T2.D
   input_variables ........ %('a'), %(1)
@@ -7704,6 +7756,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -7717,7 +7770,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... X2
-PLAN_ID .................. 212371183003254442
+PLAN_ID .................. 212372510879194787
 ROWS_OUT ................. 5
 EST_TOTAL_COST ........... 0
 STATEMENT ................ select *
@@ -7762,7 +7815,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  ON
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208427012
+  ObjectUIDs ............. 5892537540705222172
   select_list ............ TRAFODION.SCH.T010T2.A, %('a'),
                              TRAFODION.SCH.T010T2.C, TRAFODION.SCH.T010T2.D
   input_variables ........ %('a')
@@ -7783,6 +7836,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -7797,7 +7851,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... X3
-PLAN_ID .................. 212371183003341083
+PLAN_ID .................. 212372510879281025
 ROWS_OUT ................. 4
 EST_TOTAL_COST ........... 0
 STATEMENT ................ select *
@@ -7841,7 +7895,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  ON
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208427012
+  ObjectUIDs ............. 5892537540705222172
   select_list ............ TRAFODION.SCH.T010T2.A, %('a'),
                              TRAFODION.SCH.T010T2.C, TRAFODION.SCH.T010T2.D
   input_variables ........ %('a')
@@ -7862,6 +7916,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -7876,7 +7931,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... X4
-PLAN_ID .................. 212371183003439919
+PLAN_ID .................. 212372510879367346
 ROWS_OUT ................. 4
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ delete from t010t2
@@ -7920,7 +7975,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  ON
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208427012
+  ObjectUIDs ............. 5892537540705222172
   input_variables ........ %('a')
 
 
@@ -7969,6 +8024,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -7984,7 +8040,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... X5
-PLAN_ID .................. 212371183003603752
+PLAN_ID .................. 212372510879523505
 ROWS_OUT ................. 2
 EST_TOTAL_COST ........... 0
 STATEMENT ................ update t010t2
@@ -8030,7 +8086,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  ON
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208427012
+  ObjectUIDs ............. 5892537540705222172
   input_variables ........ %('upd'), %(4)
 
 
@@ -8057,7 +8113,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... Y1
-PLAN_ID .................. 212371183003680166
+PLAN_ID .................. 212372510879601502
 ROWS_OUT ................. 2
 EST_TOTAL_COST ........... 0
 STATEMENT ................ select *
@@ -8102,7 +8158,7 @@ DESCRIPTION
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... ON
   HBASE_MAX_NUM_SEARCH_KE  1
-  ObjectUIDs ............. 8861534267208427012
+  ObjectUIDs ............. 5892537540705222172
   select_list ............ TRAFODION.SCH.T010T2.A, %('a'), %(1),
                              TRAFODION.SCH.T010T2.D
   input_variables ........ %('a'), %(1)
@@ -8123,6 +8179,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -8136,7 +8193,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... Y2
-PLAN_ID .................. 212371183003746360
+PLAN_ID .................. 212372510879671371
 ROWS_OUT ................. 5
 EST_TOTAL_COST ........... 0
 STATEMENT ................ select *
@@ -8182,7 +8239,7 @@ DESCRIPTION
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... ON
   HBASE_MAX_NUM_SEARCH_KE  1
-  ObjectUIDs ............. 8861534267208427012
+  ObjectUIDs ............. 5892537540705222172
   select_list ............ TRAFODION.SCH.T010T2.A, %('a'),
                              TRAFODION.SCH.T010T2.C, TRAFODION.SCH.T010T2.D
   input_variables ........ %('a')
@@ -8203,6 +8260,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -8217,7 +8275,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... Y3
-PLAN_ID .................. 212371183003819034
+PLAN_ID .................. 212372510879752056
 ROWS_OUT ................. 4
 EST_TOTAL_COST ........... 0
 STATEMENT ................ select *
@@ -8262,7 +8320,7 @@ DESCRIPTION
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... ON
   HBASE_MAX_NUM_SEARCH_KE  1
-  ObjectUIDs ............. 8861534267208427012
+  ObjectUIDs ............. 5892537540705222172
   select_list ............ TRAFODION.SCH.T010T2.A, %('a'),
                              TRAFODION.SCH.T010T2.C, TRAFODION.SCH.T010T2.D
   input_variables ........ %('a')
@@ -8283,6 +8341,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -8297,7 +8356,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... Y4
-PLAN_ID .................. 212371183003896976
+PLAN_ID .................. 212372510879838549
 ROWS_OUT ................. 4
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ delete from t010t2
@@ -8342,7 +8401,7 @@ DESCRIPTION
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... ON
   HBASE_MAX_NUM_SEARCH_KE  1
-  ObjectUIDs ............. 8861534267208427012
+  ObjectUIDs ............. 5892537540705222172
   input_variables ........ %('a')
 
 
@@ -8391,6 +8450,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -8406,7 +8466,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... Y5
-PLAN_ID .................. 212371183004084054
+PLAN_ID .................. 212372510880023918
 ROWS_OUT ................. 2
 EST_TOTAL_COST ........... 0
 STATEMENT ................ update t010t2
@@ -8453,7 +8513,7 @@ DESCRIPTION
   QUERY_CACHE ........ 1,024
   MDAM_SCAN_METHOD ....... ON
   HBASE_MAX_NUM_SEARCH_KE  1
-  ObjectUIDs ............. 8861534267208427012
+  ObjectUIDs ............. 5892537540705222172
   input_variables ........ %('uuu'), %(4)
 
 
@@ -8630,7 +8690,7 @@ _SALT_      A            B           C            D
 >>invoke t010t1;
 
 -- Definition of Trafodion table TRAFODION.SCH.T010T1
--- Definition current  Sun Sep  3 07:17:14 2017
+-- Definition current  Mon Sep 18 16:08:26 2017
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -8643,7 +8703,7 @@ _SALT_      A            B           C            D
 >>invoke hbase."_CELL_"."TRAFODION.SCH.T010T1";
 
 -- Definition of Trafodion table HBASE."_CELL_"."TRAFODION.SCH.T010T1"
--- Definition current  Sun Sep  3 07:17:14 2017
+-- Definition current  Mon Sep 18 16:08:26 2017
 
   (
     ROW_ID                           VARCHAR(10) CHARACTER SET ISO88591 COLLATE
@@ -8662,7 +8722,7 @@ _SALT_      A            B           C            D
 >>invoke hbase."_ROW_"."TRAFODION.SCH.T010T1";
 
 -- Definition of Trafodion table HBASE."_ROW_"."TRAFODION.SCH.T010T1"
--- Definition current  Sun Sep  3 07:17:15 2017
+-- Definition current  Mon Sep 18 16:08:26 2017
 
   (
     ROW_ID                           VARCHAR(10) CHARACTER SET ISO88591 COLLATE
@@ -8793,7 +8853,7 @@ LC   RC   OP   OPERATOR              OPT       DESCRIPTION           CARD
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... XX
-PLAN_ID .................. 212371183036758320
+PLAN_ID .................. 212372510908567185
 ROWS_OUT ................ 11
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select * from t010t1 where a=1 or b='1';
@@ -8835,7 +8895,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  ON
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208430253
+  ObjectUIDs ............. 5892537540705224879
   select_list ............ TRAFODION.SCH.T010T1.A, TRAFODION.SCH.T010T1.B
 
 
@@ -8856,6 +8916,7 @@ DESCRIPTION
   begin_keys(incl)
   end_keys(incl)
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -8875,7 +8936,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... XX
-PLAN_ID .................. 212371183036836349
+PLAN_ID .................. 212372510908658564
 ROWS_OUT ................. 1
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select * from t010t1 where a=1 and b='1';
@@ -8918,7 +8979,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  ON
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208430253
+  ObjectUIDs ............. 5892537540705224879
   select_list ............ 1, '1'
 
 
@@ -8938,6 +8999,7 @@ DESCRIPTION
   columns ................ all
   unique_rows ............ 1
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed .......... 1
@@ -8956,7 +9018,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... XX
-PLAN_ID .................. 212371183036917671
+PLAN_ID .................. 212372510908738883
 ROWS_OUT ................ 10
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select * from t010t1 where b='1';
@@ -8998,7 +9060,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  ON
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208430253
+  ObjectUIDs ............. 5892537540705224879
   select_list ............ TRAFODION.SCH.T010T1.A, '1'
 
 
@@ -9019,6 +9081,7 @@ DESCRIPTION
   begin_keys(incl)
   end_keys(incl)
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -9037,7 +9100,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... XX
-PLAN_ID .................. 212371183036997130
+PLAN_ID .................. 212372510908850085
 ROWS_OUT ................. 1
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select * from t010t1 where a=1;
@@ -9080,7 +9143,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  ON
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208430253
+  ObjectUIDs ............. 5892537540705224879
   select_list ............ 1, TRAFODION.SCH.T010T1.B
 
 
@@ -9100,6 +9163,7 @@ DESCRIPTION
   columns ................ all
   unique_rows ............ 1
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed .......... 1
@@ -9342,7 +9406,7 @@ A            B           C            D
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... X1
-PLAN_ID .................. 212371183039142934
+PLAN_ID .................. 212372510911141353
 ROWS_OUT ................. 2
 EST_TOTAL_COST ........... 0
 STATEMENT ................ select *
@@ -9386,7 +9450,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  ON
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208430622
+  ObjectUIDs ............. 5892537540705225268
   select_list ............ TRAFODION.SCH.T010T2.A, 'a', 1,
                              TRAFODION.SCH.T010T2.D
 
@@ -9406,6 +9470,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -9419,7 +9484,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... X2
-PLAN_ID .................. 212371183039200317
+PLAN_ID .................. 212372510911228720
 ROWS_OUT ................. 5
 EST_TOTAL_COST ........... 0
 STATEMENT ................ select *
@@ -9464,7 +9529,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  ON
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208430622
+  ObjectUIDs ............. 5892537540705225268
   select_list ............ TRAFODION.SCH.T010T2.A, 'a', TRAFODION.SCH.T010T2.C,
                              TRAFODION.SCH.T010T2.D
 
@@ -9484,6 +9549,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -9498,7 +9564,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... X3
-PLAN_ID .................. 212371183039291236
+PLAN_ID .................. 212372510911309816
 ROWS_OUT ................. 4
 EST_TOTAL_COST ........... 0
 STATEMENT ................ select *
@@ -9542,7 +9608,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  ON
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208430622
+  ObjectUIDs ............. 5892537540705225268
   select_list ............ TRAFODION.SCH.T010T2.A, 'a', TRAFODION.SCH.T010T2.C,
                              TRAFODION.SCH.T010T2.D
 
@@ -9562,6 +9628,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -9576,7 +9643,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... X4
-PLAN_ID .................. 212371183039376851
+PLAN_ID .................. 212372510911393357
 ROWS_OUT ................. 4
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ delete from t010t2
@@ -9620,7 +9687,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  ON
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208430622
+  ObjectUIDs ............. 5892537540705225268
 
 
 TUPLE_FLOW ================================  SEQ_NO 3        CHILDREN 1, 2
@@ -9668,6 +9735,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -9683,7 +9751,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... X5
-PLAN_ID .................. 212371183039557017
+PLAN_ID .................. 212372510911545518
 ROWS_OUT ................. 2
 EST_TOTAL_COST ........... 0
 STATEMENT ................ update t010t2
@@ -9729,7 +9797,7 @@ DESCRIPTION
   TRAF_ALIGNED_ROW_FORMAT  ON
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... ON
-  ObjectUIDs ............. 8861534267208430622
+  ObjectUIDs ............. 5892537540705225268
 
 
 TRAFODION_UPDATE ==========================  SEQ_NO 1        NO CHILDREN
@@ -9759,7 +9827,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... Y1
-PLAN_ID .................. 212371183039638279
+PLAN_ID .................. 212372510911622711
 ROWS_OUT ................. 2
 EST_TOTAL_COST ........... 0
 STATEMENT ................ select *
@@ -9804,7 +9872,7 @@ DESCRIPTION
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... ON
   HBASE_MAX_NUM_SEARCH_KE  1
-  ObjectUIDs ............. 8861534267208430622
+  ObjectUIDs ............. 5892537540705225268
   select_list ............ TRAFODION.SCH.T010T2.A, 'a', 1,
                              TRAFODION.SCH.T010T2.D
 
@@ -9824,6 +9892,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -9837,7 +9906,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... Y2
-PLAN_ID .................. 212371183039722473
+PLAN_ID .................. 212372510911684578
 ROWS_OUT ................. 5
 EST_TOTAL_COST ........... 0
 STATEMENT ................ select *
@@ -9883,7 +9952,7 @@ DESCRIPTION
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... ON
   HBASE_MAX_NUM_SEARCH_KE  1
-  ObjectUIDs ............. 8861534267208430622
+  ObjectUIDs ............. 5892537540705225268
   select_list ............ TRAFODION.SCH.T010T2.A, 'a', TRAFODION.SCH.T010T2.C,
                              TRAFODION.SCH.T010T2.D
 
@@ -9903,6 +9972,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -9917,7 +9987,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... Y3
-PLAN_ID .................. 212371183039825762
+PLAN_ID .................. 212372510911760214
 ROWS_OUT ................. 4
 EST_TOTAL_COST ........... 0
 STATEMENT ................ select *
@@ -9962,7 +10032,7 @@ DESCRIPTION
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... ON
   HBASE_MAX_NUM_SEARCH_KE  1
-  ObjectUIDs ............. 8861534267208430622
+  ObjectUIDs ............. 5892537540705225268
   select_list ............ TRAFODION.SCH.T010T2.A, 'a', TRAFODION.SCH.T010T2.C,
                              TRAFODION.SCH.T010T2.D
 
@@ -9982,6 +10052,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -9996,7 +10067,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... Y4
-PLAN_ID .................. 212371183039915766
+PLAN_ID .................. 212372510911831778
 ROWS_OUT ................. 4
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ delete from t010t2
@@ -10041,7 +10112,7 @@ DESCRIPTION
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... ON
   HBASE_MAX_NUM_SEARCH_KE  1
-  ObjectUIDs ............. 8861534267208430622
+  ObjectUIDs ............. 5892537540705225268
 
 
 TUPLE_FLOW ================================  SEQ_NO 3        CHILDREN 1, 2
@@ -10089,6 +10160,7 @@ DESCRIPTION
                              TRAFODION.SCH.T010T2
   object_type ............ Trafodion
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ........ 100
@@ -10104,7 +10176,7 @@ DESCRIPTION
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... Y5
-PLAN_ID .................. 212371183040097697
+PLAN_ID .................. 212372510912002680
 ROWS_OUT ................. 2
 EST_TOTAL_COST ........... 0
 STATEMENT ................ update t010t2
@@ -10151,7 +10223,7 @@ DESCRIPTION
   QUERY_CACHE ............ 0
   MDAM_SCAN_METHOD ....... ON
   HBASE_MAX_NUM_SEARCH_KE  1
-  ObjectUIDs ............. 8861534267208430622
+  ObjectUIDs ............. 5892537540705225268
 
 
 TRAFODION_UPDATE ==========================  SEQ_NO 1        NO CHILDREN
@@ -10662,12 +10734,12 @@ CREATE TABLE TRAFODION.SCH."delim_tab"
 --- SQL operation complete.
 >>get all volatile schemas;
 
-Schema(Active  ): VOLATILE_SCHEMA_MXID110000157412123711828437731090000000002
+Schema(Active  ): VOLATILE_SCHEMA_MXID110000268512123725106838989550000000002
 
 --- SQL operation complete.
 >>get all volatile tables;
 
-Schema(Active  ): VOLATILE_SCHEMA_MXID110000157412123711828437731090000000002
+Schema(Active  ): VOLATILE_SCHEMA_MXID110000268512123725106838989550000000002
   Table: VTAB1
   Table: VTAB2
 

--- a/core/sql/regress/seabase/EXPECTED011
+++ b/core/sql/regress/seabase/EXPECTED011
@@ -7,7 +7,7 @@
 >>invoke T011T1;
 
 -- Definition of Trafodion table TRAFODION.SCH.T011T1
--- Definition current  Sun Sep  3 07:21:45 2017
+-- Definition current  Mon Sep 18 16:13:32 2017
 
   (
     A                                INT NO DEFAULT NOT NULL NOT DROPPABLE
@@ -143,7 +143,7 @@ A            B
 ------------------------------------------------------------------ PLAN SUMMARY
 MODULE_NAME .............. DYNAMICALLY COMPILED
 STATEMENT_NAME ........... NOT NAMED
-PLAN_ID .................. 212371183306853153
+PLAN_ID .................. 212372511214096121
 ROWS_OUT ................. 7
 EST_TOTAL_COST ........... 0.01
 STATEMENT ................ select * from t011t1 where a >= 3 and a < 5;
@@ -182,7 +182,7 @@ DESCRIPTION
   QUERY_CACHE ............ 0
   TRAF_ALIGNED_ROW_FORMAT  OFF
   GENERATE_EXPLAIN ....... ON
-  ObjectUIDs ............. 931258273795435832
+  ObjectUIDs ............. 2068981457564705177
   select_list ............ TRAFODION.SCH.T011T1.A, TRAFODION.SCH.T011T1.B
 
 
@@ -203,6 +203,7 @@ DESCRIPTION
   begin_keys(incl) ....... 3
   end_keys(excl) ......... 5
   cache_size ........... 100
+  cache_blocks ........... ON
   small_scanner .......... ON
   probes ................. 1
   rows_accessed ......... 11
@@ -1275,7 +1276,7 @@ METRIC_TEXT_TABLE
 >>invoke trafodion."_REPOS_".metric_query_table;
 
 -- Definition of Trafodion table TRAFODION."_REPOS_".METRIC_QUERY_TABLE
--- Definition current  Sun Sep  3 07:23:51 2017
+-- Definition current  Mon Sep 18 16:15:51 2017
 
   (
     INSTANCE_ID                      INT UNSIGNED NO DEFAULT NOT NULL NOT
@@ -1463,7 +1464,7 @@ METRIC_TEXT_TABLE
 >>-- get qid for the prepared stmt
 >>get qid for statement explstmt;
 
-MXID11000001654212371183276408861000000000206U3333300_2289_EXPLSTMT
+MXID11000003675212372511181547316000000000206U3333300_2377_EXPLSTMT
 
 --- SQL operation complete.
 >>
@@ -1515,7 +1516,7 @@ SEQ_NUM      OPERATOR
 --- SQL command prepared.
 >>get qid for statement explstmt2;
 
-MXID11000001654212371183276408861000000000206U3333300_2300_EXPLSTMT2
+MXID11000003675212372511181547316000000000206U3333300_2388_EXPLSTMT2
 
 --- SQL operation complete.
 >>set qid MXID123456 for explstmt2;

--- a/core/sql/sqlcomp/QCache.cpp
+++ b/core/sql/sqlcomp/QCache.cpp
@@ -595,10 +595,13 @@ NABoolean ParameterTypeList::operator==(const ParameterTypeList& other) const
   if (nParms != other.entries()) {
     return FALSE;
   }
+  const NABoolean STRICT_CHK=FALSE;
+  NABoolean typeEqual;
   for (CollIndex i = 0; i < nParms; i++) {
-    const NABoolean STRICT_CHK=FALSE;
-    if (NOT (at(i).type_->isCompatible(*other.at(i).type_)) ||
-        other.at(i).type_->errorsCanOccur(*at(i).type_, STRICT_CHK)) {
+    typeEqual = (at(i).type_ == other.at(i).type_);
+    if (!typeEqual && // if types are equal don't check any further
+	(!(at(i).type_->isCompatible(*other.at(i).type_)) ||
+	 other.at(i).type_->errorsCanOccur(*at(i).type_, STRICT_CHK))) {
       return FALSE;
     }
     if (*at(i).posns_ != *other.at(i).posns_) 


### PR DESCRIPTION
…invalidation is done

This PR also includes fixes for [TRAFODION-2747] and [TRAFODION-2748].
The changes are small and the problems not severe.
Please see JIRA for an explanation

Add aditional change has been made to explain output.
cache_blocks ON is now added to explain for HBase scans. Previously
explain would only show cache_blocks OFF, if blockcache was disabled for a
HBase scan.

Files
2730 - QCache.cpp
2747 - ExSequence.cpp, ExAtp.h
2748 - GenPreCode.cpp
cache_block - GenExplain.cpp, 4 regression EXPECTED files