### PR TITLE
[TRAFODION-2811] When convert NULL to SQL_VARCHAR, the length was not be sent

### DIFF
--- a/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/ctosqlconv.cpp
+++ b/core/conn/unixodbc/odbc/odbcclient/unixcli/cli/ctosqlconv.cpp
@@ -3510,6 +3510,13 @@ unsigned long ODBC::ConvertCToSQL(SQLINTEGER	ODBCAppVersion,
 			if (OutLen < DataLen)
 				return IDS_22_001;
 			memcpy(outDataPtr, DataPtr, DataLen);
+            if (Offset != 0)    //When Datalen = 0, length was not stored in buffer
+            {
+                if(targetPrecision > SHRT_MAX)
+                    *(unsigned int *)targetDataPtr = DataLen;
+                else
+                    *(unsigned short *)targetDataPtr = DataLen;
+            }
 		}
 		if (byteSwap)
 		{

--- a/win-odbc64/odbcclient/drvr35/ctosqlconv.cpp
+++ b/win-odbc64/odbcclient/drvr35/ctosqlconv.cpp
@@ -3253,6 +3253,13 @@ unsigned long ODBC::ConvertCToSQL(SQLINTEGER	ODBCAppVersion,
 			if (OutLen < DataLen)
 				return IDS_22_001;
 			memcpy(outDataPtr, DataPtr, DataLen);
+			if (Offset != 0)	//When Datalen = 0, length was not stored in buffer
+			{
+				if (targetPrecision > SHRT_MAX)
+					*(unsigned int *)targetDataPtr = DataLen;
+				else
+					*(unsigned short *)targetDataPtr = DataLen;
+			}
 		}
 		if (byteSwap) 
 		{


### PR DESCRIPTION
When inserting NULL buffer to varchar, ODBC has not sent the real length of data to server.
Error: [Trafodion ODBC Driver][Trafodion Database] SQL ERROR:*** ERROR[8402] A string overflow occurred during the evaluation of a character expression.