### PR TITLE
additional fixes to [TRAFODION-2806]

### DIFF
--- a/core/sqf/sql/scripts/sqgen
+++ b/core/sqf/sql/scripts/sqgen
@@ -171,9 +171,16 @@ mkdir -p $MPI_TMPDIR
 # mkdir a dir for CBF data used by SQL IUS feature
 mkdir -p $HOME/cbfs
 
+# Clean HBase classpath cache file
+echo "Clean up HBase classpath cache file: $TRAF_VAR/hbase_classpath"
+rm -rf $TRAF_VAR/hbase_classpath
+
 if  [[ -n "$node_count" ]] && [[ "$node_count" -gt "1" ]]; then    
     echo
     echo "Creating directories on cluster nodes"
+
+    # Clean HBase classpath cache file on all nodes
+    $PDSH -w ${ExNodeList[@]} -x `uname -n` $PDSH_SSH_CMD rm -rf $TRAF_VAR/hbase_classpath
 
     echo "$PDSH -w ${ExNodeList[@]} -x `uname -n` $PDSH_SSH_CMD mkdir -p $SQETC_DIR "
     $PDSH -w ${ExNodeList[@]} -x `uname -n` $PDSH_SSH_CMD mkdir -p $SQETC_DIR

--- a/core/sqf/sql/scripts/sqstart
+++ b/core/sqf/sql/scripts/sqstart
@@ -418,8 +418,12 @@ rm -f $MPI_TMPDIR/monitor.port.*
 
 setup_sqpdsh
 
+# Clean HBase classpath cache file
+echo "Clean up HBase classpath cache file: $TRAF_VAR/hbase_classpath"
+$SQPDSHA "rm -rf $TRAF_VAR/hbase_classpath"
+
 # Clear unique strings
-$SQPDSHA 'cd $TRAF_HOME/sql/scripts; utilConfigDb -u'
+$SQPDSHA "cd $TRAF_HOME/sql/scripts; utilConfigDb -u"
 
 echoLog "Executing sqipcrm (output to sqipcrm.out)"
 sqipcrm > sqipcrm.out


### PR DESCRIPTION
sometimes the hbase classpath may get updated,  the cache file will be obsolete. Now we clean the cache file during 'sqstart/sqgen'