### PR TITLE
[TRAFODION-2819] Fix 4247 error on drop table when certain CQDs are present

### DIFF
--- a/core/sql/optimizer/RelRoutine.cpp
+++ b/core/sql/optimizer/RelRoutine.cpp
@@ -1667,6 +1667,7 @@ void ProxyFunc::populateColumnDesc(char *tableNam,
                       new(STMTHEAP) char[numCols * sizeof(ComTdbVirtTableColumnInfo)];
 
    cmpSBD.buildColInfoArray(COM_USER_DEFINED_ROUTINE_OBJECT,
+                            FALSE,
                             &colArray, 
                             colInfoArray, 
                             FALSE, FALSE, NULL, NULL, NULL, NULL,

--- a/core/sql/sqlcomp/CmpSeabaseDDL.h
+++ b/core/sql/sqlcomp/CmpSeabaseDDL.h
@@ -342,6 +342,7 @@ class CmpSeabaseDDL
 
   short buildColInfoArray(
                           ComObjectType objType,
+                          NABoolean isMetadataHistOrReposObject,
 			  ElemDDLColDefArray * colArray,
 			  ComTdbVirtTableColumnInfo * colInfoArray,
 			  NABoolean implicitPK,
@@ -596,6 +597,7 @@ protected:
 		    ULng32 &colFlags);
 
   short getColInfo(ElemDDLColDef * colNode, 
+                   NABoolean isMetadataHistOrReposColumn,
                    NAString &colFamily,
 		   NAString &colName,
                    NABoolean alignedFormat,

--- a/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLcommon.cpp
@@ -572,6 +572,7 @@ short CmpSeabaseDDL::processDDLandCreateDescs(
       keyInfoArray = new(CTXTHEAP) ComTdbVirtTableKeyInfo[numKeys];
 
       if (buildColInfoArray(COM_BASE_TABLE_OBJECT,
+                            TRUE, // this is a metadata, histogram or repository object
                             &colArray, colInfoArray, FALSE, FALSE, NULL, NULL, NULL, NULL, 
                             CTXTHEAP))
         {
@@ -3013,6 +3014,7 @@ short CmpSeabaseDDL::getNAColumnFromColDef
   LobsStorage lobStorage;
   NABoolean alignedFormat = FALSE;
   if (getColInfo(colNode,
+                 FALSE,
                  colFamily,
                  colName,
                  alignedFormat,
@@ -3058,6 +3060,7 @@ short CmpSeabaseDDL::getNAColumnFromColDef
 }
 
 short CmpSeabaseDDL::getColInfo(ElemDDLColDef * colNode, 
+                                NABoolean isMetadataHistOrReposColumn,
                                 NAString &colFamily,
                                 NAString &colName,
                                 NABoolean alignedFormat,
@@ -3126,7 +3129,8 @@ short CmpSeabaseDDL::getColInfo(ElemDDLColDef * colNode,
       return rc;
     }
 
-  if ((naType->getTypeQualifier() == NA_CHARACTER_TYPE) &&
+  if ((!isMetadataHistOrReposColumn) &&
+      (naType->getTypeQualifier() == NA_CHARACTER_TYPE) &&
       (naType->getNominalSize() > CmpCommon::getDefaultNumeric(TRAF_MAX_CHARACTER_COL_LENGTH)))
     {
       *CmpCommon::diags() << DgSqlCode(-4247)
@@ -5982,6 +5986,7 @@ short CmpSeabaseDDL::processColFamily(NAString &inColFamily,
 
 short CmpSeabaseDDL::buildColInfoArray(
                                        ComObjectType objType,
+                                       NABoolean isMetadataHistOrReposObject,
                                        ElemDDLColDefArray *colArray,
                                        ComTdbVirtTableColumnInfo * colInfoArray,
                                        NABoolean implicitPK,
@@ -6016,6 +6021,7 @@ short CmpSeabaseDDL::buildColInfoArray(
       Int64 colFlags;
       LobsStorage lobStorage;
       if (getColInfo(colNode,
+                     isMetadataHistOrReposObject,
                      colFamily,
                      colName,
                      alignedFormat,
@@ -6161,6 +6167,7 @@ short CmpSeabaseDDL::buildColInfoArray(
       Int64 colFlags;
       LobsStorage lobStorage;
       if (getColInfo(&colNode,
+                     FALSE,
                      colFamily,
                      colName,
                      FALSE,

--- a/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLtable.cpp
@@ -2330,6 +2330,7 @@ short CmpSeabaseDDL::createSeabaseTable2(
       keyInfoArray = new(STMTHEAP) ComTdbVirtTableKeyInfo[numKeys];
 
       if (buildColInfoArray(COM_BASE_TABLE_OBJECT,
+                            FALSE, // not a metadata, histogram or repository object
                             &colArray, colInfoArray, implicitPK,
                             alignedFormat, &identityColPos,
                             (hbaseMapFormat ? NULL : &userColFamVec), 
@@ -5472,6 +5473,7 @@ void CmpSeabaseDDL::alterSeabaseTableAddColumn(
     }
 
   retcode = getColInfo(pColDef,
+                       FALSE, // not a metadata, histogram or repository column 
                        colFamily,
                        colName, 
                        naTable->isSQLMXAlignedTable(),
@@ -6895,6 +6897,7 @@ short CmpSeabaseDDL::alignedFormatTableAlterColumnAttr
     goto label_restore;
 
   if (getColInfo(pColDef,
+                 FALSE, // not a metadata, histogram or repository column
                  colFamily,
                  colName, 
                  naTable->isSQLMXAlignedTable(),

--- a/core/sql/sqlcomp/CmpSeabaseDDLview.cpp
+++ b/core/sql/sqlcomp/CmpSeabaseDDLview.cpp
@@ -932,7 +932,7 @@ void CmpSeabaseDDL::createSeabaseView(
   ComTdbVirtTableColumnInfo * colInfoArray = 
     new(STMTHEAP) ComTdbVirtTableColumnInfo[numCols];
 
-  if (buildColInfoArray(COM_VIEW_OBJECT, &colDefArray, colInfoArray, FALSE, FALSE))
+  if (buildColInfoArray(COM_VIEW_OBJECT, FALSE, &colDefArray, colInfoArray, FALSE, FALSE))
     {
       deallocEHI(ehi); 
       processReturn();


### PR DESCRIPTION
When CQD TRAF_MAX_CHARACTER_COL_LENGTH is set to a value lower than '500', then DROP TABLE will fail when it tries to do a DELETE under the covers on the SB_HISTOGRAMS table. The latter fails with error 4247, raised in CmpSeabaseDDL::getColInfo (sqlcomp/CmpSeabaseDDLcommon.cpp).

The fix is to change CmpSeabaseDDL::getColInfo to exempt metadata, histogram and repository tables from the maximum column length check.