### PR TITLE
[TRAFODION-2856] Add optimizer/UdrErrors.h to analyzeMessageGuide.py

### DIFF
--- a/core/sqf/sql/scripts/analyzeMessageGuide.py
+++ b/core/sqf/sql/scripts/analyzeMessageGuide.py
@@ -621,6 +621,7 @@ print datetime.datetime.ctime(datetime.datetime.now()) + ": reading enum files"
 enumFileList = ( [ ['ustat/hs_const.h','USTAT_ERROR_CODES'],
     ['sqlcomp/CmpDDLCatErrorCodes.h','CatErrorCode'],
     ['optimizer/opt_error.h','OptimizerSQLErrorCode'],
+    ['optimizer/UdrErrors.h','UDRErrors'],
     ['exp/ExpErrorEnums.h','ExeErrorCode'] ] )
 for entry in enumFileList:
     fileName = mySQroot + '/../sql/' + entry[0]


### PR DESCRIPTION
This allows the script to search for references to certain messages using these enums as well as the numbers themselves.