### PR TITLE
[TRAFODION-2765] Change heuristics so MDAM is considered more often

### DIFF
--- a/core/sql/sqlcomp/DefaultConstants.h
+++ b/core/sql/sqlcomp/DefaultConstants.h
@@ -1659,6 +1659,8 @@ enum DefaultConstants
 
   MDAM_SUBSET_FACTOR,
 
+  MDAM_FSO_SIMPLE_RULE,
+
   // -------------------------------------------------------------------------
   // Makes NO ACTION referential action behave like RESTRICT.
   // -------------------------------------------------------------------------

--- a/core/sql/sqlcomp/nadefaults.cpp
+++ b/core/sql/sqlcomp/nadefaults.cpp
@@ -2196,6 +2196,10 @@ SDDkwd__(ISO_MAPPING,           (char *)SQLCHARSETSTRING_ISO88591),
   // of the key predicates)
   DDflt0_(MDAM_CPUCOST_NET_PER_PRED,		".5"),
 
+  // Added by JIRA TRAFODION-2765: Allows consideration of MDAM
+  // in more general circumstances.
+  XDDkwd__(MDAM_FSO_SIMPLE_RULE,		"ON"),
+
   // controls the max. number of seek positions under which MDAM will be
   // allowed. Set it to 0 turns off the feature.
   XDDui___(MDAM_NO_STATS_POSITIONS_THRESHOLD,       "10"),


### PR DESCRIPTION
This change adds new heuristic code to ScanOptimizer::useSimpleFileScanOptimizer (optimizer/ScanOptimizer.cpp). The new code checks to see if a single subset scan uses all the key predicates in the query. If so, we don't bother to cost MDAM. But if not, we do consider MDAM.

The old code contained some (probably unintended) odd heuristics. Given a salted table with keys A, B and C, and a query SELECT * FROM T WHERE A = 5 AND C = 20, the old code would consider MDAM for serial plans but not for parallel ones! This is because in the serial case, a single subset would be a full table scan (so it is quite reasonable to try MDAM), but in the parallel case, because the "_SALT_" column would be covered by an equality predicate, the single subset SearchKey would have equality predicates on a prefix of the key. It would assume that a single subset with equality on "_SALT_" and A was always better than considering MDAM to column C. However, if the UEC of B is low, and the UEC of C is high, using MDAM to column C can be quite efficient. The new heuristics will allow this possibility to be explored.