### PR TITLE
[TRAFODION-2750] Using function strtod is not enough to convert C_CHAR to DOUBLE

### DIFF
--- a/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/ctosqlconv.cpp
+++ b/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/ctosqlconv.cpp
@@ -3545,7 +3545,7 @@ unsigned long ODBC::ConvertCharToNumeric(SQLPOINTER srcDataPtr,
     rTrim(cTmpBuf);
     tempLen = strlen(cTmpBuf);
     errno = 0;
-	dTmp = strtod(cTmpBuf, &errorCharPtr);
+	dTmp = strtold(cTmpBuf, &errorCharPtr);
 	if (errno == ERANGE || errorCharPtr < (cTmpBuf + tempLen))
 		return IDS_22_003;
 	return SQL_SUCCESS;


### PR DESCRIPTION
client app with odbc driver :
DDL : "CREATE TABLE DOUBLE_TEST(A DOUBLE PRECISION)"
buffer =   "-2.22507e-308"
Bind SQL_C_CHAR to SQL_DOUBLE
return :
State: 22003
Native Error: 0
Error: [Trafodion ODBC Driver] NUMERIC VALUE OUT OF RANGE. Incorrect Format or Data. Row: 1 Column: 1

unit test for driver code :
char buffer[] = "-2.22507e-308";
double db;
errno = 0;
db = strtod(buffer,NULL);
return :
db = -0.000000
errno = 34