### PR TITLE
[TRAFODION-2749] Fix issue with reserved words as column names

### DIFF
--- a/core/sql/ustat/hs_globals.cpp
+++ b/core/sql/ustat/hs_globals.cpp
@@ -9392,14 +9392,14 @@ Lng32 HSGlobalsClass::ComputeMCStatistics(NABoolean usingIS)
                mgroup->clistr->append(sampleOption->data());
 
             mgroup->clistr->append(" GROUP BY ");
-            mgroup->clistr->append(mgroup->colNames->data());
+            mgroup->clistr->append(mgroupColNames);
             mgroup->clistr->append(" FOR READ UNCOMMITTED ACCESS) T(");
-            mgroup->clistr->append(mgroup->colNames->data());
+            mgroup->clistr->append(mgroupColNames);
             mgroup->clistr->append(", FMTVAL, SUMVAL)");
             if(collectMCSkewedValues)
             {
               mgroup->clistr->append(" ORDER BY ");
-              mgroup->clistr->append(mgroup->colNames->data());
+              mgroup->clistr->append(mgroupColNames);
             }
     
             cursor = new(STMTHEAP) HSCursor;


### PR DESCRIPTION
The code path in UPDATE STATISTICS where it creates multi-column histograms did not handle column names that happen to be reserved words correctly. These need to be double-quoted as delimited identifiers. (Oddly, vanilla delimited identifiers worked just fine.)