### PR TITLE
[TRAFODION-2831] Add project DOAP file for inclusion in ASF project list

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,5 @@
 # git files
 .gitignore export-ignore
 .gitattributes export-ignore
+# project description file
+doap.rdf export-ignore

--- a/doap.rdf
+++ b/doap.rdf
@@ -1,0 +1,51 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl"?>
+<rdf:RDF xml:lang="en"
+         xmlns="http://usefulinc.com/ns/doap#" 
+         xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#" 
+         xmlns:asfext="http://projects.apache.org/ns/asfext#"
+         xmlns:foaf="http://xmlns.com/foaf/0.1/">
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one or more
+    contributor license agreements.  See the NOTICE file distributed with
+    this work for additional information regarding copyright ownership.
+    The ASF licenses this file to You under the Apache License, Version 2.0
+    (the "License"); you may not use this file except in compliance with
+    the License.  You may obtain a copy of the License at
+   
+         http://www.apache.org/licenses/LICENSE-2.0
+   
+    Unless required by applicable law or agreed to in writing, software
+    distributed under the License is distributed on an "AS IS" BASIS,
+    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+    See the License for the specific language governing permissions and
+    limitations under the License.
+-->
+  <Project rdf:about="http://trafodion.incubator.apache.org">
+    <created>2017-12-07</created>
+    <license rdf:resource="http://spdx.org/licenses/Apache-2.0" />
+    <name>Apache Trafodion</name>
+    <homepage rdf:resource="http://trafodion.incubator.apache.org" />
+    <asfext:pmc rdf:resource="http://incubator.apache.org" />
+    <shortdesc>Webscale SQL-on-Hadoop solution enabling transactional or operational workloads on Apache Hadoop.</shortdesc>
+    <description>Trafodion builds on the scalability, elasticity, and flexibility of Hadoop. Trafodion extends Hadoop to provide guaranteed transactional integrity, enabling new kinds of big data applications to run on Hadoop.</description>
+    <bug-database rdf:resource="http://issues.apache.org/jira/browse/TRAFODION" />
+    <mailing-list rdf:resource="http://trafodion.incubator.apache.org/mail-lists.html" />
+    <download-page rdf:resource="http://trafodion.incubator.apache.org/download.html" />
+    <programming-language>C++</programming-language>
+    <category rdf:resource="http://projects.apache.org/category/big-data" />
+    <repository>
+      <GitRepository>
+        <location rdf:resource="http://git-wip-us.apache.org/repos/asf/incubator-trafodion.git"/>
+        <browse rdf:resource="https://git-wip-us.apache.org/repos/asf?p=incubator-trafodion.git"/>
+      </GitRepository>
+    </repository>
+    <maintainer>
+      <foaf:Person>
+        <foaf:name>Steve Varnau</foaf:name>
+          <foaf:mbox rdf:resource="mailto:svarnau@apache.org"/>
+      </foaf:Person>
+    </maintainer>
+  </Project>
+</rdf:RDF>
+

--- a/docs/src/site/site.xml
+++ b/docs/src/site/site.xml
@@ -216,12 +216,14 @@
       <item href="http:divider" name=""/>
       <item href="team-redirect.html" name="Team"/>
       <item href="presentations.html" name="Presentations"/>
+      <item href="http://www.apache.org/events/current-event.html" name="Events"/>
       <item href="logo.html" name="Logo"/>
       <item href="mail-lists.html" name="Mailing Lists"/>
       <item href="http://im.qq.com" name="QQ (Group ID:176011868)"/>
       <item href="http:divider" name=""/>
       <item href="source-repository.html" name="Source Repository"/>
       <item href="issue-tracking.html" name="Issue Tracking"/>
+      <item href="http://www.apache.org/security/" name="Security"/>
       <item href="license.html" name="License"/>
     </menu>
     <menu name="Features">


### PR DESCRIPTION
The project DOAP file was created from template at:
  https://projects.apache.org/create.html

That page also says it should not be included in source/binary packages,
hence it is excluded from git export used to create source product.