### PR TITLE
[TRAFODION-2758] Sort operator that uses TopN sort at runtime is not …

### DIFF
--- a/core/sql/bin/SqlciErrors.txt
+++ b/core/sql/bin/SqlciErrors.txt
@@ -3951,3 +3951,4 @@ $3~String1.
 30047 ZZZZZ 99999 BEGINNER MAJOR DBADMIN NAR details. HexdRow: $0~String0 ErrNum: $1~Int1 ObjectName: $2~TableName PartitionName: $3~String3 FileNum: $4~Int4 RecNum: $5~Int5
 30048 ZZZZZ 99999  BEGINNER MAJOR DBADMIN Fast Load failed. Number of error rows($0~Int0) inserted into the exception table exceeded the max allowed($1~Int1).
 30049 ZZZZZ 99999  BEGINNER MAJOR DBADMIN Fast Load succeeded. Number of error rows inserted into the exception table is $0~Int0
+30050 ZZZZZ 99999  BEGINNER MAJOR DBADMIN Memory required by input rowset buffer is $0~Int0 MB, exceeding specified limit of $1~Int1. Row length is $2~Int2 bytes and rowset has a maximum of $3~Int3 elements. 

--- a/core/sql/comexe/ComTdbSort.cpp
+++ b/core/sql/comexe/ComTdbSort.cpp
@@ -176,8 +176,8 @@ void SortOptions::displayContents(Space *space)
 {
 	char buf[100];
 
-   str_sprintf(buf, "\nFor SortOptions:\nsortNRows = %d, sortType = %d, internalSort = %d",
-   							sortNRows_,sortType_,internalSort_);
+   str_sprintf(buf, "\nFor SortOptions:\nsortType = %d, internalSort = %d",
+   							sortType_,internalSort_);
    space->allocateAndCopyToAlignedSpace(buf, str_len(buf), sizeof(short));
 
    str_sprintf(buf,"Sort Option Flags = %b", flags_);

--- a/core/sql/comexe/ComTdbSort.h
+++ b/core/sql/comexe/ComTdbSort.h
@@ -56,7 +56,6 @@ public:
     scratchFreeSpaceThreshold_ = 0; 
     sortType_ = ITER_QUICK;
     dontOverflow_ = FALSE;
-    sortNRows_ = FALSE;
     flags_ = 0;
     memoryQuotaMB_ = 0;
     bmoMaxMemThresholdMB_ =0;
@@ -84,7 +83,6 @@ public:
   UInt16 &scratchFreeSpaceThresholdPct() {return scratchFreeSpaceThreshold_;}
   Int16 &sortType(){return sortType_;};
   Int32 &dontOverflow(){return dontOverflow_;};  
-  Int32 &sortNRows(){return sortNRows_;};
   Int16 &memoryQuotaMB(){return memoryQuotaMB_;};
   UInt16 &bmoMaxMemThresholdMB(){return bmoMaxMemThresholdMB_;};
   Int16 &pressureThreshold(){return pressureThreshold_;}
@@ -137,16 +135,15 @@ protected:
   Int16 sortMaxHeapSizeMB_;          // 04-05
   UInt16 scratchFreeSpaceThreshold_; // 06-07
   Int32 dontOverflow_;              // 08-11
-  Int32 sortNRows_;                 // 12-15
-  Int16 sortType_;                  // 16-17
-  UInt16 flags_;                    // 18-19
-  Int16 memoryQuotaMB_;             // 20-21
-  Int16 pressureThreshold_;         // 22-23
-  Int16 mergeBufferUnit_;          // 24-25
-  Int16 scratchIOVectorSize_;      // 26-27
-  Int32 scratchIOBlockSize_;       // 28-31
-  UInt16 bmoMaxMemThresholdMB_;    // 32-33
-  char fillersSortOptions_[22];    // 34-55
+  Int16 sortType_;                  // 12-13
+  UInt16 flags_;                    // 14-15
+  Int16 memoryQuotaMB_;             // 16-17
+  Int16 pressureThreshold_;         // 18-19
+  Int16 mergeBufferUnit_;          // 20-21
+  Int16 scratchIOVectorSize_;      // 22-23
+  Int32 scratchIOBlockSize_;       // 24-27
+  UInt16 bmoMaxMemThresholdMB_;    // 28-29
+  char fillersSortOptions_[26];    // 30-55
 
 };
 

--- a/core/sql/executor/ex_sort.cpp
+++ b/core/sql/executor/ex_sort.cpp
@@ -695,8 +695,7 @@ short ExSortTcb::workDown()
 		"Invalid initial state in ex_sort_tcb::workDown()");
 
       if ((request == ex_queue::GET_NOMORE) ||
-	  ((sortTdb().sortOptions_->sortNRows() == TRUE) &&
-	   (request == ex_queue::GET_N) &&
+	  ((request == ex_queue::GET_N) &&
 	   (pentry_down->downState.requestValue == 0)))
 	{
 	  // Parent canceled before start, or request 0 row,
@@ -709,8 +708,7 @@ short ExSortTcb::workDown()
 	{
 	  ex_queue_entry *centry = qchild_.down->getTailEntry();
 	    
-	  if ((sortTdb().sortOptions_->sortNRows() == TRUE) &&
-	      (request == ex_queue::GET_N))
+	  if (request == ex_queue::GET_N)
 	    {
 	      centry->downState.request = ex_queue::GET_ALL;
 	    }
@@ -1670,10 +1668,9 @@ short ExSortTcb::sortReceive(ex_queue_entry * pentry_down,
 
 	      // stop if first N sorted rows have been returned.
 	      if ((request == ex_queue::GET_NOMORE) ||
-		  (sortTdb().sortOptions_->sortNRows() == TRUE) &&
-		  (request == ex_queue::GET_N)  &&
+		  ((request == ex_queue::GET_N)  &&
 		  ((Lng32)matchCount >= 
-		   pentry_down->downState.requestValue))
+		   pentry_down->downState.requestValue)))
 		{
 		  // If sort partially complete, lets cancel rest of 
 		  // of the child row reads.

--- a/core/sql/generator/GenExplain.cpp
+++ b/core/sql/generator/GenExplain.cpp
@@ -1948,6 +1948,9 @@ Sort::addSpecificExplainInfo(ExplainTupleMaster *explainTuple,
       description += "CIF: OFF ";
     }
   }
+  if (sortTdb->topNSortEnabled() && sortNRows())
+    description += "topn_enabled: yes ";
+
   explainTuple->setDescription(description);  // save what we have built
 
   return(explainTuple);

--- a/core/sql/generator/GenPreCode.cpp
+++ b/core/sql/generator/GenPreCode.cpp
@@ -2074,13 +2074,6 @@ RelExpr * RelRoot::preCodeGen(Generator * generator,
   pulledNewInputs -= (ValueIdSet) inputVars();
   GenAssert(pulledNewInputs.isEmpty(),"root can't produce these values");
 
-  // propagate the need to return top sorted N rows to all sort
-  // nodes in the query.
-  if (needFirstSortedRows() == TRUE)
-    {
-      needSortedNRows(TRUE);
-    }
-
   // Do not rollback on error for INTERNAL REFRESH commands.
   if (isRootOfInternalRefresh())
     {

--- a/core/sql/generator/GenRelMisc.cpp
+++ b/core/sql/generator/GenRelMisc.cpp
@@ -3069,11 +3069,6 @@ short Sort::generateTdb(Generator * generator,
   
   sort_options->scratchIOVectorSize() = (Int16)getDefault(SCRATCH_IO_VECTOR_SIZE_SORT);
 
-  if (sortNRows())
-    {
-      sort_options->sortNRows() = TRUE;
-    }
-
   if (CmpCommon::getDefault(EXE_BMO_SET_BUFFERED_WRITES) == DF_ON)
     sort_options->setBufferedWrites(TRUE);
   if (CmpCommon::getDefault(EXE_DIAGNOSTIC_EVENTS) == DF_ON)

--- a/core/sql/generator/GenRelPackedRows.cpp
+++ b/core/sql/generator/GenRelPackedRows.cpp
@@ -135,6 +135,22 @@ RelExpr * PhysUnPackRows::preCodeGen(Generator * generator,
     (availableValues,
      getGroupAttr()->getCharacteristicInputs());
 
+  Lng32 memLimit = (Lng32)CmpCommon::getDefaultNumeric(MEMORY_LIMIT_ROWSET_IN_MB);
+  if (memLimit > 0)
+  {
+    Lng32 rowLength = getGroupAttr()->getCharacteristicOutputs().getRowLength();
+    Lng32 rowsetSize = getGroupAttr()->getOutputLogPropList()[0]->getResultCardinality().value() ;
+    Lng32 memNeededMB = (rowLength * rowsetSize)/(1024 * 1024);
+    if (memLimit < memNeededMB)
+    {
+      *CmpCommon::diags() << DgSqlCode(-30050) << DgInt0(memNeededMB) 
+                          << DgInt1(memLimit) << DgInt2(rowLength) 
+                          << DgInt3(rowsetSize);
+      GenExit();
+      return NULL;
+    }
+  }
+
   generator->oltOptInfo()->setMultipleRowsReturned(TRUE);
 
   markAsPreCodeGenned();

--- a/core/sql/generator/GenRelScan.cpp
+++ b/core/sql/generator/GenRelScan.cpp
@@ -3123,21 +3123,31 @@ short HbaseAccess::codeGen(Generator * generator)
     new(space) ComTdbHbaseAccess::HbasePerfAttributes();
   if (CmpCommon::getDefault(COMP_BOOL_184) == DF_ON)
     hbpa->setUseMinMdamProbeSize(TRUE);
+
+  Lng32 hbaseRowSize;
+  Lng32 hbaseBlockSize;
+   if(getIndexDesc() && getIndexDesc()->getNAFileSet())
+   {
+     const NAFileSet * fileset = getIndexDesc()->getNAFileSet() ;
+     hbaseRowSize = fileset->getRecordLength();
+     hbaseRowSize += ((NAFileSet *)fileset)->getEncodedKeyLength();
+     hbaseBlockSize = fileset->getBlockSize();
+   }
+   else
+   {
+     hbaseRowSize = computedHBaseRowSizeFromMetaData;
+     hbaseBlockSize = CmpCommon::getDefaultLong(HBASE_BLOCK_SIZE);
+   }
+
   generator->setHBaseNumCacheRows(MAXOF(getEstRowsAccessed().getValue(),
                                         getMaxCardEst().getValue()), 
                                   hbpa, samplePercent()) ;
-  generator->setHBaseCacheBlocks(computedHBaseRowSizeFromMetaData,
+  generator->setHBaseCacheBlocks(hbaseRowSize,
                                  getEstRowsAccessed().getValue(),hbpa);
-
-  Lng32 hbaseBlockSize = 65536; //default HBaseValue, should not be useful as the if statement should always pass
-  if(getIndexDesc() && getIndexDesc()->getNAFileSet())
-    hbaseBlockSize = getIndexDesc()->getNAFileSet()->getBlockSize();
-
-  generator->setHBaseSmallScanner(computedHBaseRowSizeFromMetaData,
-                                getEstRowsAccessed().getValue(),
-                                hbaseBlockSize,
-                                hbpa);
-
+  generator->setHBaseSmallScanner(hbaseRowSize,
+                                  getEstRowsAccessed().getValue(),
+                                  hbaseBlockSize,
+                                  hbpa);
   generator->setHBaseParallelScanner(hbpa);
 
 

--- a/core/sql/optimizer/RelExpr.cpp
+++ b/core/sql/optimizer/RelExpr.cpp
@@ -1078,7 +1078,33 @@ void RelExpr::pushDownGenericUpdateRootOutputs( const ValueIdSet &outputs)
 //QSTUFF
 
 void RelExpr::needSortedNRows(NABoolean val)
-{
+{ 
+  // The operators listed below can create OR propogate a GET_N
+  // request. Other operatots will turn a GET_N request into GET_ALL
+  // There are a few exceptions like right side of NJ for semi join etc.
+  // but these are not relevant for FirstN sort
+  // This method should only in the generator since we are using 
+  // physical node types.
+  OperatorTypeEnum operatorType = getOperatorType();
+  if ((operatorType != REL_FIRST_N) &&
+      (operatorType != REL_EXCHANGE) &&
+      (operatorType != REL_MERGE_UNION) &&
+      (operatorType != REL_PROBE_CACHE) &&
+      (operatorType != REL_ROOT) && 
+      (operatorType != REL_LEFT_NESTED_JOIN) &&
+      (operatorType != REL_LEFT_TSJ) &&
+      (operatorType != REL_MAP_VALUEIDS))
+    return ;
+      
+  if ((operatorType == REL_LEFT_NESTED_JOIN) || 
+      (operatorType == REL_LEFT_TSJ)) {
+    // left side of left tsj propagates a GET_N request if afterPred is empty.
+    if (getSelectionPred().isEmpty())
+      child(0)->castToRelExpr()->needSortedNRows(val);
+
+    return ;
+  }
+ 
   for (Int32 i=0; i < getArity(); i++) {
     if (child(i))
       child(i)->castToRelExpr()->needSortedNRows(val);
@@ -3446,8 +3472,8 @@ void Sort::addLocalExpr(LIST(ExprNode *) &xlist,
 void Sort::needSortedNRows(NABoolean val)
 {
   sortNRows_ = val;
-
-  RelExpr::needSortedNRows(val);
+  // Sort changes a GET_N to GET_ALL, so it does not propagate a 
+  // Get_N request. It can simply act on one.
 }
 
 // -----------------------------------------------------------------------

--- a/core/sql/sqlcomp/DefaultConstants.h
+++ b/core/sql/sqlcomp/DefaultConstants.h
@@ -3888,6 +3888,7 @@ enum DefaultConstants
   BMO_MEMORY_EQUAL_QUOTA_SHARE_RATIO,
 
   EXE_MEMORY_FOR_UNPACK_ROWS_IN_MB,
+  MEMORY_LIMIT_ROWSET_IN_MB,
 
   // This enum constant must be the LAST one in the list; it's a count,
   // not an Attribute (it's not IN DefaultDefaults; it's the SIZE of it)!

--- a/core/sql/sqlcomp/nadefaults.cpp
+++ b/core/sql/sqlcomp/nadefaults.cpp
@@ -2234,6 +2234,9 @@ SDDkwd__(ISO_MAPPING,           (char *)SQLCHARSETSTRING_ISO88591),
   DDui___(MEMORY_LIMIT_HISTCACHE_UPPER_KB,     "0"),
   DDui___(MEMORY_LIMIT_NATABLECACHE_UPPER_KB,  "0"),
   DDui___(MEMORY_LIMIT_QCACHE_UPPER_KB,        "0"),
+  // Checked at compile time. Set to -1 to disable check.
+  // Value should be >= EXE_MEMORY_FOR_UNPACK_ROWS_IN_MB
+  DDint__(MEMORY_LIMIT_ROWSET_IN_MB,         "500"),
 
   // SQL/MX Compiler/Optimzer Memory Monitor.
   DDkwd__(MEMORY_MONITOR,			"OFF"),


### PR DESCRIPTION
…accurately determined at compile time

This commit includes fixes for these three issues. Please see JIRA for a description of each fix.

[TRAFODION-2758] Sort operator that uses TopN sort at runtime is not accurately determined at compile time
[TRAFODION-2759] Use of rowset with large memory leads to various errors at runtime
[TRAFODION-2760] hbase cache blocks is OFF for broad table with narrow index

[TRAFODION-2758]
comexe/ComTdbSort.cpp
comexe/ComTdbSort.h
executor/ex_sort.cpp
generator/GenExplain.cpp
generator/GenPreCode.cpp
generator/GenRelMisc.cpp
optimizer/RelExpr.cpp
[TRAFODION-2759]
bin/SqlciErrors.txt
generator/GenRelPackedRows.cpp
sqlcomp/DefaultConstants.h
sqlcomp/nadefaults.cpp
[TRAFODION-2760]
generator/GenRelScan.cpp