### PR TITLE
[TRAFODION-2785] mxosrvr dumps core generated when loading data from …

### DIFF
--- a/core/sql/exp/ExpError.cpp
+++ b/core/sql/exp/ExpError.cpp
@@ -613,11 +613,11 @@ char *stringToHex(char * out, Int32 outLen, char * in, Int32 inLen)
   if (hexLen < 0)
      hexLen = 0;
   else
+  {
+     if (inLen < hexLen) 
+        hexLen = inLen;
      out[0] = '\0';
-
-  if (inLen < hexLen) 
-     hexLen = inLen;
-
+  }
   char hex[3];
   for(int i = 0; i < hexLen; i++)
   {

--- a/core/sql/exp/ExpError.cpp
+++ b/core/sql/exp/ExpError.cpp
@@ -610,14 +610,12 @@ char *stringToHex(char * out, Int32 outLen, char * in, Int32 inLen)
 {
 
   Int32 hexLen = (outLen / 2) -1 ;
+  if (inLen < hexLen) 
+     hexLen = inLen;
   if (hexLen < 0)
      hexLen = 0;
-  else
-  {
-     if (inLen < hexLen) 
-        hexLen = inLen;
+  if (outLen > 0)
      out[0] = '\0';
-  }
   char hex[3];
   for(int i = 0; i < hexLen; i++)
   {

--- a/core/sql/exp/ExpError.cpp
+++ b/core/sql/exp/ExpError.cpp
@@ -608,17 +608,20 @@ ComDiagsArea *ExRaiseDetailSqlError(CollHeap* heap,
 
 char *stringToHex(char * out, Int32 outLen, char * in, Int32 inLen)
 {
-  //clear out buffer first
-  memset(out,0,outLen);
 
-  outLen = (outLen / 2) -1 ;
+  Int32 hexLen = (outLen / 2) -1 ;
+  if (hexLen < 0)
+     hexLen = 0;
+  else
+     out[0] = '\0';
 
-  if(inLen < outLen) outLen = inLen;
+  if (inLen < hexLen) 
+     hexLen = inLen;
 
   char hex[3];
-  for(int i = 0; i < outLen; i++)
+  for(int i = 0; i < hexLen; i++)
   {
-    sprintf(hex, "%02x", in[i]);
+    snprintf(hex, sizeof(hex), "%02x", (char)in[i]);
     strcat(out,hex);
   }
   return out;


### PR DESCRIPTION
…Oracle to Trafodion at times

When there is an error while loading the data, the hexadecimal representation
of character column upto 254 bytes is shown as part of the error message.

The function stringToHex had a subtle bug that can cause buffer overrun resulting in
stack corruption.