### PR TITLE
[TRAFODION-2822] Make [first n] views non-updatable; prevent bad MERGE plans

### DIFF
--- a/core/sql/optimizer/NormRelExpr.cpp
+++ b/core/sql/optimizer/NormRelExpr.cpp
@@ -6995,11 +6995,6 @@ NABoolean RelRoot::isUpdatableBasic(NABoolean isView,
   // QSTUFF
 
     {
-      // if child is a FirstN node, skip it.
-      if ((child(0)->castToRelExpr()->getOperatorType() == REL_FIRST_N) &&
-	  (child(0)->child(0)))
-	scan = (Scan *)child(0)->child(0)->castToRelExpr();
-      else
 	scan = (Scan *)child(0)->castToRelExpr();
     }
 

--- a/core/sql/optimizer/RelExpr.cpp
+++ b/core/sql/optimizer/RelExpr.cpp
@@ -13535,6 +13535,12 @@ MergeUpdate::MergeUpdate(const CorrName &name,
   setCacheableNode(CmpMain::BIND);
   
   setIsMergeUpdate(TRUE);
+
+  // if there is a WHERE NOT MATCHED INSERT action, then the scan
+  // has to take place in the merge node at run time, so we have
+  // to suppress the TSJ transformation on this node
+  if (insertValues)
+    setNoFlow(TRUE);
 }
 
 MergeUpdate::~MergeUpdate() {}
@@ -13629,6 +13635,12 @@ MergeDelete::MergeDelete(const CorrName &name,
   setCacheableNode(CmpMain::BIND);
   
   setIsMergeDelete(TRUE);
+
+  // if there is a WHERE NOT MATCHED INSERT action, then the scan
+  // has to take place in the merge node at run time, so we have
+  // to suppress the TSJ transformation on this node
+  if (insertValues)
+    setNoFlow(TRUE);
 }
 
 MergeDelete::~MergeDelete() {}


### PR DESCRIPTION
This pull request contains two changes:

1. Views defined using [first n] or [any n] are now marked as not updatable and not insertable. So, when a MERGE statement is attempted on a new view of this type, we will get a compile time error that the view is not insertable or updatable (instead of getting an incorrect result).

2. MERGE statements that have a WHEN NOT MATCHED INSERT action are prevented from undergoing a tuple substitution transformation (that is, the TSJRule and TSJFlowRule will not fire on a merge node possessing a WHEN NOT MATCHED INSERT action). This is necessary because the run-time implementation of insert actions takes place in the merge node itself; that is, scanning has to happen in the merge node. These two rules would take the scanning out of the merge node into a separate scan node.

Note: Existing [first n] / [any n] views remain marked as updatable and insertable. (These attributes are calculated at CREATE VIEW time and stored in the metadata.) The second change above will cause MERGE statements having WHEN NOT MATCHED INSERT actions to fail at compile time against such views with an error 2235 (Optimizer could not produce a plan for the statement). While this is a non-obvious error from a user perspective it is far better than allowing execution and getting an incorrect result.