### PR TITLE
[TRAFODION-2776] Mdam plans with more than one disjunct sometimes cause either a compiler core or have an incorrect predicate

### DIFF
--- a/core/sql/optimizer/mdam.cpp
+++ b/core/sql/optimizer/mdam.cpp
@@ -1589,8 +1589,7 @@ void MdamKey::preCodeGen(ValueIdSet& executorPredicates,
 
   // If the curDisjuncts have more than one disjunct and the chosen plan
   // only has 1 disjunct then the mdam common predicates case has occurred
-  if (getDisjuncts().entries() == 1  AND  curDisjuncts->entries() > 1 AND
-      !partKeyPredsAdded)
+  if (getDisjuncts().entries() == 1  AND  curDisjuncts->entries() > 1)
     {
       ValueIdSet commonPreds = curDisjuncts->getCommonPredicates();
       CMPASSERT(NOT commonPreds.isEmpty());


### PR DESCRIPTION
The problem is that during MdamKey::preCodegen we regenerate the disjuncts and expect to get the same number as we saw during optimize phase. This is mostly true, but in some cases not. There is some defensive code to handle this case, but it does not trigger when there is a partKey predicate. The fix removes the partKey predicate check for the defensive code.