### PR TITLE
[TRAFODION-2801] select count(*) with cqd hbase_coprocessors 'off'

### DIFF
--- a/core/sql/executor/HBaseClient_JNI.h
+++ b/core/sql/executor/HBaseClient_JNI.h
@@ -115,6 +115,7 @@ typedef enum {
  ,HTC_ERROR_ASYNC_OPERATION_NOT_COMPLETE
  ,HTC_ERROR_WRITETOWAL_EXCEPTION
  ,HTC_ERROR_WRITEBUFFERSIZE_EXCEPTION
+ ,HTC_PREPARE_FOR_NEXTCELL_EXCEPTION
  ,HTC_LAST
 } HTC_RetCode;
 
@@ -141,6 +142,8 @@ public:
      jKvFamOffset_ = NULL;
      jTimestamp_ = NULL;
      jKvBuffer_ = NULL;
+     jKvFamArray_ = NULL;
+     jKvQualArray_ = NULL;
      jRowIDs_ = NULL;
      jKvsPerRow_ = NULL;
      currentRowNum_ = -1;
@@ -162,6 +165,8 @@ public:
      p_kvQualOffset_ = NULL;
      p_timestamp_ = NULL;
      jba_kvBuffer_ = NULL;
+     jba_kvFamArray_ = NULL;
+     jba_kvQualArray_ = NULL;
      jba_rowID_ = NULL;
      fetchMode_ = UNKNOWN;
      p_rowID_ = NULL;
@@ -205,7 +210,8 @@ public:
         jintArray jKvQualLen, jintArray jKvQualOffset,
         jintArray jKvFamLen, jintArray jKvFamOffset,
         jlongArray jTimestamp, 
-        jobjectArray jKvBuffer, jobjectArray jRowIDs,
+        jobjectArray jKvBuffer, 
+        jobjectArray jKvFamArray, jobjectArray jKvQualArray, jobjectArray jRowIDs,
         jintArray jKvsPerRow, jint numCellsReturned, jint numRowsReturned);
   void getResultInfo();
   void cleanupResultInfo();
@@ -232,6 +238,7 @@ public:
                  HbaseStr &colVal,
                  Int64 &timestamp);
   HTC_RetCode completeAsyncOperation(int timeout, NABoolean *resultArray, short resultArrayLen);
+  HTC_RetCode prepareForNextCell(int idx);
 
   //  HTC_RetCode codeProcAggrGetResult();
 
@@ -299,6 +306,8 @@ private:
   jintArray jKvFamOffset_;
   jlongArray jTimestamp_;
   jobjectArray jKvBuffer_;
+  jobjectArray jKvFamArray_;
+  jobjectArray jKvQualArray_;
   jobjectArray jRowIDs_;
   jintArray jKvsPerRow_;
   jint *p_kvValLen_;
@@ -309,6 +318,8 @@ private:
   jint *p_kvFamOffset_;
   jlong *p_timestamp_;
   jbyteArray jba_kvBuffer_;
+  jbyteArray jba_kvFamArray_;
+  jbyteArray jba_kvQualArray_;
   jbyteArray jba_rowID_;
   jbyte *p_rowID_;
   jint *p_kvsPerRow_;

--- a/core/sql/executor/org_trafodion_sql_HTableClient.h
+++ b/core/sql/executor/org_trafodion_sql_HTableClient.h
@@ -16,10 +16,10 @@ extern "C" {
 /*
  * Class:     org_trafodion_sql_HTableClient
  * Method:    setResultInfo
- * Signature: (J[I[I[I[I[I[I[J[[B[[B[III)I
+ * Signature: (J[I[I[I[I[I[I[J[[B[[B[[B[[B[III)I
  */
 JNIEXPORT jint JNICALL Java_org_trafodion_sql_HTableClient_setResultInfo
-  (JNIEnv *, jobject, jlong, jintArray, jintArray, jintArray, jintArray, jintArray, jintArray, jlongArray, jobjectArray, jobjectArray, jintArray, jint, jint);
+  (JNIEnv *, jobject, jlong, jintArray, jintArray, jintArray, jintArray, jintArray, jintArray, jlongArray, jobjectArray, jobjectArray, jobjectArray, jobjectArray, jintArray, jint, jint);
 
 /*
  * Class:     org_trafodion_sql_HTableClient

--- a/core/sql/src/main/java/org/trafodion/sql/HTableClient.java
+++ b/core/sql/src/main/java/org/trafodion/sql/HTableClient.java
@@ -129,6 +129,8 @@ public class HTableClient {
 	byte[][] kvBuffer = null;
 	byte[][] rowIDs = null;
 	int[] kvsPerRow = null;
+        byte[][] kvFamArray = null;
+        byte[][] kvQualArray = null;
         static ExecutorService executorService = null;
         Future future = null;
 	boolean preFetch = false;
@@ -1242,6 +1244,8 @@ public class HTableClient {
 			kvFamOffset = new int[numTotalCells];
 			kvTimestamp = new long[numTotalCells];
 			kvBuffer = new byte[numTotalCells][];
+                        kvFamArray = new byte[numTotalCells][];
+                        kvQualArray = new byte[numTotalCells][];
 		}
                
 		if (rowIDs == null || (rowIDs != null &&
@@ -1271,6 +1275,8 @@ public class HTableClient {
 				kvFamOffset[cellNum] = kv.getFamilyOffset();
 				kvTimestamp[cellNum] = kv.getTimestamp();
 				kvBuffer[cellNum] = kv.getValueArray();
+                                kvFamArray[cellNum] = kv.getFamilyArray();
+                                kvQualArray[cellNum] = kv.getQualifierArray();
 				colFound = true;
 			}
 		}
@@ -1282,11 +1288,11 @@ public class HTableClient {
 		if (cellsReturned == 0)
 			setResultInfo(jniObject, null, null,
 				null, null, null, null,
-				null, null, rowIDs, kvsPerRow, cellsReturned, rowsReturned);
+				null, null, null, null, rowIDs, kvsPerRow, cellsReturned, rowsReturned);
 		else 
 			setResultInfo(jniObject, kvValLen, kvValOffset,
 				kvQualLen, kvQualOffset, kvFamLen, kvFamOffset,
-				kvTimestamp, kvBuffer, rowIDs, kvsPerRow, cellsReturned, rowsReturned);
+				kvTimestamp, kvBuffer, kvFamArray, kvQualArray, rowIDs, kvsPerRow, cellsReturned, rowsReturned);
 		return rowsReturned;	
 	}		
 	
@@ -1294,6 +1300,7 @@ public class HTableClient {
 			throws IOException {
 		int rowsReturned = 1;
 		int numTotalCells;
+
 		if (numColsInScan == 0)
 			numTotalCells = result.size();
 		else
@@ -1316,6 +1323,8 @@ public class HTableClient {
 			kvFamOffset = new int[numTotalCells];
 			kvTimestamp = new long[numTotalCells];
 			kvBuffer = new byte[numTotalCells][];
+                        kvFamArray = new byte[numTotalCells][];
+                        kvQualArray = new byte[numTotalCells][];
 		}
 		if (rowIDs == null)
 		{
@@ -1342,15 +1351,17 @@ public class HTableClient {
 			kvFamOffset[colNum] = kv.getFamilyOffset();
 			kvTimestamp[colNum] = kv.getTimestamp();
 			kvBuffer[colNum] = kv.getValueArray();
+                        kvFamArray[colNum] = kv.getFamilyArray();
+                        kvQualArray[colNum] = kv.getQualifierArray();
 		}
 		if (numColsReturned == 0)
 			setResultInfo(jniObject, null, null,
 				null, null, null, null,
-				null, null, rowIDs, kvsPerRow, numColsReturned, rowsReturned);
+				null, null, null, null, rowIDs, kvsPerRow, numColsReturned, rowsReturned);
 		else
 			setResultInfo(jniObject, kvValLen, kvValOffset,
 				kvQualLen, kvQualOffset, kvFamLen, kvFamOffset,
-				kvTimestamp, kvBuffer, rowIDs, kvsPerRow, numColsReturned, rowsReturned);
+				kvTimestamp, kvBuffer, kvFamArray, kvQualArray, rowIDs, kvsPerRow, numColsReturned, rowsReturned);
 		return rowsReturned;	
 	}		
 	
@@ -1876,7 +1887,10 @@ public class HTableClient {
 				int[] kvQualLen, int[] kvQualOffset,
 				int[] kvFamLen, int[] kvFamOffset,
   				long[] timestamp, 
-				byte[][] kvBuffer, byte[][] rowIDs,
+				byte[][] kvBuffer, 
+                                byte[][] kvFamArray,
+                                byte[][] kvQualArray,
+                                byte[][] rowIDs,
 				int[] kvsPerRow, int numCellsReturned,
 				int rowsReturned);
 


### PR DESCRIPTION
and cqd traf_table_snapshot_scan 'latest' fail

Changed to pass two more arrays references - familyArray and QualifierArray
from Java to JNI to extract the family and the qualifier names correctly
on the native side