### PR TITLE
[TRAFODION-2783] jdbc_test_cdh fails at times with type 2 JDBC driver…

### DIFF
--- a/core/sql/cli/CliExtern.cpp
+++ b/core/sql/cli/CliExtern.cpp
@@ -77,10 +77,6 @@
 #include "dfs2rec.h"
 #include "Statement.h"
 #include "ComSqlId.h"
-
-CLISemaphore globalSemaphore ;
-
-
 #include "seabed/ms.h"
 #include "seabed/fs.h"
 #include "seabed/fserr.h"
@@ -92,7 +88,6 @@ CLISemaphore globalSemaphore ;
 #include <unistd.h>
 #include "QRLogger.h"
 
-void initStaticVariables();
 extern char ** environ;
 
 // this is set to true after the first CLI call.
@@ -871,8 +866,6 @@ short sqInit()
       exit(1);
     }
 
-    // Initialize static variables
-    initStaticVariables();
     // Initialize an Instruction Info array's offset index
     ex_conv_clause::populateInstrOffsetIndex();
 
@@ -6999,8 +6992,3 @@ Lng32 SQL_EXEC_PutRoutine
 #ifdef __cplusplus
 }
 #endif
-
-void initStaticVariables()
-{
-   CharInfo::initBuiltinCollationDB();
-}

--- a/core/sql/cli/CliExtern.cpp
+++ b/core/sql/cli/CliExtern.cpp
@@ -92,6 +92,7 @@ CLISemaphore globalSemaphore ;
 #include <unistd.h>
 #include "QRLogger.h"
 
+void initStaticVariables();
 extern char ** environ;
 
 // this is set to true after the first CLI call.
@@ -870,7 +871,8 @@ short sqInit()
       exit(1);
     }
 
-
+    // Initialize static variables
+    initStaticVariables();
     // Initialize an Instruction Info array's offset index
     ex_conv_clause::populateInstrOffsetIndex();
 
@@ -6998,5 +7000,7 @@ Lng32 SQL_EXEC_PutRoutine
 }
 #endif
 
-
-
+void initStaticVariables()
+{
+   CharInfo::initBuiltinCollationDB();
+}

--- a/core/sql/cli/CliSemaphore.h
+++ b/core/sql/cli/CliSemaphore.h
@@ -83,5 +83,6 @@ inline CLISemaphore::~CLISemaphore()
    DeleteCriticalSection(&cs);
 }
 
+extern CLISemaphore globalSemaphore;
 
 #endif

--- a/core/sql/cli/Globals.cpp
+++ b/core/sql/cli/Globals.cpp
@@ -66,15 +66,9 @@
 
 
 #include "ExCextdecs.h"
-#ifndef NA_NO_GLOBAL_EXE_VARS
-// if global variables are allowed in the CLI, and if there isn't
-// a cheat define set, then simply define the CLI globals here
-#ifndef CLI_GLOBALS_DEF_
 CliGlobals * cli_globals = NULL;
-#endif
-// On NSK we store the cli globals in a flat segment with a fixed
-// segment id.
-#endif
+
+CLISemaphore globalSemaphore ;
 
 #include "CmpContext.h"
 

--- a/core/sql/common/charinfo.cpp
+++ b/core/sql/common/charinfo.cpp
@@ -103,7 +103,7 @@ static const struct mapCS mapCSArray[] = {
   { /*18*/ CharInfo::GBK,            SQLCHARSETSTRING_GBK,         3, TRUE,    FALSE,  1,    2, "?" },
 };
 
-static const size_t SIZEOF_CS = sizeof(mapCSArray)/sizeof(mapCS);
+#define SIZEOF_CS  (sizeof(mapCSArray)/sizeof(mapCS))
 
 const char* CharInfo::getCharSetName(CharSet cs, NABoolean retUnknownAsBlank)
 {
@@ -363,7 +363,7 @@ void CollationInfo::display() const
 CollationDB::CollationDB(CollHeap *h)
   : CollationDBSupertype(h), heap_(h), refreshNeeded_(TRUE)
 {
-    if (this == &CharInfo::builtinCollationDB_) return;
+    if (this == CharInfo::builtinCollationDB_) return;
     cmpCurrentContext->getCollationDBList()->insert(this);
 }
 
@@ -371,13 +371,14 @@ CollationDB::CollationDB(CollHeap *h, const CollationInfo *co, size_t count)
   : CollationDBSupertype(h), heap_(h), refreshNeeded_(!!count)
 { 
    while (count--) CollationDBSupertype::insert(co++);
-   if (this == &CharInfo::builtinCollationDB_) return;
-   cmpCurrentContext->getCollationDBList()->insert(this);
+   if (this == CharInfo::builtinCollationDB_) return;
+   if (cmpCurrentContext != NULL)
+      cmpCurrentContext->getCollationDBList()->insert(this);
 }
 
 CollationDB::~CollationDB()
 { 
-   if (this == &CharInfo::builtinCollationDB_) return;
+   if (this == CharInfo::builtinCollationDB_) return;
    clearAndReset();
    cmpCurrentContext->getCollationDBList()->remove(this);
 }
@@ -529,8 +530,10 @@ static const CollationInfo mapCOArray[] = {
   CollationInfo(NULL, CharInfo::UNKNOWN_COLLATION,  SQLCOLLATIONSTRING_UNKNOWN,
   			STATIC_NEG)
 };
-static const size_t SIZEOF_CO = sizeof(mapCOArray)/sizeof(CollationInfo);
-const CollationDB CharInfo::builtinCollationDB_(NULL, mapCOArray, SIZEOF_CO);
+
+#define SIZEOF_CO (sizeof(mapCOArray)/sizeof(CollationInfo))
+
+const CollationDB *CharInfo::builtinCollationDB_;
 
 CharInfo::Collation CharInfo::getCollationEnum(const char* name,
 					       NABoolean formatNSK,
@@ -550,18 +553,18 @@ CharInfo::Collation CharInfo::getCollationEnum(const char* name,
     return CharInfo::UNKNOWN_COLLATION;
 
   // Collapse any nonzero formatNSK to single bit, for XOR
-  return builtinCollationDB_.getCollationEnum(name, !!formatNSK, namlen);
+  return builtinCollationDB_->getCollationEnum(name, !!formatNSK, namlen);
 }
 
 const char* CharInfo::getCollationName(Collation co,
 				       NABoolean retUnknownAsBlank)
 {
-  return builtinCollationDB_.getCollationName(co, retUnknownAsBlank);
+  return builtinCollationDB_->getCollationName(co, retUnknownAsBlank);
 }
 
 Int32 CharInfo::getCollationFlags(Collation co)
 {
-  return builtinCollationDB_.getCollationFlags(co);
+  return builtinCollationDB_->getCollationFlags(co);
 }
 
 //****************************************************************************
@@ -693,3 +696,9 @@ Int32 CharInfo::getMaxConvertedLenInBytes(CharSet sourceCS,
   return ((sourceLenInBytes/minBytesPerChar(sourceCS)) *
           maxBytesPerChar(targetCS));
 }
+
+void CharInfo::initBuiltinCollationDB()
+{
+   builtinCollationDB_ = new CollationDB(NULL, mapCOArray, SIZEOF_CO);
+}
+

--- a/core/sql/common/charinfo.h
+++ b/core/sql/common/charinfo.h
@@ -260,7 +260,7 @@ public:
                                          Int32   sourceLenInBytes,
                                          CharSet targetCS);
 
-  static void initBuiltinCollationDB();
+  static const CollationDB *builtinCollationDB();
  
 
 private:

--- a/core/sql/common/charinfo.h
+++ b/core/sql/common/charinfo.h
@@ -50,6 +50,7 @@
 #include "NAWinNT.h"
 #include "ComCharSetDefs.h"
 #include "sql_charset_strings.h"
+#include "charinfo.h"
 
 // Forward references
 class ComMPLoc;
@@ -260,11 +261,14 @@ public:
                                          Int32   sourceLenInBytes,
                                          CharSet targetCS);
 
+  static void initBuiltinCollationDB();
+ 
+
 private:
 friend class CollationDB;			// needs to access builtinCDB_
 
    static const char*	const localeCharSet_;
-   static const CollationDB   builtinCollationDB_;
+   static const CollationDB   *builtinCollationDB_;
 
 }; // CharInfo
 

--- a/core/sql/common/charinfo.h
+++ b/core/sql/common/charinfo.h
@@ -50,7 +50,6 @@
 #include "NAWinNT.h"
 #include "ComCharSetDefs.h"
 #include "sql_charset_strings.h"
-#include "charinfo.h"
 
 // Forward references
 class ComMPLoc;


### PR DESCRIPTION
… dumping core

In case of Type 2 JDBC driver, the Trafodion SQL engine is a library that is dynamic
loaded into the process. Initialization of C++ static objects in the dynamic loaded libraries
are supposed to be done before dlopen returns. But the behavior seems to be nondeterministic when
there are multiple threads and when there are dependent static objects (An static object expects
another to be initialized before it). I think, the order of the initialization is not guaranteed
by the standard.

Refactored the code to initialize static object CharInfo::builtinCollationDB_ in a thread safe manner.