### PR TITLE
[TRAFODION-2763] Left join with non-equi join predicate in ON clause …

### DIFF
--- a/core/sql/bin/SqlciErrors.txt
+++ b/core/sql/bin/SqlciErrors.txt
@@ -1447,6 +1447,8 @@ $1~String1 --------------------------------
 4491 42000 99999 BEGINNER MINOR LOGONLY The user does not have $0~string0 privilege on sequence $1~string1$2~string2.
 4492 ZZZZZ 99999 BEGINNER MINOR LOGONLY BULK LOAD option UPDATE STATISTICS cannot be used with UPSERT USING LOAD option.
 4493 ZZZZZ 99999 BEGINNER MINOR LOGONLY Stored Descriptor Status: $0~String0
+4494 ZZZZZ 99999 BEGINNER MINOR LOGONLY LOAD is not supported on a table with LOB columns. Table $0~TableName has LOB column $1~ColumnName.
+4495 ZZZZZ 99999 BEGINNER MINOR LOGONLY UNLOAD is not supported on a SELECT with LOB columns. $0~ColumnName is a LOB column.
 5000 ZZZZZ 99999 ADVANCED MAJOR DBADMIN Internal error in the query normalizer.
 5001 ZZZZZ 99999 ADVANDED MINOR LOGONLY Common subexpression $0~String0 will not be shared among multiple consumers. Reason: $1~String1.
 6000 ZZZZZ 99999 ADVANCED MAJOR DBADMIN Internal error in the query optimizer.

--- a/core/sql/optimizer/BindRelExpr.cpp
+++ b/core/sql/optimizer/BindRelExpr.cpp
@@ -10622,6 +10622,8 @@ RelExpr *Insert::bindNode(BindWA *bindWA)
     //4486--Constraints not supported with bulk load. Disable the constraints and try again.
     *CmpCommon::diags() << DgSqlCode(-4486)
                         <<  DgString0("bulk load") ;
+    bindWA->setErrStatus();
+    return boundExpr;
   }
   if (getIsTrafLoadPrep())
   {
@@ -10633,10 +10635,34 @@ RelExpr *Insert::bindNode(BindWA *bindWA)
       {
         partns = np->getNumEntries();
         if(partns > 1  && CmpCommon::getDefault(ATTEMPT_ESP_PARALLELISM) == DF_OFF)
-          // 4490 - BULK LOAD into a salted table is not supported if ESP parallelism is turned off
-          *CmpCommon::diags() << DgSqlCode(-4490);
+	  {
+	    // 4490 - BULK LOAD into a salted table is not supported if 
+	    // ESP parallelism is turned off
+	    *CmpCommon::diags() << DgSqlCode(-4490);
+	     bindWA->setErrStatus();
+	     return boundExpr;
+	  }
       }
-  }
+
+    const NATable* naTable = getTableDesc()->getNATable();
+    if (naTable->hasLobColumn())
+      {
+	NAColumn *nac;
+	for (CollIndex c = 0; c < naTable->getColumnCount(); c++) 
+	  {
+	    nac = naTable->getNAColumnArray()[c];
+	    if (nac->getType()->isLob())
+	      break;
+	  }
+	*CmpCommon::diags() << DgSqlCode(-4494)
+			    << DgTableName(naTable->getTableName().
+					   getQualifiedNameAsAnsiString()) 
+			    << DgColumnName(nac->getColName());
+	bindWA->setErrStatus();
+	return boundExpr;
+      } // has Lob column
+  } // isLoadPrep
+
   NABoolean toMerge = FALSE;
   if (isUpsertThatNeedsTransformation(isAlignedRowFormat, omittedDefaultCols, omittedCurrentDefaultClassCols,toMerge)) {
     if ((CmpCommon::getDefault(TRAF_UPSERT_TO_EFF_TREE) == DF_OFF) ||toMerge)	
@@ -17618,6 +17644,22 @@ RelExpr * FastExtract::bindNode(BindWA *bindWA)
           }
         }
     }
+  else 
+    {
+      NABoolean hasLob = FALSE;
+      CollIndex i = 0;
+      for (i = 0; (i < vidList.entries() && !hasLob); i++)
+	hasLob = vidList[i].getType().isLob();
+      if (hasLob) {
+	*CmpCommon::diags() << DgSqlCode(-4495) 
+			    << DgColumnName(childRETDesc->getColRefNameObj(i).
+					    getColRefAsAnsiString());
+	bindWA->setErrStatus();
+	return NULL;
+      }
+      
+    }
+    
 
   setSelectList(vidList);
 


### PR DESCRIPTION
…may cause corefiles

This PR also includes a small change for
[TRAFODION-2764] LOAD and UNLOAD statements with LOB columns cause runtime errors
The files affected by each change is different. Please see JIRA for a description of the problem and the fix.

2763
generator/GenPreCode.cpp
2764
bin/SqlciErrors.txt
optimizer/BindRelExpr.cpp