### PR TITLE
[TRAFODION-2420] RMS Enhancements

### DIFF
--- a/core/sql/bin/ex_esp_main.cpp
+++ b/core/sql/bin/ex_esp_main.cpp
@@ -363,7 +363,6 @@ Int32 runESP(Int32 argc, char** argv, GuaReceiveFastStart *guaReceiveFastStart)
 
   ExEspFragInstanceDir espFragInstanceDir(cliGlobals,
                                           espExecutorHeap,
-                                          espExecutorHeap,
                                           (StatsGlobals *)statsGlobals);
 
   ExEspControlMessage espIpcControlMessage(&espFragInstanceDir,

--- a/core/sql/executor/ExExeUtilGetStats.cpp
+++ b/core/sql/executor/ExExeUtilGetStats.cpp
@@ -1644,9 +1644,9 @@ void ExExeUtilGetRTSStatisticsTcb::formatOperStats(SQLSTATS_ITEM* operStatsItems
   {
     moveRowToUpQueue("");
     isHeadingDisplayed_ = TRUE;
-    sprintf(statsBuf_, "%5s%5s%5s%5s%5s%5s %-25s%5s%13s%19s%19s%19s %10s", 
-      "LC","RC","Id","PaId", "ExId","Frag","TDB Name","DOP", "Dispatches","Oper CPU Time","Est. Records Used", 
-      "Act. Records Used","Details");
+    sprintf(statsBuf_, "%5s%5s%5s%5s%5s%5s %-25s%5s%13s%19s%19s%19s %s", 
+      "LC","RC","Id","PaId", "ExId","Frag","TDBName","DOP", "Dispatches","OperCPUTime","EstRowsUsed", 
+      "ActRowsUsed","Details");
     moveRowToUpQueue(statsBuf_);
     moveRowToUpQueue("");
   } 

--- a/core/sql/executor/ex_esp_frag_dir.h
+++ b/core/sql/executor/ex_esp_frag_dir.h
@@ -144,8 +144,7 @@ public:
     };
 
   ExEspFragInstanceDir(CliGlobals *cliGlobals,
-		       CollHeap *heap,
-		       CollHeap *exHeap,
+		       NAHeap *heap,
                        StatsGlobals *statsGlobals);
   ~ExEspFragInstanceDir();
 
@@ -294,9 +293,7 @@ private:
 
   CliGlobals                 *cliGlobals_;
 
-  CollHeap                   *heap_;
-
-  CollHeap                   *exHeap_;
+  NAHeap                     *heap_;
 
   StatsGlobals               *statsGlobals_;
   NAHeap                     *statsHeap_;

--- a/core/sql/regress/core/EXPECTEDRTS
+++ b/core/sql/regress/core/EXPECTEDRTS
@@ -1972,7 +1972,7 @@ Max. Execute Time        0.033737 secs
 Avg. Execute Time        0.033737 secs
 Stats Collection Type    OPERATOR_STATS
 
-   LC   RC   Id PaId ExId Frag TDB Name                   DOP   Dispatches      Oper CPU Time  Est. Records Used  Act. Records Used    Details
+   LC   RC   Id PaId ExId Frag TDBName                    DOP   Dispatches        OperCPUTime        EstRowsUsed        ActRowsUsed Details
 
    10    .   11    .    5    0 EX_ROOT                      1            5                  9                  0                  4 1821
     9    .   10   11    4    0 EX_SPLIT_TOP                 1            5                 40                  2                  4
@@ -2025,7 +2025,7 @@ Max. Execute Time        0.033737 secs
 Avg. Execute Time        0.033737 secs
 Stats Collection Type    OPERATOR_STATS
 
-   LC   RC   Id PaId ExId Frag TDB Name                   DOP   Dispatches      Oper CPU Time  Est. Records Used  Act. Records Used    Details
+   LC   RC   Id PaId ExId Frag TDBName                    DOP   Dispatches        OperCPUTime        EstRowsUsed        ActRowsUsed Details
 
    10    .   11    .    5    0 EX_ROOT                      1            5                  9                  0                  4 1821
     9    .   10   11    4    0 EX_SPLIT_TOP                 1            5                 40                  2                  4
@@ -2488,7 +2488,7 @@ Max. Execute Time        0.033737 secs
 Avg. Execute Time        0.033737 secs
 Stats Collection Type    OPERATOR_STATS
 
-   LC   RC   Id PaId ExId Frag TDB Name                   DOP   Dispatches      Oper CPU Time  Est. Records Used  Act. Records Used    Details
+   LC   RC   Id PaId ExId Frag TDBName                    DOP   Dispatches        OperCPUTime        EstRowsUsed        ActRowsUsed Details
 
    10    .   11    .    5    0 EX_ROOT                      1            5                  9                  0                  4 1821
     9    .   10   11    4    0 EX_SPLIT_TOP                 1            5                 40                  2                  4
@@ -2541,7 +2541,7 @@ Max. Execute Time        0.033737 secs
 Avg. Execute Time        0.033737 secs
 Stats Collection Type    OPERATOR_STATS
 
-   LC   RC   Id PaId ExId Frag TDB Name                   DOP   Dispatches      Oper CPU Time  Est. Records Used  Act. Records Used    Details
+   LC   RC   Id PaId ExId Frag TDBName                    DOP   Dispatches        OperCPUTime        EstRowsUsed        ActRowsUsed Details
 
    10    .   11    .    5    0 EX_ROOT                      1            5                  9                  0                  4
     9    .   10   11    4    0 EX_SPLIT_TOP                 1            5                 40                  2                  4
@@ -2595,7 +2595,7 @@ Max. Execute Time        0.033737 secs
 Avg. Execute Time        0.033737 secs
 Stats Collection Type    OPERATOR_STATS
 
-   LC   RC   Id PaId ExId Frag TDB Name                   DOP   Dispatches      Oper CPU Time  Est. Records Used  Act. Records Used    Details
+   LC   RC   Id PaId ExId Frag TDBName                    DOP   Dispatches        OperCPUTime        EstRowsUsed        ActRowsUsed Details
 
    10    .   11    .    5    0 EX_ROOT                      1            5                  9                  0                  4 1821
     9    .   10   11    4    0 EX_SPLIT_TOP                 1            5                 40                  2                  4
@@ -2902,7 +2902,7 @@ Max. Execute Time        0.033737 secs
 Avg. Execute Time        0.033737 secs
 Stats Collection Type    OPERATOR_STATS
 
-   LC   RC   Id PaId ExId Frag TDB Name                   DOP   Dispatches      Oper CPU Time  Est. Records Used  Act. Records Used    Details
+   LC   RC   Id PaId ExId Frag TDBName                    DOP   Dispatches        OperCPUTime        EstRowsUsed        ActRowsUsed Details
 
    10    .   11    .    5    0 EX_ROOT                      1            5                  9                  0                  4 1821
     9    .   10   11    4    0 EX_SPLIT_TOP                 1            5                 40                  2                  4
@@ -2958,7 +2958,7 @@ Max. Execute Time        0.033737 secs
 Avg. Execute Time        0.033737 secs
 Stats Collection Type    OPERATOR_STATS
 
-   LC   RC   Id PaId ExId Frag TDB Name                   DOP   Dispatches      Oper CPU Time  Est. Records Used  Act. Records Used    Details
+   LC   RC   Id PaId ExId Frag TDBName                    DOP   Dispatches        OperCPUTime        EstRowsUsed        ActRowsUsed Details
 
    10    .   11    .    5    0 EX_ROOT                      1            5                  9                  0                  4 1821
     9    .   10   11    4    0 EX_SPLIT_TOP                 1            5                 40                  2                  4
@@ -3377,7 +3377,7 @@ Max. Execute Time        0.033737 secs
 Avg. Execute Time        0.019772 secs
 Stats Collection Type    OPERATOR_STATS
 
-   LC   RC   Id PaId ExId Frag TDB Name                   DOP   Dispatches      Oper CPU Time  Est. Records Used  Act. Records Used    Details
+   LC   RC   Id PaId ExId Frag TDBName                    DOP   Dispatches        OperCPUTime        EstRowsUsed        ActRowsUsed Details
 
    10    .   11    .    5    0 EX_ROOT                      1            5                  6                  0                  4 303
     9    .   10   11    4    0 EX_SPLIT_TOP                 1            5                  5                  2                  4
@@ -3497,7 +3497,7 @@ Max. Execute Time        0.033737 secs
 Avg. Execute Time        0.018444 secs
 Stats Collection Type    OPERATOR_STATS
 
-   LC   RC   Id PaId ExId Frag TDB Name                   DOP   Dispatches      Oper CPU Time  Est. Records Used  Act. Records Used    Details
+   LC   RC   Id PaId ExId Frag TDBName                    DOP   Dispatches        OperCPUTime        EstRowsUsed        ActRowsUsed Details
 
    10    .   11    .    5    0 EX_ROOT                      1            5                  6                  0                  4 332
     9    .   10   11    4    0 EX_SPLIT_TOP                 1            5                  5                  2                  4


### PR DESCRIPTION
Refactored the ESP memory management so that all the SQL memory both
heap and space objects are accounted correctly in RMS

With this change, the total SQL memory used by all processes involved
in the query is represented in the counter "SQL Heap WM"