### PR TITLE
[TRAFODION-1715] Improve memory use in UPDATE STATS when sample table…

### DIFF
--- a/core/sql/ustat/hs_globals.h
+++ b/core/sql/ustat/hs_globals.h
@@ -1810,6 +1810,12 @@ private:
                          NABoolean internalSortWhenBetter,
                          NABoolean trySampleTableBypass = FALSE);
 
+    // If we decide to create and load a sample table, deallocate column memory
+    // and reset PENDING group states back to UNPROCESSED before creating and
+    // loading the sample table. We'll call getColsToProcess to reallocate it
+    // again afterwards.
+    void deallocatePendingMemory(void);
+
     // After an allocation failure, this is called to reduce the amount of
     // memory we estimate is available.
     static void memReduceAllowance();


### PR DESCRIPTION
… is used

UPDATE STATISTICS allocates memory for columns before deciding whether to create and populate a sample table. (It may turn out that creating one is unnecessary.)

This change deallocates that memory when a sample table is created and populated, improving the amount of memory available for the latter. The memory is reallocated again once the sample table is populated.