### PR TITLE
[TRAFODION-2791] 'Not casespecific' column comparison returns wrong

### DIFF
--- a/core/sql/optimizer/ItemColRef.h
+++ b/core/sql/optimizer/ItemColRef.h
@@ -350,6 +350,14 @@ public:
            NAMemory * outHeap = CmpCommon::statementHeap()
         );
 
+  ConstValue(const NAString& strval,
+           NABoolean isCaseInSensitive,
+           enum CharInfo::CharSet charSet=CharInfo::DefaultCharSet,
+           enum CharInfo::Collation collation=CharInfo::DefaultCollation,
+           enum CharInfo::Coercibility coercibility=CharInfo::COERCIBLE,
+           NAMemory * outHeap = CmpCommon::statementHeap()
+        );
+
   // constructor for a wide (unicode) string constant
   ConstValue(const NAWString& strval,
            enum CharInfo::CharSet charSet=CharInfo::UNICODE,
@@ -358,6 +366,16 @@ public:
            NAMemory * outHeap = CmpCommon::statementHeap(),
            enum CharInfo::CharSet strLitPrefixCharSet=CharInfo::UnknownCharSet
         );
+
+  ConstValue(const NAWString& strval,
+           NABoolean isCaseInSensitive,
+           enum CharInfo::CharSet charSet=CharInfo::UNICODE,
+           enum CharInfo::Collation collation=CharInfo::DefaultCollation,
+           enum CharInfo::Coercibility coercibility=CharInfo::COERCIBLE,
+           NAMemory * outHeap = CmpCommon::statementHeap(),
+           enum CharInfo::CharSet strLitPrefixCharSet=CharInfo::UnknownCharSet
+        );
+
 
 // constructor for a string constant with unknown charset (both the
 // single-byte and double-byte string values are known)

--- a/core/sql/optimizer/ItemExpr.cpp
+++ b/core/sql/optimizer/ItemExpr.cpp
@@ -9971,6 +9971,22 @@ ConstValue::ConstValue(const NAString & strval,
     ((char*)strval.data(), strval.length(), outHeap);
 }
 
+ConstValue::ConstValue(const NAString & strval,
+             NABoolean isCaseInSensitive,
+             enum CharInfo::CharSet charSet,
+             enum CharInfo::Collation collation,
+             enum CharInfo::Coercibility coercibility,
+             NAMemory * outHeap)
+: ItemExpr(ITM_CONSTANT), isNull_(IS_NOT_NULL),
+  textIsValidatedSQLLiteralInUTF8_(FALSE), isStrLitWithCharSetPrefix_(FALSE),
+  isSystemSupplied_(FALSE), locale_wstrval(0), rebindNeeded_(FALSE)
+{
+   initCharConstValue(strval, charSet, collation, coercibility, isCaseInSensitive, outHeap);
+   locale_strval = new (outHeap) NAString
+    ((char*)strval.data(), strval.length(), outHeap);
+}
+
+
 void ConstValue::initCharConstValue
 (
      const NAString & strval,
@@ -10064,6 +10080,30 @@ ConstValue::ConstValue(const NAWString& wstrval,
    rebindNeeded_(FALSE)
 {
    initCharConstValue(wstrval, charSet, collation, coercibility, FALSE, outHeap,
+                      strLitPrefixCharSet);
+
+   locale_wstrval = new (CmpCommon::statementHeap()) NAWString
+      (wstrval.data(), wstrval.length(), CmpCommon::statementHeap());
+}
+
+ConstValue::ConstValue(const NAWString& wstrval,
+             NABoolean isCaseInSensitive,
+             enum CharInfo::CharSet charSet,
+             enum CharInfo::Collation collation,
+             enum CharInfo::Coercibility coercibility,
+             NAMemory * outHeap,
+             enum CharInfo::CharSet strLitPrefixCharSet
+)
+ : ItemExpr(ITM_CONSTANT), isNull_(IS_NOT_NULL),
+   isSystemSupplied_(FALSE),
+   value_(0),
+   text_(0),
+   locale_strval(0),
+   locale_wstrval(0),
+   isStrLitWithCharSetPrefix_(FALSE),
+   rebindNeeded_(FALSE)
+{
+   initCharConstValue(wstrval, charSet, collation, coercibility, isCaseInSensitive, outHeap,
                       strLitPrefixCharSet);
 
    locale_wstrval = new (CmpCommon::statementHeap()) NAWString

--- a/core/sql/optimizer/OptRange.cpp
+++ b/core/sql/optimizer/OptRange.cpp
@@ -503,7 +503,13 @@ ConstValue* OptRangeSpec::getConstOperand(ItemExpr* predExpr, Lng32 constInx)
   // currently support. Predicates involving types not yet supported will be
   // treated as residual predicates.
   if (QRDescGenerator::typeSupported(static_cast<ConstValue*>(right)->getType()))
+  {
+    /* add constvalue ‘not casespecific’ to type_*/
+      ((CharType*)getType())->setCaseinsensitive(
+              ((CharType *)(((ConstValue*)(right))->getType()))->isCaseinsensitive());
+
     return static_cast<ConstValue*>(right);
+  }
   else
     return NULL;
 } // getConstOperand()
@@ -1712,10 +1718,13 @@ ItemExpr* OptRangeSpec::makeSubrangeItemExpr(SubrangeBase* subrange,
                              (Subrange<RangeWString>*)subrange;
               if (parentOfStart)
                 parentOfStart->child(1) =
-                            new(mvqrHeap_) ConstValue(wcharSubrange->start);
+                    new(mvqrHeap_) ConstValue(wcharSubrange->start,
+                                              ((CharType *)type)->isCaseinsensitive());
+
               if (parentOfEnd)
                 parentOfEnd->child(1) =
-                            new(mvqrHeap_) ConstValue(wcharSubrange->end);
+                    new(mvqrHeap_) ConstValue(wcharSubrange->end,
+                                              ((CharType *)type)->isCaseinsensitive());
             }
           else
             {
@@ -1724,10 +1733,15 @@ ItemExpr* OptRangeSpec::makeSubrangeItemExpr(SubrangeBase* subrange,
                       = (Subrange<RangeString>*)subrange;
               if (parentOfStart)
                 parentOfStart->child(1) =
-                            new(mvqrHeap_) ConstValue(charSubrange->start, ((CharType *)type)->getCharSet() );
+                    new(mvqrHeap_) ConstValue(charSubrange->start,
+                                              ((CharType *)type)->isCaseinsensitive(),
+                                              ((CharType *)type)->getCharSet() );
+
               if (parentOfEnd)
                 parentOfEnd->child(1) =
-                            new(mvqrHeap_) ConstValue(charSubrange->end, ((CharType *)type)->getCharSet() );
+                    new(mvqrHeap_) ConstValue(charSubrange->end,
+                                              ((CharType *)type)->isCaseinsensitive(),
+                                              ((CharType *)type)->getCharSet() );
             }
         }
         break;


### PR DESCRIPTION
'Not casespecific' column comparison returns wrongresult,  now like and t.c1=t.c2 not support