### PR TITLE
TRAFODION-2812 sqenv.sh file not found

### DIFF
--- a/dcs/src/main/java/org/trafodion/dcs/Constants.java
+++ b/dcs/src/main/java/org/trafodion/dcs/Constants.java
@@ -92,7 +92,7 @@ public final class Constants {
     public static final String DCS_SERVER_USER_PROGRAM_COMMAND = "dcs.server.user.program.command";
 
     /** Default value for DCS server user program command */
-    public static final String DEFAULT_DCS_SERVER_USER_PROGRAM_COMMAND = "cd ${dcs.user.program.home};. sqenv.sh;mxosrvr -ZKHOST -RZ -ZKPNODE -CNGTO -ZKSTO -EADSCO -TCPADD -MAXHEAPPCT -STATISTICSINTERVAL -STATISTICSLIMIT -STATISTICSTYPE -STATISTICSENABLE -SQLPLAN -PORTMAPTOSECS -PORTBINDTOSECS";
+    public static final String DEFAULT_DCS_SERVER_USER_PROGRAM_COMMAND = "cd ${dcs.user.program.home};. ./sqenv.sh;mxosrvr -ZKHOST -RZ -ZKPNODE -CNGTO -ZKSTO -EADSCO -TCPADD -MAXHEAPPCT -STATISTICSINTERVAL -STATISTICSLIMIT -STATISTICSTYPE -STATISTICSENABLE -SQLPLAN -PORTMAPTOSECS -PORTBINDTOSECS";
 
     /** Configuration key for DCS server user program connecting timeout */
     public static final String DCS_SERVER_USER_PROGRAM_CONNECTING_TIMEOUT = "dcs.server.user.program.connecting.timeout";


### PR DESCRIPTION
Trafci connection failure,Check the DCS log,it shows:
2017-11-13 07:58:01,465, INFO, org.trafodion.dcs.server.ServerManager, Node Number: , CPU: , PIN: , Process Name: , , ,Server handler [1:4] is not running
2017-11-13 07:58:01,466, INFO, org.trafodion.dcs.server.ServerManager, Node Number: , CPU: , PIN: , Process Name: , , ,User program exec [cd /home/gongpj/incubator-trafodion/core/sqf;. sqenv.sh;mxosrvr -ZKHOST localhost:2181 -RZ workspace-gongpj:1:4 -ZKPNODE "/gongpj" -CNGTO 60 -ZKSTO 180 -EADSCO 0 -TCPADD 192.168.0.70 -MAXHEAPPCT 0 -STATISTICSINTERVAL 60 -STATISTICSLIMIT 60 -STATISTICSTYPE aggregated -STATISTICSENABLE true -SQLPLAN true -PORTMAPTOSECS -1 -PORTBINDTOSECS -1]
2017-11-13 07:58:01,533, INFO, org.trafodion.dcs.server.ServerManager, Node Number: , CPU: , PIN: , Process Name: , , ,Server handler [1:2] is running
2017-11-13 07:58:01,591, INFO, org.trafodion.dcs.server.ServerManager, Node Number: , CPU: , PIN: , Process Name: , , ,User program exit [0]
2017-11-13 07:58:01,592, INFO, org.trafodion.dcs.server.ServerManager, Node Number: , CPU: , PIN: , Process Name: , , ,exit code [0], stderr [/bin/sh: line 0: .: sqenv.sh: file not found]
2017-11-13 07:58:02,041, INFO, org.trafodion.dcs.server.ServerManager, Node Number: , CPU: , PIN: , Process Name: , , ,mxosrvr 0,12973 exited, restarting, restart attempt time : 1