### PR TITLE
[TRAFODION-2771] Fix lob_guide/pom_xml to copy LOB guide to right place

### DIFF
--- a/docs/lob_guide/pom.xml
+++ b/docs/lob_guide/pom.xml
@@ -244,15 +244,15 @@
                   - target/docs/<version>/<document> contains the PDF version and the web book. The web book is named index.html
                 --> 
                 <!-- Copy the PDF file to its target directories -->
-                <copy file="${basedir}/target/index.pdf" tofile="${basedir}/../target/docs/sql_reference/Trafodion_SQL_Large_Objects_Guide.pdf" />
-                <copy file="${basedir}/target/index.pdf" tofile="${basedir}/../target/docs/${project.version}/sql_reference/Trafodion_SQL_Large_Objects_Guide.pdf" />
+                <copy file="${basedir}/target/index.pdf" tofile="${basedir}/../target/docs/lob_guide/Trafodion_SQL_Large_Objects_Guide.pdf" />
+                <copy file="${basedir}/target/index.pdf" tofile="${basedir}/../target/docs/${project.version}/lob_guide/Trafodion_SQL_Large_Objects_Guide.pdf" />
                 <!-- Copy the Web Book files to their target directories -->
-                <copy todir="${basedir}/../target/docs/sql_reference">
+                <copy todir="${basedir}/../target/docs/lob_guide">
                   <fileset dir="${basedir}/target/site">
                     <include name="**/*.*"/>  <!--All sub-directories, too-->
                   </fileset>
                 </copy>
-                <copy todir="${basedir}/../target/docs/${project.version}/sql_reference">
+                <copy todir="${basedir}/../target/docs/${project.version}/lob_guide">
                   <fileset dir="${basedir}/target/site">
                     <include name="**/*.*"/>  <!--All sub-directories, too-->
                   </fileset>


### PR DESCRIPTION
The last pull request for this JIRA copied the LOB Guide to the sql_reference directory, overwriting the SQL Reference Manual. This one copies it to the right place on the web site.