### PR TITLE
[TRAFODION-2771] Add build step and web site link for Trafodion LOB Guide

### DIFF
--- a/docs/lob_guide/pom.xml
+++ b/docs/lob_guide/pom.xml
@@ -244,8 +244,8 @@
                   - target/docs/<version>/<document> contains the PDF version and the web book. The web book is named index.html
                 --> 
                 <!-- Copy the PDF file to its target directories -->
-                <copy file="${basedir}/target/index.pdf" tofile="${basedir}/../target/docs/sql_reference/Trafodion_SQL_Reference_Manual.pdf" />
-                <copy file="${basedir}/target/index.pdf" tofile="${basedir}/../target/docs/${project.version}/sql_reference/Trafodion_SQL_Reference_Manual.pdf" />
+                <copy file="${basedir}/target/index.pdf" tofile="${basedir}/../target/docs/sql_reference/Trafodion_SQL_Large_Objects_Guide.pdf" />
+                <copy file="${basedir}/target/index.pdf" tofile="${basedir}/../target/docs/${project.version}/sql_reference/Trafodion_SQL_Large_Objects_Guide.pdf" />
                 <!-- Copy the Web Book files to their target directories -->
                 <copy todir="${basedir}/../target/docs/sql_reference">
                   <fileset dir="${basedir}/target/site">

--- a/docs/src/site/markdown/documentation.md
+++ b/docs/src/site/markdown/documentation.md
@@ -26,6 +26,7 @@ Trafodion Control Query Default (CQD) Reference Guide | [Web Book](docs/cqd_refe
 Trafodion Database Connectivity Services Guide        | [Web Book](docs/dcs_reference/index.html),      [API](docs/dcs_reference/apidocs/index.html)
 Trafodion JDBC Type 4 Programmer Reference Guide      | [Web Book](docs/jdbct4ref_guide/index.html),    [PDF](docs/jdbct4ref_guide/Trafodion_JDBCT4_Reference_Guide.pdf)
 Trafodion Load and Transform Guide                    | [Web Book](docs/load_transform/index.html),     [PDF](docs/load_transform/Trafodion_Load_Transform_Guide.pdf)
+Trafodion SQL Large Objects Guide                     | [Web Book](docs/lob_guide/index.html),          [PDF](docs/lob_guide/Trafodion_SQL_Large_Objects_Guide.pdf)
 Trafodion Messages Guide                              | [Web Book](docs/messages_guide/index.html),     [PDF](docs/messages_guide/Trafodion_Messages_Guide.pdf)
 Trafodion Manageability                               | [wiki](https://cwiki.apache.org/confluence/display/TRAFODION/Trafodion+Manageability)
 Trafodion odb User Guide                              | [Web Book](docs/odb/index.html),                [PDF](docs/odb/Trafodion_odb_User_Guide.pdf)

--- a/pom.xml
+++ b/pom.xml
@@ -143,6 +143,7 @@
     <module>docs/odb_user</module>
     <module>docs/spj_guide</module>
     <module>docs/sql_reference</module>
+    <module>docs/lob_guide</module>
     <module>docs/jdbct4ref_guide</module>
   </modules>
 


### PR DESCRIPTION
These changes do the following:

1. Add an entry to the top-level pom.xml file so that the new Trafodion LOB Guide will get built as part of the documentation build (mvn post-site step).

2. Add an entry to the documentation.md file so that links to the new Guide will appear on the Trafodion documentation web page.

3. Change the lob_guide/pom.xml file to provide an appropriate name for the pdf file for the LOB Guide.